### PR TITLE
MassFlowSources require nPorts>=1

### DIFF
--- a/Modelica/Fluid/Sources.mo
+++ b/Modelica/Fluid/Sources.mo
@@ -425,7 +425,7 @@ with exception of boundary pressure, do not have an effect.
   model MassFlowSource_T
     "Ideal flow source that produces a prescribed mass flow with prescribed temperature, mass fraction and trace substances"
     import Modelica.Media.Interfaces.Choices.IndependentVariables;
-    extends Sources.BaseClasses.PartialFlowSource;
+    extends Sources.BaseClasses.PartialFlowSource(nPorts(min=1));
     parameter Boolean use_m_flow_in = false
       "Get the mass flow rate from the input connector"
       annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
@@ -578,7 +578,7 @@ with exception of boundary flow rate, do not have an effect.
   model MassFlowSource_h
     "Ideal flow source that produces a prescribed mass flow with prescribed specific enthalpy, mass fraction and trace substances"
     import Modelica.Media.Interfaces.Choices.IndependentVariables;
-    extends Sources.BaseClasses.PartialFlowSource;
+    extends Sources.BaseClasses.PartialFlowSource(nPorts(min=1));
     parameter Boolean use_m_flow_in = false
       "Get the mass flow rate from the input connector"
       annotation(Evaluate=true, HideResult=true, choices(checkBox=true));


### PR DESCRIPTION
Underlying issue: If the mass flow source has nPorts=0 (the default) the model is singular (since the mass-flow is given in some way and also zero since there is nothing connected). Note that the other fluid-boundary elements do not have this restriction, and flow-sources in other domains at least have the connector-elements.

In general this can be complicated to detect - but in this case we can just set a minimum for nPorts to document that the model requires nPorts>=1 (the actual value of nPorts should be indirectly set by connecting to the ports), and help tools test this model and detect when it is used incorrectly. **That's what I did.**

It might be that this modifier should be on the original declaration in PartialFlowSource instead, and/or that an assertion would be clearer.