### PR TITLE
Avoid division by zero in default homotopy-code for Modelica.Fluid.Machines.BaseClasses.PartialPump

### DIFF
--- a/Modelica/Fluid/Machines.mo
+++ b/Modelica/Fluid/Machines.mo
@@ -428,13 +428,13 @@ Then the model can be replaced with a Pump with rotational shaft or with a Presc
     if not checkValve then
       // Regular flow characteristics without check valve
       head = homotopy((N/N_nominal)^2*flowCharacteristic(V_flow_single*N_nominal/N),
-                       N/N_nominal*(flowCharacteristic(0)+delta_head_init*V_flow_single/V_flow_single_init));
+                       N/N_nominal*(flowCharacteristic(0)+V_flow_single*noEvent(if abs(V_flow_single_init)>0 then delta_head_init/V_flow_single_init else 0)));
       s = 0;
     else
       // Flow characteristics when check valve is open
       head = homotopy(if s > 0 then (N/N_nominal)^2*flowCharacteristic(V_flow_single*N_nominal/N)
                                else (N/N_nominal)^2*flowCharacteristic(0) - s*unitHead,
-                      N/N_nominal*(flowCharacteristic(0)+delta_head_init*V_flow_single/V_flow_single_init));
+                      N/N_nominal*(flowCharacteristic(0)+V_flow_single*noEvent(if abs(V_flow_single_init)>0 then delta_head_init/V_flow_single_init else 0)));
       V_flow_single = homotopy(if s > 0 then s*unitMassFlowRate/rho else 0,
                                s*unitMassFlowRate/rho_nominal);
     end if;


### PR DESCRIPTION
The change dc4f6d3e2a0f27b72f7146e72b9cdaaddc08d3a4 for #1995 / #2101 causes a division by zero if homotopy is activated in default configuration, since system.m_flow_start is as default zero. This change avoid the division by zero by just skipping the extra part - restoring previous behavior.

Closes #1995
