### PR TITLE
Fixes for issues #2385, #2490 and #2499

### DIFF
--- a/Modelica/Media/IdealGases/MixtureGases.mo
+++ b/Modelica/Media/IdealGases/MixtureGases.mo
@@ -33,7 +33,7 @@ package MixtureGases "Medium models consisting of mixtures of ideal gases"
     "Moist air without condensation";
 
   package FlueGasLambdaOnePlus
-    "Simple flue gas for over0stochiometric O2-fuel ratios"
+    "Simple flue gas for overstochiometric O2-fuel ratios"
     extends Common.MixtureGasNasa(
        mediumName="FlueGasLambda1plus",
        data={Common.SingleGasesData.N2,

--- a/Modelica/Media/Water/IF97_Utilities.mo
+++ b/Modelica/Media/Water/IF97_Utilities.mo
@@ -159,7 +159,7 @@ package IF97_Utilities
     record triple "Triple point data"
       extends Modelica.Icons.Record;
       constant SI.Temperature Ttriple=273.16 "The triple point temperature";
-      constant SI.Pressure ptriple=611.657 "The triple point temperature";
+      constant SI.Pressure ptriple=611.657 "The triple point pressure";
       constant SI.Density dltriple=999.792520031617642
         "The triple point liquid density";
       constant SI.Density dvtriple=0.485457572477861372e-2

--- a/Modelica/Media/Water/IF97_Utilities.mo
+++ b/Modelica/Media/Water/IF97_Utilities.mo
@@ -3017,7 +3017,7 @@ package IF97_Utilities
         Real Tlim=min(T, data.TCRIT);
       algorithm
         assert(T >= 273.16, "IF97 medium function psat: input temperature (= "
-           + String(triple.ptriple) + " K).\n" +
+           + String(triple.Ttriple) + " K).\n" +
           "lower than the triple point temperature 273.16 K");
         o[1] := -650.17534844798 + Tlim;
         o[2] := 1/o[1];


### PR DESCRIPTION
Fixes for issues #2490 (a one letter typo) and #2385 (a one letter typo that is significant, a wrong assert).

Close #2490. Close #2385. Close #2499.