### PR TITLE
Avoid default Real parameter evaluation

### DIFF
--- a/Modelica/Fluid/Sources.mo
+++ b/Modelica/Fluid/Sources.mo
@@ -144,21 +144,17 @@ with exception of boundary pressure, do not have an effect.
       annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
     parameter Medium.AbsolutePressure p = Medium.p_default
       "Fixed value of pressure"
-      annotation (Evaluate = true,
-                  Dialog(enable = not use_p_in));
+      annotation (Dialog(enable = not use_p_in));
     parameter Medium.Temperature T = Medium.T_default
       "Fixed value of temperature"
-      annotation (Evaluate = true,
-                  Dialog(enable = not use_T_in));
+      annotation (Dialog(enable = not use_T_in));
     parameter Medium.MassFraction X[Medium.nX] = Medium.X_default
       "Fixed value of composition"
-      annotation (Evaluate = true,
-                  Dialog(enable = (not use_X_in) and Medium.nXi > 0));
+      annotation (Dialog(enable = (not use_X_in) and Medium.nXi > 0));
     parameter Medium.ExtraProperty C[Medium.nC](
          quantity=Medium.extraPropertiesNames)=fill(0, Medium.nC)
       "Fixed values of trace substances"
-      annotation (Evaluate=true,
-                  Dialog(enable = (not use_C_in) and Medium.nC > 0));
+      annotation (Dialog(enable = (not use_C_in) and Medium.nC > 0));
     Modelica.Blocks.Interfaces.RealInput p_in if use_p_in
       "Prescribed boundary pressure"
       annotation (Placement(transformation(extent={{-140,60},{-100,100}})));
@@ -292,21 +288,17 @@ with exception of boundary pressure, do not have an effect.
       annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
     parameter Medium.AbsolutePressure p = Medium.p_default
       "Fixed value of pressure"
-      annotation (Evaluate = true,
-                  Dialog(enable = not use_p_in));
+      annotation (Dialog(enable = not use_p_in));
     parameter Medium.SpecificEnthalpy h = Medium.h_default
       "Fixed value of specific enthalpy"
-      annotation (Evaluate = true,
-                  Dialog(enable = not use_h_in));
+      annotation (Dialog(enable = not use_h_in));
     parameter Medium.MassFraction X[Medium.nX] = Medium.X_default
       "Fixed value of composition"
-      annotation (Evaluate = true,
-                  Dialog(enable = (not use_X_in) and Medium.nXi > 0));
+      annotation (Dialog(enable = (not use_X_in) and Medium.nXi > 0));
     parameter Medium.ExtraProperty C[Medium.nC](
          quantity=Medium.extraPropertiesNames)=fill(0, Medium.nC)
       "Fixed values of trace substances"
-      annotation (Evaluate=true,
-                  Dialog(enable = (not use_C_in) and Medium.nC > 0));
+      annotation (Dialog(enable = (not use_C_in) and Medium.nC > 0));
     Modelica.Blocks.Interfaces.RealInput p_in if use_p_in
       "Prescribed boundary pressure"
       annotation (Placement(transformation(extent={{-140,60},{-100,100}})));
@@ -440,21 +432,17 @@ with exception of boundary pressure, do not have an effect.
       annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
     parameter Medium.MassFlowRate m_flow = 0
       "Fixed mass flow rate going out of the fluid port"
-      annotation (Evaluate = true,
-                  Dialog(enable = not use_m_flow_in));
+      annotation (Dialog(enable = not use_m_flow_in));
     parameter Medium.Temperature T = Medium.T_default
       "Fixed value of temperature"
-      annotation (Evaluate = true,
-                  Dialog(enable = not use_T_in));
+      annotation (Dialog(enable = not use_T_in));
     parameter Medium.MassFraction X[Medium.nX] = Medium.X_default
       "Fixed value of composition"
-      annotation (Evaluate = true,
-                  Dialog(enable = (not use_X_in) and Medium.nXi > 0));
+      annotation (Dialog(enable = (not use_X_in) and Medium.nXi > 0));
     parameter Medium.ExtraProperty C[Medium.nC](
          quantity=Medium.extraPropertiesNames)=fill(0, Medium.nC)
       "Fixed values of trace substances"
-      annotation (Evaluate=true,
-                  Dialog(enable = (not use_C_in) and Medium.nC > 0));
+      annotation (Dialog(enable = (not use_C_in) and Medium.nC > 0));
     Modelica.Blocks.Interfaces.RealInput m_flow_in if     use_m_flow_in
       "Prescribed mass flow rate"
       annotation (Placement(transformation(extent={{-120,60},{-80,100}}), iconTransformation(extent={{-120,60},{-80,100}})));
@@ -593,21 +581,17 @@ with exception of boundary flow rate, do not have an effect.
       annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
     parameter Medium.MassFlowRate m_flow = 0
       "Fixed mass flow rate going out of the fluid port"
-      annotation (Evaluate = true,
-                  Dialog(enable = not use_m_flow_in));
+      annotation (Dialog(enable = not use_m_flow_in));
     parameter Medium.SpecificEnthalpy h = Medium.h_default
       "Fixed value of specific enthalpy"
-      annotation (Evaluate = true,
-                  Dialog(enable = not use_h_in));
+      annotation (Dialog(enable = not use_h_in));
     parameter Medium.MassFraction X[Medium.nX] = Medium.X_default
       "Fixed value of composition"
-      annotation (Evaluate = true,
-                  Dialog(enable = (not use_X_in) and Medium.nXi > 0));
+      annotation (Dialog(enable = (not use_X_in) and Medium.nXi > 0));
     parameter Medium.ExtraProperty C[Medium.nC](
          quantity=Medium.extraPropertiesNames)=fill(0, Medium.nC)
       "Fixed values of trace substances"
-      annotation (Evaluate=true,
-                  Dialog(enable = (not use_C_in) and Medium.nC > 0));
+      annotation (Dialog(enable = (not use_C_in) and Medium.nC > 0));
     Modelica.Blocks.Interfaces.RealInput m_flow_in if     use_m_flow_in
       "Prescribed mass flow rate"
       annotation (Placement(transformation(extent={{-120,60},{-80,100}})));


### PR DESCRIPTION
* Remove Evaluate=true annotation for Real parameters
* Keep Evaluate=true annotation for Boolean and enumeration parameters
* See https://stackoverflow.com/q/21957303/8520615

@thorade FYI