### PR TITLE
Extend obsolete classes from ObsoleteModel

### DIFF
--- a/Modelica/Blocks/Interfaces.mo
+++ b/Modelica/Blocks/Interfaces.mo
@@ -1341,10 +1341,10 @@ has a 3D icon (e.g., used in Blocks.Logical library).
   package Adaptors
     "Obsolete package with components to send signals to a bus or receive signals from a bus (only for backward compatibility)"
     extends Modelica.Icons.Package;
-    // extends Modelica.Icons.ObsoleteModel;
+    extends Modelica.Icons.ObsoleteModel;
 
     block SendReal "Obsolete block to send Real signal to bus"
-      // extends Modelica.Icons.ObsoleteModel;
+      extends Modelica.Icons.ObsoleteModel;
       RealOutput toBus "Output signal to be connected to bus" annotation (
           Placement(transformation(extent={{100,-10},{120,10}})));
       RealInput u "Input signal to be send to bus" annotation (Placement(
@@ -1378,7 +1378,7 @@ for signal buses, see example
     end SendReal;
 
     block SendBoolean "Obsolete block to send Boolean signal to bus"
-      // extends Modelica.Icons.ObsoleteModel;
+      extends Modelica.Icons.ObsoleteModel;
       BooleanOutput toBus "Output signal to be connected to bus" annotation (
           Placement(transformation(extent={{100,-10},{120,10}})));
       BooleanInput u "Input signal to be send to bus" annotation (Placement(
@@ -1412,7 +1412,7 @@ for signal buses, see example
     end SendBoolean;
 
     block SendInteger "Obsolete block to send Integer signal to bus"
-      // extends Modelica.Icons.ObsoleteModel;
+      extends Modelica.Icons.ObsoleteModel;
       IntegerOutput toBus "Output signal to be connected to bus" annotation (
           Placement(transformation(extent={{100,-10},{120,10}})));
       IntegerInput u "Input signal to be send to bus" annotation (Placement(
@@ -1446,7 +1446,7 @@ for signal buses, see example
     end SendInteger;
 
     block ReceiveReal "Obsolete block to receive Real signal from bus"
-      // extends Modelica.Icons.ObsoleteModel;
+      extends Modelica.Icons.ObsoleteModel;
       RealInput fromBus "To be connected with signal on bus" annotation (
           Placement(transformation(extent={{-120,-10},{-100,10}})));
       RealOutput y "Output signal to be received from bus" annotation (
@@ -1480,7 +1480,7 @@ for signal buses, see example
     end ReceiveReal;
 
     block ReceiveBoolean "Obsolete block to receive Boolean signal from bus"
-      // extends Modelica.Icons.ObsoleteModel;
+      extends Modelica.Icons.ObsoleteModel;
       BooleanInput fromBus "To be connected with signal on bus" annotation (
           Placement(transformation(extent={{-120,-10},{-100,10}})));
       BooleanOutput y "Output signal to be received from bus" annotation (
@@ -1514,7 +1514,7 @@ for signal buses, see example
     end ReceiveBoolean;
 
     block ReceiveInteger "Obsolete block to receive Integer signal from bus"
-      // extends Modelica.Icons.ObsoleteModel;
+      extends Modelica.Icons.ObsoleteModel;
       IntegerInput fromBus "To be connected with signal on bus" annotation (
           Placement(transformation(extent={{-120,-10},{-100,10}})));
       IntegerOutput y "Output signal to be received from bus" annotation (
@@ -1600,7 +1600,7 @@ converts from one unit into another one.
 
   partial block BlockIcon
     "This icon will be removed in future Modelica versions, use Modelica.Blocks.Icons.Block instead."
-    // extends Modelica.Icons.ObsoleteModel;
+    extends Modelica.Icons.ObsoleteModel;
 
     annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
               {100,100}}), graphics={Rectangle(
@@ -1621,7 +1621,7 @@ Instead the icon <a href=\"modelica://Modelica.Blocks.Icons.Block\">Modelica.Blo
 
   partial block BooleanBlockIcon
     "This icon will be removed in future Modelica versions, use Modelica.Blocks.Icons.BooleanBlock instead."
-    // extends Modelica.Icons.ObsoleteModel;
+    extends Modelica.Icons.ObsoleteModel;
 
     annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
               {100,100}}), graphics={Rectangle(
@@ -1642,7 +1642,7 @@ Instead the icon <a href=\"modelica://Modelica.Blocks.Icons.BooleanBlock\">Model
 
   partial block DiscreteBlockIcon
     "This icon will be removed in future Modelica versions, use Modelica.Blocks.Icons.DiscreteBlock instead."
-    // extends Modelica.Icons.ObsoleteModel;
+    extends Modelica.Icons.ObsoleteModel;
 
     annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
               {100,100}}), graphics={Rectangle(
@@ -1664,7 +1664,7 @@ Instead the icon <a href=\"modelica://Modelica.Blocks.Icons.DiscreteBlock\">Mode
 
   partial block IntegerBlockIcon
     "This icon will be removed in future Modelica versions, use Modelica.Blocks.Icons.IntegerBlock instead."
-    // extends Modelica.Icons.ObsoleteModel;
+    extends Modelica.Icons.ObsoleteModel;
 
     annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
               {100,100}}), graphics={Rectangle(
@@ -1685,7 +1685,7 @@ Instead the icon <a href=\"modelica://Modelica.Blocks.Icons.IntegerBlock\">Model
 
   partial block partialBooleanBlockIcon
     "This icon will be removed in future Modelica versions, use Modelica.Blocks.Icons.PartialBooleanBlock instead."
-    // extends Modelica.Icons.ObsoleteModel;
+    extends Modelica.Icons.ObsoleteModel;
 
     annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
               {100,100}}), graphics={Rectangle(

--- a/Modelica/Electrical/Digital.mo
+++ b/Modelica/Electrical/Digital.mo
@@ -4396,7 +4396,7 @@ The values val... are given by parameters.</p>
         end LogicToReal;
 
         block LogicToXO1 "This model will be removed in future Modelica versions, use 'LogicToX01' instead!"
-          // extends Modelica.Icons.ObsoleteModel;
+          extends Modelica.Icons.ObsoleteModel;
           import D = Modelica.Electrical.Digital;
           import T = Modelica.Electrical.Digital.Tables;
           D.Interfaces.DigitalInput x[n]
@@ -4471,7 +4471,7 @@ If the signal width is greater than 1 this conversion is done for each signal.
         end LogicToXO1;
 
         block LogicToXO1Z "This model will be removed in future Modelica versions, use 'LogicToX01Z' instead!"
-          // extends Modelica.Icons.ObsoleteModel;
+          extends Modelica.Icons.ObsoleteModel;
           import D = Modelica.Electrical.Digital;
           import T = Modelica.Electrical.Digital.Tables;
           D.Interfaces.DigitalInput x[n]

--- a/Modelica/Electrical/Machines.mo
+++ b/Modelica/Electrical/Machines.mo
@@ -11500,12 +11500,13 @@ Ideal transformer with 3 windings: no magnetizing current.
 
       partial model BasicTransformer "Partial model of three-phase transformer"
         extends Machines.Interfaces.PartialBasicTransformer;
-        //dummy will be removed when conversion script is applicable
+        extends Modelica.Icons.ObsoleteModel;
         annotation (Documentation(info="<html>
 Partial model of a three-phase transformer, containing primary and secondary resistances and stray inductances, as well as the iron core.
 Circuit layout (vector group) of primary and secondary windings have to be defined.<br>
 Exactly the same as Interfaces.PartialBasicTransformer, included for compatibility reasons.
-</html>"));
+</html>"),
+        obsolete = "Obsolete model - use Modelica.Electrical.Machines.Interfaces.PartialBasicTransformer instead");
       end BasicTransformer;
       annotation (Documentation(info="<html>
 This package contains components for modeling electrical machines, specially three-phase induction machines, based on space phasor theory.

--- a/Modelica/Fluid/Icons.mo
+++ b/Modelica/Fluid/Icons.mo
@@ -4,7 +4,7 @@ package Icons
   partial class VariantLibrary
     "This icon will be removed in future Modelica versions, use Modelica.Icons.VariantsPackage instead."
     // extends Modelica.Icons.VariantsPackage;
-    // extends Modelica.Icons.ObsoleteModel;
+    extends Modelica.Icons.ObsoleteModel;
     annotation (Documentation(info="<html>
 <p>
 This icon will be removed in future versions of the Modelica Standard Library.
@@ -50,7 +50,7 @@ Instead the icon <a href=\"modelica://Modelica.Icons.VariantsPackage\">Modelica.
   partial package BaseClassLibrary
     "This icon will be removed in future Modelica versions, use Modelica.Icons.BasePackage instead."
     extends Modelica.Icons.BasesPackage;
-    // extends Modelica.Icons.ObsoleteModel;
+    extends Modelica.Icons.ObsoleteModel;
     annotation(Documentation(info="<html>
 <p>
 This icon will be removed in future versions of the Modelica Standard Library.

--- a/Modelica/Icons.mo
+++ b/Modelica/Icons.mo
@@ -802,7 +802,7 @@ corresponding library in a future release.
 
   partial package Library
     "This icon will be removed in future Modelica versions, use Package instead"
-    // extends Modelica.Icons.ObsoleteModel;
+    extends Modelica.Icons.ObsoleteModel;
     annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics={
           Rectangle(
             lineColor={200,200,200},
@@ -823,7 +823,7 @@ corresponding library in a future release.
 
   partial package Library2
     "This icon will be removed in future Modelica versions, use Package instead"
-    // extends Modelica.Icons.ObsoleteModel;
+    extends Modelica.Icons.ObsoleteModel;
 
     annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics={
           Rectangle(
@@ -844,7 +844,7 @@ corresponding library in a future release.
 
   partial class GearIcon
     "This icon will be removed in future Modelica versions"
-    // extends Modelica.Icons.ObsoleteModel;
+    extends Modelica.Icons.ObsoleteModel;
 
     annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,100}}), graphics={
           Rectangle(
@@ -885,7 +885,7 @@ This icon of a <strong>gearbox</strong> will be removed in future versions of th
 
   partial class MotorIcon
     "This icon will be removed in future Modelica versions."
-    // extends Modelica.Icons.ObsoleteModel;
+    extends Modelica.Icons.ObsoleteModel;
 
     annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,100}}), graphics={
           Rectangle(
@@ -912,7 +912,7 @@ This icon of an <strong>electrical motor</strong> model will be removed in futur
   end MotorIcon;
 
   partial class Info "This icon will be removed in future Modelica versions."
-    // extends Modelica.Icons.ObsoleteModel;
+    extends Modelica.Icons.ObsoleteModel;
     annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics={
           Ellipse(
             lineColor={75,138,73},

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -13082,7 +13082,7 @@ end log10;
 
 partial function baseIcon1
   "This icon will be removed in future Modelica versions, use Modelica.Math.Icons.AxisLeft instead."
-  // extends Modelica.Icons.ObsoleteModel;
+  extends Modelica.Icons.ObsoleteModel;
 
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,
@@ -13123,7 +13123,7 @@ end baseIcon1;
 
 partial function baseIcon2
   "This icon will be removed in future Modelica versions, use Modelica.Math.Icons.AxisCenter instead."
-  // extends Modelica.Icons.ObsoleteModel;
+  extends Modelica.Icons.ObsoleteModel;
 
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,

--- a/Modelica/Media/package.mo
+++ b/Modelica/Media/package.mo
@@ -3130,7 +3130,7 @@ is given to compare the approximation.
 
       connector FluidPort
         "Interface for quasi one-dimensional fluid flow in a piping network (incompressible or compressible, one or more phases, one or more substances)"
-        // extends Modelica.Icons.ObsoleteModel;
+        extends Modelica.Icons.ObsoleteModel;
         replaceable package Medium = Modelica.Media.Interfaces.PartialMedium
           "Medium model" annotation (choicesAllMatching=true);
 
@@ -3225,7 +3225,7 @@ is given to compare the approximation.
 
       model PortVolume
         "Fixed volume associated with a port by the finite volume method"
-        // extends Modelica.Icons.ObsoleteModel;
+        extends Modelica.Icons.ObsoleteModel;
         replaceable package Medium = Modelica.Media.Interfaces.PartialMedium
           "Medium model" annotation (choicesAllMatching=true);
 
@@ -3323,7 +3323,7 @@ transport.
 
       model FixedMassFlowRate
         "Ideal pump that produces a constant mass flow rate from a large reservoir at fixed temperature and mass fraction"
-        // extends Modelica.Icons.ObsoleteModel;
+        extends Modelica.Icons.ObsoleteModel;
         parameter Medium.MassFlowRate m_flow
           "Fixed mass flow rate from an infinite reservoir to the fluid port";
 
@@ -3401,7 +3401,7 @@ transport.
 
       model FixedAmbient
         "Ambient pressure, temperature and mass fraction source"
-        // extends Modelica.Icons.ObsoleteModel;
+        extends Modelica.Icons.ObsoleteModel;
         replaceable package Medium = Modelica.Media.Interfaces.PartialMedium
           "Medium model" annotation (choicesAllMatching=true);
 
@@ -3486,7 +3486,7 @@ with exception of ambient pressure, do not have an effect.
       end FixedAmbient;
 
       model ShortPipe "Simple pressure loss in pipe"
-        // extends Modelica.Icons.ObsoleteModel;
+        extends Modelica.Icons.ObsoleteModel;
         replaceable package Medium = Modelica.Media.Interfaces.PartialMedium
           "Medium model" annotation (choicesAllMatching=true);
 
@@ -3551,7 +3551,7 @@ no mass or energy is stored in the pipe.
 
       partial model PartialTestModel "Basic test model to test a medium"
         import SI = Modelica.SIunits;
-        // extends Modelica.Icons.ObsoleteModel;
+        extends Modelica.Icons.ObsoleteModel;
 
         replaceable package Medium = Modelica.Media.Interfaces.PartialMedium
           "Medium model" annotation (choicesAllMatching=true);
@@ -3612,7 +3612,7 @@ no mass or energy is stored in the pipe.
       partial model PartialTestModel2
         "Slightly larger test model to test a medium"
         import SI = Modelica.SIunits;
-        // extends Modelica.Icons.ObsoleteModel;
+        extends Modelica.Icons.ObsoleteModel;
         replaceable package Medium = Modelica.Media.Interfaces.PartialMedium
           "Medium model" annotation (choicesAllMatching=true);
         parameter SI.AbsolutePressure p_start=1.0e5 "Initial value of pressure";


### PR DESCRIPTION
This is for preparation of #1578. All obsolete models should finally be marked by the ObsoleteModel icon.