### PR TITLE
Workaround for dummy usertab function

### DIFF
--- a/Modelica/Resources/BuildProjects/VisualStudio2005/ModelicaStandardTables.vcproj
+++ b/Modelica/Resources/BuildProjects/VisualStudio2005/ModelicaStandardTables.vcproj
@@ -275,6 +275,10 @@
 				RelativePath="..\..\C-Sources\ModelicaStandardTables.c"
 				>
 			</File>
+			<File
+				RelativePath="..\..\C-Sources\ModelicaStandardTablesUsertab.c"
+				>
+			</File>
 		</Filter>
 		<Filter
 			Name="Header Files"

--- a/Modelica/Resources/BuildProjects/autotools/Makefile.am
+++ b/Modelica/Resources/BuildProjects/autotools/Makefile.am
@@ -4,7 +4,7 @@ libModelicaIO_la_SOURCES             = ../../C-Sources/ModelicaIO.c
 libModelicaIO_la_LIBADD              = libModelicaMatIO.la
 libModelicaMatIO_la_SOURCES          = ../../C-Sources/ModelicaMatIO.c
 libModelicaMatIO_la_LIBADD           = libzlib.la @LIBZLIB@ @LIBHDF5@
-libModelicaStandardTables_la_SOURCES = ../../C-Sources/ModelicaStandardTables.c
+libModelicaStandardTables_la_SOURCES = ../../C-Sources/ModelicaStandardTables.c  ../../C-Sources/ModelicaStandardTablesUsertab.c
 libModelicaStandardTables_la_LIBADD  = libModelicaMatIO.la
 
 # If the OS does not have zlib available, compile it and include it together with libModelicaStandardTables

--- a/Modelica/Resources/BuildProjects/gcc/Makefile
+++ b/Modelica/Resources/BuildProjects/gcc/Makefile
@@ -8,7 +8,8 @@ INC = -I"../../C-Sources/zlib"
 TARGETDIR = linux64
 
 TABLES_OBJS = \
-	ModelicaStandardTables.o
+	ModelicaStandardTables.o \
+	ModelicaStandardTablesUsertab.o
 
 MATIO_OBJS = \
 	ModelicaMatIO.o

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -5697,11 +5697,3 @@ static READ_RESULT readTable(_In_z_ const char* fileName, _In_z_ const char* tab
     return NULL;
 #endif /* #if !defined(NO_FILE_SYSTEM) */
 }
-
-#if defined(DUMMY_FUNCTION_USERTAB)
-int usertab(char* tableName, int nipo, int dim[], int* colWise,
-            double** table) {
-    ModelicaError("Function \"usertab\" is not implemented\n");
-    return 1; /* Error */
-}
-#endif /* #if defined(DUMMY_FUNCTION_USERTAB) */

--- a/Modelica/Resources/C-Sources/ModelicaStandardTablesUsertab.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTablesUsertab.c
@@ -1,0 +1,58 @@
+/* ModelicaStandardTablesUsertab.c - A dummy usertab function
+
+   Copyright (C) 2013-2017, Modelica Association, DLR, and ESI ITI GmbH
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* The usertab function needs to be in a separate object or gcc/clang
+ * optimize the code in such a way that the user-defined usertab gets
+ * sent the wrong input.
+ *
+ * NOTE: If a dummy usertab is included in your code, you may be unable
+ * to also provide a user-defined usertab. If you use dynamic linking
+ * this is sometimes possible: when the simulation executable provides
+ * a usertab object, it will be part of the table of loaded objects and
+ * when later loading the shared object version of ModelicaStandardTables,
+ * the dummy usertab will not be loaded by the dynamic linker; this is
+ * what can confuse C-compilers and why this function is in a separate
+ * file).
+ *
+ * The interface of usertab is defined in ModelicaStandardTables.c
+ */
+#include "ModelicaUtilities.h"
+
+#if defined(DUMMY_FUNCTION_USERTAB)
+#if defined(__clang__) || defined(__GNUC__)
+int usertab(char* tableName, int nipo, int dim[], int* colWise,
+            double** table) __attribute__ ((weak, alias ("dummy_usertab")));
+#define USERTAB_NAME dummy_usertab
+#else
+#define USERTAB_NAME usertab
+#endif /* clang/gcc weak linking */
+int USERTAB_NAME(char* tableName, int nipo, int dim[], int* colWise,
+            double** table) {
+    ModelicaError("Function \"usertab\" is not implemented\n");
+    return 1; /* Error */
+}
+#endif /* #if defined(DUMMY_FUNCTION_USERTAB) */

--- a/Modelica/Resources/C-Sources/ModelicaStandardTablesUsertab.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTablesUsertab.c
@@ -48,7 +48,7 @@
 #include "ModelicaUtilities.h"
 
 #if defined(DUMMY_FUNCTION_USERTAB)
-#if (defined(__clang__) || defined(__GNUC__)) && !(defined(__MINGW32__) || defined(__MINGW64__))
+#if (defined(__clang__) || defined(__GNUC__)) && !(defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__))
 int usertab(char* tableName, int nipo, int dim[], int* colWise,
             double** table) __attribute__ ((weak, alias ("dummy_usertab")));
 #define USERTAB_NAME dummy_usertab
