### PR TITLE
update versionBuild and point to semver as alternative for usage in ModelicaReference

### DIFF
--- a/Complex.mo
+++ b/Complex.mo
@@ -237,7 +237,7 @@ operator record Complex "Complex number with overloaded operators"
 
 annotation (
 version="3.2.3",
-versionBuild=0,
+versionBuild=1,
 versionDate="2018-08-01",
 dateModified = "2018-04-20 12:00:00Z",
 revisionId="$Id::                                       $",

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -7899,7 +7899,7 @@ end UsersGuide;
 annotation (
 preferredView="info",
 version="3.2.3",
-versionBuild=0,
+versionBuild=1,
 versionDate="2018-08-01",
 dateModified = "2018-08-01 12:00:00Z",
 revisionId="$Id::                                       $",

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -377,7 +377,6 @@ This can be recommended by having  <code><strong>annotation</strong> choicesAllM
 <strong>package</strong> Modelica
   <strong>annotation</strong>(version      = &quot;3.0.1&quot;,
              versionDate  = &quot;2008-04-10&quot;,
-             versionBuild = 4,
              <em>dateModified = &quot;2009-02-15 16:33:14Z&quot;</em>,
              revisionId   = &quot;$I&#8203;d:: package.mo 2566 2009-02-15 16:33:14Z #$&quot;);
   ...
@@ -1177,7 +1176,6 @@ The preferredView annotation defines the default view when selecting the class. 
 <pre><strong>package</strong> Modelica
   <strong>annotation</strong>(version      = &quot;3.0.1&quot;,
              versionDate  = &quot;2008-04-10&quot;,
-             versionBuild = 4,
              dateModified = &quot;2009-02-15 16:33:14Z&quot;,
              <em>revisionId   = &quot;$I&#8203;d:: package.mo 2566 2009-02-15 16:33:14Z #$&quot;</em>);
   ...
@@ -1186,7 +1184,6 @@ The preferredView annotation defines the default view when selecting the class. 
 <ul>
   <li><a href=\"modelica://ModelicaReference.Annotations.version\">version</a></li>
   <li><a href=\"modelica://ModelicaReference.Annotations.versionDate\">versionDate</a></li>
-  <li><a href=\"modelica://ModelicaReference.Annotations.versionBuild\">versionBuild</a></li>
   <li><a href=\"modelica://ModelicaReference.Annotations.dateModified\">dateModified</a></li>
 </ul>
 </html>"));
@@ -1440,7 +1437,12 @@ This allows a tool to access multiple versions of the same package.
     extends ModelicaReference.Icons.Information;
 
     annotation (Documentation(info="<html>
-<p>Defines the optional build number of the library. <em>(This is a deprecated annotation. It should  no longer be used, since it will be removed in one of the next Modelica releases.)</em></p>
+<p>Defines the optional build number of the library.</p>
+
+<blockquote>
+<em>This is a <strong>deprecated</strong> annotation. It should no longer be used, since it will be removed in one of the next Modelica releases. Use instead <a href=\"https://semver.org/\">Semantic Versioning</a> which provides a better mechanism for maintaining releases and bugfixes in a well defined way.</emp>
+</blockquote>
+
 <h4>Syntax</h4>
 <blockquote><pre>
 <strong>annotation</strong>&quot;(&quot; versionBuild &quot;=&quot; INTEGER &quot;)&quot;
@@ -1491,7 +1493,6 @@ A &ldquo;<code>versionBuild</code>&rdquo; number A that is higher as &ldquo;<cod
 <strong>package</strong> Modelica
   <strong>annotation</strong>(version      = &quot;3.0.1&quot;,
              <em>versionDate  = &quot;2008-04-10&quot;</em>,
-             versionBuild = 4,
              dateModified = &quot;2009-02-15 16:33:14Z&quot;,
              revisionId   = &quot;$I&#8203;d:: package.mo 2566 2009-02-15 16:33:14Z #$&quot;);
   ...
@@ -6932,7 +6933,7 @@ end Icons;
 annotation (
   DocumentationClass=true,
   version="3.2.2",
-  versionBuild=0,
+  versionBuild=1,
   versionDate="2016-01-15",
   dateModified = "2016-01-15 08:44:41Z",
   revisionId="$Id::                                       $",

--- a/ModelicaServices/package.mo
+++ b/ModelicaServices/package.mo
@@ -212,7 +212,7 @@ Specification (version &ge; 3.3).
   annotation (
     preferredView="info",
     version="3.2.3",
-    versionBuild=0,
+    versionBuild=1,
     versionDate="2018-08-01",
     dateModified = "2018-04-20 12:00:00Z",
     revisionId="$Id::                                       $",

--- a/ModelicaTest/package.mo
+++ b/ModelicaTest/package.mo
@@ -52,7 +52,7 @@ end testAllFunctions;
 
   annotation (preferredView="info",
        version="3.2.3",
-       versionBuild=0,
+       versionBuild=1,
        versionDate="2018-08-01",
        dateModified = "2018-04-20 12:00:00Z",
        revisionId="$Id::                                       $",

--- a/ModelicaTestOverdetermined.mo
+++ b/ModelicaTestOverdetermined.mo
@@ -608,7 +608,7 @@ The initial equations are consistent however and a tool shall reduce them approp
           fillColor={75,138,73},
           fillPattern=FillPattern.Solid)}),
        preferredView="info",
-       versionBuild=0,
+       versionBuild=1,
        version="3.2.3",
        versionDate="2018-08-01",
        dateModified = "2018-04-20 12:00:00Z",


### PR DESCRIPTION
For the future semver based version numbers offer a better solution. But since they are already not actively used anymore they should simply not be advertised in the MSL.