### PR TITLE
Consistent simple guess-values for Modelica.Fluid.Examples.HeatingSystem

### DIFF
--- a/Modelica/Fluid/Examples/HeatingSystem.mo
+++ b/Modelica/Fluid/Examples/HeatingSystem.mo
@@ -96,8 +96,8 @@ public
     use_HeatTransfer=true,
     modelStructure=Modelica.Fluid.Types.ModelStructure.a_v_b,
     p_a_start=110000,
-    state_a(p(start=110000)),
-    state_b(p(start=110000)))
+    state_a(p(start=1e5)),
+    state_b(p(start=1e5)))
     annotation (Placement(transformation(extent={{20,-80},{0,-60}})));
 
 protected


### PR DESCRIPTION
Solves conflicting (non-fixed) start-value for the example. One of the issues reported in #2515   -  the idea is to use a simple guess-value for all pressures, 1e5, instead of the more exact 1.1e5 that was used for some variables. It would also be possible to use 1.1e5 everywhere.

Note that #2515 is still open since the preferred medium states issue isn't solved.