@@ -56,7 +56,7 @@ int usertab(char* tableName, int nipo, int dim[], int* colWise,
 #define USERTAB_NAME usertab
 #endif /* clang/gcc weak linking */
 int USERTAB_NAME(char* tableName, int nipo, int dim[], int* colWise,
-            double** table) {
+                 double** table) {
     ModelicaError("Function \"usertab\" is not implemented\n");
     return 1; /* Error */
 }

--- a/Modelica/Resources/C-Sources/ModelicaStandardTablesUsertab.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTablesUsertab.c
@@ -30,20 +30,21 @@
 */
 
 /* The usertab function needs to be in a separate object or gcc/clang
- * optimize the code in such a way that the user-defined usertab gets
- * sent the wrong input.
- *
- * NOTE: If a dummy usertab is included in your code, you may be unable
- * to also provide a user-defined usertab. If you use dynamic linking
- * this is sometimes possible: when the simulation executable provides
- * a usertab object, it will be part of the table of loaded objects and
- * when later loading the shared object version of ModelicaStandardTables,
- * the dummy usertab will not be loaded by the dynamic linker; this is
- * what can confuse C-compilers and why this function is in a separate
- * file).
- *
- * The interface of usertab is defined in ModelicaStandardTables.c
+   optimize the code in such a way that the user-defined usertab gets
+   sent the wrong input.
+
+   NOTE: If a dummy usertab is included in your code, you may be unable
+   to also provide a user-defined usertab. If you use dynamic linking
+   this is sometimes possible: when the simulation executable provides
+   a usertab object, it will be part of the table of loaded objects and
+   when later loading the shared object version of ModelicaStandardTables,
+   the dummy usertab will not be loaded by the dynamic linker; this is
+   what can confuse C-compilers and why this function is in a separate
+   file).
+
+   The interface of usertab is defined in ModelicaStandardTables.c
  */
+
 #include "ModelicaUtilities.h"
 
 #if defined(DUMMY_FUNCTION_USERTAB)

--- a/Modelica/Resources/C-Sources/ModelicaStandardTablesUsertab.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTablesUsertab.c
@@ -43,7 +43,7 @@
 #include "ModelicaUtilities.h"
 
 #if defined(DUMMY_FUNCTION_USERTAB)
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && !(defined(__MINGW32__) || defined(__MINGW64__))
 int usertab(char* tableName, int nipo, int dim[], int* colWise,
             double** table) __attribute__ ((weak, alias ("dummy_usertab")));
 #define USERTAB_NAME dummy_usertab

--- a/Modelica/Resources/C-Sources/ModelicaStandardTablesUsertab.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTablesUsertab.c
@@ -1,6 +1,6 @@
 /* ModelicaStandardTablesUsertab.c - A dummy usertab function
 
-   Copyright (C) 2013-2017, Modelica Association, DLR, and ESI ITI GmbH
+   Copyright (C) 2013-2018, Modelica Association, DLR, and ESI ITI GmbH
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
@@ -12,6 +12,10 @@
    2. Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
+
+   3. Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
 
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED

--- a/Modelica/Resources/C-Sources/_readme.txt
+++ b/Modelica/Resources/C-Sources/_readme.txt
@@ -16,6 +16,7 @@ to the following object libraries
 
 - ModelicaStandardTables (.lib, .dll, .a, .so, depending on tool and OS) containing:
   ModelicaStandardTables.c
+  ModelicaStandardTablesUsertab.c
 
 - zlib (.lib, .dll, .a, .so, depending on tool and OS) containing:
   zlib/*.c
@@ -51,4 +52,4 @@ Additionally, a tool vendor has to provide library "lapack"
 and this library should be used in the linker when a model is compiled
 that uses this library in its library annotation.
 
-April 05, 2017.
+January 05, 2018.


### PR DESCRIPTION
This is a workaround for GCC/LLVM optimizing the function call to
usertab which assumes that usertab will not be relocated at runtime.
Providing both a user-defined usertab and the dummy usertab object in
the same executable is possible on Linux, but confuses the C-compilers.

The GCC/autotools projects have been updated, but since VisualStudio
does not include the dummy usertab, the new source-file is not included
for VisualStudio.

Note: There is a cleaner way to implement handling the usertab function.
By using dlopen/etc when calling the table constructor, we could query
for a usertab function at runtime and not need it during compile-time
(making it easier to work with pre-compiled ModelicaStandardTables).
That would also enable the possibility to have two different usertab
functions (passing the name of the function to the constructor) and only
keep the current (a bit inconvenient) method of Modelica tools needing
to only sometimes provide a dummy usertab function.

@beutlich without these changes, ModelicaStandardTables only works properly with the `-O0` flag if dummy usertab is provided (getting either illegal pointers or empty strings right after calling usertab). I would much rather have a `dlopen`-based approach sometime in the future.