### PR TITLE
Revert "Remove all occurences of valign=top (#2517)"

### DIFF
--- a/Modelica/Blocks/Continuous.mo
+++ b/Modelica/Blocks/Continuous.mo
@@ -825,30 +825,30 @@ blocks inside the PID controller are initialized according to the following tabl
 </p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>initType</strong></td>
-      <td><strong>I.initType</strong></td>
-      <td><strong>D.initType</strong></td></tr>
+  <tr><td valign=\"top\"><strong>initType</strong></td>
+      <td valign=\"top\"><strong>I.initType</strong></td>
+      <td valign=\"top\"><strong>D.initType</strong></td></tr>
 
-  <tr><td><strong>NoInit</strong></td>
-      <td>NoInit</td>
-      <td>NoInit</td></tr>
+  <tr><td valign=\"top\"><strong>NoInit</strong></td>
+      <td valign=\"top\">NoInit</td>
+      <td valign=\"top\">NoInit</td></tr>
 
-  <tr><td><strong>SteadyState</strong></td>
-      <td>SteadyState</td>
-      <td>SteadyState</td></tr>
+  <tr><td valign=\"top\"><strong>SteadyState</strong></td>
+      <td valign=\"top\">SteadyState</td>
+      <td valign=\"top\">SteadyState</td></tr>
 
-  <tr><td><strong>InitialState</strong></td>
-      <td>InitialState</td>
-      <td>InitialState</td></tr>
+  <tr><td valign=\"top\"><strong>InitialState</strong></td>
+      <td valign=\"top\">InitialState</td>
+      <td valign=\"top\">InitialState</td></tr>
 
-  <tr><td><strong>InitialOutput</strong><br>
+  <tr><td valign=\"top\"><strong>InitialOutput</strong><br>
           and initial equation: y = y_start</td>
-      <td>NoInit</td>
-      <td>SteadyState</td></tr>
+      <td valign=\"top\">NoInit</td>
+      <td valign=\"top\">SteadyState</td></tr>
 
-  <tr><td><strong>DoNotUse_InitialIntegratorState</strong></td>
-      <td>InitialState</td>
-      <td>NoInit</td></tr>
+  <tr><td valign=\"top\"><strong>DoNotUse_InitialIntegratorState</strong></td>
+      <td valign=\"top\">InitialState</td>
+      <td valign=\"top\">NoInit</td></tr>
 </table>
 
 <p>
@@ -1191,30 +1191,30 @@ blocks inside the PID controller are initialized according to the following tabl
 </p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>initType</strong></td>
-      <td><strong>I.initType</strong></td>
-      <td><strong>D.initType</strong></td></tr>
+  <tr><td valign=\"top\"><strong>initType</strong></td>
+      <td valign=\"top\"><strong>I.initType</strong></td>
+      <td valign=\"top\"><strong>D.initType</strong></td></tr>
 
-  <tr><td><strong>NoInit</strong></td>
-      <td>NoInit</td>
-      <td>NoInit</td></tr>
+  <tr><td valign=\"top\"><strong>NoInit</strong></td>
+      <td valign=\"top\">NoInit</td>
+      <td valign=\"top\">NoInit</td></tr>
 
-  <tr><td><strong>SteadyState</strong></td>
-      <td>SteadyState</td>
-      <td>SteadyState</td></tr>
+  <tr><td valign=\"top\"><strong>SteadyState</strong></td>
+      <td valign=\"top\">SteadyState</td>
+      <td valign=\"top\">SteadyState</td></tr>
 
-  <tr><td><strong>InitialState</strong></td>
-      <td>InitialState</td>
-      <td>InitialState</td></tr>
+  <tr><td valign=\"top\"><strong>InitialState</strong></td>
+      <td valign=\"top\">InitialState</td>
+      <td valign=\"top\">InitialState</td></tr>
 
-  <tr><td><strong>InitialOutput</strong><br>
+  <tr><td valign=\"top\"><strong>InitialOutput</strong><br>
           and initial equation: y = y_start</td>
-      <td>NoInit</td>
-      <td>SteadyState</td></tr>
+      <td valign=\"top\">NoInit</td>
+      <td valign=\"top\">SteadyState</td></tr>
 
-  <tr><td><strong>DoNotUse_InitialIntegratorState</strong></td>
-      <td>InitialState</td>
-      <td>NoInit</td></tr>
+  <tr><td valign=\"top\"><strong>DoNotUse_InitialIntegratorState</strong></td>
+      <td valign=\"top\">InitialState</td>
+      <td valign=\"top\">NoInit</td></tr>
 </table>
 
 <p>
@@ -4653,20 +4653,20 @@ values of initType are defined in
 </p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Name</strong></td>
-      <td><strong>Description</strong></td></tr>
+  <tr><td valign=\"top\"><strong>Name</strong></td>
+      <td valign=\"top\"><strong>Description</strong></td></tr>
 
-  <tr><td><strong>Init.NoInit</strong></td>
-      <td>no initialization (start values are used as guess values with fixed=false)</td></tr>
+  <tr><td valign=\"top\"><strong>Init.NoInit</strong></td>
+      <td valign=\"top\">no initialization (start values are used as guess values with fixed=false)</td></tr>
 
-  <tr><td><strong>Init.SteadyState</strong></td>
-      <td>steady state initialization (derivatives of states are zero)</td></tr>
+  <tr><td valign=\"top\"><strong>Init.SteadyState</strong></td>
+      <td valign=\"top\">steady state initialization (derivatives of states are zero)</td></tr>
 
-  <tr><td><strong>Init.InitialState</strong></td>
-      <td>Initialization with initial states</td></tr>
+  <tr><td valign=\"top\"><strong>Init.InitialState</strong></td>
+      <td valign=\"top\">Initialization with initial states</td></tr>
 
-  <tr><td><strong>Init.InitialOutput</strong></td>
-      <td>Initialization with initial outputs (and steady state of the states if possible)</td></tr>
+  <tr><td valign=\"top\"><strong>Init.InitialOutput</strong></td>
+      <td valign=\"top\">Initialization with initial outputs (and steady state of the states if possible)</td></tr>
 </table>
 
 <p>

--- a/Modelica/Blocks/Interfaces.mo
+++ b/Modelica/Blocks/Interfaces.mo
@@ -1810,11 +1810,11 @@ of noise blocks.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2942,11 +2942,11 @@ Note: The output is updated after each period defined by 1/f.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -3065,11 +3065,11 @@ Note: The output is updated after each period defined by 1/f.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -3156,11 +3156,11 @@ This block is demonstrated in the examples
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by

--- a/Modelica/Blocks/Noise.mo
+++ b/Modelica/Blocks/Noise.mo
@@ -60,11 +60,11 @@ into your model and specify the seed.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -200,11 +200,11 @@ is dragged to provide global settings for all instances.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -261,11 +261,11 @@ is dragged to provide global settings for all instances.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -349,11 +349,11 @@ is dragged to provide global settings for all instances.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -686,11 +686,11 @@ distributions are given in the documentation of package
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by

--- a/Modelica/Blocks/Nonlinear.mo
+++ b/Modelica/Blocks/Nonlinear.mo
@@ -261,10 +261,10 @@ with derivative time constant <code>Td</code>. Smaller time constant <code>Td</c
 <th>Comment</th>
 </tr>
 <tr>
-<td>4954</td>
-<td>2012-03-02</td>
-<td>A. Haumer &amp; D. Winkler</td>
-<td><p>Initial version based on discussion in ticket <a href=\"https://trac.modelica.org/Modelica/ticket/529\">#529</a></p></td>
+<td valign=\"top\">4954</td>
+<td valign=\"top\">2012-03-02</td>
+<td valign=\"top\">A. Haumer &amp; D. Winkler</td>
+<td valign=\"top\"><p>Initial version based on discussion in ticket <a href=\"https://trac.modelica.org/Modelica/ticket/529\">#529</a></p></td>
 </tr>
 </table>
 </html>"));
@@ -612,9 +612,9 @@ chapter 11.9, page 412-414, Huethig Verlag Heidelberg, 1994
 <th>Comment</th>
 </tr>
 <tr>
-<td>2015-01-05</td>
-<td>Martin Otter (DLR-SR)</td>
-<td>Introduced parameter balance=true and a new implementation
+<td valign=\"top\">2015-01-05</td>
+<td valign=\"top\">Martin Otter (DLR-SR)</td>
+<td valign=\"top\">Introduced parameter balance=true and a new implementation
  of the PadeDelay block with an optional, more reliable numerics</td>
 </tr>
 </table>

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -3268,11 +3268,11 @@ have at least the following two parameters:
 </p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>offset</strong></td>
-      <td>Value which is added to the signal</td>
+  <tr><td valign=\"top\"><strong>offset</strong></td>
+      <td valign=\"top\">Value which is added to the signal</td>
   </tr>
-  <tr><td><strong>startTime</strong></td>
-      <td>Start time of signal. For time &lt; startTime,
+  <tr><td valign=\"top\"><strong>startTime</strong></td>
+      <td valign=\"top\">Start time of signal. For time &lt; startTime,
                 the output y is set to offset.</td>
   </tr>
 </table>

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1171,11 +1171,11 @@ The result of a simulation is shown in the next diagram:
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1277,11 +1277,11 @@ manualSeed2 will produce exactly the same noise.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1345,11 +1345,11 @@ truncated normal distribution has more values centered around the mean value 1.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1450,11 +1450,11 @@ distribution have good statistical properties.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1554,11 +1554,11 @@ distribution have good statistical properties.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1621,11 +1621,11 @@ inputs:
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1664,11 +1664,11 @@ generator. Simulation results are shown in the next figure:
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1781,11 +1781,11 @@ enableNoise = false in the globalSeed component.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1963,11 +1963,11 @@ This block is demonstrated in the example
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -2034,11 +2034,11 @@ This block is demonstrated in the example
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -2106,11 +2106,11 @@ This block is demonstrated in the example
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -2147,11 +2147,11 @@ random number generator. This block is used in the example
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -2379,11 +2379,11 @@ actuator example
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -2460,11 +2460,11 @@ actuator example
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -2487,11 +2487,11 @@ actuator example
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -2517,11 +2517,11 @@ This package contains utility models that are used for the examples.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -2543,11 +2543,11 @@ to utilize the blocks from sublibrary
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by

--- a/Modelica/Electrical/Analog/Basic.mo
+++ b/Modelica/Electrical/Analog/Basic.mo
@@ -610,25 +610,25 @@ the user has to allocate the parameter vector <em>L[6] </em>, since <em>Nv=(N*(N
       <th>Comment</th>
     </tr>
    <tr>
-      <td></td>
-      <td>4163</td>
-      <td>2010-09-11</td>
-      <td>Dietmar Winkler</td>
-      <td>Documentation corrected according to documentation guidelines.</td>
+      <td valign=\"top\"></td>
+      <td valign=\"top\">4163</td>
+      <td valign=\"top\">2010-09-11</td>
+      <td valign=\"top\">Dietmar Winkler</td>
+      <td valign=\"top\">Documentation corrected according to documentation guidelines.</td>
     </tr>
     <tr>
-      <td></td>
-      <td></td>
-      <td>2008-11-24</td>
-      <td>Kristin Majetta</td>
-      <td>Documentation added.</td>
+      <td valign=\"top\"></td>
+      <td valign=\"top\"></td>
+      <td valign=\"top\">2008-11-24</td>
+      <td valign=\"top\">Kristin Majetta</td>
+      <td valign=\"top\">Documentation added.</td>
     </tr>
     <tr>
-      <td></td>
-      <td></td>
-      <td>2008-11-16</td>
-      <td>Kristin Majetta</td>
-      <td>Initially implemented</td>
+      <td valign=\"top\"></td>
+      <td valign=\"top\"></td>
+      <td valign=\"top\">2008-11-16</td>
+      <td valign=\"top\">Kristin Majetta</td>
+      <td valign=\"top\">Initially implemented</td>
     </tr>
 </table>
 </html>"));

--- a/Modelica/Electrical/Analog/Lines.mo
+++ b/Modelica/Electrical/Analog/Lines.mo
@@ -490,25 +490,25 @@ package Lines
       <th>Comment</th>
     </tr>
    <tr>
-      <td></td>
-      <td>4163</td>
-      <td>2010-09-11</td>
-      <td>Dietmar Winkler</td>
-      <td>Documentation corrected according to documentation guidelines.</td>
+      <td valign=\"top\"></td>
+      <td valign=\"top\">4163</td>
+      <td valign=\"top\">2010-09-11</td>
+      <td valign=\"top\">Dietmar Winkler</td>
+      <td valign=\"top\">Documentation corrected according to documentation guidelines.</td>
     </tr>
     <tr>
-      <td></td>
-      <td></td>
-      <td>2008-11-24</td>
-      <td>Kristin Majetta</td>
-      <td>Documentation added.</td>
+      <td valign=\"top\"></td>
+      <td valign=\"top\"></td>
+      <td valign=\"top\">2008-11-24</td>
+      <td valign=\"top\">Kristin Majetta</td>
+      <td valign=\"top\">Documentation added.</td>
     </tr>
     <tr>
-      <td></td>
-      <td></td>
-      <td>2007-02-26</td>
-      <td>Kristin Majetta</td>
-      <td>Initially implemented</td>
+      <td valign=\"top\"></td>
+      <td valign=\"top\"></td>
+      <td valign=\"top\">2007-02-26</td>
+      <td valign=\"top\">Kristin Majetta</td>
+      <td valign=\"top\">Initially implemented</td>
     </tr>
 </table>
 </html>"));

--- a/Modelica/Electrical/Digital.mo
+++ b/Modelica/Electrical/Digital.mo
@@ -1681,34 +1681,34 @@ The result can be seen in the output signals of the FullAdders according to:</p>
 <p>Its logic behavior is like this:</p>
 <p><strong>HalfAdder behavior</strong></p>
 <table cellspacing=\"0\" cellpadding=\"2\" border=\"1\"><tr>
-<td><h4>input a</h4></td>
-<td><h4>input b</h4></td>
-<td><h4>sum s</h4></td>
-<td><h4>carry c</h4></td>
+<td valign=\"top\"><h4>input a</h4></td>
+<td valign=\"top\"><h4>input b</h4></td>
+<td valign=\"top\"><h4>sum s</h4></td>
+<td valign=\"top\"><h4>carry c</h4></td>
 </tr>
 <tr>
-<td><p>0</p></td>
-<td><p>0</p></td>
-<td><p>0</p></td>
-<td><p>0</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>0</p></td>
 </tr>
 <tr>
-<td><p>1</p></td>
-<td><p>0</p></td>
-<td><p>1</p></td>
-<td><p>0</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>0</p></td>
 </tr>
 <tr>
-<td><p>0</p></td>
-<td><p>1</p></td>
-<td><p>1</p></td>
-<td><p>0</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>0</p></td>
 </tr>
 <tr>
-<td><p>1</p></td>
-<td><p>1</p></td>
-<td><p>0</p></td>
-<td><p>1</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>1</p></td>
 </tr>
 </table>
 <p>The parameter delayTime is the delay time (tLH=tHL) of both the components.</p>
@@ -1775,67 +1775,67 @@ The result can be seen in the output signals of the FullAdders according to:</p>
 <p>Its logic behavior is like this:</p>
 <p><strong>FullAdder behavior</strong></p>
 <table cellspacing=\"0\" cellpadding=\"2\" border=\"1\"><tr>
-<td><h4>input a</h4></td>
-<td><h4>input b</h4></td>
-<td><h4>input carry c_in</h4></td>
-<td><h4>sum s</h4></td>
-<td><h4>output carry c_out</h4></td>
+<td valign=\"top\"><h4>input a</h4></td>
+<td valign=\"top\"><h4>input b</h4></td>
+<td valign=\"top\"><h4>input carry c_in</h4></td>
+<td valign=\"top\"><h4>sum s</h4></td>
+<td valign=\"top\"><h4>output carry c_out</h4></td>
 </tr>
 <tr>
-<td><p>0</p></td>
-<td><p>0</p></td>
-<td><p>0</p></td>
-<td><p>0</p></td>
-<td><p>0</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>0</p></td>
 </tr>
 <tr>
-<td><p>1</p></td>
-<td><p>0</p></td>
-<td><p>0</p></td>
-<td><p>1</p></td>
-<td><p>0</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>0</p></td>
 </tr>
 <tr>
-<td><p>0</p></td>
-<td><p>1</p></td>
-<td><p>0</p></td>
-<td><p>1</p></td>
-<td><p>0</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>0</p></td>
 </tr>
 <tr>
-<td><p>1</p></td>
-<td><p>1</p></td>
-<td><p>0</p></td>
-<td><p>0</p></td>
-<td><p>1</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>1</p></td>
 </tr>
 <tr>
-<td><p>0</p></td>
-<td><p>0</p></td>
-<td><p>1</p></td>
-<td><p>0</p></td>
-<td><p>1</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>1</p></td>
 </tr>
 <tr>
-<td><p>1</p></td>
-<td><p>0</p></td>
-<td><p>1</p></td>
-<td><p>0</p></td>
-<td><p>1</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>1</p></td>
 </tr>
 <tr>
-<td><p>0</p></td>
-<td><p>1</p></td>
-<td><p>1</p></td>
-<td><p>0</p></td>
-<td><p>1</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>1</p></td>
 </tr>
 <tr>
-<td><p>1</p></td>
-<td><p>1</p></td>
-<td><p>1</p></td>
-<td><p>1</p></td>
-<td><p>1</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>1</p></td>
 </tr>
 </table>
 </html>"), Icon(coordinateSystem(
@@ -2119,19 +2119,19 @@ The result can be seen in the output signals of the FullAdders according to:</p>
 <p><strong>Code Table:</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Logic value</strong></td>
-      <td><strong>Meaning</strong></td>
+  <tr><td valign=\"top\"><strong>Logic value</strong></td>
+      <td valign=\"top\"><strong>Meaning</strong></td>
   </tr>
 
-  <tr><td>'U'</td> <td>Uninitialized</td></tr>
-  <tr><td>'X'</td> <td>Forcing Unknown</td></tr>
-  <tr><td>'0'</td> <td>Forcing 0</td></tr>
-  <tr><td>'1'</td> <td>Forcing 1</td></tr>
-  <tr><td>'Z'</td> <td>High Impedance</td></tr>
-  <tr><td>'W'</td> <td>Weak Unknown</td></tr>
-  <tr><td>'L'</td> <td>Weak 0</td></tr>
-  <tr><td>'H'</td> <td>Weak 1</td></tr>
-  <tr><td>'-'</td> <td>Do not care</td></tr>
+  <tr><td valign=\"top\">'U'</td> <td valign=\"top\">Uninitialized</td></tr>
+  <tr><td valign=\"top\">'X'</td> <td valign=\"top\">Forcing Unknown</td></tr>
+  <tr><td valign=\"top\">'0'</td> <td valign=\"top\">Forcing 0</td></tr>
+  <tr><td valign=\"top\">'1'</td> <td valign=\"top\">Forcing 1</td></tr>
+  <tr><td valign=\"top\">'Z'</td> <td valign=\"top\">High Impedance</td></tr>
+  <tr><td valign=\"top\">'W'</td> <td valign=\"top\">Weak Unknown</td></tr>
+  <tr><td valign=\"top\">'L'</td> <td valign=\"top\">Weak 0</td></tr>
+  <tr><td valign=\"top\">'H'</td> <td valign=\"top\">Weak 1</td></tr>
+  <tr><td valign=\"top\">'-'</td> <td valign=\"top\">Do not care</td></tr>
 </table>
 
 </html>"));
@@ -2145,14 +2145,14 @@ The result can be seen in the output signals of the FullAdders according to:</p>
 <p><strong>Code Table:</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Logic value</strong></td>
-      <td><strong>Meaning</strong></td>
+  <tr><td valign=\"top\"><strong>Logic value</strong></td>
+      <td valign=\"top\"><strong>Meaning</strong></td>
   </tr>
 
-  <tr><td>'U'</td> <td>Uninitialized</td></tr>
-  <tr><td>'X'</td> <td>Forcing Unknown</td></tr>
-  <tr><td>'0'</td> <td>Forcing 0</td></tr>
-  <tr><td>'1'</td> <td>Forcing 1</td></tr>
+  <tr><td valign=\"top\">'U'</td> <td valign=\"top\">Uninitialized</td></tr>
+  <tr><td valign=\"top\">'X'</td> <td valign=\"top\">Forcing Unknown</td></tr>
+  <tr><td valign=\"top\">'0'</td> <td valign=\"top\">Forcing 0</td></tr>
+  <tr><td valign=\"top\">'1'</td> <td valign=\"top\">Forcing 1</td></tr>
 
 </table>
 </html>"));
@@ -2171,20 +2171,20 @@ The result can be seen in the output signals of the FullAdders according to:</p>
 <p><strong>Strength Table:</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Strength</strong></td>
-      <td><strong>Output conversion to</strong></td>
+  <tr><td valign=\"top\"><strong>Strength</strong></td>
+      <td valign=\"top\"><strong>Output conversion to</strong></td>
   </tr>
 
-  <tr><td>'S_X01'</td> <td>Forcing X, 0, 1</td></tr>
-  <tr><td>'S_X0H'</td> <td>Forcing X, 0 and Weak 1</td></tr>
-  <tr><td>'S_XL1'</td> <td>Forcing X, 1 and Weak 0</td></tr>
-  <tr><td>'S_X0Z'</td> <td>Forcing X, 0 and High Impedance</td></tr>
-  <tr><td>'S_XZ1'</td> <td>Forcing X, 1 and High Impedance</td></tr>
-  <tr><td>'S_WLH'</td> <td>Weak X, 0, 1</td></tr>
-  <tr><td>'S_WLZ'</td> <td>Weak X, 0 and High Impedance</td></tr>
-  <tr><td>'S_WZH'</td> <td>Weak X, 1 and High Impedance</td></tr>
-  <tr><td>'S_W0H'</td> <td>Weak X, 1 and Forcing 0</td></tr>
-  <tr><td>'S_WL1'</td> <td>Weak X, 0 and Forcing 1</td></tr>
+  <tr><td valign=\"top\">'S_X01'</td> <td valign=\"top\">Forcing X, 0, 1</td></tr>
+  <tr><td valign=\"top\">'S_X0H'</td> <td valign=\"top\">Forcing X, 0 and Weak 1</td></tr>
+  <tr><td valign=\"top\">'S_XL1'</td> <td valign=\"top\">Forcing X, 1 and Weak 0</td></tr>
+  <tr><td valign=\"top\">'S_X0Z'</td> <td valign=\"top\">Forcing X, 0 and High Impedance</td></tr>
+  <tr><td valign=\"top\">'S_XZ1'</td> <td valign=\"top\">Forcing X, 1 and High Impedance</td></tr>
+  <tr><td valign=\"top\">'S_WLH'</td> <td valign=\"top\">Weak X, 0, 1</td></tr>
+  <tr><td valign=\"top\">'S_WLZ'</td> <td valign=\"top\">Weak X, 0 and High Impedance</td></tr>
+  <tr><td valign=\"top\">'S_WZH'</td> <td valign=\"top\">Weak X, 1 and High Impedance</td></tr>
+  <tr><td valign=\"top\">'S_W0H'</td> <td valign=\"top\">Weak X, 1 and Forcing 0</td></tr>
+  <tr><td valign=\"top\">'S_WL1'</td> <td valign=\"top\">Weak X, 0 and Forcing 1</td></tr>
 </table>
 </html>"));
 
@@ -3588,20 +3588,20 @@ To specify <em>setval</em>, the integer code has to be used.
 <p><strong>Code Table</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Logic value</strong></td>
-      <td><strong>Integer code</strong></td>
-      <td><strong>Meaning</strong></td>
+  <tr><td valign=\"top\"><strong>Logic value</strong></td>
+      <td valign=\"top\"><strong>Integer code</strong></td>
+      <td valign=\"top\"><strong>Meaning</strong></td>
   </tr>
 
-  <tr><td>'U'</td> <td>1</td> <td>Uninitialized</td></tr>
-  <tr><td>'X'</td> <td>2</td> <td>Forcing Unknown</td></tr>
-  <tr><td>'0'</td> <td>3</td> <td>Forcing 0</td></tr>
-  <tr><td>'1'</td> <td>4</td> <td>Forcing 1</td></tr>
-  <tr><td>'Z'</td> <td>5</td> <td>High Impedance</td></tr>
-  <tr><td>'W'</td> <td>6</td> <td>Weak Unknown</td></tr>
-  <tr><td>'L'</td> <td>7</td> <td>Weak 0</td></tr>
-  <tr><td>'H'</td> <td>8</td> <td>Weak 1</td></tr>
-  <tr><td>'-'</td> <td>9</td> <td>Do not care</td></tr>
+  <tr><td valign=\"top\">'U'</td> <td valign=\"top\">1</td> <td valign=\"top\">Uninitialized</td></tr>
+  <tr><td valign=\"top\">'X'</td> <td valign=\"top\">2</td> <td valign=\"top\">Forcing Unknown</td></tr>
+  <tr><td valign=\"top\">'0'</td> <td valign=\"top\">3</td> <td valign=\"top\">Forcing 0</td></tr>
+  <tr><td valign=\"top\">'1'</td> <td valign=\"top\">4</td> <td valign=\"top\">Forcing 1</td></tr>
+  <tr><td valign=\"top\">'Z'</td> <td valign=\"top\">5</td> <td valign=\"top\">High Impedance</td></tr>
+  <tr><td valign=\"top\">'W'</td> <td valign=\"top\">6</td> <td valign=\"top\">Weak Unknown</td></tr>
+  <tr><td valign=\"top\">'L'</td> <td valign=\"top\">7</td> <td valign=\"top\">Weak 0</td></tr>
+  <tr><td valign=\"top\">'H'</td> <td valign=\"top\">8</td> <td valign=\"top\">Weak 1</td></tr>
+  <tr><td valign=\"top\">'-'</td> <td valign=\"top\">9</td> <td valign=\"top\">Do not care</td></tr>
 </table>
 
 <p>
@@ -3661,20 +3661,20 @@ To specify the logic value parameters, the integer code has to be used.
 </p>
 <p><strong>Code Table</strong></p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Logic value</strong></td>
-      <td><strong>Integer code</strong></td>
-      <td><strong>Meaning</strong></td>
+  <tr><td valign=\"top\"><strong>Logic value</strong></td>
+      <td valign=\"top\"><strong>Integer code</strong></td>
+      <td valign=\"top\"><strong>Meaning</strong></td>
   </tr>
 
-  <tr><td>'U'</td> <td>1</td> <td>Uninitialized</td></tr>
-  <tr><td>'X'</td> <td>2</td> <td>Forcing Unknown</td></tr>
-  <tr><td>'0'</td> <td>3</td> <td>Forcing 0</td></tr>
-  <tr><td>'1'</td> <td>4</td> <td>Forcing 1</td></tr>
-  <tr><td>'Z'</td> <td>5</td> <td>High Impedance</td></tr>
-  <tr><td>'W'</td> <td>6</td> <td>Weak Unknown</td></tr>
-  <tr><td>'L'</td> <td>7</td> <td>Weak 0</td></tr>
-  <tr><td>'H'</td> <td>8</td> <td>Weak 1</td></tr>
-  <tr><td>'-'</td> <td>9</td> <td>Do not care</td></tr>
+  <tr><td valign=\"top\">'U'</td> <td valign=\"top\">1</td> <td valign=\"top\">Uninitialized</td></tr>
+  <tr><td valign=\"top\">'X'</td> <td valign=\"top\">2</td> <td valign=\"top\">Forcing Unknown</td></tr>
+  <tr><td valign=\"top\">'0'</td> <td valign=\"top\">3</td> <td valign=\"top\">Forcing 0</td></tr>
+  <tr><td valign=\"top\">'1'</td> <td valign=\"top\">4</td> <td valign=\"top\">Forcing 1</td></tr>
+  <tr><td valign=\"top\">'Z'</td> <td valign=\"top\">5</td> <td valign=\"top\">High Impedance</td></tr>
+  <tr><td valign=\"top\">'W'</td> <td valign=\"top\">6</td> <td valign=\"top\">Weak Unknown</td></tr>
+  <tr><td valign=\"top\">'L'</td> <td valign=\"top\">7</td> <td valign=\"top\">Weak 0</td></tr>
+  <tr><td valign=\"top\">'H'</td> <td valign=\"top\">8</td> <td valign=\"top\">Weak 1</td></tr>
+  <tr><td valign=\"top\">'-'</td> <td valign=\"top\">9</td> <td valign=\"top\">Do not care</td></tr>
 </table>
 <p>
 If the logic values are imported by<br><strong>import L = Digital.Interfaces.Logic;</strong><br>
@@ -3736,20 +3736,20 @@ To specify the logic value parameters, the integer code has to be used.
 </p>
 <p><strong>Code Table</strong></p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Logic value</strong></td>
-      <td><strong>Integer code</strong></td>
-      <td><strong>Meaning</strong></td>
+  <tr><td valign=\"top\"><strong>Logic value</strong></td>
+      <td valign=\"top\"><strong>Integer code</strong></td>
+      <td valign=\"top\"><strong>Meaning</strong></td>
   </tr>
 
-  <tr><td>'U'</td> <td>1</td> <td>Uninitialized</td></tr>
-  <tr><td>'X'</td> <td>2</td> <td>Forcing Unknown</td></tr>
-  <tr><td>'0'</td> <td>3</td> <td>Forcing 0</td></tr>
-  <tr><td>'1'</td> <td>4</td> <td>Forcing 1</td></tr>
-  <tr><td>'Z'</td> <td>5</td> <td>High Impedance</td></tr>
-  <tr><td>'W'</td> <td>6</td> <td>Weak Unknown</td></tr>
-  <tr><td>'L'</td> <td>7</td> <td>Weak 0</td></tr>
-  <tr><td>'H'</td> <td>8</td> <td>Weak 1</td></tr>
-  <tr><td>'-'</td> <td>9</td> <td>Do not care</td></tr>
+  <tr><td valign=\"top\">'U'</td> <td valign=\"top\">1</td> <td valign=\"top\">Uninitialized</td></tr>
+  <tr><td valign=\"top\">'X'</td> <td valign=\"top\">2</td> <td valign=\"top\">Forcing Unknown</td></tr>
+  <tr><td valign=\"top\">'0'</td> <td valign=\"top\">3</td> <td valign=\"top\">Forcing 0</td></tr>
+  <tr><td valign=\"top\">'1'</td> <td valign=\"top\">4</td> <td valign=\"top\">Forcing 1</td></tr>
+  <tr><td valign=\"top\">'Z'</td> <td valign=\"top\">5</td> <td valign=\"top\">High Impedance</td></tr>
+  <tr><td valign=\"top\">'W'</td> <td valign=\"top\">6</td> <td valign=\"top\">Weak Unknown</td></tr>
+  <tr><td valign=\"top\">'L'</td> <td valign=\"top\">7</td> <td valign=\"top\">Weak 0</td></tr>
+  <tr><td valign=\"top\">'H'</td> <td valign=\"top\">8</td> <td valign=\"top\">Weak 1</td></tr>
+  <tr><td valign=\"top\">'-'</td> <td valign=\"top\">9</td> <td valign=\"top\">Do not care</td></tr>
 </table>
 <p>
 If the logic values are imported by<br><strong>import L = Digital.Interfaces.Logic;</strong><br>
@@ -3833,20 +3833,20 @@ To specify the logic value parameters, the integer code has to be used.
 </p>
 <p><strong>Code Table</strong></p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Logic value</strong></td>
-      <td><strong>Integer code</strong></td>
-      <td><strong>Meaning</strong></td>
+  <tr><td valign=\"top\"><strong>Logic value</strong></td>
+      <td valign=\"top\"><strong>Integer code</strong></td>
+      <td valign=\"top\"><strong>Meaning</strong></td>
   </tr>
 
-  <tr><td>'U'</td> <td>1</td> <td>Uninitialized</td></tr>
-  <tr><td>'X'</td> <td>2</td> <td>Forcing Unknown</td></tr>
-  <tr><td>'0'</td> <td>3</td> <td>Forcing 0</td></tr>
-  <tr><td>'1'</td> <td>4</td> <td>Forcing 1</td></tr>
-  <tr><td>'Z'</td> <td>5</td> <td>High Impedance</td></tr>
-  <tr><td>'W'</td> <td>6</td> <td>Weak Unknown</td></tr>
-  <tr><td>'L'</td> <td>7</td> <td>Weak 0</td></tr>
-  <tr><td>'H'</td> <td>8</td> <td>Weak 1</td></tr>
-  <tr><td>'-'</td> <td>9</td> <td>Do not care</td></tr>
+  <tr><td valign=\"top\">'U'</td> <td valign=\"top\">1</td> <td valign=\"top\">Uninitialized</td></tr>
+  <tr><td valign=\"top\">'X'</td> <td valign=\"top\">2</td> <td valign=\"top\">Forcing Unknown</td></tr>
+  <tr><td valign=\"top\">'0'</td> <td valign=\"top\">3</td> <td valign=\"top\">Forcing 0</td></tr>
+  <tr><td valign=\"top\">'1'</td> <td valign=\"top\">4</td> <td valign=\"top\">Forcing 1</td></tr>
+  <tr><td valign=\"top\">'Z'</td> <td valign=\"top\">5</td> <td valign=\"top\">High Impedance</td></tr>
+  <tr><td valign=\"top\">'W'</td> <td valign=\"top\">6</td> <td valign=\"top\">Weak Unknown</td></tr>
+  <tr><td valign=\"top\">'L'</td> <td valign=\"top\">7</td> <td valign=\"top\">Weak 0</td></tr>
+  <tr><td valign=\"top\">'H'</td> <td valign=\"top\">8</td> <td valign=\"top\">Weak 1</td></tr>
+  <tr><td valign=\"top\">'-'</td> <td valign=\"top\">9</td> <td valign=\"top\">Do not care</td></tr>
 </table>
 <p>
 If the logic values are imported by<br><strong>import L = Digital.Interfaces.Logic;</strong><br>
@@ -4682,37 +4682,37 @@ If the signal width is greater than 1 this conversion is done for each signal.
 <p><strong>Truth Table for high active reset:</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Clock</strong></td>
-      <td><strong>Reset</strong></td>
-      <td><strong>DataOut</strong></td>
-      <td>Map</td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Clock</strong></td>
+      <td valign=\"top\"><strong>Reset</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
+      <td valign=\"top\">Map</td>
   </tr>
 
-  <tr><td>*</td> <td>*</td> <td>U</td > <td>U</td> <td>1</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>1</td>  <td>0</td> <td>2</td> </tr>
-  <tr><td>*</td> <td>0-Trns</td> <td>0</td>  <td>NC</td> <td>3</td> </tr>
-  <tr><td>*</td> <td>1-Trns</td> <td>0</td>  <td>DataIn</td> <td>3</td> </tr>
-  <tr><td>*</td> <td>X-Trns</td> <td>0</td>  <td>X or U or NC</td> <td>3</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>X</td> <td>X or U or 0 or NC</td> <td>4</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">U</td > <td valign=\"top\">U</td> <td valign=\"top\">1</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">1</td>  <td valign=\"top\">0</td> <td valign=\"top\">2</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0-Trns</td> <td valign=\"top\">0</td>  <td valign=\"top\">NC</td> <td valign=\"top\">3</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1-Trns</td> <td valign=\"top\">0</td>  <td valign=\"top\">DataIn</td> <td valign=\"top\">3</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X-Trns</td> <td valign=\"top\">0</td>  <td valign=\"top\">X or U or NC</td> <td valign=\"top\">3</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U or 0 or NC</td> <td valign=\"top\">4</td> </tr>
 </table>
 
 <p><strong>Truth Table for low active reset:</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Clock</strong></td>
-      <td><strong>Reset</strong></td>
-      <td><strong>DataOut</strong></td>
-      <td>Map</td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Clock</strong></td>
+      <td valign=\"top\"><strong>Reset</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
+      <td valign=\"top\">Map</td>
   </tr>
 
-  <tr><td>*</td> <td>*</td> <td>U</td > <td>U</td> <td>1</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>0</td>  <td>0</td> <td>2</td> </tr>
-  <tr><td>*</td> <td>0-Trns</td> <td>1</td>  <td>NC</td> <td>3</td> </tr>
-  <tr><td>*</td> <td>1-Trns</td> <td>1</td>  <td>DataIn</td> <td>3</td> </tr>
-  <tr><td>*</td> <td>X-Trns</td> <td>1</td>  <td>X or U or NC</td> <td>3</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>X</td> <td>X or U or 0 or NC</td> <td>4</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">U</td > <td valign=\"top\">U</td> <td valign=\"top\">1</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">0</td>  <td valign=\"top\">0</td> <td valign=\"top\">2</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0-Trns</td> <td valign=\"top\">1</td>  <td valign=\"top\">NC</td> <td valign=\"top\">3</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1-Trns</td> <td valign=\"top\">1</td>  <td valign=\"top\">DataIn</td> <td valign=\"top\">3</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X-Trns</td> <td valign=\"top\">1</td>  <td valign=\"top\">X or U or NC</td> <td valign=\"top\">3</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U or 0 or NC</td> <td valign=\"top\">4</td> </tr>
 </table>
 
 <pre>
@@ -4840,18 +4840,18 @@ Clock transition definitions:
 <p><strong>Truth Table</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Clock</strong></td>
-      <td><strong>Reset</strong></td>
-      <td><strong>DataOut</strong></td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Clock</strong></td>
+      <td valign=\"top\"><strong>Reset</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
   </tr>
 
-  <tr><td>*</td> <td>*</td> <td>U</td > <td>U</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>1</td>  <td>0</td> </tr>
-  <tr><td>*</td> <td>0-Trns</td> <td>0</td>  <td>NC</td> </tr>
-  <tr><td>*</td> <td>1-Trns</td> <td>0</td>  <td>DataIn</td> </tr>
-  <tr><td>*</td> <td>X-Trns</td> <td>0</td>  <td>X or U or NC</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>X</td> <td>X or U or 0 or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">U</td > <td valign=\"top\">U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">1</td>  <td valign=\"top\">0</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0-Trns</td> <td valign=\"top\">0</td>  <td valign=\"top\">NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1-Trns</td> <td valign=\"top\">0</td>  <td valign=\"top\">DataIn</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X-Trns</td> <td valign=\"top\">0</td>  <td valign=\"top\">X or U or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U or 0 or NC</td> </tr>
 </table>
 
 <pre>
@@ -4887,18 +4887,18 @@ Clock transition definitions:
 <p><strong>Truth Table</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Clock</strong></td>
-      <td><strong>Reset</strong></td>
-      <td><strong>DataOut</strong></td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Clock</strong></td>
+      <td valign=\"top\"><strong>Reset</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
   </tr>
 
-  <tr><td>*</td> <td>*</td> <td>U</td > <td>U</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>0</td>  <td>0</td> </tr>
-  <tr><td>*</td> <td>0-Trns</td> <td>1</td>  <td>NC</td> </tr>
-  <tr><td>*</td> <td>1-Trns</td> <td>1</td>  <td>DataIn</td> </tr>
-  <tr><td>*</td> <td>X-Trns</td> <td>1</td>  <td>X or U or NC</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>X</td> <td>X or U or 0 or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">U</td > <td valign=\"top\">U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">0</td>  <td valign=\"top\">0</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0-Trns</td> <td valign=\"top\">1</td>  <td valign=\"top\">NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1-Trns</td> <td valign=\"top\">1</td>  <td valign=\"top\">DataIn</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X-Trns</td> <td valign=\"top\">1</td>  <td valign=\"top\">X or U or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U or 0 or NC</td> </tr>
 </table>
 
 <pre>
@@ -5107,50 +5107,50 @@ Clock transition definitions:
 <p><strong>Truth Table for high active set and reset</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Clock</strong></td>
-      <td><strong>Reset</strong></td>
-      <td><strong>Set</strong></td>
-      <td><strong>DataOut</strong></td>
-      <td>Map</td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Clock</strong></td>
+      <td valign=\"top\"><strong>Reset</strong></td>
+      <td valign=\"top\"><strong>Set</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
+      <td valign=\"top\">Map</td>
   </tr>
 
-  <tr><td>*</td> <td>*</td> <td>*</td>  <td>U</td> <td>U</td> <td>1</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>U</td>  <td>*</td> <td>U</td> <td>1</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>*</td>  <td>1</td> <td>1</td> <td>2</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>1</td>  <td>0</td> <td>0</td> <td>3</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>1</td>  <td>X</td> <td>X</td> <td>6</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>X</td> <td>X</td> <td>X or U</td> <td>4</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>0</td> <td>X</td> <td>X or U or 1 or NC</td> <td>5</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>X</td> <td>0</td> <td>X or U or 0 or NC</td> <td>7</td> </tr>
-  <tr><td>*</td> <td>X-Trns</td> <td>0</td>  <td>0</td> <td>X or U or NC</td> <td>8</td> </tr>
-  <tr><td>*</td> <td>1-Trns</td> <td>0</td>  <td>0</td> <td>DataIn</td> <td>8</td> </tr>
-  <tr><td>*</td> <td>0-Trns</td> <td>0</td>  <td>0</td> <td>NC</td> <td>8</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">*</td>  <td valign=\"top\">U</td> <td valign=\"top\">U</td> <td valign=\"top\">1</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">U</td>  <td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">1</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">*</td>  <td valign=\"top\">1</td> <td valign=\"top\">1</td> <td valign=\"top\">2</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">1</td>  <td valign=\"top\">0</td> <td valign=\"top\">0</td> <td valign=\"top\">3</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">1</td>  <td valign=\"top\">X</td> <td valign=\"top\">X</td> <td valign=\"top\">6</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U</td> <td valign=\"top\">4</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U or 1 or NC</td> <td valign=\"top\">5</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">0</td> <td valign=\"top\">X or U or 0 or NC</td> <td valign=\"top\">7</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X-Trns</td> <td valign=\"top\">0</td>  <td valign=\"top\">0</td> <td valign=\"top\">X or U or NC</td> <td valign=\"top\">8</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1-Trns</td> <td valign=\"top\">0</td>  <td valign=\"top\">0</td> <td valign=\"top\">DataIn</td> <td valign=\"top\">8</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0-Trns</td> <td valign=\"top\">0</td>  <td valign=\"top\">0</td> <td valign=\"top\">NC</td> <td valign=\"top\">8</td> </tr>
 
 </table>
 
 <p><strong>Truth Table for low active set and reset </strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Clock</strong></td>
-      <td><strong>Reset</strong></td>
-      <td><strong>Set</strong></td>
-      <td><strong>DataOut</strong></td>
-      <td>Map</td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Clock</strong></td>
+      <td valign=\"top\"><strong>Reset</strong></td>
+      <td valign=\"top\"><strong>Set</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
+      <td valign=\"top\">Map</td>
   </tr>
 
-  <tr><td>*</td> <td>*</td> <td>*</td>  <td>U</td> <td>U</td> <td>1</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>U</td>  <td>*</td> <td>U</td> <td>1</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>*</td>  <td>0</td> <td>1</td> <td>2</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>0</td>  <td>1</td> <td>0</td> <td>3</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>0</td>  <td>X</td> <td>X</td> <td>6</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>X</td> <td>X</td> <td>X or U</td> <td>4</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>1</td> <td>X</td> <td>X or U or 1 or NC</td> <td>5</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>X</td> <td>1</td> <td>X or U or 0 or NC</td> <td>7</td> </tr>
-  <tr><td>*</td> <td>X-Trns</td> <td>1</td>  <td>1</td> <td>X or U or NC</td> <td>8</td> </tr>
-  <tr><td>*</td> <td>1-Trns</td> <td>1</td>  <td>1</td> <td>DataIn</td> <td>8</td> </tr>
-  <tr><td>*</td> <td>0-Trns</td> <td>1</td>  <td>1</td> <td>NC</td> <td>8</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">*</td>  <td valign=\"top\">U</td> <td valign=\"top\">U</td> <td valign=\"top\">1</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">U</td>  <td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">1</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">*</td>  <td valign=\"top\">0</td> <td valign=\"top\">1</td> <td valign=\"top\">2</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">0</td>  <td valign=\"top\">1</td> <td valign=\"top\">0</td> <td valign=\"top\">3</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">0</td>  <td valign=\"top\">X</td> <td valign=\"top\">X</td> <td valign=\"top\">6</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U</td> <td valign=\"top\">4</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U or 1 or NC</td> <td valign=\"top\">5</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">1</td> <td valign=\"top\">X or U or 0 or NC</td> <td valign=\"top\">7</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X-Trns</td> <td valign=\"top\">1</td>  <td valign=\"top\">1</td> <td valign=\"top\">X or U or NC</td> <td valign=\"top\">8</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1-Trns</td> <td valign=\"top\">1</td>  <td valign=\"top\">1</td> <td valign=\"top\">DataIn</td> <td valign=\"top\">8</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0-Trns</td> <td valign=\"top\">1</td>  <td valign=\"top\">1</td> <td valign=\"top\">NC</td> <td valign=\"top\">8</td> </tr>
 </table>
 
 <pre>
@@ -5295,24 +5295,24 @@ Clock transition definitions:
 <p><strong>Truth Table</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Clock</strong></td>
-      <td><strong>Reset</strong></td>
-      <td><strong>Set</strong></td>
-      <td><strong>DataOut</strong></td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Clock</strong></td>
+      <td valign=\"top\"><strong>Reset</strong></td>
+      <td valign=\"top\"><strong>Set</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
   </tr>
 
-  <tr><td>*</td> <td>*</td> <td>*</td>  <td>U</td> <td>U</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>U</td>  <td>*</td> <td>U</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>*</td>  <td>1</td> <td>1</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>1</td>  <td>0</td> <td>0</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>1</td>  <td>X</td> <td>X</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>X</td> <td>X</td> <td>X or U</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>0</td> <td>X</td> <td>X or U or 1 or NC</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>X</td> <td>0</td> <td>X or U or 0 or NC</td> </tr>
-  <tr><td>*</td> <td>X-Trns</td> <td>0</td>  <td>0</td> <td>X or U or NC</td> </tr>
-  <tr><td>*</td> <td>1-Trns</td> <td>0</td>  <td>0</td> <td>DataIn</td> </tr>
-  <tr><td>*</td> <td>0-Trns</td> <td>0</td>  <td>0</td> <td>NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">*</td>  <td valign=\"top\">U</td> <td valign=\"top\">U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">U</td>  <td valign=\"top\">*</td> <td valign=\"top\">U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">*</td>  <td valign=\"top\">1</td> <td valign=\"top\">1</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">1</td>  <td valign=\"top\">0</td> <td valign=\"top\">0</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">1</td>  <td valign=\"top\">X</td> <td valign=\"top\">X</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U or 1 or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">0</td> <td valign=\"top\">X or U or 0 or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X-Trns</td> <td valign=\"top\">0</td>  <td valign=\"top\">0</td> <td valign=\"top\">X or U or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1-Trns</td> <td valign=\"top\">0</td>  <td valign=\"top\">0</td> <td valign=\"top\">DataIn</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0-Trns</td> <td valign=\"top\">0</td>  <td valign=\"top\">0</td> <td valign=\"top\">NC</td> </tr>
 </table>
 
 <pre>
@@ -5356,24 +5356,24 @@ Clock transition definitions:
 <p><strong>Truth Table</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Clock</strong></td>
-      <td><strong>Reset</strong></td>
-      <td><strong>Set</strong></td>
-      <td><strong>DataOut</strong></td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Clock</strong></td>
+      <td valign=\"top\"><strong>Reset</strong></td>
+      <td valign=\"top\"><strong>Set</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
   </tr>
 
-  <tr><td>*</td> <td>*</td> <td>*</td>  <td>U</td> <td>U</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>U</td>  <td>*</td> <td>U</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>*</td>  <td>0</td> <td>1</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>0</td>  <td>1</td> <td>0</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>0</td>  <td>X</td> <td>X</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>X</td> <td>X</td> <td>X or U</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>1</td> <td>X</td> <td>X or U or 1 or NC</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>X</td> <td>1</td> <td>X or U or 0 or NC</td> </tr>
-  <tr><td>*</td> <td>X-Trns</td> <td>1</td>  <td>1</td> <td>X or U or NC</td> </tr>
-  <tr><td>*</td> <td>1-Trns</td> <td>1</td>  <td>1</td> <td>DataIn</td> </tr>
-  <tr><td>*</td> <td>0-Trns</td> <td>1</td>  <td>1</td> <td>NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">*</td>  <td valign=\"top\">U</td> <td valign=\"top\">U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">U</td>  <td valign=\"top\">*</td> <td valign=\"top\">U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">*</td>  <td valign=\"top\">0</td> <td valign=\"top\">1</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">0</td>  <td valign=\"top\">1</td> <td valign=\"top\">0</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">0</td>  <td valign=\"top\">X</td> <td valign=\"top\">X</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U or 1 or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">1</td> <td valign=\"top\">X or U or 0 or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X-Trns</td> <td valign=\"top\">1</td>  <td valign=\"top\">1</td> <td valign=\"top\">X or U or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1-Trns</td> <td valign=\"top\">1</td>  <td valign=\"top\">1</td> <td valign=\"top\">DataIn</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0-Trns</td> <td valign=\"top\">1</td>  <td valign=\"top\">1</td> <td valign=\"top\">NC</td> </tr>
 </table>
 
 <pre>
@@ -5497,39 +5497,39 @@ Clock transition definitions:
 <p><strong>Truth Table for high active reset:</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Enable</strong></td>
-      <td><strong>Reset</strong></td>
-      <td><strong>DataOut</strong></td>
-      <td>Map</td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Enable</strong></td>
+      <td valign=\"top\"><strong>Reset</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
+      <td valign=\"top\">Map</td>
   </tr>
 
-  <tr><td>*</td> <td>*</td> <td>U</td > <td>U</td> <td>1</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>1</td>  <td>0</td> <td>2</td> </tr>
-  <tr><td>*</td> <td>0</td> <td>0</td>  <td>NC</td> <td>3</td> </tr>
-  <tr><td>*</td> <td>1</td> <td>0</td>  <td>DataIn</td> <td>3</td> </tr>
-  <tr><td>*</td> <td>X</td> <td>0</td>  <td>X or U or NC</td> <td>3</td> </tr>
-  <tr><td>*</td> <td>U</td> <td>~1</td> <td>U</td> <td>4</td> </tr>
-  <tr><td>*</td> <td>~U</td> <td>X</td> <td>X or U or 0 or NC</td> <td>4</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">U</td > <td valign=\"top\">U</td> <td valign=\"top\">1</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">1</td>  <td valign=\"top\">0</td> <td valign=\"top\">2</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">0</td>  <td valign=\"top\">NC</td> <td valign=\"top\">3</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">0</td>  <td valign=\"top\">DataIn</td> <td valign=\"top\">3</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">0</td>  <td valign=\"top\">X or U or NC</td> <td valign=\"top\">3</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">~1</td> <td valign=\"top\">U</td> <td valign=\"top\">4</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">~U</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U or 0 or NC</td> <td valign=\"top\">4</td> </tr>
 </table>
 
 <p><strong>Truth Table for low active reset:</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Enable</strong></td>
-      <td><strong>Reset</strong></td>
-      <td><strong>DataOut</strong></td>
-      <td>Map</td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Enable</strong></td>
+      <td valign=\"top\"><strong>Reset</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
+      <td valign=\"top\">Map</td>
   </tr>
 
-  <tr><td>*</td> <td>*</td> <td>U</td> <td>U</td> <td>1</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>0</td> <td>0</td> <td>2</td> </tr>
-  <tr><td>*</td> <td>0</td> <td>1</td> <td>NC</td> <td>3</td> </tr>
-  <tr><td>*</td> <td>1</td> <td>1</td> <td>DataIn</td> <td>3</td> </tr>
-  <tr><td>*</td> <td>X</td> <td>1</td> <td>X or U or NC</td> <td>3</td> </tr>
-  <tr><td>*</td> <td>U</td> <td>~0</td> <td>U</td> <td>4</td> </tr>
-  <tr><td>*</td> <td>~U</td> <td>X</td> <td>X or U or 0 or NC</td> <td>4</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">U</td> <td valign=\"top\">1</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">0</td> <td valign=\"top\">2</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">1</td> <td valign=\"top\">NC</td> <td valign=\"top\">3</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">1</td> <td valign=\"top\">DataIn</td> <td valign=\"top\">3</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">1</td> <td valign=\"top\">X or U or NC</td> <td valign=\"top\">3</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">~0</td> <td valign=\"top\">U</td> <td valign=\"top\">4</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">~U</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U or 0 or NC</td> <td valign=\"top\">4</td> </tr>
 </table>
 
 <pre>
@@ -5650,19 +5650,19 @@ Clock transition definitions:
 <p><strong>Truth Table</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Enable</strong></td>
-      <td><strong>Reset</strong></td>
-      <td><strong>DataOut</strong></td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Enable</strong></td>
+      <td valign=\"top\"><strong>Reset</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
   </tr>
 
-  <tr><td>*</td> <td>*</td> <td>U</td > <td>U</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>1</td>  <td>0</td> </tr>
-  <tr><td>*</td> <td>0</td> <td>0</td>  <td>NC</td> </tr>
-  <tr><td>*</td> <td>1</td> <td>0</td>  <td>DataIn</td> </tr>
-  <tr><td>*</td> <td>X</td> <td>0</td>  <td>X or U or NC</td> </tr>
-  <tr><td>*</td> <td>U</td> <td>~1</td> <td>U</td> </tr>
-  <tr><td>*</td> <td>~U</td> <td>X</td> <td>X or U or 0 or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">U</td > <td valign=\"top\">U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">1</td>  <td valign=\"top\">0</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">0</td>  <td valign=\"top\">NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">0</td>  <td valign=\"top\">DataIn</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">0</td>  <td valign=\"top\">X or U or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">~1</td> <td valign=\"top\">U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">~U</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U or 0 or NC</td> </tr>
 </table>
 
 <pre>
@@ -5738,19 +5738,19 @@ Clock transition definitions:
 <p><strong>Truth Table</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Enable</strong></td>
-      <td><strong>Reset</strong></td>
-      <td><strong>DataOut</strong></td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Enable</strong></td>
+      <td valign=\"top\"><strong>Reset</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
   </tr>
 
-  <tr><td>*</td> <td>*</td> <td>U</td> <td>U</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>0</td> <td>0</td> </tr>
-  <tr><td>*</td> <td>0</td> <td>1</td> <td>NC</td> </tr>
-  <tr><td>*</td> <td>1</td> <td>1</td> <td>DataIn</td> </tr>
-  <tr><td>*</td> <td>X</td> <td>1</td> <td>X or U or NC</td> </tr>
-  <tr><td>*</td> <td>U</td> <td>~0</td> <td>U</td> </tr>
-  <tr><td>*</td> <td>~U</td> <td>X</td> <td>X or U or 0 or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">0</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">1</td> <td valign=\"top\">NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">1</td> <td valign=\"top\">DataIn</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">1</td> <td valign=\"top\">X or U or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">~0</td> <td valign=\"top\">U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">~U</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U or 0 or NC</td> </tr>
 </table>
 
 <pre>
@@ -5917,52 +5917,52 @@ Clock transition definitions:
 <p><strong>Truth Table for high active set and reset</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Enable</strong></td>
-      <td><strong>Reset</strong></td>
-      <td><strong>Set</strong></td>
-      <td><strong>DataOut</strong></td>
-      <td>Map</td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Enable</strong></td>
+      <td valign=\"top\"><strong>Reset</strong></td>
+      <td valign=\"top\"><strong>Set</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
+      <td valign=\"top\">Map</td>
   </tr>
 
-  <tr><td>*</td> <td>*</td> <td>*</td>  <td>U</td> <td>U</td> <td>1</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>U</td>  <td>~1</td> <td>U</td> <td>1</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>*</td>  <td>1</td> <td>1</td> <td>2</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>1</td>  <td>0</td> <td>0</td> <td>3</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>1</td>  <td>X</td> <td>X</td> <td>6</td> </tr>
-  <tr><td>*</td> <td>U</td> <td>~1</td> <td>~1</td> <td>U</td> <td>4,5,7,8</td> </tr>
-  <tr><td>*</td> <td>~U</td> <td>X</td> <td>X</td> <td>X or U</td> <td>4</td> </tr>
-  <tr><td>*</td> <td>~U</td> <td>0</td> <td>X</td> <td>X or U or 1 or NC</td> <td>5</td> </tr>
-  <tr><td>*</td> <td>~U</td> <td>X</td> <td>0</td> <td>X or U or 0 or NC</td> <td>7</td> </tr>
-  <tr><td>*</td> <td>X</td> <td>0</td>  <td>0</td> <td>X or U or NC</td> <td>8</td> </tr>
-  <tr><td>*</td> <td>1</td> <td>0</td>  <td>0</td> <td>DataIn</td> <td>8</td> </tr>
-  <tr><td>*</td> <td>0</td> <td>0</td>  <td>0</td> <td>NC</td> <td>8</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">*</td>  <td valign=\"top\">U</td> <td valign=\"top\">U</td> <td valign=\"top\">1</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">U</td>  <td valign=\"top\">~1</td> <td valign=\"top\">U</td> <td valign=\"top\">1</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">*</td>  <td valign=\"top\">1</td> <td valign=\"top\">1</td> <td valign=\"top\">2</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">1</td>  <td valign=\"top\">0</td> <td valign=\"top\">0</td> <td valign=\"top\">3</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">1</td>  <td valign=\"top\">X</td> <td valign=\"top\">X</td> <td valign=\"top\">6</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">~1</td> <td valign=\"top\">~1</td> <td valign=\"top\">U</td> <td valign=\"top\">4,5,7,8</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">~U</td> <td valign=\"top\">X</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U</td> <td valign=\"top\">4</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">~U</td> <td valign=\"top\">0</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U or 1 or NC</td> <td valign=\"top\">5</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">~U</td> <td valign=\"top\">X</td> <td valign=\"top\">0</td> <td valign=\"top\">X or U or 0 or NC</td> <td valign=\"top\">7</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">0</td>  <td valign=\"top\">0</td> <td valign=\"top\">X or U or NC</td> <td valign=\"top\">8</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">0</td>  <td valign=\"top\">0</td> <td valign=\"top\">DataIn</td> <td valign=\"top\">8</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">0</td>  <td valign=\"top\">0</td> <td valign=\"top\">NC</td> <td valign=\"top\">8</td> </tr>
 
 </table>
 
 <p><strong>Truth Table for low active set and reset </strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Enable</strong></td>
-      <td><strong>Reset</strong></td>
-      <td><strong>Set</strong></td>
-      <td><strong>DataOut</strong></td>
-      <td>Map</td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Enable</strong></td>
+      <td valign=\"top\"><strong>Reset</strong></td>
+      <td valign=\"top\"><strong>Set</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
+      <td valign=\"top\">Map</td>
   </tr>
 
-  <tr><td>*</td> <td>*</td> <td>*</td>  <td>U</td> <td>U</td> <td>1</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>U</td>  <td>~0</td> <td>U</td> <td>1</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>*</td>  <td>0</td> <td>1</td> <td>2</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>0</td>  <td>1</td> <td>0</td> <td>3</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>0</td>  <td>X</td> <td>X</td> <td>6</td> </tr>
-  <tr><td>*</td> <td>U</td> <td>~0</td> <td>~0</td> <td>U</td> <td>4,5,7,8</td> </tr>
-  <tr><td>*</td> <td>~U</td> <td>X</td> <td>X</td> <td>X or U</td> <td>4</td> </tr>
-  <tr><td>*</td> <td>~U</td> <td>1</td> <td>X</td> <td>X or U or 1 or NC</td> <td>5</td> </tr>
-  <tr><td>*</td> <td>~U</td> <td>X</td> <td>1</td> <td>X or U or 0 or NC</td> <td>7</td> </tr>
-  <tr><td>*</td> <td>X</td> <td>1</td>  <td>1</td> <td>X or U or NC</td> <td>8</td> </tr>
-  <tr><td>*</td> <td>1</td> <td>1</td>  <td>1</td> <td>DataIn</td> <td>8</td> </tr>
-  <tr><td>*</td> <td>0</td> <td>1</td>  <td>1</td> <td>NC</td> <td>8</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">*</td>  <td valign=\"top\">U</td> <td valign=\"top\">U</td> <td valign=\"top\">1</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">U</td>  <td valign=\"top\">~0</td> <td valign=\"top\">U</td> <td valign=\"top\">1</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">*</td>  <td valign=\"top\">0</td> <td valign=\"top\">1</td> <td valign=\"top\">2</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">0</td>  <td valign=\"top\">1</td> <td valign=\"top\">0</td> <td valign=\"top\">3</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">0</td>  <td valign=\"top\">X</td> <td valign=\"top\">X</td> <td valign=\"top\">6</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">~0</td> <td valign=\"top\">~0</td> <td valign=\"top\">U</td> <td valign=\"top\">4,5,7,8</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">~U</td> <td valign=\"top\">X</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U</td> <td valign=\"top\">4</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">~U</td> <td valign=\"top\">1</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U or 1 or NC</td> <td valign=\"top\">5</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">~U</td> <td valign=\"top\">X</td> <td valign=\"top\">1</td> <td valign=\"top\">X or U or 0 or NC</td> <td valign=\"top\">7</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">1</td>  <td valign=\"top\">1</td> <td valign=\"top\">X or U or NC</td> <td valign=\"top\">8</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">1</td>  <td valign=\"top\">1</td> <td valign=\"top\">DataIn</td> <td valign=\"top\">8</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">1</td>  <td valign=\"top\">1</td> <td valign=\"top\">NC</td> <td valign=\"top\">8</td> </tr>
 
 </table>
 
@@ -6099,25 +6099,25 @@ Clock transition definitions:
 <p><strong>Truth Table:</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Enable</strong></td>
-      <td><strong>Reset</strong></td>
-      <td><strong>Set</strong></td>
-      <td><strong>DataOut</strong></td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Enable</strong></td>
+      <td valign=\"top\"><strong>Reset</strong></td>
+      <td valign=\"top\"><strong>Set</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
   </tr>
 
-  <tr><td>*</td> <td>*</td> <td>*</td>  <td>U</td> <td>U</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>U</td>  <td>~1</td> <td>U</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>*</td>  <td>1</td> <td>1</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>1</td>  <td>0</td> <td>0</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>1</td>  <td>X</td> <td>X</td> </tr>
-  <tr><td>*</td> <td>U</td> <td>~1</td> <td>~1</td> <td>U</td> </tr>
-  <tr><td>*</td> <td>~U</td> <td>X</td> <td>X</td> <td>X or U</td> </tr>
-  <tr><td>*</td> <td>~U</td> <td>0</td> <td>X</td> <td>X or U or 1 or NC</td> </tr>
-  <tr><td>*</td> <td>~U</td> <td>X</td> <td>0</td> <td>X or U or 0 or NC</td> </tr>
-  <tr><td>*</td> <td>X</td> <td>0</td>  <td>0</td> <td>X or U or NC</td> </tr>
-  <tr><td>*</td> <td>1</td> <td>0</td>  <td>0</td> <td>DataIn</td> </tr>
-  <tr><td>*</td> <td>0</td> <td>0</td>  <td>0</td> <td>NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">*</td>  <td valign=\"top\">U</td> <td valign=\"top\">U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">U</td>  <td valign=\"top\">~1</td> <td valign=\"top\">U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">*</td>  <td valign=\"top\">1</td> <td valign=\"top\">1</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">1</td>  <td valign=\"top\">0</td> <td valign=\"top\">0</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">1</td>  <td valign=\"top\">X</td> <td valign=\"top\">X</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">~1</td> <td valign=\"top\">~1</td> <td valign=\"top\">U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">~U</td> <td valign=\"top\">X</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">~U</td> <td valign=\"top\">0</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U or 1 or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">~U</td> <td valign=\"top\">X</td> <td valign=\"top\">0</td> <td valign=\"top\">X or U or 0 or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">0</td>  <td valign=\"top\">0</td> <td valign=\"top\">X or U or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">0</td>  <td valign=\"top\">0</td> <td valign=\"top\">DataIn</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">0</td>  <td valign=\"top\">0</td> <td valign=\"top\">NC</td> </tr>
 
 </table>
 
@@ -6199,25 +6199,25 @@ Clock transition definitions:
 <p><strong>Truth Table</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Enable</strong></td>
-      <td><strong>Reset</strong></td>
-      <td><strong>Set</strong></td>
-      <td><strong>DataOut</strong></td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Enable</strong></td>
+      <td valign=\"top\"><strong>Reset</strong></td>
+      <td valign=\"top\"><strong>Set</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
   </tr>
 
-  <tr><td>*</td> <td>*</td> <td>*</td>  <td>U</td> <td>U</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>U</td>  <td>~0</td> <td>U</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>*</td>  <td>0</td> <td>1</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>0</td>  <td>1</td> <td>0</td> </tr>
-  <tr><td>*</td> <td>*</td> <td>0</td>  <td>X</td> <td>X</td> </tr>
-  <tr><td>*</td> <td>U</td> <td>~0</td> <td>~0</td> <td>U</td> </tr>
-  <tr><td>*</td> <td>~U</td> <td>X</td> <td>X</td> <td>X or U</td> </tr>
-  <tr><td>*</td> <td>~U</td> <td>1</td> <td>X</td> <td>X or U or 1 or NC</td> </tr>
-  <tr><td>*</td> <td>~U</td> <td>X</td> <td>1</td> <td>X or U or 0 or NC</td> </tr>
-  <tr><td>*</td> <td>X</td> <td>1</td>  <td>1</td> <td>X or U or NC</td> </tr>
-  <tr><td>*</td> <td>1</td> <td>1</td>  <td>1</td> <td>DataIn</td> </tr>
-  <tr><td>*</td> <td>0</td> <td>1</td>  <td>1</td> <td>NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">*</td>  <td valign=\"top\">U</td> <td valign=\"top\">U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">U</td>  <td valign=\"top\">~0</td> <td valign=\"top\">U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">*</td>  <td valign=\"top\">0</td> <td valign=\"top\">1</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">0</td>  <td valign=\"top\">1</td> <td valign=\"top\">0</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">*</td> <td valign=\"top\">0</td>  <td valign=\"top\">X</td> <td valign=\"top\">X</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">~0</td> <td valign=\"top\">~0</td> <td valign=\"top\">U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">~U</td> <td valign=\"top\">X</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">~U</td> <td valign=\"top\">1</td> <td valign=\"top\">X</td> <td valign=\"top\">X or U or 1 or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">~U</td> <td valign=\"top\">X</td> <td valign=\"top\">1</td> <td valign=\"top\">X or U or 0 or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">1</td>  <td valign=\"top\">1</td> <td valign=\"top\">X or U or NC</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">1</td>  <td valign=\"top\">1</td> <td valign=\"top\">DataIn</td> </tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">1</td>  <td valign=\"top\">1</td> <td valign=\"top\">NC</td> </tr>
 </table>
 
 <pre>
@@ -6316,20 +6316,20 @@ Clock transition definitions:
 <p>Description in VHDL is given by http://www.cs.sfu.ca/~ggbaker/reference/std_logic/src/std_logic_entities.vhd</p>
 <p><strong>Truth Table</strong></p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Enable</strong></td>
-      <td><strong>DataOut</strong></td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Enable</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
   </tr>
 
-  <tr><td>*</td> <td>U</td> <td>U</td></tr>
-  <tr><td>*</td> <td>X</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>0</td> <td>Z</td></tr>
-  <tr><td>*</td> <td>1</td> <td>DataIn</td></tr>
-  <tr><td>*</td> <td>Z</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>W</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>L</td> <td>Z</td></tr>
-  <tr><td>*</td> <td>H</td> <td>DataIn</td></tr>
-  <tr><td>*</td> <td>-</td> <td>UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">U</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">Z</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">DataIn</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">Z</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">W</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">L</td> <td valign=\"top\">Z</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">H</td> <td valign=\"top\">DataIn</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">-</td> <td valign=\"top\">UX</td></tr>
 </table>
 
 <pre>
@@ -6398,20 +6398,20 @@ Clock transition definitions:
 <p>Description in VHDL is given by http://www.cs.sfu.ca/~ggbaker/reference/std_logic/src/std_logic_entities.vhd</p>
 <p><strong>Truth Table</strong></p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Enable</strong></td>
-      <td><strong>DataOut</strong></td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Enable</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
   </tr>
 
-  <tr><td>*</td> <td>U</td> <td>U</td></tr>
-  <tr><td>*</td> <td>X</td> <td>UW</td></tr>
-  <tr><td>*</td> <td>0</td> <td>Z</td></tr>
-  <tr><td>*</td> <td>1</td> <td>DataIn, Strength Reduced</td></tr>
-  <tr><td>*</td> <td>Z</td> <td>UW</td></tr>
-  <tr><td>*</td> <td>W</td> <td>UW</td></tr>
-  <tr><td>*</td> <td>L</td> <td>Z</td></tr>
-  <tr><td>*</td> <td>H</td> <td>DataIn, Strength Reduced</td></tr>
-  <tr><td>*</td> <td>-</td> <td>UW</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">U</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">UW</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">Z</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">DataIn, Strength Reduced</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">Z</td> <td valign=\"top\">UW</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">W</td> <td valign=\"top\">UW</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">L</td> <td valign=\"top\">Z</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">H</td> <td valign=\"top\">DataIn, Strength Reduced</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">-</td> <td valign=\"top\">UW</td></tr>
 </table>
 
 <pre>
@@ -6480,20 +6480,20 @@ Clock transition definitions:
 <p>Description in VHDL is given by http://www.cs.sfu.ca/~ggbaker/reference/std_logic/src/std_logic_entities.vhd</p>
 <p><strong>Truth Table</strong></p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Enable</strong></td>
-      <td><strong>DataOut</strong></td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Enable</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
   </tr>
 
-  <tr><td>*</td> <td>U</td> <td>U</td></tr>
-  <tr><td>*</td> <td>X</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>0</td> <td>DataIn</td></tr>
-  <tr><td>*</td> <td>1</td> <td>Z</td></tr>
-  <tr><td>*</td> <td>Z</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>W</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>L</td> <td>DataIn</td></tr>
-  <tr><td>*</td> <td>H</td> <td>Z</td></tr>
-  <tr><td>*</td> <td>-</td> <td>UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">U</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">DataIn</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">Z</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">Z</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">W</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">L</td> <td valign=\"top\">DataIn</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">H</td> <td valign=\"top\">Z</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">-</td> <td valign=\"top\">UX</td></tr>
 </table>
 
 <pre>
@@ -6562,20 +6562,20 @@ Clock transition definitions:
 <p>Description in VHDL is given by http://www.cs.sfu.ca/~ggbaker/reference/std_logic/src/std_logic_entities.vhd</p>
 <p><strong>Truth Table</strong></p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Enable</strong></td>
-      <td><strong>DataOut</strong></td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Enable</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
   </tr>
 
-  <tr><td>*</td> <td>U</td> <td>U</td></tr>
-  <tr><td>*</td> <td>X</td> <td>UW</td></tr>
-  <tr><td>*</td> <td>0</td> <td>DataIn, Strength Reduced</td></tr>
-  <tr><td>*</td> <td>1</td> <td>Z</td></tr>
-  <tr><td>*</td> <td>Z</td> <td>UW</td></tr>
-  <tr><td>*</td> <td>W</td> <td>UW</td></tr>
-  <tr><td>*</td> <td>L</td> <td>DataIn, Strength Reduced</td></tr>
-  <tr><td>*</td> <td>H</td> <td>Z</td></tr>
-  <tr><td>*</td> <td>-</td> <td>UW</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">U</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">UW</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">DataIn, Strength Reduced</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">Z</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">Z</td> <td valign=\"top\">UW</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">W</td> <td valign=\"top\">UW</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">L</td> <td valign=\"top\">DataIn, Strength Reduced</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">H</td> <td valign=\"top\">Z</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">-</td> <td valign=\"top\">UW</td></tr>
 </table>
 <p>
   UW: if dataIn == U then U else W
@@ -6640,20 +6640,20 @@ Clock transition definitions:
 <p>and for tristate table http://www.cs.sfu.ca/~ggbaker/reference/std_logic/src/std_logic_misc.vhd</p>
 <p><strong>Truth Table</strong></p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Enable</strong></td>
-      <td><strong>DataOut*</strong></td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Enable</strong></td>
+      <td valign=\"top\"><strong>DataOut*</strong></td>
   </tr>
 
-  <tr><td>*</td> <td>U</td> <td>U</td></tr>
-  <tr><td>*</td> <td>X</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>0</td> <td>Z</td></tr>
-  <tr><td>*</td> <td>1</td> <td>DataIn</td></tr>
-  <tr><td>*</td> <td>Z</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>W</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>L</td> <td>Z</td></tr>
-  <tr><td>*</td> <td>H</td> <td>DataIn</td></tr>
-  <tr><td>*</td> <td>-</td> <td>UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">U</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">Z</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">DataIn</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">Z</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">W</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">L</td> <td valign=\"top\">Z</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">H</td> <td valign=\"top\">DataIn</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">-</td> <td valign=\"top\">UX</td></tr>
 </table>
 
 <pre>
@@ -6719,20 +6719,20 @@ Clock transition definitions:
 <p>and for tristate table http://www.cs.sfu.ca/~ggbaker/reference/std_logic/src/std_logic_misc.vhd</p>
 <p><strong>Truth Table</strong></p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Enable</strong></td>
-      <td><strong>DataOut*</strong></td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Enable</strong></td>
+      <td valign=\"top\"><strong>DataOut*</strong></td>
   </tr>
 
-  <tr><td>*</td> <td>U</td> <td>U</td></tr>
-  <tr><td>*</td> <td>X</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>0</td> <td>DataIn</td></tr>
-  <tr><td>*</td> <td>1</td> <td>Z</td></tr>
-  <tr><td>*</td> <td>Z</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>W</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>L</td> <td>DataIn</td></tr>
-  <tr><td>*</td> <td>H</td> <td>Z</td></tr>
-  <tr><td>*</td> <td>-</td> <td>UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">U</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">DataIn</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">Z</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">Z</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">W</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">L</td> <td valign=\"top\">DataIn</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">H</td> <td valign=\"top\">Z</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">-</td> <td valign=\"top\">UX</td></tr>
 </table>
 
 <pre>
@@ -6803,20 +6803,20 @@ Clock transition definitions:
 <p>and for tristate table http://www.cs.sfu.ca/~ggbaker/reference/std_logic/src/std_logic_misc.vhd</p>
 <p><strong>Truth Table</strong></p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Enable</strong></td>
-      <td><strong>DataOut*</strong></td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Enable</strong></td>
+      <td valign=\"top\"><strong>DataOut*</strong></td>
   </tr>
 
-  <tr><td>*</td> <td>U</td> <td>U</td></tr>
-  <tr><td>*</td> <td>X</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>0</td> <td>Z</td></tr>
-  <tr><td>*</td> <td>1</td> <td>Not DataIn</td></tr>
-  <tr><td>*</td> <td>Z</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>W</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>L</td> <td>Z</td></tr>
-  <tr><td>*</td> <td>H</td> <td>Not DataIn</td></tr>
-  <tr><td>*</td> <td>-</td> <td>UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">U</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">Z</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">Not DataIn</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">Z</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">W</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">L</td> <td valign=\"top\">Z</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">H</td> <td valign=\"top\">Not DataIn</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">-</td> <td valign=\"top\">UX</td></tr>
 </table>
 
 <pre>
@@ -6887,20 +6887,20 @@ Clock transition definitions:
 <p>and for tristate table http://www.cs.sfu.ca/~ggbaker/reference/std_logic/src/std_logic_misc.vhd</p>
 <p><strong>Truth Table</strong></p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>DataIn</strong></td>
-      <td><strong>Enable</strong></td>
-      <td><strong>DataOut*</strong></td>
+  <tr><td valign=\"top\"><strong>DataIn</strong></td>
+      <td valign=\"top\"><strong>Enable</strong></td>
+      <td valign=\"top\"><strong>DataOut*</strong></td>
   </tr>
 
-  <tr><td>*</td> <td>U</td> <td>U</td></tr>
-  <tr><td>*</td> <td>X</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>0</td> <td>Not DataIn</td></tr>
-  <tr><td>*</td> <td>1</td> <td>Z</td></tr>
-  <tr><td>*</td> <td>Z</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>W</td> <td>UX</td></tr>
-  <tr><td>*</td> <td>L</td> <td>Not DataIn</td></tr>
-  <tr><td>*</td> <td>H</td> <td>Z</td></tr>
-  <tr><td>*</td> <td>-</td> <td>UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">U</td> <td valign=\"top\">U</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">X</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">0</td> <td valign=\"top\">Not DataIn</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">1</td> <td valign=\"top\">Z</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">Z</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">W</td> <td valign=\"top\">UX</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">L</td> <td valign=\"top\">Not DataIn</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">H</td> <td valign=\"top\">Z</td></tr>
+  <tr><td valign=\"top\">*</td> <td valign=\"top\">-</td> <td valign=\"top\">UX</td></tr>
 </table>
 
 <pre>
@@ -7007,26 +7007,26 @@ Description in VHDL is given by <a href=\"http://www.cs.sfu.ca/~ggbaker/referenc
 </p>
 <p><strong>Truth Table for high active read enable RE:</strong></p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>RE</strong></td>
-      <td><strong>Addr</strong></td>
-      <td><strong>DataOut</strong></td>
+  <tr><td valign=\"top\"><strong>RE</strong></td>
+      <td valign=\"top\"><strong>Addr</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
   </tr>
-  <tr><td>0</td>  <td>*</td>              <td>Z over all</td>  </tr>
-  <tr><td>1</td>  <td>  no X in Addr</td> <td>DataOut=m(Addr)</td>     </tr>
-  <tr><td>1</td>  <td>X in Addr</td>      <td>X over all</td>  </tr>
-  <tr><td>X</td>  <td>*</td>              <td>X over all</td>  </tr>
+  <tr><td valign=\"top\">0</td>  <td valign=\"top\">*</td>              <td valign=\"top\">Z over all</td>  </tr>
+  <tr><td valign=\"top\">1</td>  <td valign=\"top\">  no X in Addr</td> <td valign=\"top\">DataOut=m(Addr)</td>     </tr>
+  <tr><td valign=\"top\">1</td>  <td valign=\"top\">X in Addr</td>      <td valign=\"top\">X over all</td>  </tr>
+  <tr><td valign=\"top\">X</td>  <td valign=\"top\">*</td>              <td valign=\"top\">X over all</td>  </tr>
 </table>
 <p><strong>Truth Table for high active write enable WE:</strong></p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>WE</strong></td>
-      <td><strong>Addr</strong></td>
-      <td><strong>Memory</strong></td>
+  <tr><td valign=\"top\"><strong>WE</strong></td>
+      <td valign=\"top\"><strong>Addr</strong></td>
+      <td valign=\"top\"><strong>Memory</strong></td>
   </tr>
-  <tr><td>0</td>  <td>*</td>              <td>no write</td>           </tr>
-  <tr><td>1</td>  <td>no X in Addr</td>   <td>m(Addr)=DataIn</td>     </tr>
-  <tr><td>1</td>  <td>X in Addr</td>      <td>no write</td>  </tr>
-  <tr><td>X</td>  <td>no X in Addr</td>   <td>m(Addr)=X over all</td> </tr>
-  <tr><td>X</td>  <td>X in Addr</td>      <td>no write</td>  </tr>
+  <tr><td valign=\"top\">0</td>  <td valign=\"top\">*</td>              <td valign=\"top\">no write</td>           </tr>
+  <tr><td valign=\"top\">1</td>  <td valign=\"top\">no X in Addr</td>   <td valign=\"top\">m(Addr)=DataIn</td>     </tr>
+  <tr><td valign=\"top\">1</td>  <td valign=\"top\">X in Addr</td>      <td valign=\"top\">no write</td>  </tr>
+  <tr><td valign=\"top\">X</td>  <td valign=\"top\">no X in Addr</td>   <td valign=\"top\">m(Addr)=X over all</td> </tr>
+  <tr><td valign=\"top\">X</td>  <td valign=\"top\">X in Addr</td>      <td valign=\"top\">no write</td>  </tr>
 </table>
 
 <pre>
@@ -7105,14 +7105,14 @@ Description in VHDL is given by <a href=\"http://www.cs.sfu.ca/~ggbaker/referenc
 </p>
 <p><strong>Truth Table for high active read enable RE:</strong></p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>RE</strong></td>
-      <td><strong>Addr</strong></td>
-      <td><strong>DataOut</strong></td>
+  <tr><td valign=\"top\"><strong>RE</strong></td>
+      <td valign=\"top\"><strong>Addr</strong></td>
+      <td valign=\"top\"><strong>DataOut</strong></td>
   </tr>
-  <tr><td>0</td> <td>*</td> <td>Z over all</td>  </tr>
-  <tr><td>1</td> <td>  no X in Addr</td> <td>DataOut=m(Addr)</td>  </tr>
-  <tr><td>1</td> <td>X in Addr</td> <td>X over all</td> </tr>
-  <tr><td>X</td> <td>*</td> <td>X over all</td> </tr>
+  <tr><td valign=\"top\">0</td> <td valign=\"top\">*</td> <td valign=\"top\">Z over all</td>  </tr>
+  <tr><td valign=\"top\">1</td> <td valign=\"top\">  no X in Addr</td> <td valign=\"top\">DataOut=m(Addr)</td>  </tr>
+  <tr><td valign=\"top\">1</td> <td valign=\"top\">X in Addr</td> <td valign=\"top\">X over all</td> </tr>
+  <tr><td valign=\"top\">X</td> <td valign=\"top\">*</td> <td valign=\"top\">X over all</td> </tr>
 </table>
 
 <pre>
@@ -7218,44 +7218,44 @@ Description in VHDL is given by <a href=\"http://www.cs.sfu.ca/~ggbaker/referenc
 <p>and for Multiplexer table <a href=\"http://www.cs.sfu.ca/~ggbaker/reference/std_logic/src/std_logic_misc.vhd\">http://www.cs.sfu.ca/~ggbaker/reference/std_logic/src/std_logic_misc.vhd</a></p>
 <h4>Truth Table</h4>
 <table cellspacing=\"0\" cellpadding=\"2\" border=\"1\"><tr>
-<td><h4>DataIn</h4></td>
-<td><h4>Select</h4></td>
-<td><h4>DataOut</h4></td>
+<td valign=\"top\"><h4>DataIn</h4></td>
+<td valign=\"top\"><h4>Select</h4></td>
+<td valign=\"top\"><h4>DataOut</h4></td>
 </tr>
 <tr>
-<td><p>*</p></td>
-<td><p>0</p></td>
-<td><p>Input0</p></td>
+<td valign=\"top\"><p>*</p></td>
+<td valign=\"top\"><p>0</p></td>
+<td valign=\"top\"><p>Input0</p></td>
 </tr>
 <tr>
-<td><p>*</p></td>
-<td><p>1</p></td>
-<td><p>Input1</p></td>
+<td valign=\"top\"><p>*</p></td>
+<td valign=\"top\"><p>1</p></td>
+<td valign=\"top\"><p>Input1</p></td>
 </tr>
 <tr>
-<td><p>Inputs equal</p></td>
-<td><p>U</p></td>
-<td><p>Input</p></td>
+<td valign=\"top\"><p>Inputs equal</p></td>
+<td valign=\"top\"><p>U</p></td>
+<td valign=\"top\"><p>Input</p></td>
 </tr>
 <tr>
-<td><p>Inputs not equal</p></td>
-<td><p>U</p></td>
-<td><p>U</p></td>
+<td valign=\"top\"><p>Inputs not equal</p></td>
+<td valign=\"top\"><p>U</p></td>
+<td valign=\"top\"><p>U</p></td>
 </tr>
 <tr>
-<td><p>U in Input</p></td>
-<td><p>X</p></td>
-<td><p>U</p></td>
+<td valign=\"top\"><p>U in Input</p></td>
+<td valign=\"top\"><p>X</p></td>
+<td valign=\"top\"><p>U</p></td>
 </tr>
 <tr>
-<td><p>Inputs equal</p></td>
-<td><p>X</p></td>
-<td><p>Input</p></td>
+<td valign=\"top\"><p>Inputs equal</p></td>
+<td valign=\"top\"><p>X</p></td>
+<td valign=\"top\"><p>Input</p></td>
 </tr>
 <tr>
-<td><p>no U in Input and Inputs not equal</p></td>
-<td><p>X</p></td>
-<td><p>X</p></td>
+<td valign=\"top\"><p>no U in Input and Inputs not equal</p></td>
+<td valign=\"top\"><p>X</p></td>
+<td valign=\"top\"><p>X</p></td>
 </tr>
 </table>
 <pre>
@@ -7306,20 +7306,20 @@ for both setting of input and interpreting the output values.
 <p><strong>Code Table:</strong></p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Logic value</strong></td>
-      <td><strong>Integer code</strong></td>
-      <td><strong>Meaning</strong></td>
+  <tr><td valign=\"top\"><strong>Logic value</strong></td>
+      <td valign=\"top\"><strong>Integer code</strong></td>
+      <td valign=\"top\"><strong>Meaning</strong></td>
   </tr>
 
-  <tr><td>'U'</td> <td>1</td> <td>Uninitialized</td></tr>
-  <tr><td>'X'</td> <td>2</td> <td>Forcing Unknown</td></tr>
-  <tr><td>'0'</td> <td>3</td> <td>Forcing 0</td></tr>
-  <tr><td>'1'</td> <td>4</td> <td>Forcing 1</td></tr>
-  <tr><td>'Z'</td> <td>5</td> <td>High Impedance</td></tr>
-  <tr><td>'W'</td> <td>6</td> <td>Weak Unknown</td></tr>
-  <tr><td>'L'</td> <td>7</td> <td>Weak 0</td></tr>
-  <tr><td>'H'</td> <td>8</td> <td>Weak 1</td></tr>
-  <tr><td>'-'</td> <td>9</td> <td>Do not care</td></tr>
+  <tr><td valign=\"top\">'U'</td> <td valign=\"top\">1</td> <td valign=\"top\">Uninitialized</td></tr>
+  <tr><td valign=\"top\">'X'</td> <td valign=\"top\">2</td> <td valign=\"top\">Forcing Unknown</td></tr>
+  <tr><td valign=\"top\">'0'</td> <td valign=\"top\">3</td> <td valign=\"top\">Forcing 0</td></tr>
+  <tr><td valign=\"top\">'1'</td> <td valign=\"top\">4</td> <td valign=\"top\">Forcing 1</td></tr>
+  <tr><td valign=\"top\">'Z'</td> <td valign=\"top\">5</td> <td valign=\"top\">High Impedance</td></tr>
+  <tr><td valign=\"top\">'W'</td> <td valign=\"top\">6</td> <td valign=\"top\">Weak Unknown</td></tr>
+  <tr><td valign=\"top\">'L'</td> <td valign=\"top\">7</td> <td valign=\"top\">Weak 0</td></tr>
+  <tr><td valign=\"top\">'H'</td> <td valign=\"top\">8</td> <td valign=\"top\">Weak 1</td></tr>
+  <tr><td valign=\"top\">'-'</td> <td valign=\"top\">9</td> <td valign=\"top\">Do not care</td></tr>
 </table>
 
 <p>

--- a/Modelica/Electrical/Machines.mo
+++ b/Modelica/Electrical/Machines.mo
@@ -385,8 +385,8 @@ SM_ElectricalExcited</a>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
     <tr>
-      <td>[Lang1984]</td>
-      <td>W. Lang,
+      <td valign=\"top\">[Lang1984]</td>
+      <td valign=\"top\">W. Lang,
         &quot;&Uuml;ber die Bemessung verlustarmer Asynchronmotoren mit K&auml;figl&auml;ufer f&uuml;r
         Pulsumrichterspeisung,&quot;
         Doctoral Thesis,
@@ -6920,108 +6920,108 @@ Resistance and stray inductance of stator is modeled directly in stator phases, 
 <p><strong>Default values for machine's parameters (a realistic example) are:</strong><br></p>
 <table>
 <tr>
-<td>number of pole pairs p</td>
-<td>2</td><td> </td>
+<td valign=\"top\">number of pole pairs p</td>
+<td valign=\"top\">2</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator's moment of inertia</td>
-<td>0.29</td><td>kg.m2</td>
+<td valign=\"top\">stator's moment of inertia</td>
+<td valign=\"top\">0.29</td><td valign=\"top\">kg.m2</td>
 </tr>
 <tr>
-<td>rotor's moment of inertia</td>
-<td>0.29</td><td>kg.m2</td>
+<td valign=\"top\">rotor's moment of inertia</td>
+<td valign=\"top\">0.29</td><td valign=\"top\">kg.m2</td>
 </tr>
 <tr>
-<td>nominal frequency fNominal</td>
-<td>50</td><td>Hz</td>
+<td valign=\"top\">nominal frequency fNominal</td>
+<td valign=\"top\">50</td><td valign=\"top\">Hz</td>
 </tr>
 <tr>
-<td>nominal voltage per phase</td>
-<td>100</td><td>V RMS</td>
+<td valign=\"top\">nominal voltage per phase</td>
+<td valign=\"top\">100</td><td valign=\"top\">V RMS</td>
 </tr>
 <tr>
-<td>nominal current per phase</td>
-<td>100</td><td>A RMS</td>
+<td valign=\"top\">nominal current per phase</td>
+<td valign=\"top\">100</td><td valign=\"top\">A RMS</td>
 </tr>
 <tr>
-<td>nominal torque</td>
-<td>161.4</td><td>Nm</td>
+<td valign=\"top\">nominal torque</td>
+<td valign=\"top\">161.4</td><td valign=\"top\">Nm</td>
 </tr>
 <tr>
-<td>nominal speed</td>
-<td>1440.45</td><td>rpm</td>
+<td valign=\"top\">nominal speed</td>
+<td valign=\"top\">1440.45</td><td valign=\"top\">rpm</td>
 </tr>
 <tr>
-<td>nominal mechanical output</td>
-<td>24.346</td><td>kW</td>
+<td valign=\"top\">nominal mechanical output</td>
+<td valign=\"top\">24.346</td><td valign=\"top\">kW</td>
 </tr>
 <tr>
-<td>efficiency</td>
-<td>92.7</td><td>%</td>
+<td valign=\"top\">efficiency</td>
+<td valign=\"top\">92.7</td><td valign=\"top\">%</td>
 </tr>
 <tr>
-<td>power factor</td>
-<td>0.875</td><td> </td>
+<td valign=\"top\">power factor</td>
+<td valign=\"top\">0.875</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator resistance</td>
-<td>0.03</td><td>Ohm per phase at reference temperature</td>
+<td valign=\"top\">stator resistance</td>
+<td valign=\"top\">0.03</td><td valign=\"top\">Ohm per phase at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature TsRef</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature TsRef</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20s </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20s </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>rotor resistance</td>
-<td>0.04</td><td>Ohm at reference temperature</td>
+<td valign=\"top\">rotor resistance</td>
+<td valign=\"top\">0.04</td><td valign=\"top\">Ohm at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature TrRef</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature TrRef</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20r </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20r </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>stator reactance Xs</td>
-<td>3</td><td>Ohm per phase</td>
+<td valign=\"top\">stator reactance Xs</td>
+<td valign=\"top\">3</td><td valign=\"top\">Ohm per phase</td>
 </tr>
 <tr>
-<td>rotor reactance Xr</td>
-<td>3</td><td>Ohm</td>
+<td valign=\"top\">rotor reactance Xr</td>
+<td valign=\"top\">3</td><td valign=\"top\">Ohm</td>
 </tr>
 <tr>
-<td>total stray coefficient sigma</td>
-<td>0.0667</td><td> </td>
+<td valign=\"top\">total stray coefficient sigma</td>
+<td valign=\"top\">0.0667</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator operational temperature TsOperational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">stator operational temperature TsOperational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>rotor operational temperature TrOperational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">rotor operational temperature TrOperational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>These values give the following inductances:</td>
-<td> </td><td> </td>
+<td valign=\"top\">These values give the following inductances:</td>
+<td valign=\"top\"> </td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator stray inductance per phase</td>
-<td>Xs * (1 - sqrt(1-sigma))/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">stator stray inductance per phase</td>
+<td valign=\"top\">Xs * (1 - sqrt(1-sigma))/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>rotor stray inductance</td>
-<td>Xr * (1 - sqrt(1-sigma))/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">rotor stray inductance</td>
+<td valign=\"top\">Xr * (1 - sqrt(1-sigma))/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>main field inductance per phase</td>
-<td>sqrt(Xs*Xr * (1-sigma))/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">main field inductance per phase</td>
+<td valign=\"top\">sqrt(Xs*Xr * (1-sigma))/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 </table>
 </html>"));
@@ -7197,112 +7197,112 @@ Resistance and stray inductance of stator and rotor are modeled directly in stat
 <p><strong>Default values for machine's parameters (a realistic example) are:</strong><br></p>
 <table>
 <tr>
-<td>number of pole pairs p</td>
-<td>2</td><td> </td>
+<td valign=\"top\">number of pole pairs p</td>
+<td valign=\"top\">2</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator's moment of inertia</td>
-<td>0.29</td><td>kg.m2</td>
+<td valign=\"top\">stator's moment of inertia</td>
+<td valign=\"top\">0.29</td><td valign=\"top\">kg.m2</td>
 </tr>
 <tr>
-<td>rotor's moment of inertia</td>
-<td>0.29</td><td>kg.m2</td>
+<td valign=\"top\">rotor's moment of inertia</td>
+<td valign=\"top\">0.29</td><td valign=\"top\">kg.m2</td>
 </tr>
 <tr>
-<td>nominal frequency fNominal</td>
-<td>50</td><td>Hz</td>
+<td valign=\"top\">nominal frequency fNominal</td>
+<td valign=\"top\">50</td><td valign=\"top\">Hz</td>
 </tr>
 <tr>
-<td>nominal voltage per phase</td>
-<td>100</td><td>V RMS</td>
+<td valign=\"top\">nominal voltage per phase</td>
+<td valign=\"top\">100</td><td valign=\"top\">V RMS</td>
 </tr>
 <tr>
-<td>nominal current per phase</td>
-<td>100</td><td>A RMS</td>
+<td valign=\"top\">nominal current per phase</td>
+<td valign=\"top\">100</td><td valign=\"top\">A RMS</td>
 </tr>
 <tr>
-<td>nominal torque</td>
-<td>161.4</td><td>Nm</td>
+<td valign=\"top\">nominal torque</td>
+<td valign=\"top\">161.4</td><td valign=\"top\">Nm</td>
 </tr>
 <tr>
-<td>nominal speed</td>
-<td>1440.45</td><td>rpm</td>
+<td valign=\"top\">nominal speed</td>
+<td valign=\"top\">1440.45</td><td valign=\"top\">rpm</td>
 </tr>
 <tr>
-<td>nominal mechanical output</td>
-<td>24.346</td><td>kW</td>
+<td valign=\"top\">nominal mechanical output</td>
+<td valign=\"top\">24.346</td><td valign=\"top\">kW</td>
 </tr>
 <tr>
-<td>efficiency</td>
-<td>92.7</td><td>%</td>
+<td valign=\"top\">efficiency</td>
+<td valign=\"top\">92.7</td><td valign=\"top\">%</td>
 </tr>
 <tr>
-<td>power factor</td>
-<td>0.875</td><td> </td>
+<td valign=\"top\">power factor</td>
+<td valign=\"top\">0.875</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator resistance</td>
-<td>0.03</td><td>Ohm per phase at reference temperature</td>
+<td valign=\"top\">stator resistance</td>
+<td valign=\"top\">0.03</td><td valign=\"top\">Ohm per phase at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature TsRef</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature TsRef</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20s </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20s </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>rotor resistance</td>
-<td>0.04</td><td>Ohm per phase at reference temperature</td>
+<td valign=\"top\">rotor resistance</td>
+<td valign=\"top\">0.04</td><td valign=\"top\">Ohm per phase at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature TrRef</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature TrRef</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20r </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20r </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>stator reactance Xs</td>
-<td>3</td><td>Ohm per phase</td>
+<td valign=\"top\">stator reactance Xs</td>
+<td valign=\"top\">3</td><td valign=\"top\">Ohm per phase</td>
 </tr>
 <tr>
-<td>rotor reactance Xr</td>
-<td>3</td><td>Ohm per phase</td>
+<td valign=\"top\">rotor reactance Xr</td>
+<td valign=\"top\">3</td><td valign=\"top\">Ohm per phase</td>
 </tr>
 <tr>
-<td>total stray coefficient sigma</td>
-<td>0.0667</td><td> </td>
+<td valign=\"top\">total stray coefficient sigma</td>
+<td valign=\"top\">0.0667</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>turnsRatio</td>
-<td>1</td><td>effective ratio of stator and rotor current</td>
+<td valign=\"top\">turnsRatio</td>
+<td valign=\"top\">1</td><td valign=\"top\">effective ratio of stator and rotor current</td>
 </tr>
 <tr>
-<td>stator operational temperature TsOperational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">stator operational temperature TsOperational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>rotor operational temperature TrOperational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">rotor operational temperature TrOperational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>These values give the following inductances:</td>
-<td> </td><td> </td>
+<td valign=\"top\">These values give the following inductances:</td>
+<td valign=\"top\"> </td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator stray inductance per phase</td>
-<td>Xs * (1 - sqrt(1-sigma))/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">stator stray inductance per phase</td>
+<td valign=\"top\">Xs * (1 - sqrt(1-sigma))/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>rotor stray inductance</td>
-<td>Xr * (1 - sqrt(1-sigma))/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">rotor stray inductance</td>
+<td valign=\"top\">Xr * (1 - sqrt(1-sigma))/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>main field inductance per phase</td>
-<td>sqrt(Xs*Xr * (1-sigma))/(2*pi*f)</td><td> </td>
+<td valign=\"top\">main field inductance per phase</td>
+<td valign=\"top\">sqrt(Xs*Xr * (1-sigma))/(2*pi*f)</td><td valign=\"top\"> </td>
 </tr>
 </table>
 <p>
@@ -7545,136 +7545,136 @@ Resistance and stray inductance of stator is modeled directly in stator phases, 
 <br><strong>Default values for machine's parameters (a realistic example) are:</strong><br></p>
 <table>
 <tr>
-<td>number of pole pairs p</td>
-<td>2</td><td> </td>
+<td valign=\"top\">number of pole pairs p</td>
+<td valign=\"top\">2</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator's moment of inertia</td>
-<td>0.29</td><td>kg.m2</td>
+<td valign=\"top\">stator's moment of inertia</td>
+<td valign=\"top\">0.29</td><td valign=\"top\">kg.m2</td>
 </tr>
 <tr>
-<td>rotor's moment of inertia</td>
-<td>0.29</td><td>kg.m2</td>
+<td valign=\"top\">rotor's moment of inertia</td>
+<td valign=\"top\">0.29</td><td valign=\"top\">kg.m2</td>
 </tr>
 <tr>
-<td>nominal frequency fNominal</td>
-<td>50</td><td>Hz</td>
+<td valign=\"top\">nominal frequency fNominal</td>
+<td valign=\"top\">50</td><td valign=\"top\">Hz</td>
 </tr>
 <tr>
-<td>nominal voltage per phase</td>
-<td>100</td><td>V RMS</td>
+<td valign=\"top\">nominal voltage per phase</td>
+<td valign=\"top\">100</td><td valign=\"top\">V RMS</td>
 </tr>
 <tr>
-<td>no-load voltage per phase</td>
-<td>112.3</td><td>V RMS @ nominal speed</td>
+<td valign=\"top\">no-load voltage per phase</td>
+<td valign=\"top\">112.3</td><td valign=\"top\">V RMS @ nominal speed</td>
 </tr>
 <tr>
-<td>nominal current per phase</td>
-<td>100</td><td>A RMS</td>
+<td valign=\"top\">nominal current per phase</td>
+<td valign=\"top\">100</td><td valign=\"top\">A RMS</td>
 </tr>
 <tr>
-<td>nominal torque</td>
-<td>181.4</td><td>Nm</td>
+<td valign=\"top\">nominal torque</td>
+<td valign=\"top\">181.4</td><td valign=\"top\">Nm</td>
 </tr>
 <tr>
-<td>nominal speed</td>
-<td>1500</td><td>rpm</td>
+<td valign=\"top\">nominal speed</td>
+<td valign=\"top\">1500</td><td valign=\"top\">rpm</td>
 </tr>
 <tr>
-<td>nominal mechanical output</td>
-<td>28.5</td><td>kW</td>
+<td valign=\"top\">nominal mechanical output</td>
+<td valign=\"top\">28.5</td><td valign=\"top\">kW</td>
 </tr>
 <tr>
-<td>nominal rotor angle</td>
-<td>20.75</td><td>degree</td>
+<td valign=\"top\">nominal rotor angle</td>
+<td valign=\"top\">20.75</td><td valign=\"top\">degree</td>
 </tr>
 <tr>
-<td>efficiency</td>
-<td>95.0</td><td>%</td>
+<td valign=\"top\">efficiency</td>
+<td valign=\"top\">95.0</td><td valign=\"top\">%</td>
 </tr>
 <tr>
-<td>power factor</td>
-<td>0.98</td><td> </td>
+<td valign=\"top\">power factor</td>
+<td valign=\"top\">0.98</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator resistance</td>
-<td>0.03</td><td>Ohm per phase at reference temperature</td>
+<td valign=\"top\">stator resistance</td>
+<td valign=\"top\">0.03</td><td valign=\"top\">Ohm per phase at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature TsRef</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature TsRef</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20s </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20s </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>stator reactance Xd</td>
-<td>0.4</td><td>Ohm per phase in d-axis</td>
+<td valign=\"top\">stator reactance Xd</td>
+<td valign=\"top\">0.4</td><td valign=\"top\">Ohm per phase in d-axis</td>
 </tr>
 <tr>
-<td>stator reactance Xq</td>
-<td>0.4</td><td>Ohm per phase in q-axis</td>
+<td valign=\"top\">stator reactance Xq</td>
+<td valign=\"top\">0.4</td><td valign=\"top\">Ohm per phase in q-axis</td>
 </tr>
 <tr>
-<td>stator stray reactance Xss</td>
-<td>0.1</td><td>Ohm per phase</td>
+<td valign=\"top\">stator stray reactance Xss</td>
+<td valign=\"top\">0.1</td><td valign=\"top\">Ohm per phase</td>
 </tr>
 <tr>
-<td>damper resistance in d-axis</td>
-<td>0.04</td><td>Ohm at reference temperature</td>
+<td valign=\"top\">damper resistance in d-axis</td>
+<td valign=\"top\">0.04</td><td valign=\"top\">Ohm at reference temperature</td>
 </tr>
 <tr>
-<td>damper resistance in q-axis</td>
-<td>same as d-axis</td><td> </td>
+<td valign=\"top\">damper resistance in q-axis</td>
+<td valign=\"top\">same as d-axis</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>reference temperature TrRef</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature TrRef</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20r </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20r </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>damper stray reactance in d-axis XDds</td>
-<td>0.05</td><td>Ohm</td>
+<td valign=\"top\">damper stray reactance in d-axis XDds</td>
+<td valign=\"top\">0.05</td><td valign=\"top\">Ohm</td>
 </tr>
 <tr>
-<td>damper stray reactance in q-axis XDqs</td>
-<td>same as d-axis</td><td> </td>
+<td valign=\"top\">damper stray reactance in q-axis XDqs</td>
+<td valign=\"top\">same as d-axis</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator operational temperature TsOperational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">stator operational temperature TsOperational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>damper operational temperature TrOperational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">damper operational temperature TrOperational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>These values give the following inductances:</td>
-<td> </td><td> </td>
+<td valign=\"top\">These values give the following inductances:</td>
+<td valign=\"top\"> </td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>main field inductance in d-axis</td>
-<td>(Xd - Xss)/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">main field inductance in d-axis</td>
+<td valign=\"top\">(Xd - Xss)/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>main field inductance in q-axis</td>
-<td>(Xq - Xss)/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">main field inductance in q-axis</td>
+<td valign=\"top\">(Xq - Xss)/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator stray inductance per phase</td>
-<td>Xss/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">stator stray inductance per phase</td>
+<td valign=\"top\">Xss/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>damper stray inductance in d-axis</td>
-<td>XDds/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">damper stray inductance in d-axis</td>
+<td valign=\"top\">XDds/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>damper stray inductance in q-axis</td>
-<td>XDqs/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">damper stray inductance in q-axis</td>
+<td valign=\"top\">XDqs/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 </table>
 </html>"));
@@ -7918,169 +7918,169 @@ Resistance and stray inductance of stator is modeled directly in stator phases, 
 <br><strong>Default values for machine's parameters (a realistic example) are:</strong><br></p>
 <table>
 <tr>
-<td>number of pole pairs p</td>
-<td>2</td><td> </td>
+<td valign=\"top\">number of pole pairs p</td>
+<td valign=\"top\">2</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator's moment of inertia</td>
-<td>0.29</td><td>kg.m2</td>
+<td valign=\"top\">stator's moment of inertia</td>
+<td valign=\"top\">0.29</td><td valign=\"top\">kg.m2</td>
 </tr>
 <tr>
-<td>rotor's moment of inertia</td>
-<td>0.29</td><td>kg.m2</td>
+<td valign=\"top\">rotor's moment of inertia</td>
+<td valign=\"top\">0.29</td><td valign=\"top\">kg.m2</td>
 </tr>
 <tr>
-<td>nominal frequency fNominal</td>
-<td>50</td><td>Hz</td>
+<td valign=\"top\">nominal frequency fNominal</td>
+<td valign=\"top\">50</td><td valign=\"top\">Hz</td>
 </tr>
 <tr>
-<td>nominal voltage per phase</td>
-<td>100</td><td>V RMS</td>
+<td valign=\"top\">nominal voltage per phase</td>
+<td valign=\"top\">100</td><td valign=\"top\">V RMS</td>
 </tr>
 <tr>
-<td>no-load excitation current<br>
+<td valign=\"top\">no-load excitation current<br>
     @ nominal voltage and frequency</td>
-<td>10</td><td>A DC</td>
+<td valign=\"top\">10</td><td valign=\"top\">A DC</td>
 </tr>
 <tr>
-<td>warm excitation resistance</td>
-<td>2.5</td><td>Ohm</td>
+<td valign=\"top\">warm excitation resistance</td>
+<td valign=\"top\">2.5</td><td valign=\"top\">Ohm</td>
 </tr>
 <tr>
-<td>nominal current per phase</td>
-<td>100</td><td>A RMS</td>
+<td valign=\"top\">nominal current per phase</td>
+<td valign=\"top\">100</td><td valign=\"top\">A RMS</td>
 </tr>
 <tr>
-<td>nominal apparent power</td>
-<td>-30000</td><td>VA</td>
+<td valign=\"top\">nominal apparent power</td>
+<td valign=\"top\">-30000</td><td valign=\"top\">VA</td>
 </tr>
 <tr>
-<td>power factor</td>
-<td>-1.0</td><td>ind./cap.</td>
+<td valign=\"top\">power factor</td>
+<td valign=\"top\">-1.0</td><td valign=\"top\">ind./cap.</td>
 </tr>
 <tr>
-<td>nominal excitation current</td>
-<td>19</td><td>A</td>
+<td valign=\"top\">nominal excitation current</td>
+<td valign=\"top\">19</td><td valign=\"top\">A</td>
 </tr>
 <tr>
-<td>efficiency w/o excitation</td>
-<td>97.1</td><td>%</td>
+<td valign=\"top\">efficiency w/o excitation</td>
+<td valign=\"top\">97.1</td><td valign=\"top\">%</td>
 </tr>
 <tr>
-<td>nominal torque</td>
-<td>-196.7</td><td>Nm</td>
+<td valign=\"top\">nominal torque</td>
+<td valign=\"top\">-196.7</td><td valign=\"top\">Nm</td>
 </tr>
 <tr>
-<td>nominal speed</td>
-<td>1500</td><td>rpm</td>
+<td valign=\"top\">nominal speed</td>
+<td valign=\"top\">1500</td><td valign=\"top\">rpm</td>
 </tr>
 <tr>
-<td>nominal rotor angle</td>
-<td>-57.23</td><td>degree</td>
+<td valign=\"top\">nominal rotor angle</td>
+<td valign=\"top\">-57.23</td><td valign=\"top\">degree</td>
 </tr>
 <tr>
-<td>stator resistance</td>
-<td>0.03</td><td>Ohm per phase at reference temperature</td>
+<td valign=\"top\">stator resistance</td>
+<td valign=\"top\">0.03</td><td valign=\"top\">Ohm per phase at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature TsRef</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature TsRef</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20s </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20s </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>stator reactance Xd</td>
-<td>1.6</td><td>Ohm per phase in d-axis</td>
+<td valign=\"top\">stator reactance Xd</td>
+<td valign=\"top\">1.6</td><td valign=\"top\">Ohm per phase in d-axis</td>
 </tr>
 <tr>
-<td>giving Kc</td>
-<td>0.625</td><td> </td>
+<td valign=\"top\">giving Kc</td>
+<td valign=\"top\">0.625</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator reactance Xq</td>
-<td>1.6</td><td>Ohm per phase in q-axis</td>
+<td valign=\"top\">stator reactance Xq</td>
+<td valign=\"top\">1.6</td><td valign=\"top\">Ohm per phase in q-axis</td>
 </tr>
 <tr>
-<td>stator stray reactance Xss</td>
-<td>0.1</td><td>Ohm per phase</td>
+<td valign=\"top\">stator stray reactance Xss</td>
+<td valign=\"top\">0.1</td><td valign=\"top\">Ohm per phase</td>
 </tr>
 <tr>
-<td>damper resistance in d-axis</td>
-<td>0.04</td><td>Ohm at reference temperature</td>
+<td valign=\"top\">damper resistance in d-axis</td>
+<td valign=\"top\">0.04</td><td valign=\"top\">Ohm at reference temperature</td>
 </tr>
 <tr>
-<td>damper resistance in q-axis</td>
-<td>same as d-axis</td><td> </td>
+<td valign=\"top\">damper resistance in q-axis</td>
+<td valign=\"top\">same as d-axis</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>reference temperature TrRef</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature TrRef</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20r </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20r </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>damper stray reactance in d-axis XDds</td>
-<td>0.05</td><td>Ohm</td>
+<td valign=\"top\">damper stray reactance in d-axis XDds</td>
+<td valign=\"top\">0.05</td><td valign=\"top\">Ohm</td>
 </tr>
 <tr>
-<td>damper stray reactance in q-axis XDqs</td>
-<td>same as d-axis</td><td> </td>
+<td valign=\"top\">damper stray reactance in q-axis XDqs</td>
+<td valign=\"top\">same as d-axis</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>excitation resistance</td>
-<td>2.5</td><td>Ohm at reference temperature</td>
+<td valign=\"top\">excitation resistance</td>
+<td valign=\"top\">2.5</td><td valign=\"top\">Ohm at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature TeRef</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature TeRef</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20e </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20e </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>excitation stray inductance</td>
-<td>2.5</td><td>% of total excitation inductance</td>
+<td valign=\"top\">excitation stray inductance</td>
+<td valign=\"top\">2.5</td><td valign=\"top\">% of total excitation inductance</td>
 </tr>
 <tr>
-<td>stator operational temperature TsOperational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">stator operational temperature TsOperational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>damper operational temperature TrOperational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">damper operational temperature TrOperational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>excitation operational temperature TeOperational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">excitation operational temperature TeOperational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>These values give the following inductances:</td>
-<td> </td><td> </td>
+<td valign=\"top\">These values give the following inductances:</td>
+<td valign=\"top\"> </td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>main field inductance in d-axis</td>
-<td>(Xd - Xss)/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">main field inductance in d-axis</td>
+<td valign=\"top\">(Xd - Xss)/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>main field inductance in q-axis</td>
-<td>(Xq - Xss)/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">main field inductance in q-axis</td>
+<td valign=\"top\">(Xq - Xss)/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator stray inductance per phase</td>
-<td>Xss/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">stator stray inductance per phase</td>
+<td valign=\"top\">Xss/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>damper stray inductance in d-axis</td>
-<td>XDds/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">damper stray inductance in d-axis</td>
+<td valign=\"top\">XDds/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>damper stray inductance in q-axis</td>
-<td>XDqs/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">damper stray inductance in q-axis</td>
+<td valign=\"top\">XDqs/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 </table>
 </html>"));
@@ -8235,128 +8235,128 @@ Resistance and stray inductance of stator is modeled directly in stator phases, 
 <br><strong>Default values for machine's parameters (a realistic example) are:</strong><br></p>
 <table>
 <tr>
-<td>number of pole pairs p</td>
-<td>2</td><td> </td>
+<td valign=\"top\">number of pole pairs p</td>
+<td valign=\"top\">2</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator's moment of inertia</td>
-<td>0.29</td><td>kg.m2</td>
+<td valign=\"top\">stator's moment of inertia</td>
+<td valign=\"top\">0.29</td><td valign=\"top\">kg.m2</td>
 </tr>
 <tr>
-<td>rotor's moment of inertia</td>
-<td>0.29</td><td>kg.m2</td>
+<td valign=\"top\">rotor's moment of inertia</td>
+<td valign=\"top\">0.29</td><td valign=\"top\">kg.m2</td>
 </tr>
 <tr>
-<td>nominal frequency fNominal</td>
-<td>50</td><td>Hz</td>
+<td valign=\"top\">nominal frequency fNominal</td>
+<td valign=\"top\">50</td><td valign=\"top\">Hz</td>
 </tr>
 <tr>
-<td>nominal voltage per phase</td>
-<td>100</td><td>V RMS</td>
+<td valign=\"top\">nominal voltage per phase</td>
+<td valign=\"top\">100</td><td valign=\"top\">V RMS</td>
 </tr>
 <tr>
-<td>nominal current per phase</td>
-<td>50</td><td>A RMS</td>
+<td valign=\"top\">nominal current per phase</td>
+<td valign=\"top\">50</td><td valign=\"top\">A RMS</td>
 </tr>
 <tr>
-<td>nominal torque</td>
-<td> 46</td><td>Nm</td>
+<td valign=\"top\">nominal torque</td>
+<td valign=\"top\"> 46</td><td valign=\"top\">Nm</td>
 </tr>
 <tr>
-<td>nominal speed</td>
-<td>1500</td><td>rpm</td>
+<td valign=\"top\">nominal speed</td>
+<td valign=\"top\">1500</td><td valign=\"top\">rpm</td>
 </tr>
 <tr>
-<td>nominal mechanical output</td>
-<td> 7.23</td><td>kW</td>
+<td valign=\"top\">nominal mechanical output</td>
+<td valign=\"top\"> 7.23</td><td valign=\"top\">kW</td>
 </tr>
 <tr>
-<td>efficiency</td>
-<td>96.98</td><td>%</td>
+<td valign=\"top\">efficiency</td>
+<td valign=\"top\">96.98</td><td valign=\"top\">%</td>
 </tr>
 <tr>
-<td>power factor</td>
-<td>0.497</td><td> </td>
+<td valign=\"top\">power factor</td>
+<td valign=\"top\">0.497</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator resistance</td>
-<td>0.03</td><td>Ohm per phase at reference temperature</td>
+<td valign=\"top\">stator resistance</td>
+<td valign=\"top\">0.03</td><td valign=\"top\">Ohm per phase at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature TsRef</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature TsRef</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20s </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20s </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>rotor resistance in d-axis</td>
-<td>0.04</td><td>Ohm at reference temperature</td>
+<td valign=\"top\">rotor resistance in d-axis</td>
+<td valign=\"top\">0.04</td><td valign=\"top\">Ohm at reference temperature</td>
 </tr>
 <tr>
-<td>rotor resistance in q-axis</td>
-<td>same as d-axis</td><td> </td>
+<td valign=\"top\">rotor resistance in q-axis</td>
+<td valign=\"top\">same as d-axis</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>reference temperature TrRef</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature TrRef</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20r </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20r </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>stator reactance Xsd in d-axis</td>
-<td>3</td><td>Ohm per phase</td>
+<td valign=\"top\">stator reactance Xsd in d-axis</td>
+<td valign=\"top\">3</td><td valign=\"top\">Ohm per phase</td>
 </tr>
 <tr>
-<td>stator reactance Xsq in q-axis</td>
-<td>1</td><td>Ohm</td>
+<td valign=\"top\">stator reactance Xsq in q-axis</td>
+<td valign=\"top\">1</td><td valign=\"top\">Ohm</td>
 </tr>
 <tr>
-<td>stator stray reactance Xss</td>
-<td>0.1</td><td>Ohm per phase</td>
+<td valign=\"top\">stator stray reactance Xss</td>
+<td valign=\"top\">0.1</td><td valign=\"top\">Ohm per phase</td>
 </tr>
 <tr>
-<td>rotor stray reactance in d-axis Xrds</td>
-<td>0.05</td><td>Ohm per phase</td>
+<td valign=\"top\">rotor stray reactance in d-axis Xrds</td>
+<td valign=\"top\">0.05</td><td valign=\"top\">Ohm per phase</td>
 </tr>
 <tr>
-<td>rotor stray reactance in q-axis Xrqs</td>
-<td>same as d-axis</td><td> </td>
+<td valign=\"top\">rotor stray reactance in q-axis Xrqs</td>
+<td valign=\"top\">same as d-axis</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator operational temperature TsOperational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">stator operational temperature TsOperational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>damper operational temperature TrOperational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">damper operational temperature TrOperational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>These values give the following inductances:</td>
-<td> </td><td> </td>
+<td valign=\"top\">These values give the following inductances:</td>
+<td valign=\"top\"> </td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>stator stray inductance per phase</td>
-<td>Xss/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">stator stray inductance per phase</td>
+<td valign=\"top\">Xss/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>rotor stray inductance in d-axis</td>
-<td>Xrds/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">rotor stray inductance in d-axis</td>
+<td valign=\"top\">Xrds/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>rotor stray inductance in q-axis</td>
-<td>Xrqs/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">rotor stray inductance in q-axis</td>
+<td valign=\"top\">Xrqs/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>main field inductance per phase in d-axis</td>
-<td>(Xsd-Xss)/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">main field inductance per phase in d-axis</td>
+<td valign=\"top\">(Xsd-Xss)/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>main field inductance per phase in q-axis</td>
-<td>(Xsq-Xss)/(2*pi*fNominal)</td><td> </td>
+<td valign=\"top\">main field inductance per phase in q-axis</td>
+<td valign=\"top\">(Xsq-Xss)/(2*pi*fNominal)</td><td valign=\"top\"> </td>
 </tr>
 </table>
 </html>"));
@@ -8512,60 +8512,60 @@ Armature resistance and inductance are modeled directly after the armature pins,
 <br><strong>Default values for machine's parameters (a realistic example) are:</strong><br></p>
 <table>
 <tr>
-<td>stator's moment of inertia</td>
-<td>0.29</td><td>kg.m2</td>
+<td valign=\"top\">stator's moment of inertia</td>
+<td valign=\"top\">0.29</td><td valign=\"top\">kg.m2</td>
 </tr>
 <tr>
-<td>rotor's moment of inertia</td>
-<td>0.15</td><td>kg.m2</td>
+<td valign=\"top\">rotor's moment of inertia</td>
+<td valign=\"top\">0.15</td><td valign=\"top\">kg.m2</td>
 </tr>
 <tr>
-<td>nominal armature voltage</td>
-<td>100</td><td>V</td>
+<td valign=\"top\">nominal armature voltage</td>
+<td valign=\"top\">100</td><td valign=\"top\">V</td>
 </tr>
 <tr>
-<td>nominal armature current</td>
-<td>100</td><td>A</td>
+<td valign=\"top\">nominal armature current</td>
+<td valign=\"top\">100</td><td valign=\"top\">A</td>
 </tr>
 <tr>
-<td>nominal speed</td>
-<td>1425</td><td>rpm</td>
+<td valign=\"top\">nominal speed</td>
+<td valign=\"top\">1425</td><td valign=\"top\">rpm</td>
 </tr>
 <tr>
-<td>nominal torque</td>
-<td>63.66</td><td>Nm</td>
+<td valign=\"top\">nominal torque</td>
+<td valign=\"top\">63.66</td><td valign=\"top\">Nm</td>
 </tr>
 <tr>
-<td>nominal mechanical output</td>
-<td>9.5</td><td>kW</td>
+<td valign=\"top\">nominal mechanical output</td>
+<td valign=\"top\">9.5</td><td valign=\"top\">kW</td>
 </tr>
 <tr>
-<td>efficiency</td>
-<td>95.0</td><td>%</td>
+<td valign=\"top\">efficiency</td>
+<td valign=\"top\">95.0</td><td valign=\"top\">%</td>
 </tr>
 <tr>
-<td>armature resistance</td>
-<td>0.05</td><td>Ohm at reference temperature</td>
+<td valign=\"top\">armature resistance</td>
+<td valign=\"top\">0.05</td><td valign=\"top\">Ohm at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature TaRef</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature TaRef</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20a </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20a </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>armature inductance</td>
-<td>0.0015</td><td>H</td>
+<td valign=\"top\">armature inductance</td>
+<td valign=\"top\">0.0015</td><td valign=\"top\">H</td>
 </tr>
 <tr>
-<td>armature nominal temperature TaNominal</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">armature nominal temperature TaNominal</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>armature operational temperature TaOperational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">armature operational temperature TaOperational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 </table>
 Armature resistance resp. inductance include resistance resp. inductance of commutating pole winding and compensation winding, if present.
@@ -8719,96 +8719,96 @@ Shunt or separate excitation is defined by the user's external circuit.
 <br><strong>Default values for machine's parameters (a realistic example) are:</strong><br></p>
 <table>
 <tr>
-<td>stator's moment of inertia</td>
-<td>0.29</td><td>kg.m2</td>
+<td valign=\"top\">stator's moment of inertia</td>
+<td valign=\"top\">0.29</td><td valign=\"top\">kg.m2</td>
 </tr>
 <tr>
-<td>rotor's moment of inertia</td>
-<td>0.15</td><td>kg.m2</td>
+<td valign=\"top\">rotor's moment of inertia</td>
+<td valign=\"top\">0.15</td><td valign=\"top\">kg.m2</td>
 </tr>
 <tr>
-<td>nominal armature voltage</td>
-<td>100</td><td>V</td>
+<td valign=\"top\">nominal armature voltage</td>
+<td valign=\"top\">100</td><td valign=\"top\">V</td>
 </tr>
 <tr>
-<td>nominal armature current</td>
-<td>100</td><td>A</td>
+<td valign=\"top\">nominal armature current</td>
+<td valign=\"top\">100</td><td valign=\"top\">A</td>
 </tr>
 <tr>
-<td>nominal torque</td>
-<td>63.66</td><td>Nm</td>
+<td valign=\"top\">nominal torque</td>
+<td valign=\"top\">63.66</td><td valign=\"top\">Nm</td>
 </tr>
 <tr>
-<td>nominal speed</td>
-<td>1425</td><td>rpm</td>
+<td valign=\"top\">nominal speed</td>
+<td valign=\"top\">1425</td><td valign=\"top\">rpm</td>
 </tr>
 <tr>
-<td>nominal mechanical output</td>
-<td>9.5</td><td>kW</td>
+<td valign=\"top\">nominal mechanical output</td>
+<td valign=\"top\">9.5</td><td valign=\"top\">kW</td>
 </tr>
 <tr>
-<td>efficiency</td>
-<td>95.0</td><td>% only armature</td>
+<td valign=\"top\">efficiency</td>
+<td valign=\"top\">95.0</td><td valign=\"top\">% only armature</td>
 </tr>
 <tr>
-<td>efficiency</td>
-<td>94.06</td><td>% including excitation</td>
+<td valign=\"top\">efficiency</td>
+<td valign=\"top\">94.06</td><td valign=\"top\">% including excitation</td>
 </tr>
 <tr>
-<td>armature resistance</td>
-<td>0.05</td><td>Ohm at reference temperature</td>
+<td valign=\"top\">armature resistance</td>
+<td valign=\"top\">0.05</td><td valign=\"top\">Ohm at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature TaRef</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature TaRef</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20a </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20a </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>armature inductance</td>
-<td>0.0015</td><td>H</td>
+<td valign=\"top\">armature inductance</td>
+<td valign=\"top\">0.0015</td><td valign=\"top\">H</td>
 </tr>
 <tr>
-<td>nominal excitation voltage</td>
-<td>100</td><td>V</td>
+<td valign=\"top\">nominal excitation voltage</td>
+<td valign=\"top\">100</td><td valign=\"top\">V</td>
 </tr>
 <tr>
-<td>nominal excitation current</td>
-<td>1</td><td>A</td>
+<td valign=\"top\">nominal excitation current</td>
+<td valign=\"top\">1</td><td valign=\"top\">A</td>
 </tr>
 <tr>
-<td>excitation resistance</td>
-<td>100</td><td>Ohm at reference temperature</td>
+<td valign=\"top\">excitation resistance</td>
+<td valign=\"top\">100</td><td valign=\"top\">Ohm at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature TeRef</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature TeRef</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20e </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20e </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>excitation inductance</td>
-<td>1</td><td>H</td>
+<td valign=\"top\">excitation inductance</td>
+<td valign=\"top\">1</td><td valign=\"top\">H</td>
 </tr>
 <tr>
-<td>stray part of excitation inductance</td>
-<td>0</td><td> </td>
+<td valign=\"top\">stray part of excitation inductance</td>
+<td valign=\"top\">0</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>armature nominal temperature TaNominal</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">armature nominal temperature TaNominal</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>armature operational temperature TaOperational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">armature operational temperature TaOperational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>(shunt) excitation operational temperature TeOperational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">(shunt) excitation operational temperature TeOperational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 </table>
 Armature resistance resp. inductance include resistance resp. inductance of commutating pole winding and
@@ -8967,88 +8967,88 @@ Series excitation has to be connected by the user's external circuit.
 <br><strong>Default values for machine's parameters (a realistic example) are:</strong><br></p>
 <table>
 <tr>
-<td>stator's moment of inertia</td>
-<td>0.29</td><td>kg.m2</td>
+<td valign=\"top\">stator's moment of inertia</td>
+<td valign=\"top\">0.29</td><td valign=\"top\">kg.m2</td>
 </tr>
 <tr>
-<td>rotor's moment of inertia</td>
-<td>0.15</td><td>kg.m2</td>
+<td valign=\"top\">rotor's moment of inertia</td>
+<td valign=\"top\">0.15</td><td valign=\"top\">kg.m2</td>
 </tr>
 <tr>
-<td>nominal armature voltage</td>
-<td>100</td><td>V</td>
+<td valign=\"top\">nominal armature voltage</td>
+<td valign=\"top\">100</td><td valign=\"top\">V</td>
 </tr>
 <tr>
-<td>nominal armature current</td>
-<td>100</td><td>A</td>
+<td valign=\"top\">nominal armature current</td>
+<td valign=\"top\">100</td><td valign=\"top\">A</td>
 </tr>
 <tr>
-<td>nominal torque</td>
-<td>63.66</td><td>Nm</td>
+<td valign=\"top\">nominal torque</td>
+<td valign=\"top\">63.66</td><td valign=\"top\">Nm</td>
 </tr>
 <tr>
-<td>nominal speed</td>
-<td>1410</td><td>rpm</td>
+<td valign=\"top\">nominal speed</td>
+<td valign=\"top\">1410</td><td valign=\"top\">rpm</td>
 </tr>
 <tr>
-<td>nominal mechanical output</td>
-<td>9.4</td><td>kW</td>
+<td valign=\"top\">nominal mechanical output</td>
+<td valign=\"top\">9.4</td><td valign=\"top\">kW</td>
 </tr>
 <tr>
-<td>efficiency</td>
-<td>94.0</td><td>% only armature</td>
+<td valign=\"top\">efficiency</td>
+<td valign=\"top\">94.0</td><td valign=\"top\">% only armature</td>
 </tr>
 <tr>
-<td>armature resistance</td>
-<td>0.05</td><td>Ohm at reference temperature</td>
+<td valign=\"top\">armature resistance</td>
+<td valign=\"top\">0.05</td><td valign=\"top\">Ohm at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature TaRef</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature TaRef</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20a </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20a </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>armature inductance</td>
-<td>0.0015</td><td>H</td>
+<td valign=\"top\">armature inductance</td>
+<td valign=\"top\">0.0015</td><td valign=\"top\">H</td>
 </tr>
 <tr>
-<td>excitation resistance</td>
-<td>0.01</td><td>Ohm at reference temperature</td>
+<td valign=\"top\">excitation resistance</td>
+<td valign=\"top\">0.01</td><td valign=\"top\">Ohm at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature TeRef</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature TeRef</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20e</td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20e</td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>excitation inductance</td>
-<td>0.0005</td><td>H</td>
+<td valign=\"top\">excitation inductance</td>
+<td valign=\"top\">0.0005</td><td valign=\"top\">H</td>
 </tr>
 <tr>
-<td>stray part of excitation inductance</td>
-<td>0</td><td> </td>
+<td valign=\"top\">stray part of excitation inductance</td>
+<td valign=\"top\">0</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>armature nominal temperature TaNominal</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">armature nominal temperature TaNominal</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>series excitation nominal temperature TeNominal</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">series excitation nominal temperature TeNominal</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>armature operational temperature TaOperational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">armature operational temperature TaOperational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>series excitation operational temperature TeOperational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">series excitation operational temperature TeOperational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 </table>
 Armature resistance resp. inductance include resistance resp. inductance of commutating pole winding and
@@ -15946,76 +15946,76 @@ Circuit layout (vector group) of primary and secondary windings have to be defin
 <br><strong>Default values for transformer's parameters (a realistic example) are:</strong><br>
 <table>
 <tr>
-<td>turns ratio n</td>
-<td>1</td><td> </td>
+<td valign=\"top\">turns ratio n</td>
+<td valign=\"top\">1</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>nominal frequency fNominal</td>
-<td>50</td><td>Hz</td>
+<td valign=\"top\">nominal frequency fNominal</td>
+<td valign=\"top\">50</td><td valign=\"top\">Hz</td>
 </tr>
 <tr>
-<td>nominal voltage per phase</td>
-<td>100</td><td>V RMS</td>
+<td valign=\"top\">nominal voltage per phase</td>
+<td valign=\"top\">100</td><td valign=\"top\">V RMS</td>
 </tr>
 <tr>
-<td>nominal current per phase</td>
-<td>100</td><td>A RMS</td>
+<td valign=\"top\">nominal current per phase</td>
+<td valign=\"top\">100</td><td valign=\"top\">A RMS</td>
 </tr>
 <tr>
-<td>nominal apparent power</td>
-<td>30</td><td>kVA</td>
+<td valign=\"top\">nominal apparent power</td>
+<td valign=\"top\">30</td><td valign=\"top\">kVA</td>
 </tr>
 <tr>
-<td>primary resistance R1</td>
-<td>0.005</td><td>Ohm per phase at reference temperature</td>
+<td valign=\"top\">primary resistance R1</td>
+<td valign=\"top\">0.005</td><td valign=\"top\">Ohm per phase at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature T1Ref</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature T1Ref</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20_1 </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20_1 </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>primary stray inductance L1sigma</td>
-<td>78E-6</td><td>H per phase</td>
+<td valign=\"top\">primary stray inductance L1sigma</td>
+<td valign=\"top\">78E-6</td><td valign=\"top\">H per phase</td>
 </tr>
 <tr>
-<td>secondary resistance R2</td>
-<td>0.005</td><td>Ohm per phase at reference temperature</td>
+<td valign=\"top\">secondary resistance R2</td>
+<td valign=\"top\">0.005</td><td valign=\"top\">Ohm per phase at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature T2Ref</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature T2Ref</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20_2 </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20_2 </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>secondary stray inductance L2sigma</td>
-<td>78E-6</td><td>H per phase</td>
+<td valign=\"top\">secondary stray inductance L2sigma</td>
+<td valign=\"top\">78E-6</td><td valign=\"top\">H per phase</td>
 </tr>
 <tr>
-<td>operational temperature T1Operational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">operational temperature T1Operational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>operational temperature T2Operational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">operational temperature T2Operational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>These values give the operational parameters:</td>
-<td> </td><td> </td>
+<td valign=\"top\">These values give the operational parameters:</td>
+<td valign=\"top\"> </td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>nominal voltage drop</td>
-<td>0.05</td><td>p.u.</td>
+<td valign=\"top\">nominal voltage drop</td>
+<td valign=\"top\">0.05</td><td valign=\"top\">p.u.</td>
 </tr>
 <tr>
-<td>nominal copper losses</td>
-<td>300</td><td>W</td>
+<td valign=\"top\">nominal copper losses</td>
+<td valign=\"top\">300</td><td valign=\"top\">W</td>
 </tr>
 </table>
 </html>"));

--- a/Modelica/Electrical/MultiPhase.mo
+++ b/Modelica/Electrical/MultiPhase.mo
@@ -169,8 +169,8 @@ email: <a href=\"mailto:a.haumer@haumer.at\">a.haumer@haumer.at</a><br>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
     <tr>
-      <td>[Vaske1963]</td>
-      <td>P. Vaske,
+      <td valign=\"top\">[Vaske1963]</td>
+      <td valign=\"top\">P. Vaske,
         &quot;&Uuml;ber die Drehfelder und Drehmomente symmetrischer Komponenten in Induktionsmaschinen,&quot;
         (in German), <em>Archiv f&uuml;r Elektrotechnik</em>
         vol 2, 1963, pp. 97-117.</td>

--- a/Modelica/Electrical/PowerConverters.mo
+++ b/Modelica/Electrical/PowerConverters.mo
@@ -149,23 +149,23 @@ email: <a href=\"mailto:a.haumer@haumer.at\">a.haumer@haumer.at</a>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
     <tr>
-      <td>[Skvarenina01]</td>
-      <td>Timothy L. Skvarenina,
+      <td valign=\"top\">[Skvarenina01]</td>
+      <td valign=\"top\">Timothy L. Skvarenina,
         <a href=\"http://www.crcpress.com/product/isbn/9780849373367\">
         <em>The Power Electronics Handbook</em></a>,
         CRC Press 2001, ISBN 9780849373367</td>
     </tr>
 
     <tr>
-      <td>[Luo05]</td>
-      <td>Fang Lin Luo, Hong Ye and Muhammad H. Rashid,
+      <td valign=\"top\">[Luo05]</td>
+      <td valign=\"top\">Fang Lin Luo, Hong Ye and Muhammad H. Rashid,
         <a href=\"http://store.elsevier.com/product.jsp?isbn=9780120887576&amp;_requestid=1725\"><em>Digital Power Electronics and Applications</em></a>,
         Elsevier Academic Press, 2005, ISBN 978-0120887576</td>
     </tr>
 
     <tr>
-      <td>[Williams2006]</td>
-      <td><a href=\"http://www.freescience.info/go.php?pagename=books&amp;id=1732\">
+      <td valign=\"top\">[Williams2006]</td>
+      <td valign=\"top\"><a href=\"http://www.freescience.info/go.php?pagename=books&amp;id=1732\">
 <em>Principles and Elements of Power Electronics: Devices, Drivers, Applications, and Passive Components</em></a>, available at <a href=\"http://www.freescience.info/go.php?pagename=books&amp;id=1732\">FreeScience</a>, ISBN 978-0-9553384-0-3</td>
     </tr>
 </table>

--- a/Modelica/Electrical/QuasiStationary/Machines.mo
+++ b/Modelica/Electrical/QuasiStationary/Machines.mo
@@ -2383,76 +2383,76 @@ Circuit layout (vector group) of primary and secondary windings have to be defin
 <br><strong>Default values for transformer's parameters (a realistic example) are:</strong><br>
 <table>
 <tr>
-<td>turns ratio n</td>
-<td>1</td><td> </td>
+<td valign=\"top\">turns ratio n</td>
+<td valign=\"top\">1</td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>nominal frequency fNominal</td>
-<td>50</td><td>Hz</td>
+<td valign=\"top\">nominal frequency fNominal</td>
+<td valign=\"top\">50</td><td valign=\"top\">Hz</td>
 </tr>
 <tr>
-<td>nominal voltage per phase</td>
-<td>100</td><td>V RMS</td>
+<td valign=\"top\">nominal voltage per phase</td>
+<td valign=\"top\">100</td><td valign=\"top\">V RMS</td>
 </tr>
 <tr>
-<td>nominal current per phase</td>
-<td>100</td><td>A RMS</td>
+<td valign=\"top\">nominal current per phase</td>
+<td valign=\"top\">100</td><td valign=\"top\">A RMS</td>
 </tr>
 <tr>
-<td>nominal apparent power</td>
-<td>30</td><td>kVA</td>
+<td valign=\"top\">nominal apparent power</td>
+<td valign=\"top\">30</td><td valign=\"top\">kVA</td>
 </tr>
 <tr>
-<td>primary resistance R1</td>
-<td>0.005</td><td>Ohm per phase at reference temperature</td>
+<td valign=\"top\">primary resistance R1</td>
+<td valign=\"top\">0.005</td><td valign=\"top\">Ohm per phase at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature T1Ref</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature T1Ref</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20_1 </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20_1 </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>primary stray inductance L1sigma</td>
-<td>78E-6</td><td>H per phase</td>
+<td valign=\"top\">primary stray inductance L1sigma</td>
+<td valign=\"top\">78E-6</td><td valign=\"top\">H per phase</td>
 </tr>
 <tr>
-<td>secondary resistance R2</td>
-<td>0.005</td><td>Ohm per phase at reference temperature</td>
+<td valign=\"top\">secondary resistance R2</td>
+<td valign=\"top\">0.005</td><td valign=\"top\">Ohm per phase at reference temperature</td>
 </tr>
 <tr>
-<td>reference temperature T2Ref</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">reference temperature T2Ref</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>temperature coefficient alpha20_2 </td>
-<td>0</td><td>1/K</td>
+<td valign=\"top\">temperature coefficient alpha20_2 </td>
+<td valign=\"top\">0</td><td valign=\"top\">1/K</td>
 </tr>
 <tr>
-<td>secondary stray inductance L2sigma</td>
-<td>78E-6</td><td>H per phase</td>
+<td valign=\"top\">secondary stray inductance L2sigma</td>
+<td valign=\"top\">78E-6</td><td valign=\"top\">H per phase</td>
 </tr>
 <tr>
-<td>operational temperature T1Operational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">operational temperature T1Operational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>operational temperature T2Operational</td>
-<td>20</td><td>&deg;C</td>
+<td valign=\"top\">operational temperature T2Operational</td>
+<td valign=\"top\">20</td><td valign=\"top\">&deg;C</td>
 </tr>
 <tr>
-<td>These values give the operational parameters:</td>
-<td> </td><td> </td>
+<td valign=\"top\">These values give the operational parameters:</td>
+<td valign=\"top\"> </td><td valign=\"top\"> </td>
 </tr>
 <tr>
-<td>nominal voltage drop</td>
-<td>0.05</td><td>p.u.</td>
+<td valign=\"top\">nominal voltage drop</td>
+<td valign=\"top\">0.05</td><td valign=\"top\">p.u.</td>
 </tr>
 <tr>
-<td>nominal copper losses</td>
-<td>300</td><td>W</td>
+<td valign=\"top\">nominal copper losses</td>
+<td valign=\"top\">300</td><td valign=\"top\">W</td>
 </tr>
 </table>
 </html>"));

--- a/Modelica/Electrical/QuasiStationary/UsersGuide.mo
+++ b/Modelica/Electrical/QuasiStationary/UsersGuide.mo
@@ -479,50 +479,50 @@ ideal AC DC converter</a>, which is used in the
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
     <tr>
-      <td>[Dorf1993]</td>
-      <td>R. C. Dorf
+      <td valign=\"top\">[Dorf1993]</td>
+      <td valign=\"top\">R. C. Dorf
         <em>The Electrical Engineering</em>,
         VDE, 1993.</td>
     </tr>
 
     <tr>
-      <td>[Boas1966]</td>
-      <td>M. L. Boas
+      <td valign=\"top\">[Boas1966]</td>
+      <td valign=\"top\">M. L. Boas
         <em>Mathematical Methods in the Physical Sciences</em>,
         J. Wiley &amp; Sons, New York, 1966.</td>
     </tr>
 
     <tr>
-      <td>[Burton1994]</td>
-      <td>T. Burton
+      <td valign=\"top\">[Burton1994]</td>
+      <td valign=\"top\">T. Burton
         <em>Introduction to Dynamic Systems Analysis</em>,
         McGraw Hill, New York, 1994.</td>
     </tr>
 
     <tr>
-      <td>[Landolt1936]</td>
-      <td>M. Landolt
+      <td valign=\"top\">[Landolt1936]</td>
+      <td valign=\"top\">M. Landolt
         <em>Komplexe Zahlen und Zeiger in der Wechselstromlehre</em>,
         Springer Verlag, Berlin, 1936</td>
     </tr>
 
     <tr>
-      <td>[Philippow1967]</td>
-      <td>E. Philippow
+      <td valign=\"top\">[Philippow1967]</td>
+      <td valign=\"top\">E. Philippow
         <em>Grundlagen der Elektrotechnik</em>,
        Akademischer Verlag, Leipzig, 1967.</td>
     </tr>
 
     <tr>
-      <td>[Weyh1967]</td>
-      <td>Weyh and Benzinger
+      <td valign=\"top\">[Weyh1967]</td>
+      <td valign=\"top\">Weyh and Benzinger
         <em>Die Grundlagen der Wechselstromlehre</em>,
        R. Oldenbourg Verlag, 1967.</td>
     </tr>
 
     <tr>
-      <td>[Vaske1973]</td>
-      <td>P. Vaske
+      <td valign=\"top\">[Vaske1973]</td>
+      <td valign=\"top\">P. Vaske
         <em>Berechnung von Drehstromschaltungen</em>,
        B.G. Teubner Verlag, 1973.</td>
     </tr>

--- a/Modelica/Electrical/QuasiStationary/package.mo
+++ b/Modelica/Electrical/QuasiStationary/package.mo
@@ -41,11 +41,11 @@ Copyright &copy; 1998-2018, Modelica Association, Anton Haumer, Christian Kral a
       <th>Comment</th>
     </tr>
     <tr>
-      <td>1.0.0</td>
-      <td> </td>
-      <td>2010-01-30</td>
-      <td>A. Haumer<br>C. Kral</td>
-      <td></td>
+      <td valign=\"top\">1.0.0</td>
+      <td valign=\"top\"> </td>
+      <td valign=\"top\">2010-01-30</td>
+      <td valign=\"top\">A. Haumer<br>C. Kral</td>
+      <td valign=\"top\"></td>
     </tr>
 </table>
 </html>"),

--- a/Modelica/Electrical/Spice3.mo
+++ b/Modelica/Electrical/Spice3.mo
@@ -55,7 +55,7 @@ extends Modelica.Icons.Package;
 <table cellspacing=\"0\" cellpadding=\"0\" border=\"1\">
 <caption>Table 1: Translation of the SPICE3 netlist (left side) to Modelica (right side)</caption>
 <tr>
-<td><pre>
+<td valign=\"top\"><pre>
 inverter
 
 Mp1 11 1 13 11 MPmos
@@ -83,7 +83,7 @@ Vdrain 11 0 PULSE(0 5 0s 1s)
 
 .tran 0.01 5
 .end</pre></td>
-<td><pre>
+<td valign=\"top\"><pre>
 model inverter
   Spice3.Basic.Ground g;
   Spice3&hellip;M Mp1(mtype=true, M(GAMMA=0.37));
@@ -182,28 +182,28 @@ connect(p_out, n2);
 
     annotation (Documentation(info="<html>
 <table cellspacing=\"0\" cellpadding=\"2\" border=\"0\"><tr>
-<td><p>[B&ouml;hme2009]</p></td>
-<td><p>S. B&ouml;hme, K. Majetta, C. Clauss, P. Schneider, &quot;Spice3 Modelica Library,&quot; <em>7th Modelica Conference</em>, Como, Italy (2009)</p></td>
+<td valign=\"top\"><p>[B&ouml;hme2009]</p></td>
+<td valign=\"top\"><p>S. B&ouml;hme, K. Majetta, C. Clauss, P. Schneider, &quot;Spice3 Modelica Library,&quot; <em>7th Modelica Conference</em>, Como, Italy (2009)</p></td>
 <td></td>
 </tr>
 <tr>
-<td><p>[Antognetti1988]</p></td>
-<td><p>P. Antognetti, G. Massobrio, <em>Semiconductor Device Modeling with SPICE.</em>, McGraw-Hill Book Company, USA, 1988</p></td>
+<td valign=\"top\"><p>[Antognetti1988]</p></td>
+<td valign=\"top\"><p>P. Antognetti, G. Massobrio, <em>Semiconductor Device Modeling with SPICE.</em>, McGraw-Hill Book Company, USA, 1988</p></td>
 <td></td>
 </tr>
 <tr>
-<td><p>[Connelly1992]</p></td>
-<td><p>A. Connelly, A, P. Choi, <em>Macromodeling with SPICE.</em>, Prentice-Hall, New Jersey, USA (1992)</p></td>
+<td valign=\"top\"><p>[Connelly1992]</p></td>
+<td valign=\"top\"><p>A. Connelly, A, P. Choi, <em>Macromodeling with SPICE.</em>, Prentice-Hall, New Jersey, USA (1992)</p></td>
 <td></td>
 </tr>
 <tr>
-<td><p>[Johnson1991]</p></td>
-<td><p>B. Johnson, T. Quarles, A.R. Newton, D. O. Pederson, A. Sangiovanni-Vincentelli, <em>SPICE3 Version 3f User's Manual.</em>, University of Berkeley, Department of Electrical Engineering and Computer Sciences, USA (1991): <a href=\"modelica://Modelica/Resources/Documentation/Electrical/Spice3/Spice_3f3_Users_Manual.pdf\">SPICE3 user's manual</a> (&copy; Regents of the University of California)</p></td>
+<td valign=\"top\"><p>[Johnson1991]</p></td>
+<td valign=\"top\"><p>B. Johnson, T. Quarles, A.R. Newton, D. O. Pederson, A. Sangiovanni-Vincentelli, <em>SPICE3 Version 3f User's Manual.</em>, University of Berkeley, Department of Electrical Engineering and Computer Sciences, USA (1991): <a href=\"modelica://Modelica/Resources/Documentation/Electrical/Spice3/Spice_3f3_Users_Manual.pdf\">SPICE3 user's manual</a> (&copy; Regents of the University of California)</p></td>
 <td></td>
 </tr>
 <tr>
-<td><p>[Kielkowski1994]</p></td>
-<td><p>R. Kielkowski, <em>Inside SPICE - Overcoming the obstacles of circuit simulation.</em>, McGraw-Hill, USA (1994)</p></td>
+<td valign=\"top\"><p>[Kielkowski1994]</p></td>
+<td valign=\"top\"><p>R. Kielkowski, <em>Inside SPICE - Overcoming the obstacles of circuit simulation.</em>, McGraw-Hill, USA (1994)</p></td>
 </tr>
 </table>
 </html>"));

--- a/Modelica/Magnetic/FluxTubes.mo
+++ b/Modelica/Magnetic/FluxTubes.mo
@@ -397,58 +397,58 @@ Several models to describe the static hysteresis behavior of ferromagnetic mater
  </tr>
 
  <tr>
-  <td><a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets.GenericHystTellinenSoft\">GenericHystTellinenSoft</a><br><img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/GenericHystTellinenS.png\">
+  <td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets.GenericHystTellinenSoft\">GenericHystTellinenSoft</a><br><img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/GenericHystTellinenS.png\">
   </td>
-  <td>
+  <td valign=\"top\">
   Flux tube element for modeling soft magnetic materials with ferromagnetic and dynamic hysteresis (eddy currents). The ferromagnetic hysteresis behavior is defined by the <a href=\"modelica://Modelica.Magnetic.FluxTubes.UsersGuide.Hysteresis.StaticHysteresis.Tellinen\">Tellinen hysteresis model</a>. The shape of the limiting hysteresis loop is described by simple hyperbolic tangent functions with 4 parameters. Therefore, the hysteresis shape variety is limited but the parameterization of the model is very simple and the model is relatively fast and robust.
   </td>
  </tr>
 
  <tr>
-  <td><a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets.GenericHystTellinenHard\">GenericHystTellinenHard</a><br><img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/GenericHystTellinenH.png\">
+  <td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets.GenericHystTellinenHard\">GenericHystTellinenHard</a><br><img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/GenericHystTellinenH.png\">
   </td>
-  <td>
+  <td valign=\"top\">
   Flux tube element for modeling the ferromagnetic (static) hysteresis of hard magnetic materials. The ferromagnetic hysteresis behavior is defined by the <a href=\"modelica://Modelica.Magnetic.FluxTubes.UsersGuide.Hysteresis.StaticHysteresis.Tellinen\">Tellinen hysteresis model</a>. The shape of the limiting hysteresis loop is described by simple hyperbolic tangent functions with 4 parameters.
   </td>
  </tr>
 
  <tr>
-  <td><a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets.GenericHystTellinenEverett\">GenericHystTellinenEverett</a><br><img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/GenericHystTellinenE.png\">
+  <td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets.GenericHystTellinenEverett\">GenericHystTellinenEverett</a><br><img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/GenericHystTellinenE.png\">
   </td>
-  <td>
+  <td valign=\"top\">
   Flux tube element for modeling soft magnetic materials with ferromagnetic and dynamic hysteresis (eddy currents). The ferromagnetic hysteresis behavior is defined by the <a href=\"modelica://Modelica.Magnetic.FluxTubes.UsersGuide.Hysteresis.StaticHysteresis.Tellinen\">Tellinen hysteresis model</a>. The Shape of the limiting ferromagnetic hysteresis loop is specified by an analytical description of the Everett function, which is also used to parameterize the <a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets.GenericHystPreisachEverett\">GenericHystPreisachEverett</a> model. A library of predefined parameter sets can be found in <a href=\"modelica://Modelica.Magnetic.FluxTubes.Material.HysteresisEverettParameter\">FluxTubes.Material.HysteresisEverettParameter</a>.
   </td>
  </tr>
 
  <tr>
-  <td><a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets.GenericHystTellinenTable\">GenericHystTellinenTable</a><br><img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/GenericHystTellinenT.png\">
+  <td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets.GenericHystTellinenTable\">GenericHystTellinenTable</a><br><img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/GenericHystTellinenT.png\">
   </td>
-  <td>
+  <td valign=\"top\">
   Flux tube element for modeling magnetic materials with ferromagnetic and dynamic hysteresis (eddy currents). The ferromagnetic hysteresis behavior is defined by the <a href=\"modelica://Modelica.Magnetic.FluxTubes.UsersGuide.Hysteresis.StaticHysteresis.Tellinen\">Tellinen hysteresis model</a>. The rising and falling branch of the limiting ferromagnetic hysteresis loop are specified by table data. Therefore, almost any hysteresis shapes are possible. A library with predefined tables can be found at <a href=\"modelica://Modelica.Magnetic.FluxTubes.Material.HysteresisTableData\">FluxTubes.Material.HysteresisTableData</a>.
   </td>
  </tr>
 
  <tr>
-  <td><a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets.GenericHystPreisachEverett\">GenericHystPreisachEverett</a><br><img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/GenericHystPreisachE.png\">
+  <td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets.GenericHystPreisachEverett\">GenericHystPreisachEverett</a><br><img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/GenericHystPreisachE.png\">
   </td>
-  <td>
+  <td valign=\"top\">
   Flux tube element for modeling magnetic materials with ferromagnetic and dynamic hysteresis (eddy currents). The ferromagnetic hysteresis behavior is defined by the
 <a href=\"modelica://Modelica.Magnetic.FluxTubes.UsersGuide.Hysteresis.StaticHysteresis.Preisach\">Preisach hysteresis model</a>. The Shape of the limiting ferromagnetic hysteresis loop is specified by an analytical description of the Everett function. A library of predefined parameter sets can be found in <a href=\"modelica://Modelica.Magnetic.FluxTubes.Material.HysteresisEverettParameter\">FluxTubes.Material.HysteresisEverettParameter</a>.
   </td>
  </tr>
 
  <tr>
-  <td><a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets.GenericHystTellinenPermanentMagnet\">GenericHystTellinenPermanentMagnet</a><br><img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/GenericHystTellinenPM.png\">
+  <td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets.GenericHystTellinenPermanentMagnet\">GenericHystTellinenPermanentMagnet</a><br><img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/GenericHystTellinenPM.png\">
   </td>
-  <td>
+  <td valign=\"top\">
   Flux tube element for modeling the hard magnetic hysteresis of permanent magnets. The model is similar to <a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets.GenericHystTellinenHard\">GenericHystTellinenHard</a> but has an initial magnetization preset of -100% and an adapted icon for better readability of the diagram.
   </td>
  </tr>
 
  <tr>
-  <td><a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets.GenericLinearPermanentMagnet\">GenericLinearPermanentMagnet</a><br><img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/GenericLinearPM.png\">
+  <td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets.GenericLinearPermanentMagnet\">GenericLinearPermanentMagnet</a><br><img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/GenericLinearPM.png\">
   </td>
-  <td>
+  <td valign=\"top\">
   Simple model of a linear permanent Magnet. Typical characteristics of common permanent magnetic materials can be found at <a href=\"modelica://Modelica.Magnetic.FluxTubes.Material.HardMagnetic\">FluxTubes.Material.HardMagnetic</a>.
   </td>
  </tr>
@@ -468,8 +468,8 @@ Several models to describe the static hysteresis behavior of ferromagnetic mater
 
 <br><table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
     <tr>
-      <td>[B&ouml;08]</td>
-      <td>B&ouml;drich, T.:
+      <td valign=\"top\">[B&ouml;08]</td>
+      <td valign=\"top\">B&ouml;drich, T.:
         <em>Electromagnetic Actuator Modelling with the Extended Modelica Magnetic Library</em>,
         Modelica 2008 Conference, Bielefeld, Germany,pp. 221-227, March 3-4, 2008. Download from: <a href=\"https://www.modelica.org/events/modelica2008/Proceedings/sessions/session2d2.pdf\">https://www.modelica.org/events/modelica2008/&shy;Proceedings/sessions/session2d2.pdf</a></td>
     </tr>
@@ -480,8 +480,8 @@ Several models to describe the static hysteresis behavior of ferromagnetic mater
 
 <br><table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
     <tr>
-      <td>[Ro41]</td>
-      <td>Roters, H.:
+      <td valign=\"top\">[Ro41]</td>
+      <td valign=\"top\">Roters, H.:
         <em>Electromagnetic Devices</em>,
         New York: John Wiley &amp; Sons 1941 (8th Printing 1961)</td>
     </tr>
@@ -492,15 +492,15 @@ Several models to describe the static hysteresis behavior of ferromagnetic mater
 
 <br><table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
     <tr>
-      <td>[KEQ+12]</td>
-      <td>Kallenbach, E.; Eick, R.; Quendt, P.; Str&ouml;hla, T.; Feindt, K.; Kallenbach, M.; Radler, O.:
+      <td valign=\"top\">[KEQ+12]</td>
+      <td valign=\"top\">Kallenbach, E.; Eick, R.; Quendt, P.; Str&ouml;hla, T.; Feindt, K.; Kallenbach, M.; Radler, O.:
         <em>Elektromagnete: Grundlagen, Berechnung, Entwurf und Anwendung</em>,
         3rd ed., Wiesbaden: Vieweg Teubner 2008 (in German).</td>
     </tr>
 
     <tr>
-      <td>[Ro00]</td>
-      <td>Roschke, T.:
+      <td valign=\"top\">[Ro00]</td>
+      <td valign=\"top\">Roschke, T.:
         <em>Entwurf geregelter elektromagnetischer Antriebe f&uuml;r Luftsch&uuml;tze</em>,
         Fortschritt-Berichte VDI, Reihe 21, Nr. 293, D&uuml;sseldorf: VDI-Verlag 2000 (in German).</td>
     </tr>
@@ -511,8 +511,8 @@ Several models to describe the static hysteresis behavior of ferromagnetic mater
 
 <br><table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
     <tr>
-      <td>[HM94]</td>
-      <td>Hendershot, J.R. Jr.; Miller, T.J.E.:
+      <td valign=\"top\">[HM94]</td>
+      <td valign=\"top\">Hendershot, J.R. Jr.; Miller, T.J.E.:
         <em>Design of Brushless Permanent-Magnet Motors</em>,
         Magna Physics Publishing and Oxford University Press 1994.</td>
     </tr>
@@ -523,50 +523,50 @@ Several models to describe the static hysteresis behavior of ferromagnetic mater
 
 <br><table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
     <tr>
-      <td>[BE01]</td>
-      <td>Bergqvist, A. J.; Engdahl, S. G.:
+      <td valign=\"top\">[BE01]</td>
+      <td valign=\"top\">Bergqvist, A. J.; Engdahl, S. G.:
         <em>A Homogenization Procedure of Field Quantities in Laminated Electric Steel</em>,
         IEEE Transactions on Magnetics, vol.37, no.5, pp.3329-3331, 2001.</td>
     </tr>
     <tr>
-      <td>[Te98]</td>
-      <td>Tellinen, J:
+      <td valign=\"top\">[Te98]</td>
+      <td valign=\"top\">Tellinen, J:
         <em>A simple scalar model for magnetic hysteresis</em>,
         IEEE Translation Journal on Magnetics in Japan, vol.4, no.6, pp.353-359, 1989.</td>
     </tr>
     <tr>
-      <td>[Pr35]</td>
-      <td>Preisach, F.:
+      <td valign=\"top\">[Pr35]</td>
+      <td valign=\"top\">Preisach, F.:
         <em>&Uuml;ber die magnetische Nachwirkung</em>,
         Zeitschrift f&uuml;r Physik A Hadrons and Nuclei, vol. 94, pp. 277-302, 1935.</td>
     </tr>
     <tr>
-      <td>[Ma03]</td>
-      <td>Mayergoyz, I.:
+      <td valign=\"top\">[Ma03]</td>
+      <td valign=\"top\">Mayergoyz, I.:
         <em>Mathematical Models of Hysteresis and their Application</em>,
         Elsevier, 2003.</td>
     </tr>
     <tr>
-      <td>[Va01]</td>
-      <td>VAC Vacuumschmelze:
+      <td valign=\"top\">[Va01]</td>
+      <td valign=\"top\">VAC Vacuumschmelze:
         <em>Soft Magnetic Cobalt-Iron-Alloys</em>, 2001.
         Download from: <a  href=\"http://www.vacuumschmelze.com/fileadmin/docroot/medialib/documents/broschueren/htbrosch/Pht-004_e.pdf\">http://www.vacuumschmelze.com/fileadmin/&shy;docroot/medialib/documents/&shy;broschueren/htbrosch/Pht-004_e.pdf</a></td>
     </tr>
     <tr>
-      <td>[YUY89]</td>
-      <td>Yamaguchi, T.; Ueda, F.; Yamamoto, E.:
+      <td valign=\"top\">[YUY89]</td>
+      <td valign=\"top\">Yamaguchi, T.; Ueda, F.; Yamamoto, E.:
         <em>Simulation of Hysteresis Characteristics of Core Materials Using the Everett Function</em>,
         IEEE Translation Journal on Magnetics in Japan, vol.4, no.6, pp.353-359, 1989.</td>
     </tr>
     <tr>
-      <td>[ZB12]</td>
-      <td>Ziske, J.; B&ouml;drich, T.:
+      <td valign=\"top\">[ZB12]</td>
+      <td valign=\"top\">Ziske, J.; B&ouml;drich, T.:
         <em>Magnetic Hysteresis Models for Modelica</em>,
         Proc. of the 9th Modelica Conference, Munich, Germany, pp. 151-158, September 3-5, 2012. Download from: <a  href=\"http://www.ep.liu.se/ecp/076/014/ecp12076014.pdf\">http://www.ep.liu.se/ecp/&shy;076/014/ecp12076014.pdf</a></td>
     </tr>
     <tr>
-      <td>[ZB14]</td>
-      <td>Ziske, J.; B&ouml;drich, T.:
+      <td valign=\"top\">[ZB14]</td>
+      <td valign=\"top\">Ziske, J.; B&ouml;drich, T.:
         <em>http://www.ep.liu.se/ecp/096/017/ecp14096017.pdf</em>,
         Proc. of the 10th Modelica Conference, Lund, Sweden, pp. 165-172, March 10-12, 2014. Download from: <a  href=\"http://www.ep.liu.se/ecp/096/017/ecp14096017.pdf\">http://www.ep.liu.se/ecp/&shy;096/017/ecp14096017.pdf</a></td>
     </tr>

--- a/Modelica/Magnetic/FundamentalWave.mo
+++ b/Modelica/Magnetic/FundamentalWave.mo
@@ -577,8 +577,8 @@ model from R to G</li>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
     <tr>
-      <td>[Beuschel00]</td>
-      <td>M. Beuschel,
+      <td valign=\"top\">[Beuschel00]</td>
+      <td valign=\"top\">M. Beuschel,
         &quot;<a href=\"https://www.modelica.org/events/workshop2000/proceedings/Beuschel.pdf\">
         A uniform approach for modelling electrical machines</a>,&quot;
         <em>Modelica Workshop</em>,
@@ -586,38 +586,38 @@ model from R to G</li>
     </tr>
 
     <tr>
-      <td>[Eckhardt82]</td>
-      <td>H. Eckhardt,
+      <td valign=\"top\">[Eckhardt82]</td>
+      <td valign=\"top\">H. Eckhardt,
         <em>Grundz&uuml;ge der elektrischen Maschinen</em> (in German),
         B. G. Teubner Verlag, Stuttgart, 1982.</td>
     </tr>
 
     <tr>
-      <td>[Haumer09]</td>
-      <td>A. Haumer, and C. Kral,
+      <td valign=\"top\">[Haumer09]</td>
+      <td valign=\"top\">A. Haumer, and C. Kral,
         &quot;<a href=\"https://www.modelica.org/events/modelica2009/Proceedings/memorystick/pages/papers/0103/0103.pdf\">The
         AdvancedMachines Library: Loss Models for Electric Machines</a>,&quot;
         <em>Modelica Conference</em>, 2009.</td>
     </tr>
 
     <tr>
-      <td>[Lang84]</td>
-      <td>W. Lang,
+      <td valign=\"top\">[Lang84]</td>
+      <td valign=\"top\">W. Lang,
         <em>&Uuml;ber die Bemessung verlustarmer Asynchronmotoren mit K&auml;figl&auml;ufer f&uuml;r Pulsumrichterspeisung</em>
        (in German),
        Doctoral Thesis, Technical University of Vienna, 1984.</td>
     </tr>
 
     <tr>
-      <td>[Laughton02]</td>
-      <td>M.A. Laughton, D.F. Warne
+      <td valign=\"top\">[Laughton02]</td>
+      <td valign=\"top\">M.A. Laughton, D.F. Warne
         <em>Electrical Engineer's Reference Book</em>
         Butterworth Heinemann, 16th edition, ISBN 978-0750646376, 2002</td>
     </tr>
 
     <tr>
-      <td>[Li07]</td>
-      <td>Y. Li, Z. Q. Zhu, D. Howe, and C. M. Bingham,
+      <td valign=\"top\">[Li07]</td>
+      <td valign=\"top\">Y. Li, Z. Q. Zhu, D. Howe, and C. M. Bingham,
         &quot;Modeling of Cross-Coupling Magnetic Saturation in Signal-Injection-Based
         Sensorless Control of Permanent-Magnet Brushless AC Motors,&quot;
         <em>IEEE Transactions on Magnetics</em>,
@@ -625,15 +625,15 @@ model from R to G</li>
     </tr>
 
     <tr>
-      <td>[Mueller70]</td>
-      <td>G, M&uuml;ller,
+      <td valign=\"top\">[Mueller70]</td>
+      <td valign=\"top\">G, M&uuml;ller,
         <em>Elektrische Maschinen -- Grundlagen, Aufbau und Wirkungsweise</em> (in German),
         VEB Verlag Technik Berlin, 4th edition, 1970.</td>
     </tr>
 
     <tr>
-      <td>[Spaeth73]</td>
-      <td>H. Sp&auml;th,
+      <td valign=\"top\">[Spaeth73]</td>
+      <td valign=\"top\">H. Sp&auml;th,
         <em>Elektrische Maschinen -- Eine Einf&uuml;hrung in die Theorie des Betriebsverhaltens</em> (in German),
         Springer-Verlag, Berlin, Heidelberg, New York, 1973.</td>
     </tr>

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave.mo
@@ -235,8 +235,8 @@ email: <a href=\"mailto:a.haumer@haumer.at\">a.haumer@haumer.at</a><br>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
     <tr>
-      <td>[Lang1984]</td>
-      <td>W. Lang,
+      <td valign=\"top\">[Lang1984]</td>
+      <td valign=\"top\">W. Lang,
         &quot;&Uuml;ber die Bemessung verlustarmer Asynchronmotoren mit K&auml;figl&auml;ufer f&uuml;r
         Pulsumrichterspeisung,&quot;
         Doctoral Thesis,

--- a/Modelica/Math/Distributions.mo
+++ b/Modelica/Math/Distributions.mo
@@ -48,11 +48,11 @@ For more details, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -119,11 +119,11 @@ For more details, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -198,11 +198,11 @@ For more details, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -249,11 +249,11 @@ For more details of this distribution see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -313,11 +313,11 @@ For more details, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -384,11 +384,11 @@ For more details, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -468,11 +468,11 @@ For more details, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -529,11 +529,11 @@ For more details of this distribution see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -612,11 +612,11 @@ of truncated distributions, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -704,11 +704,11 @@ of truncated distributions, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -805,11 +805,11 @@ of truncated distributions, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -877,11 +877,11 @@ of truncated distributions, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -950,11 +950,11 @@ For more details, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1030,11 +1030,11 @@ For more details, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1109,11 +1109,11 @@ For more details, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1165,11 +1165,11 @@ For more details of this distribution see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1248,11 +1248,11 @@ of truncated distributions, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1339,11 +1339,11 @@ of truncated distributions, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1440,11 +1440,11 @@ of truncated distributions, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1509,11 +1509,11 @@ of truncated distributions, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1543,11 +1543,11 @@ arguments of the probability density functions.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1574,11 +1574,11 @@ arguments of the cumulative distribution functions.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1606,11 +1606,11 @@ arguments of the quantile functions.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1637,11 +1637,11 @@ arguments of the probability density functions of truncated distributions.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1668,11 +1668,11 @@ arguments of the cumulative distribution functions for a truncated distribution.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1699,11 +1699,11 @@ arguments of the quantile functions for truncated distributions.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1725,11 +1725,11 @@ truncated distribution functions.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1868,11 +1868,11 @@ compared with its truncated distribution:
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by

--- a/Modelica/Math/FastFourierTransform.mo
+++ b/Modelica/Math/FastFourierTransform.mo
@@ -67,8 +67,8 @@ package FastFourierTransform
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> Nov. 29, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> Nov. 29, 2015 </td>
+    <td valign=\"top\">
      Initial version implemented by
      Martin R. Kuhn and Martin Otter
      (<a href=\"http://www.dlr.de/rmc/sr/en\">DLR Institute of System Dynamics and Control</a>.</td></tr>
@@ -168,8 +168,8 @@ Furthermore, note that the FFT phases are with respect to a cos(..) signal.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> Nov. 29, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> Nov. 29, 2015 </td>
+    <td valign=\"top\">
      Initial version implemented by
      Martin R. Kuhn and Martin Otter
      (<a href=\"http://www.dlr.de/rmc/sr/en\">DLR Institute of System Dynamics and Control</a>.</td></tr>
@@ -186,8 +186,8 @@ with the only difference that just the amplitudes of the FFT are stored on file 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> Nov. 29, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> Nov. 29, 2015 </td>
+    <td valign=\"top\">
      Initial version implemented by
      Martin R. Kuhn and Martin Otter
      (<a href=\"http://www.dlr.de/rmc/sr/en\">DLR Institute of System Dynamics and Control</a>.</td></tr>
@@ -234,8 +234,8 @@ with the only difference that just the amplitudes of the FFT are stored on file 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> Nov. 29, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> Nov. 29, 2015 </td>
+    <td valign=\"top\">
      Initial version implemented by
      Martin R. Kuhn and Martin Otter
      (<a href=\"http://www.dlr.de/rmc/sr/en\">DLR Institute of System Dynamics and Control</a>.</td></tr>
@@ -323,8 +323,8 @@ results in the following output:
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> Nov. 29, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> Nov. 29, 2015 </td>
+    <td valign=\"top\">
      Initial version implemented by
      Martin R. Kuhn and Martin Otter
      (<a href=\"http://www.dlr.de/rmc/sr/en\">DLR Institute of System Dynamics and Control</a>.</td></tr>
@@ -447,8 +447,8 @@ results in the following output:
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> Nov. 29, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> Nov. 29, 2015 </td>
+    <td valign=\"top\">
      Initial version implemented by
      Martin R. Kuhn and Martin Otter
      (<a href=\"http://www.dlr.de/rmc/sr/en\">DLR Institute of System Dynamics and Control</a>.</td></tr>
@@ -645,8 +645,8 @@ See detailed example model:
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> Nov. 29, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> Nov. 29, 2015 </td>
+    <td valign=\"top\">
      Initial version implemented by
      Martin R. Kuhn and Martin Otter
      (<a href=\"http://www.dlr.de/rmc/sr/en\">DLR Institute of System Dynamics and Control</a>.</td></tr>
@@ -747,8 +747,8 @@ used in this function.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> Nov. 29, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> Nov. 29, 2015 </td>
+    <td valign=\"top\">
      Initial version implemented by
      Martin R. Kuhn and Martin Otter
      (<a href=\"http://www.dlr.de/rmc/sr/en\">DLR Institute of System Dynamics and Control</a>.</td></tr>
@@ -778,8 +778,8 @@ If this is not possible, success = false, and e2, e3, e5 are dummy values.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> Nov. 29, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> Nov. 29, 2015 </td>
+    <td valign=\"top\">
      Initial version implemented by
      Martin R. Kuhn and Martin Otter
      (<a href=\"http://www.dlr.de/rmc/sr/en\">DLR Institute of System Dynamics and Control</a>.</td></tr>
@@ -837,8 +837,8 @@ resulting in:
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> Nov. 29, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> Nov. 29, 2015 </td>
+    <td valign=\"top\">
      Initial version implemented by
      Martin R. Kuhn and Martin Otter
      (<a href=\"http://www.dlr.de/rmc/sr/en\">DLR Institute of System Dynamics and Control</a>.</td></tr>

--- a/Modelica/Math/Random.mo
+++ b/Modelica/Math/Random.mo
@@ -73,11 +73,11 @@ with a sample period of 0.05 s. Simulations results are shown in the figure belo
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -98,11 +98,11 @@ This package contains examples demonstrating the usage of the functions in packa
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -195,11 +195,11 @@ and the returned state is the one from the last iteration.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -260,11 +260,11 @@ same random number r is returned.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -287,11 +287,11 @@ For an overview, comparison with other random number generators, and links to ar
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -368,11 +368,11 @@ random number generator is used to fill the internal state vector with 64 bit ra
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -433,11 +433,11 @@ same random number r is returned.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -461,11 +461,11 @@ other random number generators, and links to articles, see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -545,11 +545,11 @@ random number generator is used to fill the internal state vector with 64 bit ra
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -610,11 +610,11 @@ same random number r is returned.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -637,11 +637,11 @@ For an overview, comparison with other random number generators, and links to ar
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -832,11 +832,11 @@ These numbers are mapped to the 52 bit mantissa of double numbers in the range 0
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -895,11 +895,11 @@ These numbers are mapped to the 52 bit mantissa of double numbers in the range 0
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -980,11 +980,11 @@ This function should be only called once during initialization.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1072,11 +1072,11 @@ random number generator to fill the internal state vector with 64 bit random num
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1146,11 +1146,11 @@ is returned, so the function is impure.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1209,11 +1209,11 @@ is returned, so the function is impure.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 <tr><td>June 2, 2017</td><td>Correct probabilities - especially for small ranges, by Hans Olsson, <a href=\"https://www.3ds.com\">Dassault Syst&egrave;mes</a></td></tr>
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1235,11 +1235,11 @@ that are usually of no interest for the user
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1290,11 +1290,11 @@ package <a href=\"modelica://Modelica.Blocks.Noise\">Blocks.Noise</a>).
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by

--- a/Modelica/Math/Special.mo
+++ b/Modelica/Math/Special.mo
@@ -94,11 +94,11 @@ For more details, see <a href=\"http://en.wikipedia.org/wiki/Error_function\">Wi
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -178,11 +178,11 @@ see <a href=\"http://en.wikipedia.org/wiki/Error_function\">Wikipedia</a>.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -264,11 +264,11 @@ For more details, see <a href=\"http://en.wikipedia.org/wiki/Error_function\">Wi
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -355,11 +355,11 @@ For more details, see <a href=\"http://en.wikipedia.org/wiki/Error_function\">Wi
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -384,11 +384,11 @@ For more details, see <a href=\"http://en.wikipedia.org/wiki/Error_function\">Wi
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -449,11 +449,11 @@ Evaluate a polynomial using Horner's scheme.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -569,11 +569,11 @@ Utility function in order to compute part of erf(..) and erfc(..).
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -824,11 +824,11 @@ Utility function in order to compute erfInv(..) and erfcInv(..).
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -850,11 +850,11 @@ by the user.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -877,11 +877,11 @@ cannot be expressed analytically.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -183,17 +183,17 @@ Besides the Euclidean norm (p=2), also the 1-norm and the
 infinity-norm are sometimes used:
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>1-norm</strong></td>
-      <td>= sum(abs(v))</td>
-      <td><strong>norm</strong>(v,1)</td>
+  <tr><td valign=\"top\"><strong>1-norm</strong></td>
+      <td valign=\"top\">= sum(abs(v))</td>
+      <td valign=\"top\"><strong>norm</strong>(v,1)</td>
   </tr>
-  <tr><td><strong>2-norm</strong></td>
-      <td>= sqrt(v*v)</td>
-      <td><strong>norm</strong>(v) or <strong>norm</strong>(v,2)</td>
+  <tr><td valign=\"top\"><strong>2-norm</strong></td>
+      <td valign=\"top\">= sqrt(v*v)</td>
+      <td valign=\"top\"><strong>norm</strong>(v) or <strong>norm</strong>(v,2)</td>
   </tr>
-  <tr><td><strong>infinity-norm</strong></td>
-      <td>= max(abs(v))</td>
-      <td><strong>norm</strong>(v,Modelica.Constants.<strong>inf</strong>)</td>
+  <tr><td valign=\"top\"><strong>infinity-norm</strong></td>
+      <td valign=\"top\">= max(abs(v))</td>
+      <td valign=\"top\"><strong>norm</strong>(v,Modelica.Constants.<strong>inf</strong>)</td>
   </tr>
 </table>
 <p>
@@ -1670,10 +1670,10 @@ more convenient to just use the function
 <p>
 The optional third (Integer) output argument has the following meaning:</p>
 <table border=0 cellspacing=0 cellpadding=2>
-  <tr><td>info = 0:</td>
-      <td>successful exit</td></tr>
-  <tr><td>info &gt; 0:</td>
-      <td>if info = i, U[i,i] is exactly zero. The factorization
+  <tr><td valign=\"top\">info = 0:</td>
+      <td valign=\"top\">successful exit</td></tr>
+  <tr><td valign=\"top\">info &gt; 0:</td>
+      <td valign=\"top\">if info = i, U[i,i] is exactly zero. The factorization
           has been completed,<br>
           but the factor U is exactly
           singular, and division by zero will occur<br> if it is used

--- a/Modelica/Mechanics/MultiBody/Examples/Elementary/package.mo
+++ b/Modelica/Mechanics/MultiBody/Examples/Elementary/package.mo
@@ -11,110 +11,110 @@ the usage of the MultiBody library
 <h4>Content</h4>
 <table border=1 cellspacing=0 cellpadding=2>
   <tr><th><strong><em>Model</em></strong></th><th><strong><em>Description</em></strong></th></tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulum\">DoublePendulum</a></td>
-      <td> Simple double pendulum with two revolute joints and two bodies.<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulum\">DoublePendulum</a></td>
+      <td valign=\"top\"> Simple double pendulum with two revolute joints and two bodies.<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/DoublePendulumSmall.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.ForceAndTorque\">ForceAndTorque</a></td>
-      <td> Demonstrates usage of Forces.ForceAndTorque element.<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.ForceAndTorque\">ForceAndTorque</a></td>
+      <td valign=\"top\"> Demonstrates usage of Forces.ForceAndTorque element.<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/ForceAndTorque_small.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.FreeBody\">FreeBody</a></td>
-      <td> Free flying body attached by two springs to environment.<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.FreeBody\">FreeBody</a></td>
+      <td valign=\"top\"> Free flying body attached by two springs to environment.<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/FreeBody_small.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.InitSpringConstant\">InitSpringConstant</a></td>
-      <td> Determine spring constant such that system is in steady state
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.InitSpringConstant\">InitSpringConstant</a></td>
+      <td valign=\"top\"> Determine spring constant such that system is in steady state
            at given position.<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/InitSpringConstant_small.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.LineForceWithTwoMasses\">LineForceWithTwoMasses</a></td>
-      <td> Demonstrates a line force with two point masses using a
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.LineForceWithTwoMasses\">LineForceWithTwoMasses</a></td>
+      <td valign=\"top\"> Demonstrates a line force with two point masses using a
            Joints.Assemblies.JointUPS and alternatively a
            Forces.LineForceWithTwoMasses component.<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/LineForceWithTwoMasses_small.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum\">Pendulum</a></td>
-      <td> Simple pendulum with one revolute joint and one body.<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum\">Pendulum</a></td>
+      <td valign=\"top\"> Simple pendulum with one revolute joint and one body.<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/Pendulum_small.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.PendulumWithSpringDamper\">PendulumWithSpringDamper</a></td>
-      <td> Simple spring/damper/mass system<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.PendulumWithSpringDamper\">PendulumWithSpringDamper</a></td>
+      <td valign=\"top\"> Simple spring/damper/mass system<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/PendulumWithSpringDamper_small.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.PointGravity\">PointGravity</a></td>
-      <td> Two bodies in a point gravity field<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.PointGravity\">PointGravity</a></td>
+      <td valign=\"top\"> Two bodies in a point gravity field<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/PointGravity_small.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.PointGravityWithPointMasses\">PointGravityWithPointMasses</a></td>
-      <td> Two point masses in a point gravity field (rotation of bodies is neglected)<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.PointGravityWithPointMasses\">PointGravityWithPointMasses</a></td>
+      <td valign=\"top\"> Two point masses in a point gravity field (rotation of bodies is neglected)<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/PointGravityWithPointMasses_small.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.PointGravityWithPointMasses2\">PointGravityWithPointMasses2</a></td>
-      <td> Rigidly connected point masses in a point gravity field<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.PointGravityWithPointMasses2\">PointGravityWithPointMasses2</a></td>
+      <td valign=\"top\"> Rigidly connected point masses in a point gravity field<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/PointGravityWithPointMasses2_small.png\">
       </td>
   </tr>
 
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.RollingWheel\">RollingWheel</a></td>
-      <td> Single wheel rolling on ground starting from an initial speed<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.RollingWheel\">RollingWheel</a></td>
+      <td valign=\"top\"> Single wheel rolling on ground starting from an initial speed<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/RollingWheel.png\">
       </td>
   </tr>
 
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.RollingWheelSetDriving\">RollingWheelSetDriving</a></td>
-      <td> Rolling wheel set that is driven by torques driving the wheels<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.RollingWheelSetDriving\">RollingWheelSetDriving</a></td>
+      <td valign=\"top\"> Rolling wheel set that is driven by torques driving the wheels<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/RollingWheelSetDriving.png\">
       </td>
   </tr>
 
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.RollingWheelSetPulling\">RollingWheelSetPulling</a></td>
-      <td> Rolling wheel set that is pulled by a force<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.RollingWheelSetPulling\">RollingWheelSetPulling</a></td>
+      <td valign=\"top\"> Rolling wheel set that is pulled by a force<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/RollingWheelSetPulling.png\">
       </td>
   </tr>
 
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.SpringDamperSystem\">SpringDamperSystem</a></td>
-      <td> Spring/damper system with a prismatic joint and
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.SpringDamperSystem\">SpringDamperSystem</a></td>
+      <td valign=\"top\"> Spring/damper system with a prismatic joint and
            attached on free flying body<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/SpringDamperSystem_small.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.SpringMassSystem\">SpringMassSystem</a></td>
-      <td> Mass attached via a prismatic joint and a spring to the world frame<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.SpringMassSystem\">SpringMassSystem</a></td>
+      <td valign=\"top\"> Mass attached via a prismatic joint and a spring to the world frame<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/SpringMassSystem_small.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.SpringWithMass\">SpringWithMass</a></td>
-      <td> Point mass hanging on a spring<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.SpringWithMass\">SpringWithMass</a></td>
+      <td valign=\"top\"> Point mass hanging on a spring<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/SpringWithMass_small.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.ThreeSprings\">ThreeSprings</a></td>
-      <td> 3-dimensional springs in series and parallel connection<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.ThreeSprings\">ThreeSprings</a></td>
+      <td valign=\"top\"> 3-dimensional springs in series and parallel connection<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/ThreeSprings_small.png\">
       </td>
   </tr>
 
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.HeatLosses\">HeatLosses</a></td>
-      <td> Demonstrate the modeling of heat losses.  </td>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.HeatLosses\">HeatLosses</a></td>
+      <td valign=\"top\"> Demonstrate the modeling of heat losses.  </td>
   </tr>
 
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.UserDefinedGravityField\">UserDefinedGravityField </a></td>
-      <td> Demonstrate the modeling of a user-defined gravity field.  </td>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.UserDefinedGravityField\">UserDefinedGravityField </a></td>
+      <td valign=\"top\"> Demonstrate the modeling of a user-defined gravity field.  </td>
   </tr>
 
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.Surfaces\">Surfaces</a></td>
-      <td> Demonstrate the visualization of a sine surface,
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.Surfaces\">Surfaces</a></td>
+      <td valign=\"top\"> Demonstrate the visualization of a sine surface,
        as well as a torus and a wheel constructed from a surface<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Elementary/Surfaces_small.png\">
       </td>

--- a/Modelica/Mechanics/MultiBody/Examples/Loops/package.mo
+++ b/Modelica/Mechanics/MultiBody/Examples/Loops/package.mo
@@ -11,48 +11,48 @@ mechanical systems with kinematic loops can be modeled.
 <h4>Content</h4>
 <table border=1 cellspacing=0 cellpadding=2>
   <tr><th><strong><em>Model</em></strong></th><th><strong><em>Description</em></strong></th></tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.Engine1a\">Engine1a</a><br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.Engine1a\">Engine1a</a><br>
              <a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.Engine1b\">Engine1b</a><br>
              <a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.Engine1b_analytic\">Engine1b_analytic</a></td>
-      <td> Model of one cylinder engine (Engine1a: simple, without combustion; Engine1b: with combustion;
+      <td valign=\"top\"> Model of one cylinder engine (Engine1a: simple, without combustion; Engine1b: with combustion;
            Engine1b_analytic: same as Engine1b but analytic loop handling)<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Loops/Engine.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6\">EngineV6</a><br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6\">EngineV6</a><br>
 <a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6_analytic\">EngineV6_analytic</a></td>
-      <td> V6 engine with 6 cylinders, 6 planar loops and 1 degree-of-freedom.
+      <td valign=\"top\"> V6 engine with 6 cylinders, 6 planar loops and 1 degree-of-freedom.
            Second version with analytic handling of kinematic loops and CAD data
            animation.<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Loops/EngineV6_small.png\">
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Loops/EngineV6_CAD_smaller.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar1\">Fourbar1</a></td>
-      <td> One kinematic loop with four bars (with only revolute joints;
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar1\">Fourbar1</a></td>
+      <td valign=\"top\"> One kinematic loop with four bars (with only revolute joints;
            5 non-linear equations)<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Loops/Fourbar1_small.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar2\">Fourbar2</a></td>
-      <td> One kinematic loop with four bars (with UniversalSpherical
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar2\">Fourbar2</a></td>
+      <td valign=\"top\"> One kinematic loop with four bars (with UniversalSpherical
            joint; 1 non-linear equation)<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Loops/Fourbar2_small.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar_analytic\">Fourbar_analytic</a></td>
-      <td> One kinematic loop with four bars (with JointSSP joint;
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar_analytic\">Fourbar_analytic</a></td>
+      <td valign=\"top\"> One kinematic loop with four bars (with JointSSP joint;
            analytic solution of non-linear algebraic loop)<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Loops/Fourbar_analytic_small.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.PlanarFourbar\">PlanarFourbar</a></td>
-      <td> Planar four bars  with one kinematic loop (with RevolutePlanarLoopConstraint joint)<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.PlanarFourbar\">PlanarFourbar</a></td>
+      <td valign=\"top\"> Planar four bars  with one kinematic loop (with RevolutePlanarLoopConstraint joint)<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Loops/PlanarFourbar_small.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.PlanarLoops_analytic\">PlanarLoops_analytic</a></td>
-      <td> Mechanism with three planar kinematic loops and one
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Loops.PlanarLoops_analytic\">PlanarLoops_analytic</a></td>
+      <td valign=\"top\"> Mechanism with three planar kinematic loops and one
            degree-of-freedom with analytic loop handling
            (with JointRRR joints)<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Loops/PlanarLoops_small.png\">

--- a/Modelica/Mechanics/MultiBody/Examples/Systems/package.mo
+++ b/Modelica/Mechanics/MultiBody/Examples/Systems/package.mo
@@ -11,10 +11,10 @@ from different domains are used, including 3-dimensional mechanics.
 <h4>Content</h4>
 <table border=1 cellspacing=0 cellpadding=2>
   <tr><th><strong><em>Model</em></strong></th><th><strong><em>Description</em></strong></th></tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Systems.RobotR3\">RobotR3</a><br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Systems.RobotR3\">RobotR3</a><br>
 <a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Systems.RobotR3.oneAxis\">RobotR3.oneAxis</a><br>
 <a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Systems.RobotR3.fullRobot\">RobotR3.fullRobot</a></td>
-      <td> 6 degree of freedom robot with path planning,
+      <td valign=\"top\"> 6 degree of freedom robot with path planning,
            controllers, motors, brakes, gears and mechanics.
            \"oneAxis\" models only one drive train. \"fullRobot\" is
            the complete, detailed robot model.<br>

--- a/Modelica/Mechanics/MultiBody/Forces.mo
+++ b/Modelica/Mechanics/MultiBody/Forces.mo
@@ -98,14 +98,14 @@ coordinates shall be resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>Types.ResolveInFrameB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve input force in world frame (= default)</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve input force in world frame (= default)</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve input force in frame_b</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve input force in frame_b</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve input force in frame_resolve (frame_resolve must be connected)</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve input force in frame_resolve (frame_resolve must be connected)</td></tr>
 </table>
 
 <p>
@@ -235,14 +235,14 @@ coordinates shall be resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>Types.ResolveInFrameB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve input torque in world frame (= default)</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve input torque in world frame (= default)</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve input torque in frame_b</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve input torque in frame_b</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve input torque in frame_resolve (frame_resolve must be connected)</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve input torque in frame_resolve (frame_resolve must be connected)</td></tr>
 </table>
 
 <p>
@@ -468,14 +468,14 @@ coordinates shall be resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>Types.ResolveInFrameB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve input force and torque in world frame (= default)</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve input force and torque in world frame (= default)</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve input force and torque in frame_b</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve input force and torque in frame_b</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve input force and torque in frame_resolve
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve input force and torque in frame_resolve
                     (frame_resolve must be connected)</td></tr>
 </table>
 
@@ -661,17 +661,17 @@ coordinates shall be resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>Types.ResolveInFrameAB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve input force in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve input force in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve input force in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve input force in frame_a</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve input force in frame_b (= default)</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve input force in frame_b (= default)</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve input force in frame_resolve (frame_resolve must be connected)</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve input force in frame_resolve (frame_resolve must be connected)</td></tr>
 </table>
 
 <p>
@@ -848,17 +848,17 @@ coordinates shall be resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>Types.ResolveInFrameAB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve input torque in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve input torque in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve input torque in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve input torque in frame_a</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve input torque in frame_b (= default)</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve input torque in frame_b (= default)</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve input torque in frame_resolve (frame_resolve must be connected)</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve input torque in frame_resolve (frame_resolve must be connected)</td></tr>
 </table>
 
 <p>
@@ -1102,17 +1102,17 @@ coordinates shall be resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>Types.ResolveInFrameAB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve input force/torque in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve input force/torque in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve input force/torque in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve input force/torque in frame_a</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve input force/torque in frame_b (= default)</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve input force/torque in frame_b (= default)</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve input force/torque in frame_resolve (frame_resolve must be connected)</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve input force/torque in frame_resolve (frame_resolve must be connected)</td></tr>
 </table>
 
 <p>
@@ -2563,17 +2563,17 @@ coordinates shall be resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>Types.ResolveInFrameAB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve input force in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve input force in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve input force in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve input force in frame_a</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve input force in frame_b (= default)</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve input force in frame_b (= default)</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve input force in frame_resolve (frame_resolve must be connected)</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve input force in frame_resolve (frame_resolve must be connected)</td></tr>
 </table>
 
 <p>
@@ -2689,17 +2689,17 @@ coordinates shall be resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>Types.ResolveInFrameAB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve input torque in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve input torque in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve input torque in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve input torque in frame_a</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve input torque in frame_b (= default)</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve input torque in frame_b (= default)</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve input torque in frame_resolve (frame_resolve must be connected)</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve input torque in frame_resolve (frame_resolve must be connected)</td></tr>
 </table>
 
 <p>
@@ -2789,14 +2789,14 @@ coordinates shall be resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>Types.ResolveInFrameB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve input force in world frame (= default)</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve input force in world frame (= default)</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve input force in frame_b</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve input force in frame_b</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve input force in frame_resolve (frame_resolve must be connected)</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve input force in frame_resolve (frame_resolve must be connected)</td></tr>
 </table>
 
 <p>
@@ -2897,14 +2897,14 @@ coordinates shall be resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>Types.ResolveInFrameB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve input torque in world frame (= default)</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve input torque in world frame (= default)</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve input torque in frame_b</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve input torque in frame_b</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve input torque in frame_resolve (frame_resolve must be connected)</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve input torque in frame_resolve (frame_resolve must be connected)</td></tr>
 </table>
 
 <p>
@@ -2977,20 +2977,20 @@ between two frame connectors, e.g., between two parts.
 <h4>Content</h4>
 <table border=1 cellspacing=0 cellpadding=2>
   <tr><th><strong><em>Model</em></strong></th><th><strong><em>Description</em></strong></th></tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.WorldForce\">WorldForce</a></td>
-      <td> External force acting at the frame to which this component
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.WorldForce\">WorldForce</a></td>
+      <td valign=\"top\"> External force acting at the frame to which this component
            is connected and defined by 3 input signals,
            that are interpreted as one vector resolved in frame world, frame_b or frame_resolve.<br>
            <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/ArrowForce.png\"></td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.WorldTorque\">WorldTorque</a></td>
-      <td> External torque acting at the frame to which this component
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.WorldTorque\">WorldTorque</a></td>
+      <td valign=\"top\"> External torque acting at the frame to which this component
            is connected and defined by 3 input signals,
            that are interpreted as one vector resolved in frame world, frame_b or frame_resolve.<br>
            <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/ArrowTorque.png\"></td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.WorldForceAndTorque\">WorldForceAndTorque</a></td>
-      <td> External force and external torque acting at the frame
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.WorldForceAndTorque\">WorldForceAndTorque</a></td>
+      <td valign=\"top\"> External force and external torque acting at the frame
            to which this component
            is connected and defined by 3+3 input signals,
            that are interpreted as a force and as a torque vector
@@ -2999,47 +2999,47 @@ between two frame connectors, e.g., between two parts.
            <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/ArrowTorque.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.Force\">Force</a></td>
-      <td> Force acting between two frames defined by 3 input signals
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.Force\">Force</a></td>
+      <td valign=\"top\"> Force acting between two frames defined by 3 input signals
            resolved in frame world, frame_a, frame_b or in frame_resolve.<br>
            <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/ArrowForce2.png\"></td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.Torque\">Torque</a></td>
-      <td> Torque acting between two frames defined by 3 input signals
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.Torque\">Torque</a></td>
+      <td valign=\"top\"> Torque acting between two frames defined by 3 input signals
            resolved in frame world, frame_a, frame_b or in frame_resolve.<br>
            <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/ArrowTorque2.png\"></td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.ForceAndTorque\">ForceAndTorque</a></td>
-      <td> Force and torque acting between two frames defined by 3+3 input signals
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.ForceAndTorque\">ForceAndTorque</a></td>
+      <td valign=\"top\"> Force and torque acting between two frames defined by 3+3 input signals
            resolved in frame world, frame_a, frame_b or in frame_resolve.<br>
            <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/ArrowForce2.png\"><br>
            <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/ArrowTorque2.png\"></td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.LineForceWithMass\">LineForceWithMass</a></td>
-      <td>  General line force component with an optional point mass
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.LineForceWithMass\">LineForceWithMass</a></td>
+      <td valign=\"top\">  General line force component with an optional point mass
             on the connection line. The force law can be defined by a
             component of Modelica.Mechanics.Translational<br>
            <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/LineForceWithMass.png\"></td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.LineForceWithTwoMasses\">LineForceWithTwoMasses</a></td>
-      <td>  General line force component with two optional point masses
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.LineForceWithTwoMasses\">LineForceWithTwoMasses</a></td>
+      <td valign=\"top\">  General line force component with two optional point masses
             on the connection line. The force law can be defined by a
             component of Modelica.Mechanics.Translational<br>
            <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/LineForceWithTwoMasses.png\"></td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.Spring\">Spring</a></td>
-      <td> Linear translational spring with optional mass<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.Spring\">Spring</a></td>
+      <td valign=\"top\"> Linear translational spring with optional mass<br>
            <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/Spring2.png\"></td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.Damper\">Damper</a></td>
-      <td> Linear (velocity dependent) damper<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.Damper\">Damper</a></td>
+      <td valign=\"top\"> Linear (velocity dependent) damper<br>
            <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/Damper2.png\"></td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.SpringDamperParallel\">SpringDamperParallel</a></td>
-      <td> Linear spring and damper in parallel connection </td>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.SpringDamperParallel\">SpringDamperParallel</a></td>
+      <td valign=\"top\"> Linear spring and damper in parallel connection </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.SpringDamperSeries\">SpringDamperSeries</a></td>
-      <td> Linear spring and damper in series connection </td>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Forces.SpringDamperSeries\">SpringDamperSeries</a></td>
+      <td valign=\"top\"> Linear spring and damper in series connection </td>
   </tr>
 </table>
 </html>"));

--- a/Modelica/Mechanics/MultiBody/Frames.mo
+++ b/Modelica/Mechanics/MultiBody/Frames.mo
@@ -2031,86 +2031,86 @@ The used variables have the following declaration:
 </pre>
 <table border=1 cellspacing=0 cellpadding=2>
   <tr><th><strong><em>Function/type</em></strong></th><th><strong><em>Description</em></strong></th></tr>
-  <tr><td><strong>Orientation Q;</strong></td>
-      <td>New type defining a quaternion object that describes<br>
+  <tr><td valign=\"top\"><strong>Orientation Q;</strong></td>
+      <td valign=\"top\">New type defining a quaternion object that describes<br>
           the rotation of frame 1 into frame 2.
       </td>
   </tr>
-  <tr><td><strong>der_Orientation</strong> der_Q;</td>
-      <td>New type defining the first time derivative
+  <tr><td valign=\"top\"><strong>der_Orientation</strong> der_Q;</td>
+      <td valign=\"top\">New type defining the first time derivative
          of Frames.Quaternions.Orientation.
       </td>
   </tr>
-  <tr><td>res_ori = <strong>orientationConstraint</strong>(Q);</td>
-      <td>Return the constraints between the variables of a quaternion object<br>
+  <tr><td valign=\"top\">res_ori = <strong>orientationConstraint</strong>(Q);</td>
+      <td valign=\"top\">Return the constraints between the variables of a quaternion object<br>
       (shall be zero).</td>
   </tr>
-  <tr><td>w1 = <strong>angularVelocity1</strong>(Q, der_Q);</td>
-      <td>Return angular velocity resolved in frame 1 from
+  <tr><td valign=\"top\">w1 = <strong>angularVelocity1</strong>(Q, der_Q);</td>
+      <td valign=\"top\">Return angular velocity resolved in frame 1 from
           quaternion object Q<br> and its derivative der_Q.
      </td>
   </tr>
-  <tr><td>w2 = <strong>angularVelocity2</strong>(Q, der_Q);</td>
-      <td>Return angular velocity resolved in frame 2 from
+  <tr><td valign=\"top\">w2 = <strong>angularVelocity2</strong>(Q, der_Q);</td>
+      <td valign=\"top\">Return angular velocity resolved in frame 2 from
           quaternion object Q<br> and its derivative der_Q.
      </td>
   </tr>
-  <tr><td>v1 = <strong>resolve1</strong>(Q,v2);</td>
-      <td>Transform vector v2 from frame 2 to frame 1.
+  <tr><td valign=\"top\">v1 = <strong>resolve1</strong>(Q,v2);</td>
+      <td valign=\"top\">Transform vector v2 from frame 2 to frame 1.
       </td>
   </tr>
-  <tr><td>v2 = <strong>resolve2</strong>(Q,v1);</td>
-      <td>Transform vector v1 from frame 1 to frame 2.
+  <tr><td valign=\"top\">v2 = <strong>resolve2</strong>(Q,v1);</td>
+      <td valign=\"top\">Transform vector v1 from frame 1 to frame 2.
      </td>
   </tr>
-  <tr><td>[v1,w1] = <strong>multipleResolve1</strong>(Q, [v2,w2]);</td>
-      <td>Transform several vectors from frame 2 to frame 1.
+  <tr><td valign=\"top\">[v1,w1] = <strong>multipleResolve1</strong>(Q, [v2,w2]);</td>
+      <td valign=\"top\">Transform several vectors from frame 2 to frame 1.
       </td>
   </tr>
-  <tr><td>[v2,w2] = <strong>multipleResolve2</strong>(Q, [v1,w1]);</td>
-      <td>Transform several vectors from frame 1 to frame 2.
+  <tr><td valign=\"top\">[v2,w2] = <strong>multipleResolve2</strong>(Q, [v1,w1]);</td>
+      <td valign=\"top\">Transform several vectors from frame 1 to frame 2.
       </td>
   </tr>
-  <tr><td>Q = <strong>nullRotation</strong>()</td>
-      <td>Return quaternion object R that does not rotate a frame.
+  <tr><td valign=\"top\">Q = <strong>nullRotation</strong>()</td>
+      <td valign=\"top\">Return quaternion object R that does not rotate a frame.
       </td>
   </tr>
-  <tr><td>Q_inv = <strong>inverseRotation</strong>(Q);</td>
-      <td>Return inverse quaternion object.
+  <tr><td valign=\"top\">Q_inv = <strong>inverseRotation</strong>(Q);</td>
+      <td valign=\"top\">Return inverse quaternion object.
       </td>
   </tr>
-  <tr><td>Q_rel = <strong>relativeRotation</strong>(Q1,Q2);</td>
-      <td>Return relative quaternion object from two absolute
+  <tr><td valign=\"top\">Q_rel = <strong>relativeRotation</strong>(Q1,Q2);</td>
+      <td valign=\"top\">Return relative quaternion object from two absolute
           quaternion objects.
       </td>
   </tr>
-  <tr><td>Q2 = <strong>absoluteRotation</strong>(Q1,Q_rel);</td>
-      <td>Return absolute quaternion object from another
+  <tr><td valign=\"top\">Q2 = <strong>absoluteRotation</strong>(Q1,Q_rel);</td>
+      <td valign=\"top\">Return absolute quaternion object from another
           absolute<br> and a relative quaternion object.
       </td>
   </tr>
-  <tr><td>Q = <strong>planarRotation</strong>(e, angle);</td>
-      <td>Return quaternion object of a planar rotation.
+  <tr><td valign=\"top\">Q = <strong>planarRotation</strong>(e, angle);</td>
+      <td valign=\"top\">Return quaternion object of a planar rotation.
       </td>
   </tr>
-  <tr><td>phi = <strong>smallRotation</strong>(Q);</td>
-      <td>Return rotation angles phi valid for a small rotation.
+  <tr><td valign=\"top\">phi = <strong>smallRotation</strong>(Q);</td>
+      <td valign=\"top\">Return rotation angles phi valid for a small rotation.
       </td>
   </tr>
-  <tr><td>Q = <strong>from_T</strong>(T);</td>
-      <td>Return quaternion object Q from transformation matrix T.
+  <tr><td valign=\"top\">Q = <strong>from_T</strong>(T);</td>
+      <td valign=\"top\">Return quaternion object Q from transformation matrix T.
       </td>
   </tr>
-  <tr><td>Q = <strong>from_T_inv</strong>(T_inv);</td>
-      <td>Return quaternion object Q from inverse transformation matrix T_inv.
+  <tr><td valign=\"top\">Q = <strong>from_T_inv</strong>(T_inv);</td>
+      <td valign=\"top\">Return quaternion object Q from inverse transformation matrix T_inv.
       </td>
   </tr>
-  <tr><td>T = <strong>to_T</strong>(Q);</td>
-      <td>Return transformation matrix T from quaternion object Q.
+  <tr><td valign=\"top\">T = <strong>to_T</strong>(Q);</td>
+      <td valign=\"top\">Return transformation matrix T from quaternion object Q.
       </td>
   </tr>
-  <tr><td>T_inv = <strong>to_T_inv</strong>(Q);</td>
-      <td>Return inverse transformation matrix T_inv from quaternion object Q.
+  <tr><td valign=\"top\">T_inv = <strong>to_T_inv</strong>(Q);</td>
+      <td valign=\"top\">Return inverse transformation matrix T_inv from quaternion object Q.
       </td>
   </tr>
 </table>
@@ -3443,133 +3443,133 @@ The used variables have the following declaration:
 </pre>
 <table border=1 cellspacing=0 cellpadding=2>
   <tr><th><strong><em>Function/type</em></strong></th><th><strong><em>Description</em></strong></th></tr>
-  <tr><td><strong>Orientation T;</strong></td>
-      <td>New type defining an orientation object that describes<br>
+  <tr><td valign=\"top\"><strong>Orientation T;</strong></td>
+      <td valign=\"top\">New type defining an orientation object that describes<br>
           the rotation of frame 1 into frame 2.
       </td>
   </tr>
-  <tr><td><strong>der_Orientation</strong> der_T;</td>
-      <td>New type defining the first time derivative
+  <tr><td valign=\"top\"><strong>der_Orientation</strong> der_T;</td>
+      <td valign=\"top\">New type defining the first time derivative
          of Frames.Orientation.
       </td>
   </tr>
-  <tr><td>res_ori = <strong>orientationConstraint</strong>(T);</td>
-      <td>Return the constraints between the variables of an orientation object<br>
+  <tr><td valign=\"top\">res_ori = <strong>orientationConstraint</strong>(T);</td>
+      <td valign=\"top\">Return the constraints between the variables of an orientation object<br>
       (shall be zero).</td>
   </tr>
-  <tr><td>w1 = <strong>angularVelocity1</strong>(T, der_T);</td>
-      <td>Return angular velocity resolved in frame 1 from
+  <tr><td valign=\"top\">w1 = <strong>angularVelocity1</strong>(T, der_T);</td>
+      <td valign=\"top\">Return angular velocity resolved in frame 1 from
           orientation object T<br> and its derivative der_T.
      </td>
   </tr>
-  <tr><td>w2 = <strong>angularVelocity2</strong>(T, der_T);</td>
-      <td>Return angular velocity resolved in frame 2 from
+  <tr><td valign=\"top\">w2 = <strong>angularVelocity2</strong>(T, der_T);</td>
+      <td valign=\"top\">Return angular velocity resolved in frame 2 from
           orientation object T<br> and its derivative der_T.
      </td>
   </tr>
-  <tr><td>v1 = <strong>resolve1</strong>(T,v2);</td>
-      <td>Transform vector v2 from frame 2 to frame 1.
+  <tr><td valign=\"top\">v1 = <strong>resolve1</strong>(T,v2);</td>
+      <td valign=\"top\">Transform vector v2 from frame 2 to frame 1.
       </td>
   </tr>
-  <tr><td>v2 = <strong>resolve2</strong>(T,v1);</td>
-      <td>Transform vector v1 from frame 1 to frame 2.
+  <tr><td valign=\"top\">v2 = <strong>resolve2</strong>(T,v1);</td>
+      <td valign=\"top\">Transform vector v1 from frame 1 to frame 2.
      </td>
   </tr>
-  <tr><td>[v1,w1] = <strong>multipleResolve1</strong>(T, [v2,w2]);</td>
-      <td>Transform several vectors from frame 2 to frame 1.
+  <tr><td valign=\"top\">[v1,w1] = <strong>multipleResolve1</strong>(T, [v2,w2]);</td>
+      <td valign=\"top\">Transform several vectors from frame 2 to frame 1.
       </td>
   </tr>
-  <tr><td>[v2,w2] = <strong>multipleResolve2</strong>(T, [v1,w1]);</td>
-      <td>Transform several vectors from frame 1 to frame 2.
+  <tr><td valign=\"top\">[v2,w2] = <strong>multipleResolve2</strong>(T, [v1,w1]);</td>
+      <td valign=\"top\">Transform several vectors from frame 1 to frame 2.
       </td>
   </tr>
-  <tr><td>D1 = <strong>resolveDyade1</strong>(T,D2);</td>
-      <td>Transform second order tensor D2 from frame 2 to frame 1.
+  <tr><td valign=\"top\">D1 = <strong>resolveDyade1</strong>(T,D2);</td>
+      <td valign=\"top\">Transform second order tensor D2 from frame 2 to frame 1.
       </td>
   </tr>
-  <tr><td>D2 = <strong>resolveDyade2</strong>(T,D1);</td>
-      <td>Transform second order tensor D1 from frame 1 to frame 2.
+  <tr><td valign=\"top\">D2 = <strong>resolveDyade2</strong>(T,D1);</td>
+      <td valign=\"top\">Transform second order tensor D1 from frame 1 to frame 2.
      </td>
   </tr>
-  <tr><td>T= <strong>nullRotation</strong>()</td>
-      <td>Return orientation object T that does not rotate a frame.
+  <tr><td valign=\"top\">T= <strong>nullRotation</strong>()</td>
+      <td valign=\"top\">Return orientation object T that does not rotate a frame.
      </td>
   </tr>
-  <tr><td>T_inv = <strong>inverseRotation</strong>(T);</td>
-      <td>Return inverse orientation object.
+  <tr><td valign=\"top\">T_inv = <strong>inverseRotation</strong>(T);</td>
+      <td valign=\"top\">Return inverse orientation object.
       </td>
   </tr>
-  <tr><td>T_rel = <strong>relativeRotation</strong>(T1,T2);</td>
-      <td>Return relative orientation object from two absolute
+  <tr><td valign=\"top\">T_rel = <strong>relativeRotation</strong>(T1,T2);</td>
+      <td valign=\"top\">Return relative orientation object from two absolute
           orientation objects.
       </td>
   </tr>
-  <tr><td>T2 = <strong>absoluteRotation</strong>(T1,T_rel);</td>
-      <td>Return absolute orientation object from another
+  <tr><td valign=\"top\">T2 = <strong>absoluteRotation</strong>(T1,T_rel);</td>
+      <td valign=\"top\">Return absolute orientation object from another
           absolute<br> and a relative orientation object.
       </td>
   </tr>
-  <tr><td>T = <strong>planarRotation</strong>(e, angle);</td>
-      <td>Return orientation object of a planar rotation.
+  <tr><td valign=\"top\">T = <strong>planarRotation</strong>(e, angle);</td>
+      <td valign=\"top\">Return orientation object of a planar rotation.
       </td>
   </tr>
-  <tr><td>angle = <strong>planarRotationAngle</strong>(e, v1, v2);</td>
-      <td>Return angle of a planar rotation, given the rotation axis<br>
+  <tr><td valign=\"top\">angle = <strong>planarRotationAngle</strong>(e, v1, v2);</td>
+      <td valign=\"top\">Return angle of a planar rotation, given the rotation axis<br>
         and the representations of a vector in frame 1 and frame 2.
       </td>
   </tr>
-  <tr><td>T = <strong>axisRotation</strong>(i, angle);</td>
-      <td>Return orientation object T for rotation around axis i of frame 1.
+  <tr><td valign=\"top\">T = <strong>axisRotation</strong>(i, angle);</td>
+      <td valign=\"top\">Return orientation object T for rotation around axis i of frame 1.
       </td>
   </tr>
-  <tr><td>T = <strong>axesRotations</strong>(sequence, angles);</td>
-      <td>Return rotation object to rotate in sequence around 3 axes. Example:<br>
+  <tr><td valign=\"top\">T = <strong>axesRotations</strong>(sequence, angles);</td>
+      <td valign=\"top\">Return rotation object to rotate in sequence around 3 axes. Example:<br>
           T = axesRotations({1,2,3},{90,45,-90});
       </td>
   </tr>
-  <tr><td>angles = <strong>axesRotationsAngles</strong>(T, sequence);</td>
-      <td>Return the 3 angles to rotate in sequence around 3 axes to<br>
+  <tr><td valign=\"top\">angles = <strong>axesRotationsAngles</strong>(T, sequence);</td>
+      <td valign=\"top\">Return the 3 angles to rotate in sequence around 3 axes to<br>
           construct the given orientation object.
       </td>
   </tr>
-  <tr><td>phi = <strong>smallRotation</strong>(T);</td>
-      <td>Return rotation angles phi valid for a small rotation.
+  <tr><td valign=\"top\">phi = <strong>smallRotation</strong>(T);</td>
+      <td valign=\"top\">Return rotation angles phi valid for a small rotation.
       </td>
   </tr>
-  <tr><td>T = <strong>from_nxy</strong>(n_x, n_y);</td>
-      <td>Return orientation object from n_x and n_y vectors.
+  <tr><td valign=\"top\">T = <strong>from_nxy</strong>(n_x, n_y);</td>
+      <td valign=\"top\">Return orientation object from n_x and n_y vectors.
       </td>
   </tr>
-  <tr><td>T = <strong>from_nxz</strong>(n_x, n_z);</td>
-      <td>Return orientation object from n_x and n_z vectors.
+  <tr><td valign=\"top\">T = <strong>from_nxz</strong>(n_x, n_z);</td>
+      <td valign=\"top\">Return orientation object from n_x and n_z vectors.
       </td>
   </tr>
-  <tr><td>R = <strong>from_T</strong>(T);</td>
-      <td>Return orientation object R from transformation matrix T.
+  <tr><td valign=\"top\">R = <strong>from_T</strong>(T);</td>
+      <td valign=\"top\">Return orientation object R from transformation matrix T.
       </td>
   </tr>
-  <tr><td>R = <strong>from_T_inv</strong>(T_inv);</td>
-      <td>Return orientation object R from inverse transformation matrix T_inv.
+  <tr><td valign=\"top\">R = <strong>from_T_inv</strong>(T_inv);</td>
+      <td valign=\"top\">Return orientation object R from inverse transformation matrix T_inv.
       </td>
   </tr>
-  <tr><td>T = <strong>from_Q</strong>(Q);</td>
-      <td>Return orientation object T from quaternion orientation object Q.
+  <tr><td valign=\"top\">T = <strong>from_Q</strong>(Q);</td>
+      <td valign=\"top\">Return orientation object T from quaternion orientation object Q.
       </td>
   </tr>
-  <tr><td>T = <strong>to_T</strong>(R);</td>
-      <td>Return transformation matrix T from orientation object R.
+  <tr><td valign=\"top\">T = <strong>to_T</strong>(R);</td>
+      <td valign=\"top\">Return transformation matrix T from orientation object R.
       </td>
   </tr>
-  <tr><td>T_inv = <strong>to_T_inv</strong>(R);</td>
-      <td>Return inverse transformation matrix T_inv from orientation object R.
+  <tr><td valign=\"top\">T_inv = <strong>to_T_inv</strong>(R);</td>
+      <td valign=\"top\">Return inverse transformation matrix T_inv from orientation object R.
       </td>
   </tr>
-  <tr><td>Q = <strong>to_Q</strong>(T);</td>
-      <td>Return quaternion orientation object Q from orientation object T.
+  <tr><td valign=\"top\">Q = <strong>to_Q</strong>(T);</td>
+      <td valign=\"top\">Return quaternion orientation object Q from orientation object T.
       </td>
   </tr>
-  <tr><td>exy = <strong>to_exy</strong>(T);</td>
-      <td>Return [e_x, e_y] matrix of an orientation object T,<br>
+  <tr><td valign=\"top\">exy = <strong>to_exy</strong>(T);</td>
+      <td valign=\"top\">Return [e_x, e_y] matrix of an orientation object T,<br>
           with e_x and e_y vectors of frame 2, resolved in frame 1.
       </td>
   </tr>
@@ -3753,155 +3753,155 @@ The used variables have the following declaration:
 </pre>
 <table border=1 cellspacing=0 cellpadding=2>
   <tr><th><strong><em>Function/type</em></strong></th><th><strong><em>Description</em></strong></th></tr>
-  <tr><td><strong>Orientation R;</strong></td>
-      <td>New type defining an orientation object that describes<br>
+  <tr><td valign=\"top\"><strong>Orientation R;</strong></td>
+      <td valign=\"top\">New type defining an orientation object that describes<br>
           the rotation of frame 1 into frame 2.
       </td>
   </tr>
-  <tr><td>res_ori = <strong>orientationConstraint</strong>(R);</td>
-      <td>Return the constraints between the variables of an orientation object<br>
+  <tr><td valign=\"top\">res_ori = <strong>orientationConstraint</strong>(R);</td>
+      <td valign=\"top\">Return the constraints between the variables of an orientation object<br>
       (shall be zero).</td>
   </tr>
-  <tr><td>w1 = <strong>angularVelocity1</strong>(R);</td>
-      <td>Return angular velocity resolved in frame 1 from
+  <tr><td valign=\"top\">w1 = <strong>angularVelocity1</strong>(R);</td>
+      <td valign=\"top\">Return angular velocity resolved in frame 1 from
           orientation object R.
      </td>
   </tr>
-  <tr><td>w2 = <strong>angularVelocity2</strong>(R);</td>
-      <td>Return angular velocity resolved in frame 2 from
+  <tr><td valign=\"top\">w2 = <strong>angularVelocity2</strong>(R);</td>
+      <td valign=\"top\">Return angular velocity resolved in frame 2 from
           orientation object R.
      </td>
   </tr>
-  <tr><td>v1 = <strong>resolve1</strong>(R,v2);</td>
-      <td>Transform vector v2 from frame 2 to frame 1.
+  <tr><td valign=\"top\">v1 = <strong>resolve1</strong>(R,v2);</td>
+      <td valign=\"top\">Transform vector v2 from frame 2 to frame 1.
       </td>
   </tr>
-  <tr><td>v2 = <strong>resolve2</strong>(R,v1);</td>
-      <td>Transform vector v1 from frame 1 to frame 2.
+  <tr><td valign=\"top\">v2 = <strong>resolve2</strong>(R,v1);</td>
+      <td valign=\"top\">Transform vector v1 from frame 1 to frame 2.
      </td>
   </tr>
-  <tr><td>v2 = <strong>resolveRelative</strong>(v1,R1,R2);</td>
-      <td>Transform vector v1 from frame 1 to frame 2
+  <tr><td valign=\"top\">v2 = <strong>resolveRelative</strong>(v1,R1,R2);</td>
+      <td valign=\"top\">Transform vector v1 from frame 1 to frame 2
           using absolute orientation objects R1 of frame 1 and R2 of frame 2.
       </td>
   </tr>
-  <tr><td>D1 = <strong>resolveDyade1</strong>(R,D2);</td>
-      <td>Transform second order tensor D2 from frame 2 to frame 1.
+  <tr><td valign=\"top\">D1 = <strong>resolveDyade1</strong>(R,D2);</td>
+      <td valign=\"top\">Transform second order tensor D2 from frame 2 to frame 1.
       </td>
   </tr>
-  <tr><td>D2 = <strong>resolveDyade2</strong>(R,D1);</td>
-      <td>Transform second order tensor D1 from frame 1 to frame 2.
+  <tr><td valign=\"top\">D2 = <strong>resolveDyade2</strong>(R,D1);</td>
+      <td valign=\"top\">Transform second order tensor D1 from frame 1 to frame 2.
      </td>
   </tr>
-  <tr><td>R = <strong>nullRotation</strong>()</td>
-      <td>Return orientation object R that does not rotate a frame.
+  <tr><td valign=\"top\">R = <strong>nullRotation</strong>()</td>
+      <td valign=\"top\">Return orientation object R that does not rotate a frame.
      </td>
   </tr>
-  <tr><td>R_inv = <strong>inverseRotation</strong>(R);</td>
-      <td>Return inverse orientation object.
+  <tr><td valign=\"top\">R_inv = <strong>inverseRotation</strong>(R);</td>
+      <td valign=\"top\">Return inverse orientation object.
       </td>
   </tr>
-  <tr><td>R_rel = <strong>relativeRotation</strong>(R1,R2);</td>
-      <td>Return relative orientation object from two absolute
+  <tr><td valign=\"top\">R_rel = <strong>relativeRotation</strong>(R1,R2);</td>
+      <td valign=\"top\">Return relative orientation object from two absolute
           orientation objects.
       </td>
   </tr>
-  <tr><td>R2 = <strong>absoluteRotation</strong>(R1,R_rel);</td>
-      <td>Return absolute orientation object from another
+  <tr><td valign=\"top\">R2 = <strong>absoluteRotation</strong>(R1,R_rel);</td>
+      <td valign=\"top\">Return absolute orientation object from another
           absolute<br> and a relative orientation object.
       </td>
   </tr>
-  <tr><td>R = <strong>planarRotation</strong>(e, angle, der_angle);</td>
-      <td>Return orientation object of a planar rotation.
+  <tr><td valign=\"top\">R = <strong>planarRotation</strong>(e, angle, der_angle);</td>
+      <td valign=\"top\">Return orientation object of a planar rotation.
       </td>
   </tr>
-  <tr><td>angle = <strong>planarRotationAngle</strong>(e, v1, v2);</td>
-      <td>Return angle of a planar rotation, given the rotation axis<br>
+  <tr><td valign=\"top\">angle = <strong>planarRotationAngle</strong>(e, v1, v2);</td>
+      <td valign=\"top\">Return angle of a planar rotation, given the rotation axis<br>
         and the representations of a vector in frame 1 and frame 2.
       </td>
   </tr>
-  <tr><td>R = <strong>axisRotation</strong>(axis, angle, der_angle);</td>
-      <td>Return orientation object R to rotate around angle along axis of frame 1.
+  <tr><td valign=\"top\">R = <strong>axisRotation</strong>(axis, angle, der_angle);</td>
+      <td valign=\"top\">Return orientation object R to rotate around angle along axis of frame 1.
       </td>
   </tr>
-  <tr><td>R = <strong>axesRotations</strong>(sequence, angles, der_angles);</td>
-      <td>Return rotation object to rotate in sequence around 3 axes. Example:<br>
+  <tr><td valign=\"top\">R = <strong>axesRotations</strong>(sequence, angles, der_angles);</td>
+      <td valign=\"top\">Return rotation object to rotate in sequence around 3 axes. Example:<br>
           R = axesRotations({1,2,3},{pi/2,pi/4,-pi}, zeros(3));
       </td>
   </tr>
-  <tr><td>angles = <strong>axesRotationsAngles</strong>(R, sequence);</td>
-      <td>Return the 3 angles to rotate in sequence around 3 axes to<br>
+  <tr><td valign=\"top\">angles = <strong>axesRotationsAngles</strong>(R, sequence);</td>
+      <td valign=\"top\">Return the 3 angles to rotate in sequence around 3 axes to<br>
           construct the given orientation object.
       </td>
   </tr>
-  <tr><td>phi = <strong>smallRotation</strong>(R);</td>
-      <td>Return rotation angles phi valid for a small rotation R.
+  <tr><td valign=\"top\">phi = <strong>smallRotation</strong>(R);</td>
+      <td valign=\"top\">Return rotation angles phi valid for a small rotation R.
       </td>
   </tr>
-  <tr><td>R = <strong>from_nxy</strong>(n_x, n_y);</td>
-      <td>Return orientation object from n_x and n_y vectors.
+  <tr><td valign=\"top\">R = <strong>from_nxy</strong>(n_x, n_y);</td>
+      <td valign=\"top\">Return orientation object from n_x and n_y vectors.
       </td>
   </tr>
-  <tr><td>R = <strong>from_nxz</strong>(n_x, n_z);</td>
-      <td>Return orientation object from n_x and n_z vectors.
+  <tr><td valign=\"top\">R = <strong>from_nxz</strong>(n_x, n_z);</td>
+      <td valign=\"top\">Return orientation object from n_x and n_z vectors.
       </td>
   </tr>
-  <tr><td>R = <strong>from_T</strong>(T,w);</td>
-      <td>Return orientation object R from transformation matrix T and
+  <tr><td valign=\"top\">R = <strong>from_T</strong>(T,w);</td>
+      <td valign=\"top\">Return orientation object R from transformation matrix T and
           its angular velocity w.
       </td>
   </tr>
-  <tr><td>R = <strong>from_T2</strong>(T,der(T));</td>
-      <td>Return orientation object R from transformation matrix T and
+  <tr><td valign=\"top\">R = <strong>from_T2</strong>(T,der(T));</td>
+      <td valign=\"top\">Return orientation object R from transformation matrix T and
           its derivative der(T).
       </td>
   </tr>
-  <tr><td>R = <strong>from_T_inv</strong>(T_inv,w);</td>
-      <td>Return orientation object R from inverse transformation matrix T_inv and
+  <tr><td valign=\"top\">R = <strong>from_T_inv</strong>(T_inv,w);</td>
+      <td valign=\"top\">Return orientation object R from inverse transformation matrix T_inv and
           its angular velocity w.
       </td>
   </tr>
-  <tr><td>R = <strong>from_Q</strong>(Q,w);</td>
-      <td>Return orientation object R from quaternion orientation object Q
+  <tr><td valign=\"top\">R = <strong>from_Q</strong>(Q,w);</td>
+      <td valign=\"top\">Return orientation object R from quaternion orientation object Q
           and its angular velocity w.
       </td>
   </tr>
-  <tr><td>T = <strong>to_T</strong>(R);</td>
-      <td>Return transformation matrix T from orientation object R.
+  <tr><td valign=\"top\">T = <strong>to_T</strong>(R);</td>
+      <td valign=\"top\">Return transformation matrix T from orientation object R.
       </td>
   </tr>
-  <tr><td>T_inv = <strong>to_T_inv</strong>(R);</td>
-      <td>Return inverse transformation matrix T_inv from orientation object R.
+  <tr><td valign=\"top\">T_inv = <strong>to_T_inv</strong>(R);</td>
+      <td valign=\"top\">Return inverse transformation matrix T_inv from orientation object R.
       </td>
   </tr>
-  <tr><td>Q = <strong>to_Q</strong>(R);</td>
-      <td>Return quaternion orientation object Q from orientation object R.
+  <tr><td valign=\"top\">Q = <strong>to_Q</strong>(R);</td>
+      <td valign=\"top\">Return quaternion orientation object Q from orientation object R.
       </td>
   </tr>
-  <tr><td>exy = <strong>to_exy</strong>(R);</td>
-      <td>Return [e_x, e_y] matrix of an orientation object R,<br>
+  <tr><td valign=\"top\">exy = <strong>to_exy</strong>(R);</td>
+      <td valign=\"top\">Return [e_x, e_y] matrix of an orientation object R,<br>
           with e_x and e_y vectors of frame 2, resolved in frame 1.
       </td>
   </tr>
-  <tr><td>L = <strong>length</strong>(n_x);</td>
-      <td>Return length L of a vector n_x.
+  <tr><td valign=\"top\">L = <strong>length</strong>(n_x);</td>
+      <td valign=\"top\">Return length L of a vector n_x.
       </td>
   </tr>
-  <tr><td>e_x = <strong>normalize</strong>(n_x);</td>
-      <td>Return normalized vector e_x of n_x such that length of e_x is one.
+  <tr><td valign=\"top\">e_x = <strong>normalize</strong>(n_x);</td>
+      <td valign=\"top\">Return normalized vector e_x of n_x such that length of e_x is one.
       </td>
   </tr>
-  <tr><td>e = <strong>axis</strong>(i);</td>
-      <td>Return unit vector e directed along axis i
+  <tr><td valign=\"top\">e = <strong>axis</strong>(i);</td>
+      <td valign=\"top\">Return unit vector e directed along axis i
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Frames.Quaternions\">Quaternions</a></td>
-      <td><strong>Package</strong> with functions to transform rotational frame quantities based
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Frames.Quaternions\">Quaternions</a></td>
+      <td valign=\"top\"><strong>Package</strong> with functions to transform rotational frame quantities based
           on quaternions (also called Euler parameters).
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Frames.TransformationMatrices\">TransformationMatrices</a></td>
-      <td><strong>Package</strong> with functions to transform rotational frame quantities based
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Frames.TransformationMatrices\">TransformationMatrices</a></td>
+      <td valign=\"top\"><strong>Package</strong> with functions to transform rotational frame quantities based
           on transformation matrices.
       </td>
   </tr>

--- a/Modelica/Mechanics/MultiBody/Joints.mo
+++ b/Modelica/Mechanics/MultiBody/Joints.mo
@@ -6798,10 +6798,10 @@ The assembly joints in this package are named <strong>JointXYZ</strong> where
 component, in particular:
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>P</strong></td><td>Prismatic joint</td></tr>
-  <tr><td><strong>R</strong></td><td>Revolute joint</td></tr>
-  <tr><td><strong>S</strong></td><td>Spherical joint</td></tr>
-  <tr><td><strong>U</strong></td><td>Universal joint</td></tr>
+  <tr><td valign=\"top\"><strong>P</strong></td><td valign=\"top\">Prismatic joint</td></tr>
+  <tr><td valign=\"top\"><strong>R</strong></td><td valign=\"top\">Revolute joint</td></tr>
+  <tr><td valign=\"top\"><strong>S</strong></td><td valign=\"top\">Spherical joint</td></tr>
+  <tr><td valign=\"top\"><strong>U</strong></td><td valign=\"top\">Universal joint</td></tr>
 </table>
 <p>
 For example, JointUSR is an assembly joint consisting
@@ -6812,42 +6812,42 @@ of a universal, a spherical and a revolute joint.
 <h4>Content</h4>
 <table border=1 cellspacing=0 cellpadding=2>
   <tr><th><strong><em>Model</em></strong></th><th><strong><em>Description</em></strong></th></tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointUPS\">JointUPS</a></td>
-      <td> Universal - prismatic - spherical joint aggregation<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointUPS\">JointUPS</a></td>
+      <td valign=\"top\"> Universal - prismatic - spherical joint aggregation<br>
      <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointUPS.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointUSR\">JointUSR</a></td>
-      <td> Universal - spherical - revolute joint aggregation<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointUSR\">JointUSR</a></td>
+      <td valign=\"top\"> Universal - spherical - revolute joint aggregation<br>
      <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointUSR.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointUSP\">JointUSP</a></td>
-      <td> Universal - spherical - prismatic joint aggregation<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointUSP\">JointUSP</a></td>
+      <td valign=\"top\"> Universal - spherical - prismatic joint aggregation<br>
      <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointUSP.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointSSR\">JointSSR</a></td>
-      <td> Spherical - spherical - revolute joint aggregation
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointSSR\">JointSSR</a></td>
+      <td valign=\"top\"> Spherical - spherical - revolute joint aggregation
            with an optional mass point at the rod connecting
            the two spherical joints<br>
      <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointSSR.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointSSP\">JointSSP</a></td>
-      <td> Spherical - spherical - prismatic joint aggregation
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointSSP\">JointSSP</a></td>
+      <td valign=\"top\"> Spherical - spherical - prismatic joint aggregation
            with an optional mass point at the rod connecting
            the two spherical joints<br>
      <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointSSP.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointRRR\">JointRRR</a></td>
-      <td> Revolute - revolute - revolute joint aggregation for planar loops<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointRRR\">JointRRR</a></td>
+      <td valign=\"top\"> Revolute - revolute - revolute joint aggregation for planar loops<br>
      <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointRRR.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointRRP\">JointRRP</a></td>
-      <td> Revolute - revolute - prismatic joint aggregation for planar loops<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointRRP\">JointRRP</a></td>
+      <td valign=\"top\"> Revolute - revolute - prismatic joint aggregation for planar loops<br>
      <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointRRP.png\">
       </td>
   </tr>
@@ -8625,65 +8625,65 @@ solved, i.e., robustly and efficiently).
 <h4>Content</h4>
 <table border=1 cellspacing=0 cellpadding=2>
   <tr><th><strong><em>Model</em></strong></th><th><strong><em>Description</em></strong></th></tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Prismatic\">Prismatic</a></td>
-      <td>Prismatic joint and actuated prismatic joint
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Prismatic\">Prismatic</a></td>
+      <td valign=\"top\">Prismatic joint and actuated prismatic joint
           (1 translational degree-of-freedom, 2 potential states)<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Prismatic.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Revolute\">Revolute</a>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Revolute\">Revolute</a>
  </td>
-      <td>Revolute and actuated revolute joint
+      <td valign=\"top\">Revolute and actuated revolute joint
           (1 rotational degree-of-freedom, 2 potential states)<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Revolute.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Cylindrical\">Cylindrical</a></td>
-      <td>Cylindrical joint (2 degrees-of-freedom, 4 potential states)<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Cylindrical\">Cylindrical</a></td>
+      <td valign=\"top\">Cylindrical joint (2 degrees-of-freedom, 4 potential states)<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Cylindrical.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Universal\">Universal</a></td>
-      <td>Universal joint (2 degrees-of-freedom, 4 potential states)<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Universal\">Universal</a></td>
+      <td valign=\"top\">Universal joint (2 degrees-of-freedom, 4 potential states)<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Universal.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Planar\">Planar</a></td>
-      <td>Planar joint (3 degrees-of-freedom, 6 potential states)<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Planar\">Planar</a></td>
+      <td valign=\"top\">Planar joint (3 degrees-of-freedom, 6 potential states)<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Planar.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Spherical\">Spherical</a></td>
-      <td>Spherical joint (3 constraints and no potential states, or 3 degrees-of-freedom and 3 states)<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Spherical\">Spherical</a></td>
+      <td valign=\"top\">Spherical joint (3 constraints and no potential states, or 3 degrees-of-freedom and 3 states)<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Spherical.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.FreeMotion\">FreeMotion</a></td>
-      <td>Free motion joint (6 degrees-of-freedom, 12 potential states)<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.FreeMotion\">FreeMotion</a></td>
+      <td valign=\"top\">Free motion joint (6 degrees-of-freedom, 12 potential states)<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/FreeMotion.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.SphericalSpherical\">SphericalSpherical</a></td>
-      <td>Spherical - spherical joint aggregation (1 constraint,
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.SphericalSpherical\">SphericalSpherical</a></td>
+      <td valign=\"top\">Spherical - spherical joint aggregation (1 constraint,
           no potential states) with an optional point mass in the middle<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/SphericalSpherical.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.UniversalSpherical\">UniversalSpherical</a></td>
-      <td>Universal - spherical joint aggregation (1 constraint, no potential states)<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.UniversalSpherical\">UniversalSpherical</a></td>
+      <td valign=\"top\">Universal - spherical joint aggregation (1 constraint, no potential states)<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/UniversalSpherical.png\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.GearConstraint\">GearConstraint</a></td>
-      <td>Ideal 3-dim. gearbox (arbitrary shaft directions)
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.GearConstraint\">GearConstraint</a></td>
+      <td valign=\"top\">Ideal 3-dim. gearbox (arbitrary shaft directions)
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies\">MultiBody.Joints.Assemblies</a></td>
-      <td><strong>Package</strong> of joint aggregations for analytic loop handling.
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies\">MultiBody.Joints.Assemblies</a></td>
+      <td valign=\"top\"><strong>Package</strong> of joint aggregations for analytic loop handling.
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Constraints\">MultiBody.Joints.Constraints</a></td>
-      <td><strong>Package</strong> of components that define joints by constraints
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Constraints\">MultiBody.Joints.Constraints</a></td>
+      <td valign=\"top\"><strong>Package</strong> of components that define joints by constraints
       </td>
   </tr>
 </table>

--- a/Modelica/Mechanics/MultiBody/Parts.mo
+++ b/Modelica/Mechanics/MultiBody/Parts.mo
@@ -2999,70 +2999,70 @@ a \"Body\" and of several \"FixedTranslation\" components.
 <h4>Content</h4>
 <table border=1 cellspacing=0 cellpadding=2>
   <tr><th><strong><em>Model</em></strong></th><th><strong><em>Description</em></strong></th></tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.Fixed\">Fixed</a></td>
-      <td>Frame fixed in world frame at a given position.
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.Fixed\">Fixed</a></td>
+      <td valign=\"top\">Frame fixed in world frame at a given position.
           It is visualized with a shape, see <strong>shapeType</strong> below
          (the frames on the two
           sides do not belong to the component):<br>&nbsp;<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Fixed.png\" alt=\"model Parts.Fixed\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.FixedTranslation\">FixedTranslation</a></td>
-      <td>Fixed translation of frame_b with respect to frame_a.
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.FixedTranslation\">FixedTranslation</a></td>
+      <td valign=\"top\">Fixed translation of frame_b with respect to frame_a.
           It is visualized with a shape, see <strong>shapeType</strong> below
           (the frames on the two sides do not belong to the component):<br>&nbsp;<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/FixedTranslation.png\" alt=\"model Parts.FixedTranslation\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.FixedRotation\">FixedRotation</a></td>
-      <td>Fixed translation and fixed rotation of frame_b with respect to frame_a
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.FixedRotation\">FixedRotation</a></td>
+      <td valign=\"top\">Fixed translation and fixed rotation of frame_b with respect to frame_a
           It is visualized with a shape, see <strong>shapeType</strong>  below
           (the frames on the two sides do not belong to the component):<br>&nbsp;<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/FixedRotation.png\" alt=\"model Parts.FixedRotation\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.Body\">Body</a></td>
-      <td>Rigid body with mass, inertia tensor and one frame connector.
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.Body\">Body</a></td>
+      <td valign=\"top\">Rigid body with mass, inertia tensor and one frame connector.
           It is visualized with a cylinder and a sphere at the
           center of mass:<br>&nbsp;<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Body.png\" alt=\"model Parts.Body\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.BodyShape\">BodyShape</a></td>
-      <td>Rigid body with mass, inertia tensor, different shapes
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.BodyShape\">BodyShape</a></td>
+      <td valign=\"top\">Rigid body with mass, inertia tensor, different shapes
           (see <strong>shapeType</strong> below)
           for animation, and two frame connectors:<br>&nbsp;<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/BodyShape.png\" alt=\"model Parts.BodyShape\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.Fixed\">Fixed BodyBox</a></td>
-      <td>Rigid body with box shape (mass and animation properties are computed
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.Fixed\">Fixed BodyBox</a></td>
+      <td valign=\"top\">Rigid body with box shape (mass and animation properties are computed
           from box data and from density):<br>&nbsp;<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/BodyBox.png\" alt=\"model Parts.BodyBox\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.BodyCylinder\">BodyCylinder</a></td>
-      <td>Rigid body with cylinder shape (mass and animation properties
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.BodyCylinder\">BodyCylinder</a></td>
+      <td valign=\"top\">Rigid body with cylinder shape (mass and animation properties
           are computed from cylinder data and from density):<br>&nbsp;<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/BodyCylinder.png\" alt=\"model Parts.BodyCylinder\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.PointMass\">PointMass</a></td>
-      <td>Rigid body where inertia tensor and rotation is neglected:<br>&nbsp;<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.PointMass\">PointMass</a></td>
+      <td valign=\"top\">Rigid body where inertia tensor and rotation is neglected:<br>&nbsp;<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Parts/PointMass.png\" alt=\"model Parts.PointMass\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.Mounting1D\">Mounting1D</a></td>
-      <td> Propagate 1-dim. support torque to 3-dim. system
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.Mounting1D\">Mounting1D</a></td>
+      <td valign=\"top\"> Propagate 1-dim. support torque to 3-dim. system
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.Rotor1D\">Rotor1D</a></td>
-      <td>1D inertia attachable on 3-dim. bodies (without neglecting dynamic effects)<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.Rotor1D\">Rotor1D</a></td>
+      <td valign=\"top\">1D inertia attachable on 3-dim. bodies (without neglecting dynamic effects)<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Parts/Rotor1D.png\" alt=\"model Parts.Rotor1D\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.BevelGear1D\">BevelGear1D</a></td>
-      <td>1D gearbox with arbitrary shaft directions (3D bearing frame)
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Parts.BevelGear1D\">BevelGear1D</a></td>
+      <td valign=\"top\">1D gearbox with arbitrary shaft directions (3D bearing frame)
       </td>
   </tr>
 </table>

--- a/Modelica/Mechanics/MultiBody/Sensors.mo
+++ b/Modelica/Mechanics/MultiBody/Sensors.mo
@@ -340,14 +340,14 @@ a vector is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameA.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vectors in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vectors in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vectors in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vectors in frame_a</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vectors in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vectors in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -777,17 +777,17 @@ a vector is resolved (before differentiation):
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameAB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vectors in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vectors in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vectors in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vectors in frame_a</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve vectors in frame_b</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve vectors in frame_b</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vectors in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vectors in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -957,14 +957,14 @@ the position vector is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameA.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -1087,14 +1087,14 @@ the velocity vector is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameA.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -1273,14 +1273,14 @@ the angular velocity is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameA.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -1374,17 +1374,17 @@ the position vector is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameAB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve vector in frame_b</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve vector in frame_b</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -1506,17 +1506,17 @@ the velocity vector is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameAB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve vector in frame_b</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve vector in frame_b</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -1695,17 +1695,17 @@ the angular velocity is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameAB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve vector in frame_b</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve vector in frame_b</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -1931,14 +1931,14 @@ the force vector is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameA.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -2045,14 +2045,14 @@ the torque vector is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameA.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -2209,14 +2209,14 @@ the two vectors are resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameA.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -2683,14 +2683,14 @@ the position vector is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameA.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -2759,14 +2759,14 @@ the angular velocity is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameA.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -2839,17 +2839,17 @@ the position vector is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameAB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve vector in frame_b</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve vector in frame_b</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -2925,17 +2925,17 @@ the angular velocity is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameAB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve vector in frame_b</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve vector in frame_b</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -3075,14 +3075,14 @@ defined in which frame the position vector is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameA.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -3169,17 +3169,17 @@ defined in which frame the position vector is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameAB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve vector in frame_b</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve vector in frame_b</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -3395,14 +3395,14 @@ the force vector is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameA.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>
@@ -3477,14 +3477,14 @@ the torque vector is resolved:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>resolveInFrame =<br>Types.ResolveInFrameA.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve</td></tr>
 </table>
 
 <p>

--- a/Modelica/Mechanics/MultiBody/Types.mo
+++ b/Modelica/Mechanics/MultiBody/Types.mo
@@ -191,38 +191,38 @@ variable <strong>extra</strong> is used as instance name:
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>shapeType</strong></th><th>Meaning of parameter <strong>extra</strong></th></tr>
 <tr>
-  <td>\"cylinder\"</td>
-  <td>if extra&nbsp;&gt;&nbsp;0, a black line is included in the
+  <td valign=\"top\">\"cylinder\"</td>
+  <td valign=\"top\">if extra&nbsp;&gt;&nbsp;0, a black line is included in the
       cylinder to show the rotation of it.</td>
 </tr>
 <tr>
-  <td>\"cone\"</td>
-  <td>extra = diameter-left-side / diameter-right-side, i.e.,<br>
+  <td valign=\"top\">\"cone\"</td>
+  <td valign=\"top\">extra = diameter-left-side / diameter-right-side, i.e.,<br>
       extra = 1: cylinder<br>
       extra = 0: \"real\" cone.</td>
 </tr>
 <tr>
-  <td>\"pipe\"</td>
-  <td>extra = outer-diameter / inner-diameter, i.e,<br>
+  <td valign=\"top\">\"pipe\"</td>
+  <td valign=\"top\">extra = outer-diameter / inner-diameter, i.e,<br>
       extra = 1: cylinder that is completely hollow<br>
       extra = 0: cylinder without a hole.</td>
 </tr>
 <tr>
-  <td>\"gearwheel\"</td>
-  <td>extra is the number of teeth of the (external) gear.
+  <td valign=\"top\">\"gearwheel\"</td>
+  <td valign=\"top\">extra is the number of teeth of the (external) gear.
 If extra&nbsp;&lt;&nbsp;0, an internal gear is visualized with |extra| teeth.
 The axis of the gearwheel is along \"lengthDirection\", and usually:
 width = height = 2*radiusOfGearWheel.</td>
 </tr>
 <tr>
-  <td>\"spring\"</td>
-  <td>extra is the number of windings of the spring.
+  <td valign=\"top\">\"spring\"</td>
+  <td valign=\"top\">extra is the number of windings of the spring.
       Additionally, \"height\" is <strong>not</strong> the \"height\" but
       2*coil-width.</td>
 </tr>
 <tr>
-  <td>external shape</td>
-  <td>extra = 0: Visualization from file is not scaled.<br>
+  <td valign=\"top\">external shape</td>
+  <td valign=\"top\">extra = 0: Visualization from file is not scaled.<br>
                      extra = 1: Visualization from file is scaled with \"length\", \"width\" and \"height\"
                                 of the shape</td>
 </tr>
@@ -238,14 +238,14 @@ width = height = 2*radiusOfGearWheel.</td>
                                                annotation (Documentation(info="<html>
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>Types.ResolveInFrameA.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve (frame_resolve must be connected)</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve (frame_resolve must be connected)</td></tr>
 </table>
 </html>"));
   type ResolveInFrameB = enumeration(
@@ -257,14 +257,14 @@ width = height = 2*radiusOfGearWheel.</td>
                                                annotation (Documentation(info="<html>
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>Types.ResolveInFrameB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve vector in frame_b</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve vector in frame_b</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve (frame_resolve must be connected)</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve (frame_resolve must be connected)</td></tr>
 </table>
 </html>"));
   type ResolveInFrameAB = enumeration(
@@ -277,17 +277,17 @@ width = height = 2*radiusOfGearWheel.</td>
                                                annotation (Documentation(info="<html>
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>Types.ResolveInFrameAB.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>world</td>
-    <td>Resolve vector in world frame</td></tr>
+<tr><td valign=\"top\">world</td>
+    <td valign=\"top\">Resolve vector in world frame</td></tr>
 
-<tr><td>frame_a</td>
-    <td>Resolve vector in frame_a</td></tr>
+<tr><td valign=\"top\">frame_a</td>
+    <td valign=\"top\">Resolve vector in frame_a</td></tr>
 
-<tr><td>frame_b</td>
-    <td>Resolve vector in frame_b</td></tr>
+<tr><td valign=\"top\">frame_b</td>
+    <td valign=\"top\">Resolve vector in frame_b</td></tr>
 
-<tr><td>frame_resolve</td>
-    <td>Resolve vector in frame_resolve (frame_resolve must be connected)</td></tr>
+<tr><td valign=\"top\">frame_resolve</td>
+    <td valign=\"top\">Resolve vector in frame_resolve (frame_resolve must be connected)</td></tr>
 </table>
 </html>"));
 
@@ -300,15 +300,15 @@ width = height = 2*radiusOfGearWheel.</td>
         Documentation(Evaluate=true, info="<html>
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>Types.RotationTypes.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>RotationAxis</td>
-    <td>frame_b is defined by rotating the coordinate system along
+<tr><td valign=\"top\">RotationAxis</td>
+    <td valign=\"top\">frame_b is defined by rotating the coordinate system along
         an axis fixed in frame_a and with a fixed angle.</td></tr>
 
-<tr><td>TwoAxesVectors</td>
-    <td>frame_b is defined by resolving two vectors of frame_b in frame_a.</td></tr>
+<tr><td valign=\"top\">TwoAxesVectors</td>
+    <td valign=\"top\">frame_b is defined by resolving two vectors of frame_b in frame_a.</td></tr>
 
-<tr><td>PlanarRotationSequence</td>
-    <td>frame_b is defined by rotating the coordinate system along
+<tr><td valign=\"top\">PlanarRotationSequence</td>
+    <td valign=\"top\">frame_b is defined by rotating the coordinate system along
         3 consecutive axes vectors with fixed rotation angles
         (e.g., Cardan or Euler angle sequence rotation).</td></tr>
 </table>
@@ -322,14 +322,14 @@ width = height = 2*radiusOfGearWheel.</td>
       annotation (Documentation(info="<html>
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>Types.GravityTypes.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>NoGravity</td>
-    <td>No gravity field</td></tr>
+<tr><td valign=\"top\">NoGravity</td>
+    <td valign=\"top\">No gravity field</td></tr>
 
-<tr><td>UniformGravity</td>
-    <td>Gravity field is described by a vector of constant gravity acceleration</td></tr>
+<tr><td valign=\"top\">UniformGravity</td>
+    <td valign=\"top\">Gravity field is described by a vector of constant gravity acceleration</td></tr>
 
-<tr><td>PointGravity</td>
-    <td>Central gravity field. The gravity acceleration vector is directed to
+<tr><td valign=\"top\">PointGravity</td>
+    <td valign=\"top\">Central gravity field. The gravity acceleration vector is directed to
         the field center and the gravity is proportional to 1/r^2, where
         r is the distance to the field center.</td></tr>
 </table>

--- a/Modelica/Mechanics/MultiBody/Visualizers.mo
+++ b/Modelica/Mechanics/MultiBody/Visualizers.mo
@@ -116,38 +116,38 @@ Via variable <strong>extra</strong> additional data can be defined:
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>shapeType</strong></th><th>Meaning of parameter <strong>extra</strong></th></tr>
 <tr>
-  <td>\"cylinder\"</td>
-  <td>if extra&nbsp;&gt;&nbsp;0, a black line is included in the
+  <td valign=\"top\">\"cylinder\"</td>
+  <td valign=\"top\">if extra&nbsp;&gt;&nbsp;0, a black line is included in the
       cylinder to show the rotation of it.</td>
 </tr>
 <tr>
-  <td>\"cone\"</td>
-  <td>extra = diameter-left-side / diameter-right-side, i.e.,<br>
+  <td valign=\"top\">\"cone\"</td>
+  <td valign=\"top\">extra = diameter-left-side / diameter-right-side, i.e.,<br>
       extra = 1: cylinder<br>
       extra = 0: \"real\" cone.</td>
 </tr>
 <tr>
-  <td>\"pipe\"</td>
-  <td>extra = outer-diameter / inner-diameter, i.e,<br>
+  <td valign=\"top\">\"pipe\"</td>
+  <td valign=\"top\">extra = outer-diameter / inner-diameter, i.e,<br>
       extra = 1: cylinder that is completely hollow<br>
       extra = 0: cylinder without a hole.</td>
 </tr>
 <tr>
-  <td>\"gearwheel\"</td>
-  <td>extra is the number of teeth of the (external) gear.
+  <td valign=\"top\">\"gearwheel\"</td>
+  <td valign=\"top\">extra is the number of teeth of the (external) gear.
 If extra&nbsp;&lt;&nbsp;0, an internal gear is visualized with |extra| teeth.
 The axis of the gearwheel is along \"lengthDirection\", and usually:
 width = height = 2*radiusOfGearWheel.</td>
 </tr>
 <tr>
-  <td>\"spring\"</td>
-  <td>extra is the number of windings of the spring.
+  <td valign=\"top\">\"spring\"</td>
+  <td valign=\"top\">extra is the number of windings of the spring.
       Additionally, \"height\" is <strong>not</strong> the \"height\" but
       2*coil-width.</td>
 </tr>
 <tr>
-  <td>external shape</td>
-  <td>extra = 0: Visualization from file is not scaled.<br>
+  <td valign=\"top\">external shape</td>
+  <td valign=\"top\">extra = 0: Visualization from file is not scaled.<br>
                      extra = 1: Visualization from file is scaled with \"length\", \"width\" and \"height\"
                                 of the shape</td>
 </tr>
@@ -356,38 +356,38 @@ Via variable <strong>extra</strong> additional data can be defined:
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>shapeType</strong></th><th>Meaning of parameter <strong>extra</strong></th></tr>
 <tr>
-  <td>\"cylinder\"</td>
-  <td>if extra&nbsp;&gt;&nbsp;0, a black line is included in the
+  <td valign=\"top\">\"cylinder\"</td>
+  <td valign=\"top\">if extra&nbsp;&gt;&nbsp;0, a black line is included in the
       cylinder to show the rotation of it.</td>
 </tr>
 <tr>
-  <td>\"cone\"</td>
-  <td>extra = diameter-left-side / diameter-right-side, i.e.,<br>
+  <td valign=\"top\">\"cone\"</td>
+  <td valign=\"top\">extra = diameter-left-side / diameter-right-side, i.e.,<br>
       extra = 1: cylinder<br>
       extra = 0: \"real\" cone.</td>
 </tr>
 <tr>
-  <td>\"pipe\"</td>
-  <td>extra = outer-diameter / inner-diameter, i.e,<br>
+  <td valign=\"top\">\"pipe\"</td>
+  <td valign=\"top\">extra = outer-diameter / inner-diameter, i.e,<br>
       extra = 1: cylinder that is completely hollow<br>
       extra = 0: cylinder without a hole.</td>
 </tr>
 <tr>
-  <td>\"gearwheel\"</td>
-  <td>extra is the number of teeth of the (external) gear.
+  <td valign=\"top\">\"gearwheel\"</td>
+  <td valign=\"top\">extra is the number of teeth of the (external) gear.
 If extra&nbsp;&lt;&nbsp;0, an internal gear is visualized with |extra| teeth.
 The axis of the gearwheel is along \"lengthDirection\", and usually:
 width = height = 2*radiusOfGearWheel.</td>
 </tr>
 <tr>
-  <td>\"spring\"</td>
-  <td>extra is the number of windings of the spring.
+  <td valign=\"top\">\"spring\"</td>
+  <td valign=\"top\">extra is the number of windings of the spring.
       Additionally, \"height\" is <strong>not</strong> the \"height\" but
       2*coil-width.</td>
 </tr>
 <tr>
-  <td>external shape</td>
-  <td>extra = 0: Visualization from file is not scaled.<br>
+  <td valign=\"top\">external shape</td>
+  <td valign=\"top\">extra = 0: Visualization from file is not scaled.<br>
                      extra = 1: Visualization from file is scaled with \"length\", \"width\" and \"height\"
                                 of the shape</td>
 </tr>
@@ -2156,38 +2156,38 @@ Via variable <strong>extra</strong> additional data can be defined:
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>shapeType</strong></th><th>Meaning of parameter <strong>extra</strong></th></tr>
 <tr>
-  <td>\"cylinder\"</td>
-  <td>if extra&nbsp;&gt;&nbsp;0, a black line is included in the
+  <td valign=\"top\">\"cylinder\"</td>
+  <td valign=\"top\">if extra&nbsp;&gt;&nbsp;0, a black line is included in the
       cylinder to show the rotation of it.</td>
 </tr>
 <tr>
-  <td>\"cone\"</td>
-  <td>extra = diameter-left-side / diameter-right-side, i.e.,<br>
+  <td valign=\"top\">\"cone\"</td>
+  <td valign=\"top\">extra = diameter-left-side / diameter-right-side, i.e.,<br>
       extra = 1: cylinder<br>
       extra = 0: \"real\" cone.</td>
 </tr>
 <tr>
-  <td>\"pipe\"</td>
-  <td>extra = outer-diameter / inner-diameter, i.e,<br>
+  <td valign=\"top\">\"pipe\"</td>
+  <td valign=\"top\">extra = outer-diameter / inner-diameter, i.e,<br>
       extra = 1: cylinder that is completely hollow<br>
       extra = 0: cylinder without a hole.</td>
 </tr>
 <tr>
-  <td>\"gearwheel\"</td>
-  <td>extra is the number of teeth of the (external) gear.
+  <td valign=\"top\">\"gearwheel\"</td>
+  <td valign=\"top\">extra is the number of teeth of the (external) gear.
 If extra &lt; 0, an internal gear is visualized with |extra| teeth.
 The axis of the gearwheel is along \"lengthDirection\", and usually:
 width = height = 2*radiusOfGearWheel.</td>
 </tr>
 <tr>
-  <td>\"spring\"</td>
-  <td>extra is the number of windings of the spring.
+  <td valign=\"top\">\"spring\"</td>
+  <td valign=\"top\">extra is the number of windings of the spring.
       Additionally, \"height\" is <strong>not</strong> the \"height\" but
       2*coil-width.</td>
 </tr>
 <tr>
-  <td>external shape</td>
-  <td>extra = 0: Visualization from file is not scaled.<br>
+  <td valign=\"top\">external shape</td>
+  <td valign=\"top\">extra = 0: Visualization from file is not scaled.<br>
                    extra = 1: Visualization from file is scaled with \"length\", \"width\" and \"height\"
                               of the shape</td>
 </tr>
@@ -2570,31 +2570,31 @@ since they all have frame connectors).
 </p>
 <h4>Content</h4>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow\">Arrow</a></td>
-      <td>Visualizing an arrow where all parts of the arrow can vary dynamically:<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow\">Arrow</a></td>
+      <td valign=\"top\">Visualizing an arrow where all parts of the arrow can vary dynamically:<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Visualizers/Arrow.png\" alt=\"model Visualizers.Advanced.Arrow\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.Advanced.DoubleArrow\">DoubleArrow</a></td>
-      <td>Visualizing a double arrow where all parts of the arrow can vary dynamically:<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.Advanced.DoubleArrow\">DoubleArrow</a></td>
+      <td valign=\"top\">Visualizing a double arrow where all parts of the arrow can vary dynamically:<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Visualizers/DoubleArrow.png\" alt=\"model Visualizers.Advanced.DoubleArrow\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.Advanced.Shape\">Shape</a></td>
-      <td>Visualizing an elementary object with variable size.
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.Advanced.Shape\">Shape</a></td>
+      <td valign=\"top\">Visualizing an elementary object with variable size.
       The following shape types are supported:<br>&nbsp;<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/FixedShape.png\" alt=\"model Visualizers.Advanced.Shape\">
       </td>
   </tr>
 
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.Advanced.Surface\">Surface</a></td>
-      <td>Visualizing a moveable parameterized surface:<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.Advanced.Surface\">Surface</a></td>
+      <td valign=\"top\">Visualizing a moveable parameterized surface:<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Visualizers/Surface_small.png\">
       </td>
   </tr>
 
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.Advanced.PipeWithScalarField\">PipeWithScalarField</a></td>
-      <td>Visualizing a pipe with a scalar field represented by a color coding:<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.Advanced.PipeWithScalarField\">PipeWithScalarField</a></td>
+      <td valign=\"top\">Visualizing a pipe with a scalar field represented by a color coding:<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Visualizers/PipeWithScalarFieldIcon.png\">
       </td>
   </tr>
@@ -2844,24 +2844,24 @@ animation features of the MultiBody library.
 </p>
 <h4>Content</h4>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.FixedShape\">FixedShape</a><br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.FixedShape\">FixedShape</a><br>
              <a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.FixedShape2\">FixedShape2</a></td>
-      <td>Visualizing an elementary shape with dynamically varying shape attributes.
+      <td valign=\"top\">Visualizing an elementary shape with dynamically varying shape attributes.
       FixedShape has one connector frame_a, whereas FixedShape2 has additionally
           a frame_b for easier connection to further visual objects.
           The following shape types are supported:<br>&nbsp;<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/FixedShape.png\" alt=\"model Visualizers.FixedShape\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.FixedFrame\">FixedFrame</a></td>
-      <td>Visualizing a coordinate system including axes labels with fixed sizes:<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.FixedFrame\">FixedFrame</a></td>
+      <td valign=\"top\">Visualizing a coordinate system including axes labels with fixed sizes:<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/FixedFrame2.png\"
        alt=\"model Visualizers.FixedFrame\">
       </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.FixedArrow\">FixedArrow</a>,<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.FixedArrow\">FixedArrow</a>,<br>
 <a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.SignalArrow\">SignalArrow</a></td>
-      <td>Visualizing an arrow. Model \"FixedArrow\" provides
+      <td valign=\"top\">Visualizing an arrow. Model \"FixedArrow\" provides
       a fixed sized arrow, model \"SignalArrow\" provides
       an arrow with dynamically varying length that is defined
       by an input signal vector:<br>
@@ -2869,32 +2869,32 @@ animation features of the MultiBody library.
       </td>
   </tr>
 
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.Ground\">Ground</a></td>
-      <td>Visualizing the ground by a plane:<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.Ground\">Ground</a></td>
+      <td valign=\"top\">Visualizing the ground by a plane:<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Visualizers/GroundSmall.png\">
       </td>
   </tr>
 
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.Torus\">Torus</a></td>
-      <td>Visualizing a torus:<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.Torus\">Torus</a></td>
+      <td valign=\"top\">Visualizing a torus:<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Visualizers/TorusIcon.png\">
       </td>
   </tr>
 
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.VoluminousWheel\">VoluminousWheel</a></td>
-      <td>Visualizing a wheel:<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.VoluminousWheel\">VoluminousWheel</a></td>
+      <td valign=\"top\">Visualizing a wheel:<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Visualizers/VoluminousWheelIcon.png\">
       </td>
   </tr>
 
-  <tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.PipeWithScalarField\">PipeWithScalarField</a></td>
-      <td>Visualizing a pipe with a scalar field represented by a color coding:<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.PipeWithScalarField\">PipeWithScalarField</a></td>
+      <td valign=\"top\">Visualizing a pipe with a scalar field represented by a color coding:<br>
       <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Visualizers/PipeWithScalarFieldIcon.png\">
       </td>
   </tr>
 
-<tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.Advanced\">Advanced</a></td>
-      <td> <strong>Package</strong> that contains components to visualize
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Visualizers.Advanced\">Advanced</a></td>
+      <td valign=\"top\"> <strong>Package</strong> that contains components to visualize
           3-dimensional shapes where all parts of the shape
           can vary dynamically. Basic knowledge of Modelica is
           needed in order to utilize the components of this package.

--- a/Modelica/Mechanics/MultiBody/package.mo
+++ b/Modelica/Mechanics/MultiBody/package.mo
@@ -534,35 +534,35 @@ combinations are listed in the table below.
         <td colspan=\"2\"> <strong>3-dimensional Loops:</strong></td>
       </tr>
       <tr>
-        <td>JointSSR</td>
-        <td>Spherical - Spherical - Revolute</td>
+        <td valign=\"top\">JointSSR</td>
+        <td valign=\"top\">Spherical - Spherical - Revolute</td>
       </tr>
       <tr>
-        <td>JointSSP</td>
-        <td>Spherical - Spherical - Prismatic</td>
+        <td valign=\"top\">JointSSP</td>
+        <td valign=\"top\">Spherical - Spherical - Prismatic</td>
       </tr>
       <tr>
-        <td>JointUSR</td>
-        <td>Universal - Spherical - Revolute</td>
+        <td valign=\"top\">JointUSR</td>
+        <td valign=\"top\">Universal - Spherical - Revolute</td>
       </tr>
       <tr>
-        <td>JointUSP</td>
-        <td>Universal - Spherical - Prismatic</td>
+        <td valign=\"top\">JointUSP</td>
+        <td valign=\"top\">Universal - Spherical - Prismatic</td>
       </tr>
       <tr>
-        <td>JointUPS</td>
-        <td>Universal - Prismatic - Spherical</td>
+        <td valign=\"top\">JointUPS</td>
+        <td valign=\"top\">Universal - Prismatic - Spherical</td>
       </tr>
       <tr>
         <td colspan=\"2\"><strong>Planar Loops:</strong></td>
       </tr>
       <tr>
-        <td>JointRRR</td>
-        <td>Revolute - Revolute - Revolute</td>
+        <td valign=\"top\">JointRRR</td>
+        <td valign=\"top\">Revolute - Revolute - Revolute</td>
       </tr>
       <tr>
-        <td>JointRRP</td>
-        <td>Revolute - Revolute - Prismatic</td>
+        <td valign=\"top\">JointRRP</td>
+        <td valign=\"top\">Revolute - Revolute - Prismatic</td>
       </tr>
 </table>
 </div>
@@ -862,36 +862,36 @@ functions from library Modelica.Mechanics.MultiBody.Frames):
            Interfaces.Frame_a</strong></th>
     <th><strong>MultiBody.Interfaces.Frame_a</strong></th></tr>
 <tr>
-  <td>frame_a.<strong>r0</strong></td>
-  <td>= frame_a.r_0 (is converted)</td>
+  <td valign=\"top\">frame_a.<strong>r0</strong></td>
+  <td valign=\"top\">= frame_a.r_0 (is converted)</td>
 </tr>
 <tr>
-  <td>frame_a.<strong>S</strong></td>
-  <td>= transpose(frame_a.R)</td>
+  <td valign=\"top\">frame_a.<strong>S</strong></td>
+  <td valign=\"top\">= transpose(frame_a.R)</td>
 </tr>
 <tr>
-  <td>frame_a.<strong>v</strong></td>
-  <td>= resolve2(frame_a.R, <strong>der</strong>(frame_a.r_0))</td>
+  <td valign=\"top\">frame_a.<strong>v</strong></td>
+  <td valign=\"top\">= resolve2(frame_a.R, <strong>der</strong>(frame_a.r_0))</td>
 </tr>
 <tr>
-  <td>frame_a.<strong>w</strong></td>
-  <td>= angularVelocity2(frame_a.R)</td>
+  <td valign=\"top\">frame_a.<strong>w</strong></td>
+  <td valign=\"top\">= angularVelocity2(frame_a.R)</td>
 </tr>
 <tr>
-  <td>frame_a.<strong>a</strong></td>
-  <td>= resolve2(frame_a.R, <strong>der</strong>(v_0)); v_0 = der(r_0)</td>
+  <td valign=\"top\">frame_a.<strong>a</strong></td>
+  <td valign=\"top\">= resolve2(frame_a.R, <strong>der</strong>(v_0)); v_0 = der(r_0)</td>
 </tr>
 <tr>
-  <td>frame_a.<strong>z</strong></td>
-  <td>= <strong>der</strong>(w);  w = angulaVelocity2(frame_a.R)</td>
+  <td valign=\"top\">frame_a.<strong>z</strong></td>
+  <td valign=\"top\">= <strong>der</strong>(w);  w = angulaVelocity2(frame_a.R)</td>
 </tr>
 <tr>
-  <td>frame_a.<strong>f</strong></td>
-  <td>= frame_a.f (no conversion needed)</td>
+  <td valign=\"top\">frame_a.<strong>f</strong></td>
+  <td valign=\"top\">= frame_a.f (no conversion needed)</td>
 </tr>
 <tr>
-  <td>frame_a.<strong>t</strong></td>
-  <td>= frame_a.t (no conversion needed)</td>
+  <td valign=\"top\">frame_a.<strong>t</strong></td>
+  <td valign=\"top\">= frame_a.t (no conversion needed)</td>
 </tr>
 </table>
 <p>

--- a/Modelica/Mechanics/Rotational.mo
+++ b/Modelica/Mechanics/Rotational.mo
@@ -228,16 +228,16 @@ which are defined in sublibrary Interfaces:
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Name</th><th>Description</th></tr>
 <tr>
-  <td><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces.PartialCompliant\">PartialCompliant</a>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces.PartialCompliant\">PartialCompliant</a>
   </td>
-  <td>Compliant connection of two rotational 1-dim. flanges
+  <td valign=\"top\">Compliant connection of two rotational 1-dim. flanges
                    (used for force laws such as a spring or a damper).</td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces.PartialCompliantWithRelativeStates\">PartialCompliantWithRelativeStates</a>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces.PartialCompliantWithRelativeStates\">PartialCompliantWithRelativeStates</a>
   </td>
-  <td> Same as \"PartialCompliant\", but relative angle and relative speed are
+  <td valign=\"top\"> Same as \"PartialCompliant\", but relative angle and relative speed are
                     defined as preferred states. Use this partial model if the force law
                     needs anyway the relative speed. The advantage is that it is usually better
                     to use relative angles between drive train components
@@ -247,38 +247,38 @@ which are defined in sublibrary Interfaces:
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces.PartialElementaryTwoFlangesAndSupport2\">PartialElementaryTwoFlangesAndSupport2</a>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces.PartialElementaryTwoFlangesAndSupport2\">PartialElementaryTwoFlangesAndSupport2</a>
 </td>
-  <td> Partial model for a 1-dim. rotational gear consisting of the flange of
+  <td valign=\"top\"> Partial model for a 1-dim. rotational gear consisting of the flange of
                     an input shaft, the flange of an output shaft and the support.
   </td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces.PartialTorque\">PartialTorque</a>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces.PartialTorque\">PartialTorque</a>
 </td>
-  <td> Partial model of a torque acting at the flange (accelerates the flange).
+  <td valign=\"top\"> Partial model of a torque acting at the flange (accelerates the flange).
   </td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces.PartialTwoFlanges\">PartialTwoFlanges</a>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces.PartialTwoFlanges\">PartialTwoFlanges</a>
 </td>
-  <td>General connection of two rotational 1-dim. flanges.
+  <td valign=\"top\">General connection of two rotational 1-dim. flanges.
   </td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces.PartialAbsoluteSensor\">PartialAbsoluteSensor</a>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces.PartialAbsoluteSensor\">PartialAbsoluteSensor</a>
 </td>
-  <td>Measure absolute flange variables.
+  <td valign=\"top\">Measure absolute flange variables.
   </td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces.PartialRelativeSensor\">PartialRelativeSensor</a>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces.PartialRelativeSensor\">PartialRelativeSensor</a>
 </td>
-  <td>Measure relative flange variables.
+  <td valign=\"top\">Measure relative flange variables.
   </td>
 </tr>
 </table>
@@ -4406,11 +4406,11 @@ meaning:
 <table border=1 cellspacing=0 cellpadding=2>
   <tbody>
     <tr>
-      <td>|w_a|</td>
-      <td>eta_mf1</td>
-      <td>eta_mf2</td>
-      <td>|tau_bf1|</td>
-      <td>|tau_bf2|</td>
+      <td valign=\"top\">|w_a|</td>
+      <td valign=\"top\">eta_mf1</td>
+      <td valign=\"top\">eta_mf2</td>
+      <td valign=\"top\">|tau_bf1|</td>
+      <td valign=\"top\">|tau_bf2|</td>
     </tr>
     <tr>
       <td align=\"center\">...</td>
@@ -4433,27 +4433,27 @@ meaning:
 <table border=1 cellspacing=0 cellpadding=2>
   <tbody>
     <tr>
-      <td>|w_a|</td>
-      <td>Absolute value of angular velocity of input shaft flange_a</td>
+      <td valign=\"top\">|w_a|</td>
+      <td valign=\"top\">Absolute value of angular velocity of input shaft flange_a</td>
     </tr>
     <tr>
-      <td>eta_mf1</td>
-      <td>Mesh efficiency in case that flange_a is driving</td>
+      <td valign=\"top\">eta_mf1</td>
+      <td valign=\"top\">Mesh efficiency in case that flange_a is driving</td>
     </tr>
     <tr>
-      <td>eta_mf2</td>
-      <td>Mesh efficiency in case that flange_b is driving</td>
+      <td valign=\"top\">eta_mf2</td>
+      <td valign=\"top\">Mesh efficiency in case that flange_b is driving</td>
     </tr>
     <tr>
-      <td>|tau_bf1|</td>
-      <td> Absolute resultant bearing friction torque with respect to flange_a
+      <td valign=\"top\">|tau_bf1|</td>
+      <td valign=\"top\"> Absolute resultant bearing friction torque with respect to flange_a
                         in case that flange_a is driving<br>
                         (= |tau_bf_a*eta_mf1 + tau_bf_b/i|)
                         </td>
     </tr>
     <tr>
-      <td>|tau_bf2|</td>
-      <td> Absolute resultant bearing friction torque with respect to flange_a
+      <td valign=\"top\">|tau_bf2|</td>
+      <td valign=\"top\"> Absolute resultant bearing friction torque with respect to flange_a
                         in case that flange_b is driving<br>
                         (= |tau_bf_a/eta_mf2 + tau_bf_b/i|)
                         </td>

--- a/Modelica/Mechanics/Translational.mo
+++ b/Modelica/Mechanics/Translational.mo
@@ -196,16 +196,16 @@ which are defined in sublibrary Interfaces:
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Name</th><th>Description</th></tr>
 <tr>
-  <td><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces.PartialCompliant\">PartialCompliant</a>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces.PartialCompliant\">PartialCompliant</a>
   </td>
-  <td>Compliant connection of two translational 1-dim. flanges
+  <td valign=\"top\">Compliant connection of two translational 1-dim. flanges
                    (used for force laws such as a spring or a damper).</td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces.PartialCompliantWithRelativeStates\">PartialCompliantWithRelativeStates</a>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces.PartialCompliantWithRelativeStates\">PartialCompliantWithRelativeStates</a>
   </td>
-  <td> Same as \"PartialCompliant\", but relative position and relative speed are
+  <td valign=\"top\"> Same as \"PartialCompliant\", but relative position and relative speed are
                     defined as preferred states. Use this partial model if the force law
                     needs anyway the relative speed. The advantage is that it is usually better
                     to use relative positions between drive train components
@@ -214,38 +214,38 @@ which are defined in sublibrary Interfaces:
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces.PartialElementaryTwoFlangesAndSupport2\">PartialElementaryTwoFlangesAndSupport2</a>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces.PartialElementaryTwoFlangesAndSupport2\">PartialElementaryTwoFlangesAndSupport2</a>
 </td>
-  <td> Partial model for a 1-dim. translational component consisting of the flange of
+  <td valign=\"top\"> Partial model for a 1-dim. translational component consisting of the flange of
                     an input shaft, the flange of an output shaft and the support.
   </td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces.PartialForce\">PartialForce</a>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces.PartialForce\">PartialForce</a>
 </td>
-  <td> Partial model of a force acting at the flange (accelerates the flange).
+  <td valign=\"top\"> Partial model of a force acting at the flange (accelerates the flange).
   </td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces.PartialTwoFlanges\">PartialTwoFlanges</a>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces.PartialTwoFlanges\">PartialTwoFlanges</a>
 </td>
-  <td>General connection of two translational 1-dim. flanges.
+  <td valign=\"top\">General connection of two translational 1-dim. flanges.
   </td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces.PartialAbsoluteSensor\">PartialAbsoluteSensor</a>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces.PartialAbsoluteSensor\">PartialAbsoluteSensor</a>
 </td>
-  <td>Measure absolute flange variables.
+  <td valign=\"top\">Measure absolute flange variables.
   </td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces.PartialRelativeSensor\">PartialRelativeSensor</a>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces.PartialRelativeSensor\">PartialRelativeSensor</a>
 </td>
-  <td>Measure relative flange variables.
+  <td valign=\"top\">Measure relative flange variables.
   </td>
 </tr>
 </table>

--- a/Modelica/Media/Air/ReferenceAir.mo
+++ b/Modelica/Media/Air/ReferenceAir.mo
@@ -543,24 +543,24 @@ Three variable pairs can be the independent variables of the model:
 The following quantities are always computed:
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Variable</strong></td>
-      <td><strong>Unit</strong></td>
-      <td><strong>Description</strong></td></tr>
-  <tr><td>T</td>
-      <td>K</td>
-      <td>temperature</td></tr>
-  <tr><td>u</td>
-      <td>J/kg</td>
-      <td>specific internal energy</td></tr>
-  <tr><td>d</td>
-      <td>kg/m^3</td>
-      <td>density</td></tr>
-  <tr><td>p</td>
-      <td>Pa</td>
-      <td>pressure</td></tr>
-  <tr><td>h</td>
-      <td>J/kg</td>
-      <td>specific enthalpy</td></tr>
+  <tr><td valign=\"top\"><strong>Variable</strong></td>
+      <td valign=\"top\"><strong>Unit</strong></td>
+      <td valign=\"top\"><strong>Description</strong></td></tr>
+  <tr><td valign=\"top\">T</td>
+      <td valign=\"top\">K</td>
+      <td valign=\"top\">temperature</td></tr>
+  <tr><td valign=\"top\">u</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">specific internal energy</td></tr>
+  <tr><td valign=\"top\">d</td>
+      <td valign=\"top\">kg/m^3</td>
+      <td valign=\"top\">density</td></tr>
+  <tr><td valign=\"top\">p</td>
+      <td valign=\"top\">Pa</td>
+      <td valign=\"top\">pressure</td></tr>
+  <tr><td valign=\"top\">h</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">specific enthalpy</td></tr>
 </table>
 <p>
 In some cases additional medium properties are needed.

--- a/Modelica/Media/Air/ReferenceMoistAir.mo
+++ b/Modelica/Media/Air/ReferenceMoistAir.mo
@@ -4516,19 +4516,19 @@ The package MoistAir can be used as any other medium model (see <a href=\"modeli
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
 <tr>
-<td><strong>Constant</strong></td>
-<td><strong>Default Value</strong></td>
-<td><strong>Meaning</strong></td>
+<td valign=\"top\"><strong>Constant</strong></td>
+<td valign=\"top\"><strong>Default Value</strong></td>
+<td valign=\"top\"><strong>Meaning</strong></td>
 </tr>
 <tr>
-<td>useEnhancementFactor</td>
-<td>false</td>
-<td>The enhancement factor is used in the calculation of the saturation partial pressure of water in moist air. It is always very close to 1 except for high pressures (&gt;2 MPa) and low temperatures (&lt;233.15 K). For pressures less than 1 MPa this factor can be safely set to 1. Its calculation is very expensive, since it can only be calculated by an iterative method.</td>
+<td valign=\"top\">useEnhancementFactor</td>
+<td valign=\"top\">false</td>
+<td valign=\"top\">The enhancement factor is used in the calculation of the saturation partial pressure of water in moist air. It is always very close to 1 except for high pressures (&gt;2 MPa) and low temperatures (&lt;233.15 K). For pressures less than 1 MPa this factor can be safely set to 1. Its calculation is very expensive, since it can only be calculated by an iterative method.</td>
 </tr>
 <tr>
-<td>useDissociation</td>
-<td>true</td>
-<td>The effect of dissociation is taken into account for temperatures greater than 773.15 K.</td>
+<td valign=\"top\">useDissociation</td>
+<td valign=\"top\">true</td>
+<td valign=\"top\">The effect of dissociation is taken into account for temperatures greater than 773.15 K.</td>
 </tr>
 </table>
 

--- a/Modelica/Media/IdealGases/Common/package.mo
+++ b/Modelica/Media/IdealGases/Common/package.mo
@@ -514,18 +514,18 @@ are valid in the range:
 The following quantities are always computed:
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Variable</strong></td>
-      <td><strong>Unit</strong></td>
-      <td><strong>Description</strong></td></tr>
-  <tr><td>h</td>
-      <td>J/kg</td>
-      <td>specific enthalpy h = h(T)</td></tr>
-  <tr><td>u</td>
-      <td>J/kg</td>
-      <td>specific internal energy u = u(T)</td></tr>
-  <tr><td>d</td>
-      <td>kg/m^3</td>
-      <td>density d = d(p,T)</td></tr>
+  <tr><td valign=\"top\"><strong>Variable</strong></td>
+      <td valign=\"top\"><strong>Unit</strong></td>
+      <td valign=\"top\"><strong>Description</strong></td></tr>
+  <tr><td valign=\"top\">h</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">specific enthalpy h = h(T)</td></tr>
+  <tr><td valign=\"top\">u</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">specific internal energy u = u(T)</td></tr>
+  <tr><td valign=\"top\">d</td>
+      <td valign=\"top\">kg/m^3</td>
+      <td valign=\"top\">density d = d(p,T)</td></tr>
 </table>
 <p>
 For the other variables, see the functions in

--- a/Modelica/Media/Water/IF97_Utilities.mo
+++ b/Modelica/Media/Water/IF97_Utilities.mo
@@ -5974,12 +5974,12 @@ a set of equations for different regions which cover the following range
 of validity:</p>
 <table border=0 cellpadding=4>
 <tr>
-<td>273,15 K &lt; <em>T</em> &lt; 1073,15 K</td>
-<td><em>p</em> &lt; 100 MPa</td>
+<td valign=\"top\">273,15 K &lt; <em>T</em> &lt; 1073,15 K</td>
+<td valign=\"top\"><em>p</em> &lt; 100 MPa</td>
 </tr>
 <tr>
-<td>1073,15 K &lt; <em>T</em> &lt; 2273,15 K</td>
-<td><em>p</em> &lt; 10 MPa</td>
+<td valign=\"top\">1073,15 K &lt; <em>T</em> &lt; 2273,15 K</td>
+<td valign=\"top\"><em>p</em> &lt; 10 MPa</td>
 </tr>
 </table>
 <p>
@@ -6044,216 +6044,216 @@ of Water and Steam. ASME Journal of Engineering for Gas Turbines and Power 122 (
 <table border=\"1\" cellpadding=\"2\" cellspacing=\"0\">
        <tbody>
        <tr>
-       <td bgcolor=\"#cccccc\"><br>
+       <td valign=\"top\" bgcolor=\"#cccccc\"><br>
       </td>
-      <td bgcolor=\"#cccccc\"><strong>Common name</strong><br>
+      <td valign=\"top\" bgcolor=\"#cccccc\"><strong>Common name</strong><br>
        </td>
-       <td bgcolor=\"#cccccc\"><strong>Abbreviation</strong><br>
+       <td valign=\"top\" bgcolor=\"#cccccc\"><strong>Abbreviation</strong><br>
        </td>
-       <td bgcolor=\"#cccccc\"><strong>Unit</strong><br>
+       <td valign=\"top\" bgcolor=\"#cccccc\"><strong>Unit</strong><br>
        </td>
        </tr>
        <tr>
-       <td>&nbsp;1<br>
+       <td valign=\"top\">&nbsp;1<br>
       </td>
-      <td>Pressure</td>
-       <td>p<br>
+      <td valign=\"top\">Pressure</td>
+       <td valign=\"top\">p<br>
         </td>
-       <td>Pa<br>
+       <td valign=\"top\">Pa<br>
        </td>
        </tr>
        <tr>
-       <td>&nbsp;2<br>
+       <td valign=\"top\">&nbsp;2<br>
       </td>
-      <td>Temperature</td>
-       <td>T<br>
+      <td valign=\"top\">Temperature</td>
+       <td valign=\"top\">T<br>
        </td>
-       <td>K<br>
+       <td valign=\"top\">K<br>
        </td>
        </tr>
        <tr>
-       <td>&nbsp;3<br>
+       <td valign=\"top\">&nbsp;3<br>
       </td>
-      <td>Density</td>
-        <td>d<br>
+      <td valign=\"top\">Density</td>
+        <td valign=\"top\">d<br>
         </td>
-       <td>kg/m<sup>3</sup><br>
+       <td valign=\"top\">kg/m<sup>3</sup><br>
        </td>
        </tr>
        <tr>
-       <td>&nbsp;4<br>
+       <td valign=\"top\">&nbsp;4<br>
       </td>
-      <td>Specific volume</td>
-        <td>v<br>
+      <td valign=\"top\">Specific volume</td>
+        <td valign=\"top\">v<br>
         </td>
-       <td>m<sup>3</sup>/kg<br>
+       <td valign=\"top\">m<sup>3</sup>/kg<br>
        </td>
        </tr>
        <tr>
-       <td>&nbsp;5<br>
+       <td valign=\"top\">&nbsp;5<br>
       </td>
-      <td>Specific enthalpy</td>
-       <td>h<br>
+      <td valign=\"top\">Specific enthalpy</td>
+       <td valign=\"top\">h<br>
        </td>
-       <td>J/kg<br>
+       <td valign=\"top\">J/kg<br>
        </td>
        </tr>
        <tr>
-       <td>&nbsp;6<br>
+       <td valign=\"top\">&nbsp;6<br>
       </td>
-      <td>Specific entropy</td>
-       <td>s<br>
+      <td valign=\"top\">Specific entropy</td>
+       <td valign=\"top\">s<br>
        </td>
-       <td>J/(kg K)<br>
+       <td valign=\"top\">J/(kg K)<br>
        </td>
        </tr>
        <tr>
-       <td>&nbsp;7<br>
+       <td valign=\"top\">&nbsp;7<br>
       </td>
-      <td>Specific internal energy<br>
+      <td valign=\"top\">Specific internal energy<br>
        </td>
-       <td>u<br>
+       <td valign=\"top\">u<br>
        </td>
-       <td>J/kg<br>
+       <td valign=\"top\">J/kg<br>
        </td>
        </tr>
        <tr>
-       <td>&nbsp;8<br>
+       <td valign=\"top\">&nbsp;8<br>
       </td>
-      <td>Specific isobaric heat capacity</td>
-       <td>c<sub>p</sub><br>
+      <td valign=\"top\">Specific isobaric heat capacity</td>
+       <td valign=\"top\">c<sub>p</sub><br>
        </td>
-       <td>J/(kg K)<br>
+       <td valign=\"top\">J/(kg K)<br>
        </td>
        </tr>
        <tr>
-       <td>&nbsp;9<br>
+       <td valign=\"top\">&nbsp;9<br>
       </td>
-      <td>Specific isochoric heat capacity</td>
-       <td>c<sub>v</sub><br>
+      <td valign=\"top\">Specific isochoric heat capacity</td>
+       <td valign=\"top\">c<sub>v</sub><br>
        </td>
-       <td>J/(kg K)<br>
+       <td valign=\"top\">J/(kg K)<br>
        </td>
        </tr>
        <tr>
-       <td>10<br>
+       <td valign=\"top\">10<br>
       </td>
-      <td>Isentropic exponent, kappa<span class=\"nobr\">=<font face=\"Symbol\">-</font>(v/p)
+      <td valign=\"top\">Isentropic exponent, kappa<span class=\"nobr\">=<font face=\"Symbol\">-</font>(v/p)
 (dp/dv)<sub>s</sub></span></td>
-     <td>kappa (<font face=\"Symbol\">k</font>)<br>
+     <td valign=\"top\">kappa (<font face=\"Symbol\">k</font>)<br>
      </td>
-     <td>1<br>
+     <td valign=\"top\">1<br>
      </td>
      </tr>
      <tr>
-     <td>11<br>
+     <td valign=\"top\">11<br>
       </td>
-      <td>Speed of sound<br>
+      <td valign=\"top\">Speed of sound<br>
      </td>
-     <td>a<br>
+     <td valign=\"top\">a<br>
      </td>
-     <td>m/s<br>
+     <td valign=\"top\">m/s<br>
      </td>
      </tr>
      <tr>
-     <td>12<br>
+     <td valign=\"top\">12<br>
       </td>
-      <td>Dryness fraction<br>
+      <td valign=\"top\">Dryness fraction<br>
      </td>
-     <td>x<br>
+     <td valign=\"top\">x<br>
      </td>
-     <td>kg/kg<br>
+     <td valign=\"top\">kg/kg<br>
      </td>
      </tr>
      <tr>
-     <td>13<br>
+     <td valign=\"top\">13<br>
       </td>
-      <td>Specific Helmholtz free energy,     f = u - Ts</td>
-     <td>f<br>
+      <td valign=\"top\">Specific Helmholtz free energy,     f = u - Ts</td>
+     <td valign=\"top\">f<br>
      </td>
-     <td>J/kg<br>
+     <td valign=\"top\">J/kg<br>
      </td>
      </tr>
      <tr>
-     <td>14<br>
+     <td valign=\"top\">14<br>
       </td>
-      <td>Specific Gibbs free energy,     g = h - Ts</td>
-     <td>g<br>
+      <td valign=\"top\">Specific Gibbs free energy,     g = h - Ts</td>
+     <td valign=\"top\">g<br>
      </td>
-     <td>J/kg<br>
+     <td valign=\"top\">J/kg<br>
      </td>
      </tr>
      <tr>
-     <td>15<br>
+     <td valign=\"top\">15<br>
       </td>
-      <td>Isenthalpic exponent, <span class=\"nobr\"> theta = -(v/p)(dp/dv)<sub>h</sub></span></td>
-     <td>theta (<font face=\"Symbol\">q</font>)<br>
+      <td valign=\"top\">Isenthalpic exponent, <span class=\"nobr\"> theta = -(v/p)(dp/dv)<sub>h</sub></span></td>
+     <td valign=\"top\">theta (<font face=\"Symbol\">q</font>)<br>
      </td>
-     <td>1<br>
+     <td valign=\"top\">1<br>
      </td>
      </tr>
      <tr>
-     <td>16<br>
+     <td valign=\"top\">16<br>
       </td>
-      <td>Isobaric volume expansion coefficient, alpha = v<sup>-1</sup>       (dv/dT)<sub>p</sub></td>
-     <td>alpha  (<font face=\"Symbol\">a</font>)<br>
+      <td valign=\"top\">Isobaric volume expansion coefficient, alpha = v<sup>-1</sup>       (dv/dT)<sub>p</sub></td>
+     <td valign=\"top\">alpha  (<font face=\"Symbol\">a</font>)<br>
      </td>
-       <td>1/K<br>
+       <td valign=\"top\">1/K<br>
      </td>
      </tr>
      <tr>
-     <td>17<br>
+     <td valign=\"top\">17<br>
       </td>
-      <td>Isochoric pressure coefficient,     <span class=\"nobr\">beta = p<sup><font face=\"Symbol\">-</font>1</sup>(dp/dT)<sub>v</sub></span></td>
-     <td>beta (<font face=\"Symbol\">b</font>)<br>
+      <td valign=\"top\">Isochoric pressure coefficient,     <span class=\"nobr\">beta = p<sup><font face=\"Symbol\">-</font>1</sup>(dp/dT)<sub>v</sub></span></td>
+     <td valign=\"top\">beta (<font face=\"Symbol\">b</font>)<br>
      </td>
-     <td>1/K<br>
+     <td valign=\"top\">1/K<br>
      </td>
      </tr>
      <tr>
-     <td>18<br>
+     <td valign=\"top\">18<br>
      </td>
-     <td>Isothermal compressibility, <span class=\"nobr\">gamma = <font
+     <td valign=\"top\">Isothermal compressibility, <span class=\"nobr\">gamma = <font
  face=\"Symbol\">-</font>v<sup><font face=\"Symbol\">-</font>1</sup>(dv/dp)<sub>T</sub></span></td>
-     <td>gamma (<font face=\"Symbol\">g</font>)<br>
+     <td valign=\"top\">gamma (<font face=\"Symbol\">g</font>)<br>
      </td>
-     <td>1/Pa<br>
-     </td>
-     </tr>
-     <!-- <tr><td>f</td><td>Fugacity</td></tr> --> <tr>
-     <td>19<br>
-      </td>
-      <td>Dynamic viscosity</td>
-     <td>eta (<font face=\"Symbol\">h</font>)<br>
-     </td>
-     <td>Pa s<br>
+     <td valign=\"top\">1/Pa<br>
      </td>
      </tr>
-     <tr>
-     <td>20<br>
+     <!-- <tr><td valign=\"top\">f</td><td valign=\"top\">Fugacity</td></tr> --> <tr>
+     <td valign=\"top\">19<br>
       </td>
-      <td>Kinematic viscosity</td>
-     <td>nu (<font face=\"Symbol\">n</font>)<br>
+      <td valign=\"top\">Dynamic viscosity</td>
+     <td valign=\"top\">eta (<font face=\"Symbol\">h</font>)<br>
      </td>
-     <td>m<sup>2</sup>/s<br>
-     </td>
-     </tr>
-     <!-- <tr><td>Pr</td><td>Prandtl number</td></tr> --> <tr>
-     <td>21<br>
-      </td>
-      <td>Thermal conductivity</td>
-     <td>lambda (<font face=\"Symbol\">l</font>)<br>
-     </td>
-     <td>W/(m K)<br>
+     <td valign=\"top\">Pa s<br>
      </td>
      </tr>
      <tr>
-     <td>22<br>
+     <td valign=\"top\">20<br>
       </td>
-      <td>Surface tension</td>
-     <td>sigma (<font face=\"Symbol\">s</font>)<br>
+      <td valign=\"top\">Kinematic viscosity</td>
+     <td valign=\"top\">nu (<font face=\"Symbol\">n</font>)<br>
      </td>
-     <td>N/m<br>
+     <td valign=\"top\">m<sup>2</sup>/s<br>
+     </td>
+     </tr>
+     <!-- <tr><td valign=\"top\">Pr</td><td valign=\"top\">Prandtl number</td></tr> --> <tr>
+     <td valign=\"top\">21<br>
+      </td>
+      <td valign=\"top\">Thermal conductivity</td>
+     <td valign=\"top\">lambda (<font face=\"Symbol\">l</font>)<br>
+     </td>
+     <td valign=\"top\">W/(m K)<br>
+     </td>
+     </tr>
+     <tr>
+     <td valign=\"top\">22<br>
+      </td>
+      <td valign=\"top\">Surface tension</td>
+     <td valign=\"top\">sigma (<font face=\"Symbol\">s</font>)<br>
+     </td>
+     <td valign=\"top\">N/m<br>
      </td>
      </tr>
   </tbody>

--- a/Modelica/Media/Water/package.mo
+++ b/Modelica/Media/Water/package.mo
@@ -905,24 +905,24 @@ independent variables of the model:
 The following quantities are always computed:
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Variable</strong></td>
-      <td><strong>Unit</strong></td>
-      <td><strong>Description</strong></td></tr>
-  <tr><td>T</td>
-      <td>K</td>
-      <td>temperature</td></tr>
-  <tr><td>u</td>
-      <td>J/kg</td>
-      <td>specific internal energy</td></tr>
-  <tr><td>d</td>
-      <td>kg/m^3</td>
-      <td>density</td></tr>
-  <tr><td>p</td>
-      <td>Pa</td>
-      <td>pressure</td></tr>
-  <tr><td>h</td>
-      <td>J/kg</td>
-      <td>specific enthalpy</td></tr>
+  <tr><td valign=\"top\"><strong>Variable</strong></td>
+      <td valign=\"top\"><strong>Unit</strong></td>
+      <td valign=\"top\"><strong>Description</strong></td></tr>
+  <tr><td valign=\"top\">T</td>
+      <td valign=\"top\">K</td>
+      <td valign=\"top\">temperature</td></tr>
+  <tr><td valign=\"top\">u</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">specific internal energy</td></tr>
+  <tr><td valign=\"top\">d</td>
+      <td valign=\"top\">kg/m^3</td>
+      <td valign=\"top\">density</td></tr>
+  <tr><td valign=\"top\">p</td>
+      <td valign=\"top\">Pa</td>
+      <td valign=\"top\">pressure</td></tr>
+  <tr><td valign=\"top\">h</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">specific enthalpy</td></tr>
 </table>
 <p>
 In some cases additional medium properties are needed.
@@ -1096,24 +1096,24 @@ from different functions if one of the functions is called often but can be opti
 The following quantities are always computed in Medium.BaseProperties:
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Variable</strong></td>
-      <td><strong>Unit</strong></td>
-      <td><strong>Description</strong></td></tr>
-  <tr><td>T</td>
-      <td>K</td>
-      <td>temperature</td></tr>
-  <tr><td>u</td>
-      <td>J/kg</td>
-      <td>specific internal energy</td></tr>
-  <tr><td>d</td>
-      <td>kg/m^3</td>
-      <td>density</td></tr>
-  <tr><td>p</td>
-      <td>Pa</td>
-      <td>pressure</td></tr>
-  <tr><td>h</td>
-      <td>J/kg</td>
-      <td>specific enthalpy</td></tr>
+  <tr><td valign=\"top\"><strong>Variable</strong></td>
+      <td valign=\"top\"><strong>Unit</strong></td>
+      <td valign=\"top\"><strong>Description</strong></td></tr>
+  <tr><td valign=\"top\">T</td>
+      <td valign=\"top\">K</td>
+      <td valign=\"top\">temperature</td></tr>
+  <tr><td valign=\"top\">u</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">specific internal energy</td></tr>
+  <tr><td valign=\"top\">d</td>
+      <td valign=\"top\">kg/m^3</td>
+      <td valign=\"top\">density</td></tr>
+  <tr><td valign=\"top\">p</td>
+      <td valign=\"top\">Pa</td>
+      <td valign=\"top\">pressure</td></tr>
+  <tr><td valign=\"top\">h</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">specific enthalpy</td></tr>
 </table>
 <p>
 In some cases additional medium properties are needed.
@@ -1121,60 +1121,60 @@ A component that needs these optional properties has to call
 one of the following functions:
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Function call</strong></td>
-      <td><strong>Unit</strong></td>
-      <td><strong>Description</strong></td></tr>
-  <tr><td>Medium.dynamicViscosity(medium.state)</td>
-      <td>Pa.s</td>
-      <td>dynamic viscosity</td></tr>
-  <tr><td>Medium.thermalConductivity(medium.state)</td>
-      <td>W/(m.K)</td>
-      <td>thermal conductivity</td></tr>
-  <tr><td>Medium.prandtlNumber(medium.state)</td>
-      <td>1</td>
-      <td>Prandtl number</td></tr>
-  <tr><td>Medium.specificEntropy(medium.state)</td>
-      <td>J/(kg.K)</td>
-      <td>specific entropy</td></tr>
-  <tr><td>Medium.heatCapacity_cp(medium.state)</td>
-      <td>J/(kg.K)</td>
-      <td>specific heat capacity at constant pressure</td></tr>
-  <tr><td>Medium.heatCapacity_cv(medium.state)</td>
-      <td>J/(kg.K)</td>
-      <td>specific heat capacity at constant density</td></tr>
-  <tr><td>Medium.isentropicExponent(medium.state)</td>
-      <td>1</td>
-      <td>isentropic exponent</td></tr>
-  <tr><td>Medium.isentropicEnthalpy(pressure, medium.state)</td>
-      <td>J/kg</td>
-      <td>isentropic enthalpy</td></tr>
-  <tr><td>Medium.velocityOfSound(medium.state)</td>
-      <td>m/s</td>
-      <td>velocity of sound</td></tr>
-  <tr><td>Medium.isobaricExpansionCoefficient(medium.state)</td>
-      <td>1/K</td>
-      <td>isobaric expansion coefficient</td></tr>
-  <tr><td>Medium.isothermalCompressibility(medium.state)</td>
-      <td>1/Pa</td>
-      <td>isothermal compressibility</td></tr>
-  <tr><td>Medium.density_derp_h(medium.state)</td>
-      <td>kg/(m3.Pa)</td>
-      <td>derivative of density by pressure at constant enthalpy</td></tr>
-  <tr><td>Medium.density_derh_p(medium.state)</td>
-      <td>kg2/(m3.J)</td>
-      <td>derivative of density by enthalpy at constant pressure</td></tr>
-  <tr><td>Medium.density_derp_T(medium.state)</td>
-      <td>kg/(m3.Pa)</td>
-      <td>derivative of density by pressure at constant temperature</td></tr>
-  <tr><td>Medium.density_derT_p(medium.state)</td>
-      <td>kg/(m3.K)</td>
-      <td>derivative of density by temperature at constant pressure</td></tr>
-  <tr><td>Medium.density_derX(medium.state)</td>
-      <td>kg/m3</td>
-      <td>derivative of density by mass fraction</td></tr>
-  <tr><td>Medium.molarMass(medium.state)</td>
-      <td>kg/mol</td>
-      <td>molar mass</td></tr>
+  <tr><td valign=\"top\"><strong>Function call</strong></td>
+      <td valign=\"top\"><strong>Unit</strong></td>
+      <td valign=\"top\"><strong>Description</strong></td></tr>
+  <tr><td valign=\"top\">Medium.dynamicViscosity(medium.state)</td>
+      <td valign=\"top\">Pa.s</td>
+      <td valign=\"top\">dynamic viscosity</td></tr>
+  <tr><td valign=\"top\">Medium.thermalConductivity(medium.state)</td>
+      <td valign=\"top\">W/(m.K)</td>
+      <td valign=\"top\">thermal conductivity</td></tr>
+  <tr><td valign=\"top\">Medium.prandtlNumber(medium.state)</td>
+      <td valign=\"top\">1</td>
+      <td valign=\"top\">Prandtl number</td></tr>
+  <tr><td valign=\"top\">Medium.specificEntropy(medium.state)</td>
+      <td valign=\"top\">J/(kg.K)</td>
+      <td valign=\"top\">specific entropy</td></tr>
+  <tr><td valign=\"top\">Medium.heatCapacity_cp(medium.state)</td>
+      <td valign=\"top\">J/(kg.K)</td>
+      <td valign=\"top\">specific heat capacity at constant pressure</td></tr>
+  <tr><td valign=\"top\">Medium.heatCapacity_cv(medium.state)</td>
+      <td valign=\"top\">J/(kg.K)</td>
+      <td valign=\"top\">specific heat capacity at constant density</td></tr>
+  <tr><td valign=\"top\">Medium.isentropicExponent(medium.state)</td>
+      <td valign=\"top\">1</td>
+      <td valign=\"top\">isentropic exponent</td></tr>
+  <tr><td valign=\"top\">Medium.isentropicEnthalpy(pressure, medium.state)</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">isentropic enthalpy</td></tr>
+  <tr><td valign=\"top\">Medium.velocityOfSound(medium.state)</td>
+      <td valign=\"top\">m/s</td>
+      <td valign=\"top\">velocity of sound</td></tr>
+  <tr><td valign=\"top\">Medium.isobaricExpansionCoefficient(medium.state)</td>
+      <td valign=\"top\">1/K</td>
+      <td valign=\"top\">isobaric expansion coefficient</td></tr>
+  <tr><td valign=\"top\">Medium.isothermalCompressibility(medium.state)</td>
+      <td valign=\"top\">1/Pa</td>
+      <td valign=\"top\">isothermal compressibility</td></tr>
+  <tr><td valign=\"top\">Medium.density_derp_h(medium.state)</td>
+      <td valign=\"top\">kg/(m3.Pa)</td>
+      <td valign=\"top\">derivative of density by pressure at constant enthalpy</td></tr>
+  <tr><td valign=\"top\">Medium.density_derh_p(medium.state)</td>
+      <td valign=\"top\">kg2/(m3.J)</td>
+      <td valign=\"top\">derivative of density by enthalpy at constant pressure</td></tr>
+  <tr><td valign=\"top\">Medium.density_derp_T(medium.state)</td>
+      <td valign=\"top\">kg/(m3.Pa)</td>
+      <td valign=\"top\">derivative of density by pressure at constant temperature</td></tr>
+  <tr><td valign=\"top\">Medium.density_derT_p(medium.state)</td>
+      <td valign=\"top\">kg/(m3.K)</td>
+      <td valign=\"top\">derivative of density by temperature at constant pressure</td></tr>
+  <tr><td valign=\"top\">Medium.density_derX(medium.state)</td>
+      <td valign=\"top\">kg/m3</td>
+      <td valign=\"top\">derivative of density by mass fraction</td></tr>
+  <tr><td valign=\"top\">Medium.molarMass(medium.state)</td>
+      <td valign=\"top\">kg/mol</td>
+      <td valign=\"top\">molar mass</td></tr>
 </table>
 <p>More details are given in
 <a href=\"modelica://Modelica.Media.UsersGuide.MediumUsage.OptionalProperties\">
@@ -1188,51 +1188,51 @@ With reference to a model defining a pressure p, a temperature T, and a
 SaturationProperties record sat, the following functions are provided:
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Function call</strong></td>
-      <td><strong>Unit</strong></td>
-      <td><strong>Description</strong></td></tr>
-  <tr><td>Medium.saturationPressure(T)</td>
-      <td>Pa</td>
-      <td>Saturation pressure at temperature T</td></tr>
-  <tr><td>Medium.saturationTemperature(p)</td>
-      <td>K</td>
-      <td>Saturation temperature at pressure p</td></tr>
-  <tr><td>Medium.saturationTemperature_derp(p)</td>
-      <td>K/Pa</td>
-      <td>Derivative of saturation temperature with respect to pressure</td></tr>
-  <tr><td>Medium.bubbleEnthalpy(sat)</td>
-      <td>J/kg</td>
-      <td>Specific enthalpy at bubble point</td></tr>
-  <tr><td>Medium.dewEnthalpy(sat)</td>
-      <td>J/kg</td>
-      <td>Specific enthalpy at dew point</td></tr>
-  <tr><td>Medium.bubbleEntropy(sat)</td>
-      <td>J/(kg.K)</td>
-      <td>Specific entropy at bubble point</td></tr>
-  <tr><td>Medium.dewEntropy(sat)</td>
-      <td>J/(kg.K)</td>
-      <td>Specific entropy at dew point</td></tr>
-  <tr><td>Medium.bubbleDensity(sat)</td>
-      <td>kg/m3</td>
-      <td>Density at bubble point</td></tr>
-  <tr><td>Medium.dewDensity(sat)</td>
-      <td>kg/m3</td>
-      <td>Density at dew point</td></tr>
-  <tr><td>Medium.dBubbleDensity_dPressure(sat)</td>
-      <td>kg/(m3.Pa)</td>
-      <td>Derivative of density at bubble point with respect to pressure</td></tr>
-  <tr><td>Medium.dDewDensity_dPressure(sat)</td>
-      <td>kg/(m3.Pa)</td>
-      <td>Derivative of density at dew point with respect to pressure</td></tr>
-  <tr><td>Medium.dBubbleEnthalpy_dPressure(sat)</td>
-      <td>J/(kg.Pa)</td>
-      <td>Derivative of specific enthalpy at bubble point with respect to pressure</td></tr>
-  <tr><td>Medium.dDewEnthalpy_dPressure(sat)</td>
-      <td>J/(kg.Pa)</td>
-      <td>Derivative of specific enthalpy at dew point with respect to pressure</td></tr>
-  <tr><td>Medium.surfaceTension(sat)</td>
-      <td>N/m</td>
-      <td>Surface tension between liquid and vapour phase</td></tr>
+  <tr><td valign=\"top\"><strong>Function call</strong></td>
+      <td valign=\"top\"><strong>Unit</strong></td>
+      <td valign=\"top\"><strong>Description</strong></td></tr>
+  <tr><td valign=\"top\">Medium.saturationPressure(T)</td>
+      <td valign=\"top\">Pa</td>
+      <td valign=\"top\">Saturation pressure at temperature T</td></tr>
+  <tr><td valign=\"top\">Medium.saturationTemperature(p)</td>
+      <td valign=\"top\">K</td>
+      <td valign=\"top\">Saturation temperature at pressure p</td></tr>
+  <tr><td valign=\"top\">Medium.saturationTemperature_derp(p)</td>
+      <td valign=\"top\">K/Pa</td>
+      <td valign=\"top\">Derivative of saturation temperature with respect to pressure</td></tr>
+  <tr><td valign=\"top\">Medium.bubbleEnthalpy(sat)</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">Specific enthalpy at bubble point</td></tr>
+  <tr><td valign=\"top\">Medium.dewEnthalpy(sat)</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">Specific enthalpy at dew point</td></tr>
+  <tr><td valign=\"top\">Medium.bubbleEntropy(sat)</td>
+      <td valign=\"top\">J/(kg.K)</td>
+      <td valign=\"top\">Specific entropy at bubble point</td></tr>
+  <tr><td valign=\"top\">Medium.dewEntropy(sat)</td>
+      <td valign=\"top\">J/(kg.K)</td>
+      <td valign=\"top\">Specific entropy at dew point</td></tr>
+  <tr><td valign=\"top\">Medium.bubbleDensity(sat)</td>
+      <td valign=\"top\">kg/m3</td>
+      <td valign=\"top\">Density at bubble point</td></tr>
+  <tr><td valign=\"top\">Medium.dewDensity(sat)</td>
+      <td valign=\"top\">kg/m3</td>
+      <td valign=\"top\">Density at dew point</td></tr>
+  <tr><td valign=\"top\">Medium.dBubbleDensity_dPressure(sat)</td>
+      <td valign=\"top\">kg/(m3.Pa)</td>
+      <td valign=\"top\">Derivative of density at bubble point with respect to pressure</td></tr>
+  <tr><td valign=\"top\">Medium.dDewDensity_dPressure(sat)</td>
+      <td valign=\"top\">kg/(m3.Pa)</td>
+      <td valign=\"top\">Derivative of density at dew point with respect to pressure</td></tr>
+  <tr><td valign=\"top\">Medium.dBubbleEnthalpy_dPressure(sat)</td>
+      <td valign=\"top\">J/(kg.Pa)</td>
+      <td valign=\"top\">Derivative of specific enthalpy at bubble point with respect to pressure</td></tr>
+  <tr><td valign=\"top\">Medium.dDewEnthalpy_dPressure(sat)</td>
+      <td valign=\"top\">J/(kg.Pa)</td>
+      <td valign=\"top\">Derivative of specific enthalpy at dew point with respect to pressure</td></tr>
+  <tr><td valign=\"top\">Medium.surfaceTension(sat)</td>
+      <td valign=\"top\">N/m</td>
+      <td valign=\"top\">Surface tension between liquid and vapour phase</td></tr>
 </table>
 <p>Details on usage and some examples are given in:
 <a href=\"modelica://Modelica.Media.UsersGuide.MediumUsage.TwoPhase\">

--- a/Modelica/Media/package.mo
+++ b/Modelica/Media/package.mo
@@ -40,30 +40,30 @@ the medium model (nXi is the number of independent mass fractions, see
 explanation below):
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Variable</strong></td>
-      <td><strong>Unit</strong></td>
-      <td><strong>Description</strong></td></tr>
-  <tr><td>T</td>
-      <td>K</td>
-      <td>temperature</td></tr>
-  <tr><td>p</td>
-      <td>Pa</td>
-      <td>absolute pressure</td></tr>
-  <tr><td>d</td>
-      <td>kg/m3</td>
-      <td>density</td></tr>
-  <tr><td>u</td>
-      <td>J/kg</td>
-      <td>specific internal energy</td></tr>
-  <tr><td>h</td>
-      <td>J/kg</td>
-      <td>specific enthalpy (h = u + p/d)</td></tr>
-  <tr><td>Xi[nXi]</td>
-      <td>kg/kg</td>
-      <td>independent mass fractions m_i/m</td></tr>
-  <tr><td>X[nX]</td>
-      <td>kg/kg</td>
-      <td>All mass fractions m_i/m. X is defined in BaseProperties by:<br>
+  <tr><td valign=\"top\"><strong>Variable</strong></td>
+      <td valign=\"top\"><strong>Unit</strong></td>
+      <td valign=\"top\"><strong>Description</strong></td></tr>
+  <tr><td valign=\"top\">T</td>
+      <td valign=\"top\">K</td>
+      <td valign=\"top\">temperature</td></tr>
+  <tr><td valign=\"top\">p</td>
+      <td valign=\"top\">Pa</td>
+      <td valign=\"top\">absolute pressure</td></tr>
+  <tr><td valign=\"top\">d</td>
+      <td valign=\"top\">kg/m3</td>
+      <td valign=\"top\">density</td></tr>
+  <tr><td valign=\"top\">u</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">specific internal energy</td></tr>
+  <tr><td valign=\"top\">h</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">specific enthalpy (h = u + p/d)</td></tr>
+  <tr><td valign=\"top\">Xi[nXi]</td>
+      <td valign=\"top\">kg/kg</td>
+      <td valign=\"top\">independent mass fractions m_i/m</td></tr>
+  <tr><td valign=\"top\">X[nX]</td>
+      <td valign=\"top\">kg/kg</td>
+      <td valign=\"top\">All mass fractions m_i/m. X is defined in BaseProperties by:<br>
           X = <strong>if</strong> reducedX <strong>then</strong> vector([Xi; 1-<strong>sum</strong>(Xi)])
           <strong>else</strong> Xi </td></tr>
 </table>
@@ -95,21 +95,21 @@ accept either X or Xi (see explanation below) and will decide internally which o
 is provided by the user. The four fundamental setState_XXX functions are provided in PartialMedium
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Function</strong></td>
-      <td><strong>Description</strong></td>
-      <td><strong>Short-form for<br>single component medium</strong></td></tr>
-  <tr><td>setState_dTX</td>
-      <td>computes ThermodynamicState from density, temperature, and composition X or Xi</td>
-      <td>setState_dT</td></tr>
-  <tr><td>setState_phX</td>
-      <td>computes ThermodynamicState from pressure, specific enthalpy, and composition X or Xi</td>
-      <td>setState_ph</td></tr>
-  <tr><td>setState_psX</td>
-      <td>computes ThermodynamicState from pressure, specific entropy, and composition X or Xi</td>
-      <td>setState_ps</td></tr>
-  <tr><td>setState_pTX</td>
-      <td>computes ThermodynamicState from pressure, temperature, and composition X or Xi</td>
-      <td>setState_pT</td></tr>
+  <tr><td valign=\"top\"><strong>Function</strong></td>
+      <td valign=\"top\"><strong>Description</strong></td>
+      <td valign=\"top\"><strong>Short-form for<br>single component medium</strong></td></tr>
+  <tr><td valign=\"top\">setState_dTX</td>
+      <td valign=\"top\">computes ThermodynamicState from density, temperature, and composition X or Xi</td>
+      <td valign=\"top\">setState_dT</td></tr>
+  <tr><td valign=\"top\">setState_phX</td>
+      <td valign=\"top\">computes ThermodynamicState from pressure, specific enthalpy, and composition X or Xi</td>
+      <td valign=\"top\">setState_ph</td></tr>
+  <tr><td valign=\"top\">setState_psX</td>
+      <td valign=\"top\">computes ThermodynamicState from pressure, specific entropy, and composition X or Xi</td>
+      <td valign=\"top\">setState_ps</td></tr>
+  <tr><td valign=\"top\">setState_pTX</td>
+      <td valign=\"top\">computes ThermodynamicState from pressure, temperature, and composition X or Xi</td>
+      <td valign=\"top\">setState_pT</td></tr>
 </table>
 <p>
 The simple example that explained the basic usage of BaseProperties would then become
@@ -481,60 +481,60 @@ form:
 </pre>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Function call</strong></td>
-      <td><strong>Unit</strong></td>
-      <td><strong>Description</strong></td></tr>
-  <tr><td>Medium.dynamicViscosity(state)</td>
-      <td>Pa.s</td>
-      <td>dynamic viscosity</td></tr>
-  <tr><td>Medium.thermalConductivity(state)</td>
-      <td>W/(m.K)</td>
-      <td>thermal conductivity</td></tr>
-  <tr><td>Medium.prandtlNumber(state)</td>
-      <td>1</td>
-      <td>Prandtl number</td></tr>
-  <tr><td>Medium.specificEntropy(state)</td>
-      <td>J/(kg.K)</td>
-      <td>specific entropy</td></tr>
-  <tr><td>Medium.specificHeatCapacityCp(state)</td>
-      <td>J/(kg.K)</td>
-      <td>specific heat capacity at constant pressure</td></tr>
-  <tr><td>Medium.specificHeatCapacityCv(state)</td>
-      <td>J/(kg.K)</td>
-      <td>specific heat capacity at constant density</td></tr>
-  <tr><td>Medium.isentropicExponent(state)</td>
-      <td>1</td>
-      <td>isentropic exponent</td></tr>
-  <tr><td>Medium.isentropicEnthatlpy(pressure, state)</td>
-      <td>J/kg</td>
-      <td>isentropic enthalpy</td></tr>
-  <tr><td>Medium.velocityOfSound(state)</td>
-      <td>m/s</td>
-      <td>velocity of sound</td></tr>
-  <tr><td>Medium.isobaricExpansionCoefficient(state)</td>
-      <td>1/K</td>
-      <td>isobaric expansion coefficient</td></tr>
-  <tr><td>Medium.isothermalCompressibility(state)</td>
-      <td>1/Pa</td>
-      <td>isothermal compressibility</td></tr>
-  <tr><td>Medium.density_derp_h(state)</td>
-      <td>kg/(m3.Pa)</td>
-      <td>derivative of density by pressure at constant enthalpy</td></tr>
-  <tr><td>Medium.density_derh_p(state)</td>
-      <td>kg2/(m3.J)</td>
-      <td>derivative of density by enthalpy at constant pressure</td></tr>
-  <tr><td>Medium.density_derp_T(state)</td>
-      <td>kg/(m3.Pa)</td>
-      <td>derivative of density by pressure at constant temperature</td></tr>
-  <tr><td>Medium.density_derT_p(state)</td>
-      <td>kg/(m3.K)</td>
-      <td>derivative of density by temperature at constant pressure</td></tr>
-  <tr><td>Medium.density_derX(state)</td>
-      <td>kg/m3</td>
-      <td>derivative of density by mass fraction</td></tr>
-  <tr><td>Medium.molarMass(state)</td>
-      <td>kg/mol</td>
-      <td>molar mass</td></tr>
+  <tr><td valign=\"top\"><strong>Function call</strong></td>
+      <td valign=\"top\"><strong>Unit</strong></td>
+      <td valign=\"top\"><strong>Description</strong></td></tr>
+  <tr><td valign=\"top\">Medium.dynamicViscosity(state)</td>
+      <td valign=\"top\">Pa.s</td>
+      <td valign=\"top\">dynamic viscosity</td></tr>
+  <tr><td valign=\"top\">Medium.thermalConductivity(state)</td>
+      <td valign=\"top\">W/(m.K)</td>
+      <td valign=\"top\">thermal conductivity</td></tr>
+  <tr><td valign=\"top\">Medium.prandtlNumber(state)</td>
+      <td valign=\"top\">1</td>
+      <td valign=\"top\">Prandtl number</td></tr>
+  <tr><td valign=\"top\">Medium.specificEntropy(state)</td>
+      <td valign=\"top\">J/(kg.K)</td>
+      <td valign=\"top\">specific entropy</td></tr>
+  <tr><td valign=\"top\">Medium.specificHeatCapacityCp(state)</td>
+      <td valign=\"top\">J/(kg.K)</td>
+      <td valign=\"top\">specific heat capacity at constant pressure</td></tr>
+  <tr><td valign=\"top\">Medium.specificHeatCapacityCv(state)</td>
+      <td valign=\"top\">J/(kg.K)</td>
+      <td valign=\"top\">specific heat capacity at constant density</td></tr>
+  <tr><td valign=\"top\">Medium.isentropicExponent(state)</td>
+      <td valign=\"top\">1</td>
+      <td valign=\"top\">isentropic exponent</td></tr>
+  <tr><td valign=\"top\">Medium.isentropicEnthatlpy(pressure, state)</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">isentropic enthalpy</td></tr>
+  <tr><td valign=\"top\">Medium.velocityOfSound(state)</td>
+      <td valign=\"top\">m/s</td>
+      <td valign=\"top\">velocity of sound</td></tr>
+  <tr><td valign=\"top\">Medium.isobaricExpansionCoefficient(state)</td>
+      <td valign=\"top\">1/K</td>
+      <td valign=\"top\">isobaric expansion coefficient</td></tr>
+  <tr><td valign=\"top\">Medium.isothermalCompressibility(state)</td>
+      <td valign=\"top\">1/Pa</td>
+      <td valign=\"top\">isothermal compressibility</td></tr>
+  <tr><td valign=\"top\">Medium.density_derp_h(state)</td>
+      <td valign=\"top\">kg/(m3.Pa)</td>
+      <td valign=\"top\">derivative of density by pressure at constant enthalpy</td></tr>
+  <tr><td valign=\"top\">Medium.density_derh_p(state)</td>
+      <td valign=\"top\">kg2/(m3.J)</td>
+      <td valign=\"top\">derivative of density by enthalpy at constant pressure</td></tr>
+  <tr><td valign=\"top\">Medium.density_derp_T(state)</td>
+      <td valign=\"top\">kg/(m3.Pa)</td>
+      <td valign=\"top\">derivative of density by pressure at constant temperature</td></tr>
+  <tr><td valign=\"top\">Medium.density_derT_p(state)</td>
+      <td valign=\"top\">kg/(m3.K)</td>
+      <td valign=\"top\">derivative of density by temperature at constant pressure</td></tr>
+  <tr><td valign=\"top\">Medium.density_derX(state)</td>
+      <td valign=\"top\">kg/m3</td>
+      <td valign=\"top\">derivative of density by mass fraction</td></tr>
+  <tr><td valign=\"top\">Medium.molarMass(state)</td>
+      <td valign=\"top\">kg/mol</td>
+      <td valign=\"top\">molar mass</td></tr>
 </table>
 <p>
 There are also some short forms provided for user convenience that allow the computation of certain
@@ -551,21 +551,21 @@ The following functions are predefined in PartialMedium (other functions can be 
 medium implementation package if they are useful)
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td>Medium.specificEnthalpy_pTX(p,T,X)</td>
-      <td>J/kg</td>
-      <td>Specific enthalpy at p, T, X </td></tr>
-  <tr><td>Medium.temperature_phX(p,h,X)</td>
-      <td>K</td>
-      <td>Temperature at p, h, X</td></tr>
-  <tr><td>Medium.density_phX(p,h,X)</td>
-      <td>kg/m3</td>
-      <td>Density at p, h, X</td></tr>
-  <tr><td>Medium.temperature_psX(p,s,X)</td>
-      <td>K</td>
-      <td>Temperature at p, s, X</td></tr>
-  <tr><td>Medium.specificEnthalpy_psX(p,s,X)</td>
-      <td>J/(kg.K)</td>
-      <td>Specific entropy at p, s, X</td></tr>
+  <tr><td valign=\"top\">Medium.specificEnthalpy_pTX(p,T,X)</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">Specific enthalpy at p, T, X </td></tr>
+  <tr><td valign=\"top\">Medium.temperature_phX(p,h,X)</td>
+      <td valign=\"top\">K</td>
+      <td valign=\"top\">Temperature at p, h, X</td></tr>
+  <tr><td valign=\"top\">Medium.density_phX(p,h,X)</td>
+      <td valign=\"top\">kg/m3</td>
+      <td valign=\"top\">Density at p, h, X</td></tr>
+  <tr><td valign=\"top\">Medium.temperature_psX(p,s,X)</td>
+      <td valign=\"top\">K</td>
+      <td valign=\"top\">Temperature at p, s, X</td></tr>
+  <tr><td valign=\"top\">Medium.specificEnthalpy_psX(p,s,X)</td>
+      <td valign=\"top\">J/(kg.K)</td>
+      <td valign=\"top\">Specific entropy at p, s, X</td></tr>
 </table>
 <p>
 Assume for example that the dynamic viscosity eta is needed in
@@ -628,61 +628,61 @@ if a medium is declared as:
 then constants \"Medium.mediumName\", \"Medium.nX\", etc. are defined:
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Type</strong></td>
-      <td><strong>Name</strong></td>
-      <td><strong>Description</strong></td></tr>
-  <tr><td>String</td><td>mediumName</td>
-      <td>Unique name of the medium (is usually used to check whether
+  <tr><td valign=\"top\"><strong>Type</strong></td>
+      <td valign=\"top\"><strong>Name</strong></td>
+      <td valign=\"top\"><strong>Description</strong></td></tr>
+  <tr><td valign=\"top\">String</td><td valign=\"top\">mediumName</td>
+      <td valign=\"top\">Unique name of the medium (is usually used to check whether
           the media in different components connected together
           are the same, by providing Medium.mediumName as quantity
           attribute of the mass flow rate in the connector)</td></tr>
-  <tr><td>String</td><td>substanceNames[nS]</td>
-      <td>Names of the substances that make up the medium.
+  <tr><td valign=\"top\">String</td><td valign=\"top\">substanceNames[nS]</td>
+      <td valign=\"top\">Names of the substances that make up the medium.
           If only one substance is present, substanceNames = {mediumName}.</td></tr>
-  <tr><td>String</td><td>extraPropertiesNames[nC]</td>
-      <td>Names of the extra transported substances, outside of mass and
+  <tr><td valign=\"top\">String</td><td valign=\"top\">extraPropertiesNames[nC]</td>
+      <td valign=\"top\">Names of the extra transported substances, outside of mass and
           energy balances.</td></tr>
-  <tr><td>Boolean</td><td>singleState</td>
-      <td>= <strong>true</strong>, if u and d are not a function of pressure, and thus only
+  <tr><td valign=\"top\">Boolean</td><td valign=\"top\">singleState</td>
+      <td valign=\"top\">= <strong>true</strong>, if u and d are not a function of pressure, and thus only
           a function of a single thermal variable (temperature or enthalpy) and
           of Xi for a multiple substance medium. Usually, this flag is
           <strong>true</strong> for incompressible media. It is used in a model to determine
           whether 1+nXi (singleState=<strong>true</strong>) or 2+nXi (singleState=<strong>false</strong>)
           initial conditions have to be provided for a volume element that
           contains mass and energy balance.</td></tr>
-  <tr><td>AbsolutePressure</td><td>reference_p</td>
-      <td>Reference pressure for the medium</td></tr>
-  <tr><td>MassFraction</td><td>reference_X[nX]</td>
-      <td>Reference composition for the medium</td></tr>
-  <tr><td>AbsolutePressure</td><td>p_default</td>
-      <td>Default value for pressure of medium (for initialization)</td></tr>
-  <tr><td>Temperature</td><td>T_default</td>
-      <td>Default value for temperature of medium (for initialization)</td></tr>
-  <tr><td>SpecificEnthalpy</td><td>h_default</td>
-      <td>Default value for specific enthalpy of medium (for initialization)</td></tr>
-  <tr><td>MassFraction</td><td>X_default[nX]</td>
-      <td>Default value for mass fractions of medium (for initialization)</td></tr>
-  <tr><td>Integer</td><td>nS</td>
-      <td>number of substances contained in the medium.</td></tr>
-  <tr><td>Integer</td><td>nX</td>
-      <td>Size of the full mass fraction vector X nX=nS.</td></tr>
-  <tr><td>Integer</td><td>nXi</td>
-      <td>Number of independent mass fractions. If there is a single substance,
+  <tr><td valign=\"top\">AbsolutePressure</td><td valign=\"top\">reference_p</td>
+      <td valign=\"top\">Reference pressure for the medium</td></tr>
+  <tr><td valign=\"top\">MassFraction</td><td valign=\"top\">reference_X[nX]</td>
+      <td valign=\"top\">Reference composition for the medium</td></tr>
+  <tr><td valign=\"top\">AbsolutePressure</td><td valign=\"top\">p_default</td>
+      <td valign=\"top\">Default value for pressure of medium (for initialization)</td></tr>
+  <tr><td valign=\"top\">Temperature</td><td valign=\"top\">T_default</td>
+      <td valign=\"top\">Default value for temperature of medium (for initialization)</td></tr>
+  <tr><td valign=\"top\">SpecificEnthalpy</td><td valign=\"top\">h_default</td>
+      <td valign=\"top\">Default value for specific enthalpy of medium (for initialization)</td></tr>
+  <tr><td valign=\"top\">MassFraction</td><td valign=\"top\">X_default[nX]</td>
+      <td valign=\"top\">Default value for mass fractions of medium (for initialization)</td></tr>
+  <tr><td valign=\"top\">Integer</td><td valign=\"top\">nS</td>
+      <td valign=\"top\">number of substances contained in the medium.</td></tr>
+  <tr><td valign=\"top\">Integer</td><td valign=\"top\">nX</td>
+      <td valign=\"top\">Size of the full mass fraction vector X nX=nS.</td></tr>
+  <tr><td valign=\"top\">Integer</td><td valign=\"top\">nXi</td>
+      <td valign=\"top\">Number of independent mass fractions. If there is a single substance,
           then nXi = 0. </td></tr>
-  <tr><td>Boolean</td><td>reducedX</td>
-      <td>= <strong>true</strong>, if the medium has a single substance, or if the medium model
+  <tr><td valign=\"top\">Boolean</td><td valign=\"top\">reducedX</td>
+      <td valign=\"top\">= <strong>true</strong>, if the medium has a single substance, or if the medium model
           has multiple substances and contains the equation sum(X) = 1.
           In both cases, nXi = nS - 1 (unless fixedX = true).<br>
           = <strong>false</strong>, if the medium has multiple substances and does not contain the
           equation sum(X)=1, i.e., nXi = nX = nS (unless fixedX = true).
        </td></tr>
-  <tr><td>Boolean</td><td>fixedX</td>
-      <td>= <strong>false</strong>: the composition of the medium can vary, and is
+  <tr><td valign=\"top\">Boolean</td><td valign=\"top\">fixedX</td>
+      <td valign=\"top\">= <strong>false</strong>: the composition of the medium can vary, and is
           determined by nXi independent mass fractions (see reducedX above).<br>
           = <strong>true</strong>: the composition of the medium is always reference_X,
           and nXi = 0.</td></tr>
-  <tr><td>FluidConstants</td><td>fluidConstants[nS]</td>
-      <td>Critical, triple, molecular and other
+  <tr><td valign=\"top\">FluidConstants</td><td valign=\"top\">fluidConstants[nS]</td>
+      <td valign=\"top\">Critical, triple, molecular and other
           standard data that are provided for
           every substance of a medium.</td></tr>
 </table>
@@ -692,29 +692,29 @@ The record FluidConstants that is defined in PartialMedium contains the followin
 </p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Type</strong></td>
-      <td><strong>Name</strong></td>
-      <td><strong>Description</strong></td></tr>
+  <tr><td valign=\"top\"><strong>Type</strong></td>
+      <td valign=\"top\"><strong>Name</strong></td>
+      <td valign=\"top\"><strong>Description</strong></td></tr>
 
-  <tr><td>String</td>
-      <td>iupacName</td>
-      <td>complete IUPAC name</td></tr>
+  <tr><td valign=\"top\">String</td>
+      <td valign=\"top\">iupacName</td>
+      <td valign=\"top\">complete IUPAC name</td></tr>
 
-  <tr><td>String</td>
-      <td>casRegistryNumber</td>
-      <td>chemical abstracts sequencing number</td></tr>
+  <tr><td valign=\"top\">String</td>
+      <td valign=\"top\">casRegistryNumber</td>
+      <td valign=\"top\">chemical abstracts sequencing number</td></tr>
 
-  <tr><td>String</td>
-      <td>chemicalFormula</td>
-      <td>Chemical formula, (brutto, nomenclature according to Hill)</td></tr>
+  <tr><td valign=\"top\">String</td>
+      <td valign=\"top\">chemicalFormula</td>
+      <td valign=\"top\">Chemical formula, (brutto, nomenclature according to Hill)</td></tr>
 
-  <tr><td>String</td>
-      <td>structureFormula</td>
-      <td>Chemical structure formula</td></tr>
+  <tr><td valign=\"top\">String</td>
+      <td valign=\"top\">structureFormula</td>
+      <td valign=\"top\">Chemical structure formula</td></tr>
 
-  <tr><td>MolarMass</td>
-      <td>molarMass</td>
-      <td>molar mass</td></tr>
+  <tr><td valign=\"top\">MolarMass</td>
+      <td valign=\"top\">molarMass</td>
+      <td valign=\"top\">molar mass</td></tr>
 </table>
 
 <p> This record is extended in the partial packages further down the hierarchy (such as
@@ -722,98 +722,98 @@ PartialTwoPhaseMedium or PartialMixtureMedium) and may contain some or all of th
 elements</p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td>Temperature</td>
-      <td>criticalTemperature</td>
-      <td>critical temperature</td></tr>
+  <tr><td valign=\"top\">Temperature</td>
+      <td valign=\"top\">criticalTemperature</td>
+      <td valign=\"top\">critical temperature</td></tr>
 
-  <tr><td>AbsolutePressure</td>
-      <td>criticalPressure</td>
-      <td>critical pressure</td></tr>
+  <tr><td valign=\"top\">AbsolutePressure</td>
+      <td valign=\"top\">criticalPressure</td>
+      <td valign=\"top\">critical pressure</td></tr>
 
-  <tr><td>MolarVolume</td>
-      <td>criticalMolarVolume</td>
-      <td>critical molar Volume</td></tr>
+  <tr><td valign=\"top\">MolarVolume</td>
+      <td valign=\"top\">criticalMolarVolume</td>
+      <td valign=\"top\">critical molar Volume</td></tr>
 
-  <tr><td>Real</td>
-      <td>acentricFactor</td>
-      <td>Pitzer acentric factor</td></tr>
+  <tr><td valign=\"top\">Real</td>
+      <td valign=\"top\">acentricFactor</td>
+      <td valign=\"top\">Pitzer acentric factor</td></tr>
 
-  <tr><td>Temperature</td>
-      <td>triplePointTemperature</td>
-      <td>triple point temperature</td></tr>
+  <tr><td valign=\"top\">Temperature</td>
+      <td valign=\"top\">triplePointTemperature</td>
+      <td valign=\"top\">triple point temperature</td></tr>
 
-  <tr><td>AbsolutePressure</td>
-      <td>triplePointPressure</td>
-      <td>triple point pressure</td></tr>
+  <tr><td valign=\"top\">AbsolutePressure</td>
+      <td valign=\"top\">triplePointPressure</td>
+      <td valign=\"top\">triple point pressure</td></tr>
 
-  <tr><td>Temperature</td>
-      <td>meltingPoint</td>
-      <td>melting point at 101325 Pa</td></tr>
+  <tr><td valign=\"top\">Temperature</td>
+      <td valign=\"top\">meltingPoint</td>
+      <td valign=\"top\">melting point at 101325 Pa</td></tr>
 
-  <tr><td>Temperature</td>
-      <td>normalBoilingPoint</td>
-      <td>normal boiling point (at 101325 Pa)</td></tr>
+  <tr><td valign=\"top\">Temperature</td>
+      <td valign=\"top\">normalBoilingPoint</td>
+      <td valign=\"top\">normal boiling point (at 101325 Pa)</td></tr>
 
-  <tr><td>DipoleMoment</td>
-      <td>dipoleMoment</td>
-      <td>dipole moment of molecule in Debye (1 debye = 3.33564e10-30 C.m)</td></tr>
+  <tr><td valign=\"top\">DipoleMoment</td>
+      <td valign=\"top\">dipoleMoment</td>
+      <td valign=\"top\">dipole moment of molecule in Debye (1 debye = 3.33564e10-30 C.m)</td></tr>
 
-  <tr><td>Boolean</td>
-      <td>hasIdealGasHeatCapacity</td>
-      <td>true if ideal gas heat capacity is available</td></tr>
+  <tr><td valign=\"top\">Boolean</td>
+      <td valign=\"top\">hasIdealGasHeatCapacity</td>
+      <td valign=\"top\">true if ideal gas heat capacity is available</td></tr>
 
-  <tr><td>Boolean</td>
-      <td>hasCriticalData</td>
-      <td>true if critical data are known</td></tr>
+  <tr><td valign=\"top\">Boolean</td>
+      <td valign=\"top\">hasCriticalData</td>
+      <td valign=\"top\">true if critical data are known</td></tr>
 
-  <tr><td>Boolean</td>
-      <td>hasDipoleMoment</td>
-      <td>true if a dipole moment known</td></tr>
+  <tr><td valign=\"top\">Boolean</td>
+      <td valign=\"top\">hasDipoleMoment</td>
+      <td valign=\"top\">true if a dipole moment known</td></tr>
 
-  <tr><td>Boolean</td>
-      <td>hasFundamentalEquation</td>
-      <td>true if a fundamental equation</td></tr>
+  <tr><td valign=\"top\">Boolean</td>
+      <td valign=\"top\">hasFundamentalEquation</td>
+      <td valign=\"top\">true if a fundamental equation</td></tr>
 
-  <tr><td>Boolean</td>
-      <td>hasLiquidHeatCapacity</td>
-      <td>true if liquid heat capacity is available</td></tr>
+  <tr><td valign=\"top\">Boolean</td>
+      <td valign=\"top\">hasLiquidHeatCapacity</td>
+      <td valign=\"top\">true if liquid heat capacity is available</td></tr>
 
-  <tr><td>Boolean</td>
-      <td>hasSolidHeatCapacity</td>
-      <td>true if solid heat capacity is available</td></tr>
+  <tr><td valign=\"top\">Boolean</td>
+      <td valign=\"top\">hasSolidHeatCapacity</td>
+      <td valign=\"top\">true if solid heat capacity is available</td></tr>
 
-  <tr><td>Boolean</td>
-      <td>hasAccurateViscosityData</td>
-      <td>true if accurate data for a viscosity function is available</td></tr>
+  <tr><td valign=\"top\">Boolean</td>
+      <td valign=\"top\">hasAccurateViscosityData</td>
+      <td valign=\"top\">true if accurate data for a viscosity function is available</td></tr>
 
-  <tr><td>Boolean</td>
-      <td>hasAccurateConductivityData</td>
-      <td>true if accurate data for thermal conductivity is available</td></tr>
+  <tr><td valign=\"top\">Boolean</td>
+      <td valign=\"top\">hasAccurateConductivityData</td>
+      <td valign=\"top\">true if accurate data for thermal conductivity is available</td></tr>
 
-  <tr><td>Boolean</td>
-      <td>hasVapourPressureCurve</td>
-      <td>true if vapour pressure data, e.g., Antoine coefficients are known</td></tr>
+  <tr><td valign=\"top\">Boolean</td>
+      <td valign=\"top\">hasVapourPressureCurve</td>
+      <td valign=\"top\">true if vapour pressure data, e.g., Antoine coefficients are known</td></tr>
 
-  <tr><td>Boolean</td>
-      <td>hasAcentricFactor</td>
-      <td>true if Pitzer accentric factor is known</td></tr>
+  <tr><td valign=\"top\">Boolean</td>
+      <td valign=\"top\">hasAcentricFactor</td>
+      <td valign=\"top\">true if Pitzer accentric factor is known</td></tr>
 
-  <tr><td>SpecificEnthalpy</td>
-      <td>HCRIT0</td>
-      <td>Critical specific enthalpy of the fundamental equation</td></tr>
+  <tr><td valign=\"top\">SpecificEnthalpy</td>
+      <td valign=\"top\">HCRIT0</td>
+      <td valign=\"top\">Critical specific enthalpy of the fundamental equation</td></tr>
 
-  <tr><td>SpecificEntropy</td>
-      <td>SCRIT0</td>
-      <td>Critical specific entropy of the fundamental equation</td></tr>
+  <tr><td valign=\"top\">SpecificEntropy</td>
+      <td valign=\"top\">SCRIT0</td>
+      <td valign=\"top\">Critical specific entropy of the fundamental equation</td></tr>
 
-  <tr><td>SpecificEnthalpy</td>
-      <td>deltah</td>
-      <td>Difference between specific enthalpy model
+  <tr><td valign=\"top\">SpecificEnthalpy</td>
+      <td valign=\"top\">deltah</td>
+      <td valign=\"top\">Difference between specific enthalpy model
           (h_m) and f.eq. (h_f) (h_m - h_f)</td></tr>
 
-  <tr><td>SpecificEntropy</td>
-      <td>deltas</td>
-      <td>Difference between specific enthalpy model (s_m) and f.eq.
+  <tr><td valign=\"top\">SpecificEntropy</td>
+      <td valign=\"top\">deltas</td>
+      <td valign=\"top\">Difference between specific enthalpy model (s_m) and f.eq.
           (s_f) (s_m - s_f)</td></tr>
 
 </table>
@@ -837,17 +837,17 @@ functionalities are provided, which apply only to potentially two-phase media.
 The following additional medium <strong>constants</strong> are provided:
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Type</strong></td>
-      <td><strong>Name</strong></td>
-      <td><strong>Description</strong></td></tr>
-  <tr><td>Boolean</td>
-      <td>smoothModel</td>
-      <td>If this flag is false (default value), then events are triggered
+  <tr><td valign=\"top\"><strong>Type</strong></td>
+      <td valign=\"top\"><strong>Name</strong></td>
+      <td valign=\"top\"><strong>Description</strong></td></tr>
+  <tr><td valign=\"top\">Boolean</td>
+      <td valign=\"top\">smoothModel</td>
+      <td valign=\"top\">If this flag is false (default value), then events are triggered
           whenever the saturation boundary is crossed; otherwise, no events
       are generated.</td></tr>
-  <tr><td>Boolean</td>
-      <td>onePhase</td>
-      <td>If this flag is true, then the medium model assumes it will be never
+  <tr><td valign=\"top\">Boolean</td>
+      <td valign=\"top\">onePhase</td>
+      <td valign=\"top\">If this flag is true, then the medium model assumes it will be never
           called in the two-phase region. This can be useful to speed up
       the computations in a two-phase medium, when the user is sure it will
       always work in the one-phase region. Default value: false.</td></tr>
@@ -919,60 +919,60 @@ as shown in the following example.
 SaturationProperties record sat, the following functions are provided:
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Function call</strong></td>
-      <td><strong>Unit</strong></td>
-      <td><strong>Description</strong></td></tr>
-  <tr><td>Medium.saturationPressure(T)</td>
-      <td>Pa</td>
-      <td>Saturation pressure at temperature T</td></tr>
-  <tr><td>Medium.saturationTemperature(p)</td>
-      <td>K</td>
-      <td>Saturation temperature at pressure p</td></tr>
-  <tr><td>Medium.saturationTemperature_derp(p)</td>
-      <td>K/Pa</td>
-      <td>Derivative of saturation temperature with respect to pressure</td></tr>
-  <tr><td>Medium.saturationTemperature_sat(sat)</td>
-      <td>K</td>
-      <td>Saturation temperature</td></tr>
-  <tr><td>Medium.saturationPressure_sat(sat)</td>
-      <td>Pa</td>
-      <td>Saturation pressure</td></tr>
-  <tr><td>Medium.bubbleEnthalpy(sat)</td>
-      <td>J/kg</td>
-      <td>Specific enthalpy at bubble point</td></tr>
-  <tr><td>Medium.dewEnthalpy(sat)</td>
-      <td>J/kg</td>
-      <td>Specific enthalpy at dew point</td></tr>
-  <tr><td>Medium.bubbleEntropy(sat)</td>
-      <td>J/(kg.K)</td>
-      <td>Specific entropy at bubble point</td></tr>
-  <tr><td>Medium.dewEntropy(sat)</td>
-      <td>J/(kg.K)</td>
-      <td>Specific entropy at dew point</td></tr>
-  <tr><td>Medium.bubbleDensity(sat)</td>
-      <td>kg/m3</td>
-      <td>Density at bubble point</td></tr>
-  <tr><td>Medium.dewDensity(sat)</td>
-      <td>kg/m3</td>
-      <td>Density at dew point</td></tr>
-  <tr><td>Medium.saturationTemperature_derp_sat(sat)</td>
-      <td>K/Pa</td>
-      <td>Derivative of saturation temperature with respect to pressure</td></tr>
-  <tr><td>Medium.dBubbleDensity_dPressure(sat)</td>
-      <td>kg/(m3.Pa)</td>
-      <td>Derivative of density at bubble point with respect to pressure</td></tr>
-  <tr><td>Medium.dDewDensity_dPressure(sat)</td>
-      <td>kg/(m3.Pa)</td>
-      <td>Derivative of density at dew point with respect to pressure</td></tr>
-  <tr><td>Medium.dBubbleEnthalpy_dPressure(sat)</td>
-      <td>J/(kg.Pa)</td>
-      <td>Derivative of specific enthalpy at bubble point with respect to pressure</td></tr>
-  <tr><td>Medium.dDewEnthalpy_dPressure(sat)</td>
-      <td>J/(kg.Pa)</td>
-      <td>Derivative of specific enthalpy at dew point with respect to pressure</td></tr>
-  <tr><td>Medium.surfaceTension(sat)</td>
-      <td>N/m</td>
-      <td>Surface tension between liquid and vapour phase</td></tr>
+  <tr><td valign=\"top\"><strong>Function call</strong></td>
+      <td valign=\"top\"><strong>Unit</strong></td>
+      <td valign=\"top\"><strong>Description</strong></td></tr>
+  <tr><td valign=\"top\">Medium.saturationPressure(T)</td>
+      <td valign=\"top\">Pa</td>
+      <td valign=\"top\">Saturation pressure at temperature T</td></tr>
+  <tr><td valign=\"top\">Medium.saturationTemperature(p)</td>
+      <td valign=\"top\">K</td>
+      <td valign=\"top\">Saturation temperature at pressure p</td></tr>
+  <tr><td valign=\"top\">Medium.saturationTemperature_derp(p)</td>
+      <td valign=\"top\">K/Pa</td>
+      <td valign=\"top\">Derivative of saturation temperature with respect to pressure</td></tr>
+  <tr><td valign=\"top\">Medium.saturationTemperature_sat(sat)</td>
+      <td valign=\"top\">K</td>
+      <td valign=\"top\">Saturation temperature</td></tr>
+  <tr><td valign=\"top\">Medium.saturationPressure_sat(sat)</td>
+      <td valign=\"top\">Pa</td>
+      <td valign=\"top\">Saturation pressure</td></tr>
+  <tr><td valign=\"top\">Medium.bubbleEnthalpy(sat)</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">Specific enthalpy at bubble point</td></tr>
+  <tr><td valign=\"top\">Medium.dewEnthalpy(sat)</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">Specific enthalpy at dew point</td></tr>
+  <tr><td valign=\"top\">Medium.bubbleEntropy(sat)</td>
+      <td valign=\"top\">J/(kg.K)</td>
+      <td valign=\"top\">Specific entropy at bubble point</td></tr>
+  <tr><td valign=\"top\">Medium.dewEntropy(sat)</td>
+      <td valign=\"top\">J/(kg.K)</td>
+      <td valign=\"top\">Specific entropy at dew point</td></tr>
+  <tr><td valign=\"top\">Medium.bubbleDensity(sat)</td>
+      <td valign=\"top\">kg/m3</td>
+      <td valign=\"top\">Density at bubble point</td></tr>
+  <tr><td valign=\"top\">Medium.dewDensity(sat)</td>
+      <td valign=\"top\">kg/m3</td>
+      <td valign=\"top\">Density at dew point</td></tr>
+  <tr><td valign=\"top\">Medium.saturationTemperature_derp_sat(sat)</td>
+      <td valign=\"top\">K/Pa</td>
+      <td valign=\"top\">Derivative of saturation temperature with respect to pressure</td></tr>
+  <tr><td valign=\"top\">Medium.dBubbleDensity_dPressure(sat)</td>
+      <td valign=\"top\">kg/(m3.Pa)</td>
+      <td valign=\"top\">Derivative of density at bubble point with respect to pressure</td></tr>
+  <tr><td valign=\"top\">Medium.dDewDensity_dPressure(sat)</td>
+      <td valign=\"top\">kg/(m3.Pa)</td>
+      <td valign=\"top\">Derivative of density at dew point with respect to pressure</td></tr>
+  <tr><td valign=\"top\">Medium.dBubbleEnthalpy_dPressure(sat)</td>
+      <td valign=\"top\">J/(kg.Pa)</td>
+      <td valign=\"top\">Derivative of specific enthalpy at bubble point with respect to pressure</td></tr>
+  <tr><td valign=\"top\">Medium.dDewEnthalpy_dPressure(sat)</td>
+      <td valign=\"top\">J/(kg.Pa)</td>
+      <td valign=\"top\">Derivative of specific enthalpy at dew point with respect to pressure</td></tr>
+  <tr><td valign=\"top\">Medium.surfaceTension(sat)</td>
+      <td valign=\"top\">N/m</td>
+      <td valign=\"top\">Surface tension between liquid and vapour phase</td></tr>
 </table>
 <p>
 Sometimes it can be necessary to compute fluid properties in the thermodynamic
@@ -981,15 +981,15 @@ to obtain an instance of a ThermodynamicState state vector, and then use it
 to call the additional functions already defined for one-phase media.
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Function call</strong></td>
-      <td><strong>Description</strong></td></tr>
-  <tr><td>Medium.setBubbleState(sat, phase)</td>
-      <td>Obtain the thermodynamic state vector
+  <tr><td valign=\"top\"><strong>Function call</strong></td>
+      <td valign=\"top\"><strong>Description</strong></td></tr>
+  <tr><td valign=\"top\">Medium.setBubbleState(sat, phase)</td>
+      <td valign=\"top\">Obtain the thermodynamic state vector
           corresponding to the bubble point. If phase==1 (default), the state is
       on the one-phase side; if phase==2, the state is on the two-phase
       side </td></tr>
-  <tr><td>Medium.setDewState(sat, phase)</td>
-      <td>Obtain the thermodynamic state vector
+  <tr><td valign=\"top\">Medium.setDewState(sat, phase)</td>
+      <td valign=\"top\">Obtain the thermodynamic state vector
           corresponding to the dew point. If phase==1 (default), the state is
       on the one-phase side; if phase==2, the state is on the two-phase
       side </td></tr>
@@ -4509,33 +4509,33 @@ The BaseProperties model contains the following <strong>7+nXi variables</strong>
 PartialMedium):
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td><strong>Variable</strong></td>
-      <td><strong>Unit</strong></td>
-      <td><strong>Description</strong></td></tr>
-  <tr><td>T</td>
-      <td>K</td>
-      <td>temperature</td></tr>
-  <tr><td>p</td>
-      <td>Pa</td>
-      <td>absolute pressure</td></tr>
-  <tr><td>d</td>
-      <td>kg/m3</td>
-      <td>density</td></tr>
-  <tr><td>h</td>
-      <td>J/kg</td>
-      <td>specific enthalpy</td></tr>
-  <tr><td>u</td>
-      <td>J/kg</td>
-      <td>specific internal energy</td></tr>
-  <tr><td>Xi[nXi]</td>
-      <td>kg/kg</td>
-      <td>independent mass fractions m_i/m</td></tr>
-  <tr><td>R</td>
-      <td>J/kg.K</td>
-      <td>gas constant</td></tr>
-  <tr><td>M</td>
-      <td>kg/mol</td>
-      <td>molar mass</td></tr>
+  <tr><td valign=\"top\"><strong>Variable</strong></td>
+      <td valign=\"top\"><strong>Unit</strong></td>
+      <td valign=\"top\"><strong>Description</strong></td></tr>
+  <tr><td valign=\"top\">T</td>
+      <td valign=\"top\">K</td>
+      <td valign=\"top\">temperature</td></tr>
+  <tr><td valign=\"top\">p</td>
+      <td valign=\"top\">Pa</td>
+      <td valign=\"top\">absolute pressure</td></tr>
+  <tr><td valign=\"top\">d</td>
+      <td valign=\"top\">kg/m3</td>
+      <td valign=\"top\">density</td></tr>
+  <tr><td valign=\"top\">h</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">specific enthalpy</td></tr>
+  <tr><td valign=\"top\">u</td>
+      <td valign=\"top\">J/kg</td>
+      <td valign=\"top\">specific internal energy</td></tr>
+  <tr><td valign=\"top\">Xi[nXi]</td>
+      <td valign=\"top\">kg/kg</td>
+      <td valign=\"top\">independent mass fractions m_i/m</td></tr>
+  <tr><td valign=\"top\">R</td>
+      <td valign=\"top\">J/kg.K</td>
+      <td valign=\"top\">gas constant</td></tr>
+  <tr><td valign=\"top\">M</td>
+      <td valign=\"top\">kg/mol</td>
+      <td valign=\"top\">molar mass</td></tr>
 </table>
 <p>
 In order to implement an actual medium model, one can extend from this

--- a/Modelica/Thermal/FluidHeatFlow.mo
+++ b/Modelica/Thermal/FluidHeatFlow.mo
@@ -242,28 +242,28 @@ A prescribed heat source dissipates its heat through a thermal conductor to a co
 <strong>Results</strong>:<br>
 <table>
 <tr>
-<td><strong>output</strong></td>
-<td><strong>explanation</strong></td>
-<td><strong>formula</strong></td>
-<td><strong>actual steady-state value</strong></td>
+<td valign=\"top\"><strong>output</strong></td>
+<td valign=\"top\"><strong>explanation</strong></td>
+<td valign=\"top\"><strong>formula</strong></td>
+<td valign=\"top\"><strong>actual steady-state value</strong></td>
 </tr>
 <tr>
-<td>dTSource</td>
-<td>Source over Ambient</td>
-<td>dtCoolant + dtToPipe</td>
-<td>20 K</td>
+<td valign=\"top\">dTSource</td>
+<td valign=\"top\">Source over Ambient</td>
+<td valign=\"top\">dtCoolant + dtToPipe</td>
+<td valign=\"top\">20 K</td>
 </tr>
 <tr>
-<td>dTtoPipe</td>
-<td>Source over Coolant</td>
-<td>Losses / ThermalConductor.G</td>
-<td>10 K</td>
+<td valign=\"top\">dTtoPipe</td>
+<td valign=\"top\">Source over Coolant</td>
+<td valign=\"top\">Losses / ThermalConductor.G</td>
+<td valign=\"top\">10 K</td>
 </tr>
 <tr>
-<td>dTCoolant</td>
-<td>Coolant's temperature increase</td>
-<td>Losses * cp * massFlow</td>
-<td>10 K</td>
+<td valign=\"top\">dTCoolant</td>
+<td valign=\"top\">Coolant's temperature increase</td>
+<td valign=\"top\">Losses * cp * massFlow</td>
+<td valign=\"top\">10 K</td>
 </tr>
 </table>
 </html>"),        experiment(StopTime=1.0, Interval=0.001));
@@ -427,52 +427,52 @@ Two prescribed heat sources dissipate their heat through thermal conductors to c
 <strong>Results</strong>:<br>
 <table>
 <tr>
-<td><strong>output</strong></td>
-<td><strong>explanation</strong></td>
-<td><strong>formula</strong></td>
-<td><strong>actual steady-state value</strong></td>
+<td valign=\"top\"><strong>output</strong></td>
+<td valign=\"top\"><strong>explanation</strong></td>
+<td valign=\"top\"><strong>formula</strong></td>
+<td valign=\"top\"><strong>actual steady-state value</strong></td>
 </tr>
 <tr>
-<td>dTSource1</td>
-<td>Source1 over Ambient</td>
-<td>dTCoolant1 + dTtoPipe1</td>
-<td>15 K</td>
+<td valign=\"top\">dTSource1</td>
+<td valign=\"top\">Source1 over Ambient</td>
+<td valign=\"top\">dTCoolant1 + dTtoPipe1</td>
+<td valign=\"top\">15 K</td>
 </tr>
 <tr>
-<td>dTtoPipe1</td>
-<td>Source1 over Coolant1</td>
-<td>Losses1 / ThermalConductor1.G</td>
-<td> 5 K</td>
+<td valign=\"top\">dTtoPipe1</td>
+<td valign=\"top\">Source1 over Coolant1</td>
+<td valign=\"top\">Losses1 / ThermalConductor1.G</td>
+<td valign=\"top\"> 5 K</td>
 </tr>
 <tr>
-<td>dTCoolant1</td>
-<td>Coolant's temperature increase</td>
-<td>Losses * cp * totalMassFlow/2</td>
-<td>10 K</td>
+<td valign=\"top\">dTCoolant1</td>
+<td valign=\"top\">Coolant's temperature increase</td>
+<td valign=\"top\">Losses * cp * totalMassFlow/2</td>
+<td valign=\"top\">10 K</td>
 </tr>
 <tr>
-<td>dTSource2</td>
-<td>Source2 over Ambient</td>
-<td>dTCoolant2 + dTtoPipe2</td>
-<td>30 K</td>
+<td valign=\"top\">dTSource2</td>
+<td valign=\"top\">Source2 over Ambient</td>
+<td valign=\"top\">dTCoolant2 + dTtoPipe2</td>
+<td valign=\"top\">30 K</td>
 </tr>
 <tr>
-<td>dTtoPipe2</td>
-<td>Source2 over Coolant2</td>
-<td>Losses2 / ThermalConductor2.G</td>
-<td>10 K</td>
+<td valign=\"top\">dTtoPipe2</td>
+<td valign=\"top\">Source2 over Coolant2</td>
+<td valign=\"top\">Losses2 / ThermalConductor2.G</td>
+<td valign=\"top\">10 K</td>
 </tr>
 <tr>
-<td>dTCoolant2</td>
-<td>Coolant's temperature increase</td>
-<td>Losses * cp * totalMassFlow/2</td>
-<td>20 K</td>
+<td valign=\"top\">dTCoolant2</td>
+<td valign=\"top\">Coolant's temperature increase</td>
+<td valign=\"top\">Losses * cp * totalMassFlow/2</td>
+<td valign=\"top\">20 K</td>
 </tr>
 <tr>
-<td>dTmixedCoolant</td>
-<td>mixed Coolant's temperature increase</td>
-<td>(dTCoolant1+dTCoolant2)/2</td>
-<td>15 K</td>
+<td valign=\"top\">dTmixedCoolant</td>
+<td valign=\"top\">mixed Coolant's temperature increase</td>
+<td valign=\"top\">(dTCoolant1+dTCoolant2)/2</td>
+<td valign=\"top\">15 K</td>
 </tr>
 </table>
 </html>"),        experiment(StopTime=1.0, Interval=0.001));
@@ -646,40 +646,40 @@ Inner coolant's temperature rise near the source is the same as temperature drop
 <strong>Results</strong>:<br>
 <table>
 <tr>
-<td><strong>output</strong></td>
-<td><strong>explanation</strong></td>
-<td><strong>formula</strong></td>
-<td><strong>actual steady-state value</strong></td>
+<td valign=\"top\"><strong>output</strong></td>
+<td valign=\"top\"><strong>explanation</strong></td>
+<td valign=\"top\"><strong>formula</strong></td>
+<td valign=\"top\"><strong>actual steady-state value</strong></td>
 </tr>
 <tr>
-<td>dTSource</td>
-<td>Source over Ambient</td>
-<td>dtouterCoolant + dtCooler + dTinnerCoolant + dtToPipe</td>
-<td>40 K</td>
+<td valign=\"top\">dTSource</td>
+<td valign=\"top\">Source over Ambient</td>
+<td valign=\"top\">dtouterCoolant + dtCooler + dTinnerCoolant + dtToPipe</td>
+<td valign=\"top\">40 K</td>
 </tr>
 <tr>
-<td>dTtoPipe</td>
-<td>Source over inner Coolant</td>
-<td>Losses / ThermalConductor.G</td>
-<td>10 K</td>
+<td valign=\"top\">dTtoPipe</td>
+<td valign=\"top\">Source over inner Coolant</td>
+<td valign=\"top\">Losses / ThermalConductor.G</td>
+<td valign=\"top\">10 K</td>
 </tr>
 <tr>
-<td>dTinnerColant</td>
-<td>inner Coolant's temperature increase</td>
-<td>Losses * cp * innerMassFlow</td>
-<td>10 K</td>
+<td valign=\"top\">dTinnerColant</td>
+<td valign=\"top\">inner Coolant's temperature increase</td>
+<td valign=\"top\">Losses * cp * innerMassFlow</td>
+<td valign=\"top\">10 K</td>
 </tr>
 <tr>
-<td>dTCooler</td>
-<td>Cooler's temperature rise between inner and outer pipes</td>
-<td>Losses * (innerGc + outerGc)</td>
-<td>10 K</td>
+<td valign=\"top\">dTCooler</td>
+<td valign=\"top\">Cooler's temperature rise between inner and outer pipes</td>
+<td valign=\"top\">Losses * (innerGc + outerGc)</td>
+<td valign=\"top\">10 K</td>
 </tr>
 <tr>
-<td>dTouterColant</td>
-<td>outer Coolant's temperature increase</td>
-<td>Losses * cp * outerMassFlow</td>
-<td>10 K</td>
+<td valign=\"top\">dTouterColant</td>
+<td valign=\"top\">outer Coolant's temperature increase</td>
+<td valign=\"top\">Losses * cp * outerMassFlow</td>
+<td valign=\"top\">10 K</td>
 </tr>
 </table>
 </html>"),        experiment(StopTime=1.5, Interval=0.001));

--- a/Modelica/Thermal/HeatTransfer.mo
+++ b/Modelica/Thermal/HeatTransfer.mo
@@ -239,11 +239,11 @@ This example contains a simple second order thermal model of a motor.
 The periodic power losses are described by table \"lossTable\":
 </p>
 <table>
-<tr><td>time</td><td>winding losses</td><td>core losses</td></tr>
-<tr><td>   0</td><td>           100</td><td>        500</td></tr>
-<tr><td> 360</td><td>           100</td><td>        500</td></tr>
-<tr><td> 360</td><td>          1000</td><td>        500</td></tr>
-<tr><td> 600</td><td>          1000</td><td>        500</td></tr>
+<tr><td valign=\"top\">time</td><td valign=\"top\">winding losses</td><td valign=\"top\">core losses</td></tr>
+<tr><td valign=\"top\">   0</td><td valign=\"top\">           100</td><td valign=\"top\">        500</td></tr>
+<tr><td valign=\"top\"> 360</td><td valign=\"top\">           100</td><td valign=\"top\">        500</td></tr>
+<tr><td valign=\"top\"> 360</td><td valign=\"top\">          1000</td><td valign=\"top\">        500</td></tr>
+<tr><td valign=\"top\"> 600</td><td valign=\"top\">          1000</td><td valign=\"top\">        500</td></tr>
 </table>
 <p>
 Since constant speed is assumed, the core losses keep constant

--- a/Modelica/Utilities/Files.mo
+++ b/Modelica/Utilities/Files.mo
@@ -777,45 +777,45 @@ In the table below an example call to every function is given:
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
   <tr><th><strong><em>Function/type</em></strong></th><th><strong><em>Description</em></strong></th></tr>
-  <tr><td><a href=\"modelica://Modelica.Utilities.Files.list\">list</a>(name)</td>
-      <td> List content of file or of directory.</td>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Files.list\">list</a>(name)</td>
+      <td valign=\"top\"> List content of file or of directory.</td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Utilities.Files.copy\">copy</a>(oldName, newName)<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Files.copy\">copy</a>(oldName, newName)<br>
           <a href=\"modelica://Modelica.Utilities.Files.copy\">copy</a>(oldName, newName, replace=false)</td>
-      <td> Generate a copy of a file or of a directory.</td>
+      <td valign=\"top\"> Generate a copy of a file or of a directory.</td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Utilities.Files.move\">move</a>(oldName, newName)<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Files.move\">move</a>(oldName, newName)<br>
           <a href=\"modelica://Modelica.Utilities.Files.move\">move</a>(oldName, newName, replace=false)</td>
-      <td> Move a file or a directory to another place.</td>
+      <td valign=\"top\"> Move a file or a directory to another place.</td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Utilities.Files.remove\">remove</a>(name)</td>
-      <td> Remove file or directory (ignore call, if it does not exist).</td>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Files.remove\">remove</a>(name)</td>
+      <td valign=\"top\"> Remove file or directory (ignore call, if it does not exist).</td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Utilities.Files.removeFile\">removeFile</a>(name)</td>
-      <td> Remove file (ignore call, if it does not exist)</td>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Files.removeFile\">removeFile</a>(name)</td>
+      <td valign=\"top\"> Remove file (ignore call, if it does not exist)</td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Utilities.Files.createDirectory\">createDirectory</a>(name)</td>
-      <td> Create directory (if directory already exists, ignore call).</td>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Files.createDirectory\">createDirectory</a>(name)</td>
+      <td valign=\"top\"> Create directory (if directory already exists, ignore call).</td>
   </tr>
-  <tr><td>result = <a href=\"modelica://Modelica.Utilities.Files.exist\">exist</a>(name)</td>
-      <td> Inquire whether file or directory exists.</td>
+  <tr><td valign=\"top\">result = <a href=\"modelica://Modelica.Utilities.Files.exist\">exist</a>(name)</td>
+      <td valign=\"top\"> Inquire whether file or directory exists.</td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Utilities.Files.assertNew\">assertNew</a>(name,message)</td>
-      <td> Trigger an assert, if a file or directory exists.</td>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Files.assertNew\">assertNew</a>(name,message)</td>
+      <td valign=\"top\"> Trigger an assert, if a file or directory exists.</td>
   </tr>
-  <tr><td>fullName = <a href=\"modelica://Modelica.Utilities.Files.fullPathName\">fullPathName</a>(name)</td>
-      <td> Get full path name of file or directory name.</td>
+  <tr><td valign=\"top\">fullName = <a href=\"modelica://Modelica.Utilities.Files.fullPathName\">fullPathName</a>(name)</td>
+      <td valign=\"top\"> Get full path name of file or directory name.</td>
   </tr>
-  <tr><td>(directory, name, extension) = <a href=\"modelica://Modelica.Utilities.Files.splitPathName\">splitPathName</a>(name)</td>
-      <td> Split path name in directory, file name kernel, file name extension.</td>
+  <tr><td valign=\"top\">(directory, name, extension) = <a href=\"modelica://Modelica.Utilities.Files.splitPathName\">splitPathName</a>(name)</td>
+      <td valign=\"top\"> Split path name in directory, file name kernel, file name extension.</td>
   </tr>
-  <tr><td>fileName = <a href=\"modelica://Modelica.Utilities.Files.temporaryFileName\">temporaryFileName</a>()</td>
-      <td> Return arbitrary name of a file that does not exist<br>
+  <tr><td valign=\"top\">fileName = <a href=\"modelica://Modelica.Utilities.Files.temporaryFileName\">temporaryFileName</a>()</td>
+      <td valign=\"top\"> Return arbitrary name of a file that does not exist<br>
            and is in a directory where access rights allow to<br>
            write to this file (useful for temporary output of files).</td>
   </tr>
-  <tr><td>fileReference = <a href=\"modelica://Modelica.Utilities.Files.loadResource\">loadResource</a>(uri)</td>
-      <td>Return the absolute path name of a URI or local file name.</td>
+  <tr><td valign=\"top\">fileReference = <a href=\"modelica://Modelica.Utilities.Files.loadResource\">loadResource</a>(uri)</td>
+      <td valign=\"top\">Return the absolute path name of a URI or local file name.</td>
   </tr>
 </table>
 </html>"));

--- a/Modelica/Utilities/Streams.mo
+++ b/Modelica/Utilities/Streams.mo
@@ -334,37 +334,37 @@ In the table below an example call to every function is given:
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
   <tr><th><strong><em>Function/type</em></strong></th><th><strong><em>Description</em></strong></th></tr>
-  <tr><td><a href=\"modelica://Modelica.Utilities.Streams.print\">print</a>(string)<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Streams.print\">print</a>(string)<br>
           <a href=\"modelica://Modelica.Utilities.Streams.print\">print</a>(string,fileName)</td>
-      <td> Print string \"string\" or vector of strings to message window or on
+      <td valign=\"top\"> Print string \"string\" or vector of strings to message window or on
            file \"fileName\".</td>
   </tr>
-  <tr><td>stringVector =
+  <tr><td valign=\"top\">stringVector =
          <a href=\"modelica://Modelica.Utilities.Streams.readFile\">readFile</a>(fileName)</td>
-      <td> Read complete text file and return it as a vector of strings.</td>
+      <td valign=\"top\"> Read complete text file and return it as a vector of strings.</td>
   </tr>
-  <tr><td>(string, endOfFile) =
+  <tr><td valign=\"top\">(string, endOfFile) =
          <a href=\"modelica://Modelica.Utilities.Streams.readLine\">readLine</a>(fileName, lineNumber)</td>
-      <td>Returns from the file the content of line lineNumber.</td>
+      <td valign=\"top\">Returns from the file the content of line lineNumber.</td>
   </tr>
-  <tr><td>lines =
+  <tr><td valign=\"top\">lines =
          <a href=\"modelica://Modelica.Utilities.Streams.countLines\">countLines</a>(fileName)</td>
-      <td>Returns the number of lines in a file.</td>
+      <td valign=\"top\">Returns the number of lines in a file.</td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Utilities.Streams.error\">error</a>(string)</td>
-      <td> Print error message \"string\" to message window
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Streams.error\">error</a>(string)</td>
+      <td valign=\"top\"> Print error message \"string\" to message window
            and cancel all actions</td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Utilities.Streams.close\">close</a>(fileName)</td>
-      <td> Close file if it is still open. Ignore call if
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Streams.close\">close</a>(fileName)</td>
+      <td valign=\"top\"> Close file if it is still open. Ignore call if
            file is already closed or does not exist. </td>
   </tr>
-  <tr><td><a href=\"modelica://Modelica.Utilities.Streams.readMatrixSize\">readMatrixSize</a>(fileName, matrixName)</td>
-      <td> Read dimensions of a Real matrix from a MATLAB MAT file. </td></tr>
-  <tr><td><a href=\"modelica://Modelica.Utilities.Streams.readRealMatrix\">readRealMatrix</a>(fileName, matrixName, nrow, ncol)</td>
-      <td> Read a Real matrix from a MATLAB MAT file. </td></tr>
-  <tr><td><a href=\"modelica://Modelica.Utilities.Streams.writeRealMatrix\">writeRealMatrix</a>(fileName, matrixName, matrix, append, format)</td>
-      <td> Write Real matrix to a MATLAB MAT file. </td></tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Streams.readMatrixSize\">readMatrixSize</a>(fileName, matrixName)</td>
+      <td valign=\"top\"> Read dimensions of a Real matrix from a MATLAB MAT file. </td></tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Streams.readRealMatrix\">readRealMatrix</a>(fileName, matrixName, nrow, ncol)</td>
+      <td valign=\"top\"> Read a Real matrix from a MATLAB MAT file. </td></tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Streams.writeRealMatrix\">writeRealMatrix</a>(fileName, matrixName, matrix, append, format)</td>
+      <td valign=\"top\"> Write Real matrix to a MATLAB MAT file. </td></tr>
 </table>
 <p>
 Use functions <strong>scanXXX</strong> from package

--- a/Modelica/Utilities/Strings.mo
+++ b/Modelica/Utilities/Strings.mo
@@ -477,11 +477,11 @@ Returns an Integer hash value of the provided string
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -573,16 +573,16 @@ index directly after the token. The returned token is a record
 that holds the type of the token and the value of the token:
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td>token.tokenType</td>
-      <td>Type of the token, see below</td></tr>
-  <tr><td>token.real</td>
-      <td>Real value if tokenType == TokenType.RealToken</td></tr>
-  <tr><td>token.integer</td>
-      <td>Integer value if tokenType == TokenType.IntegerToken</td></tr>
-  <tr><td>token.boolean</td>
-      <td>Boolean value if tokenType == TokenType.BooleanToken</td></tr>
-  <tr><td>token.string</td>
-      <td>String value if tokenType == TokenType.StringToken/IdentifierToken/DelimiterToken</td></tr>
+  <tr><td valign=\"top\">token.tokenType</td>
+      <td valign=\"top\">Type of the token, see below</td></tr>
+  <tr><td valign=\"top\">token.real</td>
+      <td valign=\"top\">Real value if tokenType == TokenType.RealToken</td></tr>
+  <tr><td valign=\"top\">token.integer</td>
+      <td valign=\"top\">Integer value if tokenType == TokenType.IntegerToken</td></tr>
+  <tr><td valign=\"top\">token.boolean</td>
+      <td valign=\"top\">Boolean value if tokenType == TokenType.BooleanToken</td></tr>
+  <tr><td valign=\"top\">token.string</td>
+      <td valign=\"top\">String value if tokenType == TokenType.StringToken/IdentifierToken/DelimiterToken</td></tr>
 </table>
 <p>
 Variable token.tokenType is an enumeration (emulated as a package
@@ -592,21 +592,21 @@ with constants) that can have the following values:
    import T = Modelica.Utilities.Types.TokenType;
 </pre>
 <table border=1 cellspacing=0 cellpadding=2>
-  <tr><td>T.RealToken</td>
-      <td>Modelica Real literal (e.g., 1.23e-4)</td></tr>
-  <tr><td>T.IntegerToken</td>
-      <td>Modelica Integer literal (e.g., 123)</td></tr>
-  <tr><td>T.BooleanToken</td>
-      <td>Modelica Boolean literal (e.g., false)</td></tr>
-  <tr><td>T.StringToken</td>
-      <td>Modelica String literal (e.g., \"string 123\")</td></tr>
-  <tr><td>T.IdentifierToken</td>
-      <td>Modelica identifier (e.g., \"force_a\")</td></tr>
-  <tr><td>T.DelimiterToken</td>
-      <td>any character without white space that does not appear<br>
+  <tr><td valign=\"top\">T.RealToken</td>
+      <td valign=\"top\">Modelica Real literal (e.g., 1.23e-4)</td></tr>
+  <tr><td valign=\"top\">T.IntegerToken</td>
+      <td valign=\"top\">Modelica Integer literal (e.g., 123)</td></tr>
+  <tr><td valign=\"top\">T.BooleanToken</td>
+      <td valign=\"top\">Modelica Boolean literal (e.g., false)</td></tr>
+  <tr><td valign=\"top\">T.StringToken</td>
+      <td valign=\"top\">Modelica String literal (e.g., \"string 123\")</td></tr>
+  <tr><td valign=\"top\">T.IdentifierToken</td>
+      <td valign=\"top\">Modelica identifier (e.g., \"force_a\")</td></tr>
+  <tr><td valign=\"top\">T.DelimiterToken</td>
+      <td valign=\"top\">any character without white space that does not appear<br>
           as first character in the tokens above (e.g., \"&amp;\")</td></tr>
-  <tr><td>T.NoToken</td>
-      <td>White space, line comments and no other token<br>
+  <tr><td valign=\"top\">T.NoToken</td>
+      <td valign=\"top\">White space, line comments and no other token<br>
           until the end of the string</td></tr>
 </table>
 <p>
@@ -1351,52 +1351,52 @@ call to every function is given using the <strong>default</strong> options.
 </p>
 <table border=1 cellspacing=0 cellpadding=2>
   <tr><th><strong><em>Function</em></strong></th><th><strong><em>Description</em></strong></th></tr>
-  <tr><td>len = <a href=\"modelica://Modelica.Utilities.Strings.length\">length</a>(string)</td>
-      <td>Returns length of string</td></tr>
-  <tr><td>string2 = <a href=\"modelica://Modelica.Utilities.Strings.substring\">substring</a>(string1,startIndex,endIndex)
+  <tr><td valign=\"top\">len = <a href=\"modelica://Modelica.Utilities.Strings.length\">length</a>(string)</td>
+      <td valign=\"top\">Returns length of string</td></tr>
+  <tr><td valign=\"top\">string2 = <a href=\"modelica://Modelica.Utilities.Strings.substring\">substring</a>(string1,startIndex,endIndex)
        </td>
-      <td>Returns a substring defined by start and end index</td></tr>
-  <tr><td>result = <a href=\"modelica://Modelica.Utilities.Strings.repeat\">repeat</a>(n)<br>
+      <td valign=\"top\">Returns a substring defined by start and end index</td></tr>
+  <tr><td valign=\"top\">result = <a href=\"modelica://Modelica.Utilities.Strings.repeat\">repeat</a>(n)<br>
  result = <a href=\"modelica://Modelica.Utilities.Strings.repeat\">repeat</a>(n,string)</td>
-      <td>Repeat a blank or a string n times.</td></tr>
-  <tr><td>result = <a href=\"modelica://Modelica.Utilities.Strings.compare\">compare</a>(string1, string2)</td>
-      <td>Compares two substrings with regards to alphabetical order</td></tr>
-  <tr><td>identical =
+      <td valign=\"top\">Repeat a blank or a string n times.</td></tr>
+  <tr><td valign=\"top\">result = <a href=\"modelica://Modelica.Utilities.Strings.compare\">compare</a>(string1, string2)</td>
+      <td valign=\"top\">Compares two substrings with regards to alphabetical order</td></tr>
+  <tr><td valign=\"top\">identical =
 <a href=\"modelica://Modelica.Utilities.Strings.isEqual\">isEqual</a>(string1,string2)</td>
-      <td>Determine whether two strings are identical</td></tr>
-  <tr><td>result = <a href=\"modelica://Modelica.Utilities.Strings.count\">count</a>(string,searchString)</td>
-      <td>Count the number of occurrences of a string</td></tr>
+      <td valign=\"top\">Determine whether two strings are identical</td></tr>
+  <tr><td valign=\"top\">result = <a href=\"modelica://Modelica.Utilities.Strings.count\">count</a>(string,searchString)</td>
+      <td valign=\"top\">Count the number of occurrences of a string</td></tr>
   <tr>
-<td>index = <a href=\"modelica://Modelica.Utilities.Strings.find\">find</a>(string,searchString)</td>
-      <td>Find first occurrence of a string in another string</td></tr>
+<td valign=\"top\">index = <a href=\"modelica://Modelica.Utilities.Strings.find\">find</a>(string,searchString)</td>
+      <td valign=\"top\">Find first occurrence of a string in another string</td></tr>
 <tr>
-<td>index = <a href=\"modelica://Modelica.Utilities.Strings.findLast\">findLast</a>(string,searchString)</td>
-      <td>Find last occurrence of a string in another string</td></tr>
-  <tr><td>string2 = <a href=\"modelica://Modelica.Utilities.Strings.replace\">replace</a>(string,searchString,replaceString)</td>
-      <td>Replace one or all occurrences of a string</td></tr>
-  <tr><td>stringVector2 = <a href=\"modelica://Modelica.Utilities.Strings.sort\">sort</a>(stringVector1)</td>
-      <td>Sort vector of strings in alphabetic order</td></tr>
-  <tr><td>hash = <a href=\"modelica://Modelica.Utilities.Strings.hashString\">hashString</a>(string)</td>
-      <td>Create a hash value of a string</td></tr>
-  <tr><td>(token, index) = <a href=\"modelica://Modelica.Utilities.Strings.scanToken\">scanToken</a>(string,startIndex)</td>
-      <td>Scan for a token (Real/Integer/Boolean/String/Identifier/Delimiter/NoToken)</td></tr>
-  <tr><td>(number, index) = <a href=\"modelica://Modelica.Utilities.Strings.scanReal\">scanReal</a>(string,startIndex)</td>
-      <td>Scan for a Real constant</td></tr>
-  <tr><td>(number, index) = <a href=\"modelica://Modelica.Utilities.Strings.scanInteger\">scanInteger</a>(string,startIndex)</td>
-      <td>Scan for an Integer constant</td></tr>
-  <tr><td>(boolean, index) = <a href=\"modelica://Modelica.Utilities.Strings.scanBoolean\">scanBoolean</a>(string,startIndex)</td>
-      <td>Scan for a Boolean constant</td></tr>
-  <tr><td>(string2, index) = <a href=\"modelica://Modelica.Utilities.Strings.scanString\">scanString</a>(string,startIndex)</td>
-      <td>Scan for a String constant</td></tr>
-  <tr><td>(identifier, index) = <a href=\"modelica://Modelica.Utilities.Strings.scanIdentifier\">scanIdentifier</a>(string,startIndex)</td>
-      <td>Scan for an identifier</td></tr>
-  <tr><td>(delimiter, index) = <a href=\"modelica://Modelica.Utilities.Strings.scanDelimiter\">scanDelimiter</a>(string,startIndex)</td>
-      <td>Scan for delimiters</td></tr>
-  <tr><td><a href=\"modelica://Modelica.Utilities.Strings.scanNoToken\">scanNoToken</a>(string,startIndex)</td>
-      <td>Check that remaining part of string consists solely of<br>
+<td valign=\"top\">index = <a href=\"modelica://Modelica.Utilities.Strings.findLast\">findLast</a>(string,searchString)</td>
+      <td valign=\"top\">Find last occurrence of a string in another string</td></tr>
+  <tr><td valign=\"top\">string2 = <a href=\"modelica://Modelica.Utilities.Strings.replace\">replace</a>(string,searchString,replaceString)</td>
+      <td valign=\"top\">Replace one or all occurrences of a string</td></tr>
+  <tr><td valign=\"top\">stringVector2 = <a href=\"modelica://Modelica.Utilities.Strings.sort\">sort</a>(stringVector1)</td>
+      <td valign=\"top\">Sort vector of strings in alphabetic order</td></tr>
+  <tr><td valign=\"top\">hash = <a href=\"modelica://Modelica.Utilities.Strings.hashString\">hashString</a>(string)</td>
+      <td valign=\"top\">Create a hash value of a string</td></tr>
+  <tr><td valign=\"top\">(token, index) = <a href=\"modelica://Modelica.Utilities.Strings.scanToken\">scanToken</a>(string,startIndex)</td>
+      <td valign=\"top\">Scan for a token (Real/Integer/Boolean/String/Identifier/Delimiter/NoToken)</td></tr>
+  <tr><td valign=\"top\">(number, index) = <a href=\"modelica://Modelica.Utilities.Strings.scanReal\">scanReal</a>(string,startIndex)</td>
+      <td valign=\"top\">Scan for a Real constant</td></tr>
+  <tr><td valign=\"top\">(number, index) = <a href=\"modelica://Modelica.Utilities.Strings.scanInteger\">scanInteger</a>(string,startIndex)</td>
+      <td valign=\"top\">Scan for an Integer constant</td></tr>
+  <tr><td valign=\"top\">(boolean, index) = <a href=\"modelica://Modelica.Utilities.Strings.scanBoolean\">scanBoolean</a>(string,startIndex)</td>
+      <td valign=\"top\">Scan for a Boolean constant</td></tr>
+  <tr><td valign=\"top\">(string2, index) = <a href=\"modelica://Modelica.Utilities.Strings.scanString\">scanString</a>(string,startIndex)</td>
+      <td valign=\"top\">Scan for a String constant</td></tr>
+  <tr><td valign=\"top\">(identifier, index) = <a href=\"modelica://Modelica.Utilities.Strings.scanIdentifier\">scanIdentifier</a>(string,startIndex)</td>
+      <td valign=\"top\">Scan for an identifier</td></tr>
+  <tr><td valign=\"top\">(delimiter, index) = <a href=\"modelica://Modelica.Utilities.Strings.scanDelimiter\">scanDelimiter</a>(string,startIndex)</td>
+      <td valign=\"top\">Scan for delimiters</td></tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Strings.scanNoToken\">scanNoToken</a>(string,startIndex)</td>
+      <td valign=\"top\">Check that remaining part of string consists solely of<br>
           white space or line comments (\"// ...\\n\").</td></tr>
-  <tr><td><a href=\"modelica://Modelica.Utilities.Strings.syntaxError\">syntaxError</a>(string,index,message)</td>
-      <td> Print a \"syntax error message\" as well as a string and the<br>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Strings.syntaxError\">syntaxError</a>(string,index,message)</td>
+      <td valign=\"top\"> Print a \"syntax error message\" as well as a string and the<br>
            index at which scanning detected an error</td></tr>
 </table>
 <p>

--- a/Modelica/Utilities/System.mo
+++ b/Modelica/Utilities/System.mo
@@ -116,11 +116,11 @@ All returned values are of type Integer and have the following meaning:
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -160,11 +160,11 @@ getPid()   // = 3044
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -17,10 +17,10 @@ main sub-libraries:
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Library Components</th> <th>Description</th></tr>
 
-<tr><td>
+<tr><td valign=\"top\">
  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Electrical.png\">
  </td>
- <td>
+ <td valign=\"top\">
  <a href=\"modelica://Modelica.Electrical.Analog\">Analog</a><br>
  Analog electric and electronic components, such as
  resistor, capacitor, transformers, diodes, transistors,
@@ -28,10 +28,10 @@ main sub-libraries:
  </td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Digital.png\">
  </td>
- <td>
+ <td valign=\"top\">
  <a href=\"modelica://Modelica.Electrical.Digital\">Digital</a><br>
  Digital electrical components based on the VHDL standard,
  like basic logic blocks with 9-value logic, delays, gates,
@@ -39,39 +39,39 @@ main sub-libraries:
  </td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Machines.png\">
  </td>
- <td>
+ <td valign=\"top\">
  <a href=\"modelica://Modelica.Electrical.Machines\">Machines</a><br>
             Electrical asynchronous-, synchronous-, and DC-machines
  (motors and generators) as well as 3-phase transformers.
  </td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-FluxTubes.png\">
  </td>
- <td>
+ <td valign=\"top\">
  <a href=\"modelica://Modelica.Magnetic.FluxTubes\">FluxTubes</a><br>
 Based on magnetic flux tubes concepts. Especially to model electro-magnetic actuators. Nonlinear shape, force, leakage, and material models. Material data for steel, electric sheet, pure iron, Cobalt iron, Nickel iron, NdFeB, Sm2Co17, and more.
  </td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Translational.png\">
  </td>
- <td>
+ <td valign=\"top\">
  <a href=\"modelica://Modelica.Mechanics.Translational\">Translational</a><br>
  1-dim. mechanical, translational systems, e.g.,
  sliding mass, mass with stops, spring, damper.
  </td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Rotational.png\">
  </td>
- <td>
+ <td valign=\"top\">
  <a href=\"modelica://Modelica.Mechanics.Rotational\">Rotational</a><br>
  1-dim. mechanical, rotational systems, e.g., inertias, gears,
  planetary gears, convenient definition of speed/torque dependent friction
@@ -79,11 +79,11 @@ Based on magnetic flux tubes concepts. Especially to model electro-magnetic actu
  </td>
 </tr>
 
-<tr><td width=100>
+<tr><td valign=\"top\" width=100>
  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-MultiBody1.png\"><br>
  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-MultiBody2.png\">
  </td>
- <td>
+ <td valign=\"top\">
  <a href=\"modelica://Modelica.Mechanics.MultiBody\">MultiBody</a>
  3-dim. mechanical systems consisting of joints, bodies, force and
  sensor elements. Joints can be driven by drive trains defined by
@@ -93,10 +93,10 @@ Based on magnetic flux tubes concepts. Especially to model electro-magnetic actu
  </td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Fluid.png\">
  </td>
- <td>
+ <td valign=\"top\">
  <a href=\"modelica://Modelica.Fluid\">Fluid</a><br>
         1-dim. thermo-fluid flow in networks of vessels, pipes,
         fluid machines, valves and fittings. All media from the
@@ -105,10 +105,10 @@ Based on magnetic flux tubes concepts. Especially to model electro-magnetic actu
  </td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Media.png\">
  </td>
- <td>
+ <td valign=\"top\">
  <a href=\"modelica://Modelica.Media\">Media</a><br>
  Large media library providing models and functions
  to compute media properties, such as h = h(p,T), d = d(p,T),
@@ -123,10 +123,10 @@ Based on magnetic flux tubes concepts. Especially to model electro-magnetic actu
  </td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Thermal.png\">
  </td>
- <td>
+ <td valign=\"top\">
  <a href=\"modelica://Modelica.Thermal.FluidHeatFlow\">FluidHeatFlow</a>,
  <a href=\"modelica://Modelica.Thermal.HeatTransfer\">HeatTransfer</a>
  Simple thermo-fluid pipe flow, especially to model cooling of machines
@@ -136,11 +136,11 @@ Based on magnetic flux tubes concepts. Especially to model electro-magnetic actu
  </td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Blocks1.png\"><br>
  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Blocks2.png\">
  </td>
- <td>
+ <td valign=\"top\">
  <a href=\"modelica://Modelica.Blocks\">Blocks</a><br>
  Input/output blocks to model block diagrams and logical networks, e.g.,
  integrator, PI, PID, transfer function, linear state space system,
@@ -149,10 +149,10 @@ Based on magnetic flux tubes concepts. Especially to model electro-magnetic actu
  </td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-StateGraph.png\">
  </td>
- <td>
+ <td valign=\"top\">
  <a href=\"modelica://Modelica.StateGraph\">StateGraph</a><br>
  Hierarchical state machines with a similar modeling power as Statecharts.
  Modelica is used as synchronous action language, i.e., deterministic
@@ -160,7 +160,7 @@ Based on magnetic flux tubes concepts. Especially to model electro-magnetic actu
  </td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
  <pre>
  A = [1,2,3;
    3,4,5;
@@ -170,7 +170,7 @@ Based on magnetic flux tubes concepts. Especially to model electro-magnetic actu
  Matrices.eigenValues(A);
  </pre>
  </td>
- <td>
+ <td valign=\"top\">
  <a href=\"modelica://Modelica.Math\">Math</a>,
  <a href=\"modelica://Modelica.Utilities\">Utilities</a><br>
  Functions operating on vectors and matrices, such as for solving
@@ -202,161 +202,161 @@ variables is explained in section \"Connector Equations\" below):
 </p>
 
 <table border=1 cellspacing=0 cellpadding=1>
-<tr><td><strong>domain</strong></td>
-   <td><strong>potential<br>variables</strong></td>
-   <td><strong>flow<br>variables</strong></td>
-   <td><strong>stream<br>variables</strong></td>
-   <td><strong>connector definition</strong></td>
-   <td><strong>icons</strong></td></tr>
+<tr><td valign=\"top\"><strong>domain</strong></td>
+   <td valign=\"top\"><strong>potential<br>variables</strong></td>
+   <td valign=\"top\"><strong>flow<br>variables</strong></td>
+   <td valign=\"top\"><strong>stream<br>variables</strong></td>
+   <td valign=\"top\"><strong>connector definition</strong></td>
+   <td valign=\"top\"><strong>icons</strong></td></tr>
 
-<tr><td><strong>electrical<br>analog</strong></td>
-   <td>electrical potential</td>
-   <td>electrical current</td>
-   <td></td>
-   <td><a href=\"modelica://Modelica.Electrical.Analog.Interfaces\">Modelica.Electrical.Analog.Interfaces</a>
+<tr><td valign=\"top\"><strong>electrical<br>analog</strong></td>
+   <td valign=\"top\">electrical potential</td>
+   <td valign=\"top\">electrical current</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.Analog.Interfaces\">Modelica.Electrical.Analog.Interfaces</a>
      <br>Pin, PositivePin, NegativePin</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/ElectricalPins.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/ElectricalPins.png\"></td></tr>
 
-<tr><td><strong>electrical<br>multi-phase</strong></td>
+<tr><td valign=\"top\"><strong>electrical<br>multi-phase</strong></td>
    <td colspan=\"3\">vector of electrical pins</td>
-   <td><a href=\"modelica://Modelica.Electrical.MultiPhase.Interfaces\">Modelica.Electrical.MultiPhase.Interfaces</a>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.MultiPhase.Interfaces\">Modelica.Electrical.MultiPhase.Interfaces</a>
      <br>Plug, PositivePlug, NegativePlug</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/ElectricalPlugs.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/ElectricalPlugs.png\"></td></tr>
 
-<tr><td><strong>electrical<br>space phasor</strong></td>
-   <td>2 electrical potentials</td>
-   <td>2 electrical currents</td>
-   <td></td>
-   <td><a href=\"modelica://Modelica.Electrical.Machines.Interfaces\">Modelica.Electrical.Machines.Interfaces</a>
+<tr><td valign=\"top\"><strong>electrical<br>space phasor</strong></td>
+   <td valign=\"top\">2 electrical potentials</td>
+   <td valign=\"top\">2 electrical currents</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.Machines.Interfaces\">Modelica.Electrical.Machines.Interfaces</a>
      <br>SpacePhasor</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/SpacePhasor.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/SpacePhasor.png\"></td></tr>
 
-<tr><td><strong>quasi<br>stationary<br>single phase</strong></td>
-   <td>complex electrical potential</td>
-   <td>complex electrical current</td>
-   <td></td>
-   <td><a href=\"modelica://Modelica.Electrical.QuasiStationary.SinglePhase.Interfaces\">
+<tr><td valign=\"top\"><strong>quasi<br>stationary<br>single phase</strong></td>
+   <td valign=\"top\">complex electrical potential</td>
+   <td valign=\"top\">complex electrical current</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.QuasiStationary.SinglePhase.Interfaces\">
                                        Modelica.Electrical.QuasiStationary.SinglePhase.Interfaces</a>
      <br>Pin, PositivePin, NegativePin</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/QuasiStationarySinglePhasePins.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/QuasiStationarySinglePhasePins.png\"></td></tr>
 
-<tr><td><strong>quasi<br>stationary<br>multi-phase</strong></td>
+<tr><td valign=\"top\"><strong>quasi<br>stationary<br>multi-phase</strong></td>
    <td colspan=\"3\">vector of quasi stationary single phase pins</td>
-   <td><a href=\"modelica://Modelica.Electrical.QuasiStationary.MultiPhase.Interfaces\">Modelica.Electrical.QuasiStationary.MultiPhase.Interfaces</a>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.QuasiStationary.MultiPhase.Interfaces\">Modelica.Electrical.QuasiStationary.MultiPhase.Interfaces</a>
      <br>Plug, PositivePlug, NegativePlug</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/QuasiStationaryMultiPhasePlugs.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/QuasiStationaryMultiPhasePlugs.png\"></td></tr>
 
-<tr><td><strong>electrical<br>digital</strong></td>
-   <td>Integer (1..9)</td>
-   <td></td>
-   <td></td>
-   <td><a href=\"modelica://Modelica.Electrical.Digital.Interfaces\">Modelica.Electrical.Digital.Interfaces</a>
+<tr><td valign=\"top\"><strong>electrical<br>digital</strong></td>
+   <td valign=\"top\">Integer (1..9)</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.Digital.Interfaces\">Modelica.Electrical.Digital.Interfaces</a>
      <br>DigitalSignal, DigitalInput, DigitalOutput</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/Digital.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/Digital.png\"></td></tr>
 
-<tr><td><strong>magnetic<br>flux tubes</strong></td>
-   <td>magnetic potential</td>
-   <td>magnetic flux</td>
-   <td></td>
-   <td>
+<tr><td valign=\"top\"><strong>magnetic<br>flux tubes</strong></td>
+   <td valign=\"top\">magnetic potential</td>
+   <td valign=\"top\">magnetic flux</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\">
 <a href=\"modelica://Modelica.Magnetic.FluxTubes.Interfaces\">Modelica.Magnetic.FluxTubes.Interfaces</a>
      <br>MagneticPort, PositiveMagneticPort,<br>NegativeMagneticPort</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/MagneticPorts.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/MagneticPorts.png\"></td></tr>
 
-<tr><td><strong>magnetic<br>fundamental<br>wave</strong></td>
-   <td>complex magnetic potential</td>
-   <td>complex magnetic flux</td>
-   <td></td>
-   <td>
+<tr><td valign=\"top\"><strong>magnetic<br>fundamental<br>wave</strong></td>
+   <td valign=\"top\">complex magnetic potential</td>
+   <td valign=\"top\">complex magnetic flux</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\">
 <a href=\"modelica://Modelica.Magnetic.FundamentalWave.Interfaces\">Modelica.Magnetic.FundamentalWave.Interfaces</a>
      <br>MagneticPort, PositiveMagneticPort,<br>NegativeMagneticPort</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/FundamentalWavePorts.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/FundamentalWavePorts.png\"></td></tr>
 
-<tr><td><strong>translational</strong></td>
-   <td>distance</td>
-   <td>cut-force</td>
-   <td></td>
-   <td><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces\">Modelica.Mechanics.Translational.Interfaces</a>
+<tr><td valign=\"top\"><strong>translational</strong></td>
+   <td valign=\"top\">distance</td>
+   <td valign=\"top\">cut-force</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces\">Modelica.Mechanics.Translational.Interfaces</a>
      <br>Flange_a, Flange_b</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/TranslationalFlanges.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/TranslationalFlanges.png\"></td></tr>
 
-<tr><td><strong>rotational</strong></td>
-   <td>angle</td>
-   <td>cut-torque</td>
-   <td></td>
-   <td><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces\">Modelica.Mechanics.Rotational.Interfaces</a>
+<tr><td valign=\"top\"><strong>rotational</strong></td>
+   <td valign=\"top\">angle</td>
+   <td valign=\"top\">cut-torque</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces\">Modelica.Mechanics.Rotational.Interfaces</a>
      <br>Flange_a, Flange_b</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/RotationalFlanges.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/RotationalFlanges.png\"></td></tr>
 
-<tr><td><strong>3-dim.<br>mechanics</strong></td>
-   <td>position vector<br>
+<tr><td valign=\"top\"><strong>3-dim.<br>mechanics</strong></td>
+   <td valign=\"top\">position vector<br>
     orientation object</td>
-   <td>cut-force vector<br>
+   <td valign=\"top\">cut-force vector<br>
     cut-torque vector</td>
-   <td></td>
-   <td><a href=\"modelica://Modelica.Mechanics.MultiBody.Interfaces\">Modelica.Mechanics.MultiBody.Interfaces</a>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Interfaces\">Modelica.Mechanics.MultiBody.Interfaces</a>
      <br>Frame, Frame_a, Frame_b, Frame_resolve</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/MultiBodyFrames.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/MultiBodyFrames.png\"></td></tr>
 
-<tr><td><strong>simple<br>fluid flow</strong></td>
-   <td>pressure<br>
+<tr><td valign=\"top\"><strong>simple<br>fluid flow</strong></td>
+   <td valign=\"top\">pressure<br>
     specific enthalpy</td>
-   <td>mass flow rate<br>
+   <td valign=\"top\">mass flow rate<br>
     enthalpy flow rate</td>
-   <td></td>
-   <td><a href=\"modelica://Modelica.Thermal.FluidHeatFlow.Interfaces\">Modelica.Thermal.FluidHeatFlow.Interfaces</a>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Thermal.FluidHeatFlow.Interfaces\">Modelica.Thermal.FluidHeatFlow.Interfaces</a>
      <br>FlowPort, FlowPort_a, FlowPort_b</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/FluidHeatFlowPorts.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/FluidHeatFlowPorts.png\"></td></tr>
 
-<tr><td><strong>thermo<br>fluid flow</strong></td>
-   <td>pressure</td>
-   <td>mass flow rate</td>
-   <td>specific enthalpy<br>mass fractions</td>
-   <td>
+<tr><td valign=\"top\"><strong>thermo<br>fluid flow</strong></td>
+   <td valign=\"top\">pressure</td>
+   <td valign=\"top\">mass flow rate</td>
+   <td valign=\"top\">specific enthalpy<br>mass fractions</td>
+   <td valign=\"top\">
 <a href=\"modelica://Modelica.Fluid.Interfaces\">Modelica.Fluid.Interfaces</a>
      <br>FluidPort, FluidPort_a, FluidPort_b</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/FluidPorts.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/FluidPorts.png\"></td></tr>
 
-<tr><td><strong>heat<br>transfer</strong></td>
-   <td>temperature</td>
-   <td>heat flow rate</td>
-   <td></td>
-   <td><a href=\"modelica://Modelica.Thermal.HeatTransfer.Interfaces\">Modelica.Thermal.HeatTransfer.Interfaces</a>
+<tr><td valign=\"top\"><strong>heat<br>transfer</strong></td>
+   <td valign=\"top\">temperature</td>
+   <td valign=\"top\">heat flow rate</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Thermal.HeatTransfer.Interfaces\">Modelica.Thermal.HeatTransfer.Interfaces</a>
      <br>HeatPort, HeatPort_a, HeatPort_b</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/ThermalHeatPorts.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/ThermalHeatPorts.png\"></td></tr>
 
-<tr><td><strong>blocks</strong></td>
-   <td>
+<tr><td valign=\"top\"><strong>blocks</strong></td>
+   <td valign=\"top\">
     Real variable<br>
     Integer variable<br>
     Boolean variable</td>
-   <td></td>
-   <td></td>
-   <td><a href=\"modelica://Modelica.Blocks.Interfaces\">Modelica.Blocks.Interfaces</a>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Blocks.Interfaces\">Modelica.Blocks.Interfaces</a>
      <br>
       RealSignal, RealInput, RealOutput<br>
       IntegerSignal, IntegerInput, IntegerOutput<br>
       BooleanSignal, BooleanInput, BooleanOutput</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/Signals.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/Signals.png\"></td></tr>
 
-<tr><td><strong>complex<br>blocks</strong></td>
-   <td>
+<tr><td valign=\"top\"><strong>complex<br>blocks</strong></td>
+   <td valign=\"top\">
     Complex variable</td>
-   <td></td>
-   <td></td>
-   <td><a href=\"modelica://Modelica.ComplexBlocks.Interfaces\">Modelica.ComplexBlocks.Interfaces</a>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.ComplexBlocks.Interfaces\">Modelica.ComplexBlocks.Interfaces</a>
      <br>ComplexSignal, ComplexInput, ComplexOutput</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/ComplexSignals.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/ComplexSignals.png\"></td></tr>
 
-<tr><td><strong>state<br>machine</strong></td>
-   <td>Boolean variables<br>
+<tr><td valign=\"top\"><strong>state<br>machine</strong></td>
+   <td valign=\"top\">Boolean variables<br>
     (occupied, set,<br>
      available, reset)</td>
-   <td></td>
-   <td></td>
-   <td><a href=\"modelica://Modelica.StateGraph.Interfaces\">Modelica.StateGraph.Interfaces</a>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.StateGraph.Interfaces\">Modelica.StateGraph.Interfaces</a>
      <br>Step_in, Step_out, Transition_in, Transition_out</td>
-   <td><img src=\"modelica://Modelica/Resources/Images/UsersGuide/StateGraphPorts.png\"></td></tr>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/StateGraphPorts.png\"></td></tr>
 </table>
 
 <p>
@@ -1397,8 +1397,8 @@ This class summarizes general information about the implementation which is not 
 <pre>
 &lt;table border=\"0\" cellspacing=\"0\" cellpadding=\"2\"&gt;
     &lt;tr&gt;
-      &lt;td&gt;[Gao2008]&lt;/td&gt;
-      &lt;td&gt;Z. Gao, T. G. Habetler, R. G. Harley, and R. S. Colby,
+      &lt;td valign=\"top\"&gt;[Gao2008]&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;Z. Gao, T. G. Habetler, R. G. Harley, and R. S. Colby,
         &quot;A sensorless rotor temperature estimator for induction
                  machines based on a current harmonic spectral
                  estimation scheme,&quot;
@@ -1406,30 +1406,30 @@ This class summarizes general information about the implementation which is not 
         vol. 55, no. 1, pp. 407-416, Jan. 2008.&lt;/td&gt;
     &lt;/tr&gt;
     &lt;tr&gt;
-      &lt;td&gt;[Andronov1973]&lt;/td&gt;
-      &lt;td&gt;A. Andronov, E. Leontovich, I. Gordon, and A. Maier,
+      &lt;td valign=\"top\"&gt;[Andronov1973]&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;A. Andronov, E. Leontovich, I. Gordon, and A. Maier,
         &lt;em&gt;Theory of  Bifurcations of Dynamic Systems on a plane&lt;em&gt;,
         1st ed. New York: J. Wiley &amp; Sons, 1973.&lt;/td&gt;
     &lt;/tr&gt;
     &lt;tr&gt;
-      &lt;td&gt;[Woehrnschimmel1998]&lt;/td&gt;
-      &lt;td&gt;R. W&amp;ouml;hrnschimmel,
+      &lt;td valign=\"top\"&gt;[Woehrnschimmel1998]&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;R. W&amp;ouml;hrnschimmel,
         &quot;Simulation, modeling and fault detection for vector
               controlled induction machines,&quot;
         Master&#39;s thesis, Vienna University of Technology,
         Vienna, Austria, 1998.&lt;/td&gt;
     &lt;/tr&gt;
     &lt;tr&gt;
-      &lt;td&gt;[Farnleitner1999]&lt;/td&gt;
-      &lt;td&gt;E. Farnleitner,
+      &lt;td valign=\"top\"&gt;[Farnleitner1999]&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;E. Farnleitner,
         &quot;Computational Fluid dynamics analysis for rotating
               electrical machinery,&quot;
         Ph.D. dissertation, University of Leoben,
         Department of Applied Mathematics, Leoben, Austria, 1999.&lt;/td&gt;
     &lt;/tr&gt;
     &lt;tr&gt;
-      &lt;td&gt;[Marlino2005]&lt;/td&gt;
-      &lt;td&gt;L. D. Marlino,
+      &lt;td valign=\"top\"&gt;[Marlino2005]&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;L. D. Marlino,
         &quot;Oak ridge national laboratory annual progress report for the
               power electronics and electric machinery program,&quot;
       Oak Ridge National Laboratory, prepared for the U.S. Department of Energy,
@@ -1441,8 +1441,8 @@ This class summarizes general information about the implementation which is not 
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
     <tr>
-      <td>[Gao08]</td>
-      <td>Z. Gao, T. G. Habetler, R. G. Harley, and R. S. Colby,
+      <td valign=\"top\">[Gao08]</td>
+      <td valign=\"top\">Z. Gao, T. G. Habetler, R. G. Harley, and R. S. Colby,
         &quot;A sensorless rotor temperature estimator for induction
                  machines based on a current harmonic spectral
                  estimation scheme,&quot;
@@ -1450,30 +1450,30 @@ This class summarizes general information about the implementation which is not 
         vol. 55, no. 1, pp. 407-416, Jan. 2008.</td>
     </tr>
     <tr>
-      <td>[Andronov1973]</td>
-      <td>A. Andronov, E. Leontovich, I. Gordon, and A. Maier,
+      <td valign=\"top\">[Andronov1973]</td>
+      <td valign=\"top\">A. Andronov, E. Leontovich, I. Gordon, and A. Maier,
         <em>Theory of  Bifurcations of Dynamic Systems on a plane</em>,
         1st ed. New York: J. Wiley &amp; Sons, 1973.</td>
     </tr>
     <tr>
-      <td>[Woehrnschimmel1998]</td>
-      <td>R. W&ouml;hrnschimmel,
+      <td valign=\"top\">[Woehrnschimmel1998]</td>
+      <td valign=\"top\">R. W&ouml;hrnschimmel,
         &quot;Simulation, modeling and fault detection for vector
               controlled induction machines,&quot;
         Master&#39;s thesis, Vienna University of Technology,
         Vienna, Austria, 1998.</td>
     </tr>
     <tr>
-      <td>[Farnleitner1999]</td>
-      <td>E. Farnleitner,
+      <td valign=\"top\">[Farnleitner1999]</td>
+      <td valign=\"top\">E. Farnleitner,
         &quot;Computational Fluid dynamics analysis for rotating
               electrical machinery,&quot;
         Ph.D. dissertation, University of Leoben,
         Department of Applied Mathematics, Leoben, Austria, 1999.</td>
     </tr>
     <tr>
-      <td>[Marlino2005]</td>
-      <td>L. D. Marlino,
+      <td valign=\"top\">[Marlino2005]</td>
+      <td valign=\"top\">L. D. Marlino,
         &quot;Oak ridge national laboratory annual progress report for the
               power electronics and electric machinery program,&quot;
       Oak Ridge National Laboratory, prepared for the U.S. Department of Energy,
@@ -1613,16 +1613,16 @@ The authors would like to thank following persons for their support ...
     &lt;/tr&gt;
     ...
     &lt;tr&gt;
-      &lt;td&gt;1.0.1&lt;/td&gt;
-      &lt;td&gt;2008-05-26&lt;/td&gt;
-      &lt;td&gt;A. Haumer&lt;br&gt;C. Kral&lt;/td&gt;
-      &lt;td&gt;Fixed bug in documentation&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;1.0.1&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;2008-05-26&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;A. Haumer&lt;br&gt;C. Kral&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;Fixed bug in documentation&lt;/td&gt;
     &lt;/tr&gt;
     &lt;tr&gt;
-      &lt;td&gt;1.0.0&lt;/td&gt;
-      &lt;td&gt;2008-05-21&lt;/td&gt;
-      &lt;td&gt;A. Haumer&lt;/td&gt;
-      &lt;td&gt;Initial version&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;1.0.0&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;2008-05-21&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;A. Haumer&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;Initial version&lt;/td&gt;
     &lt;/tr&gt;
 &lt;/table&gt;</pre>
 
@@ -1638,47 +1638,47 @@ The authors would like to thank following persons for their support ...
       <th>Comment</th>
     </tr>
     <tr>
-      <td>3.x.x</td>
-      <td>2017-07-04</td>
-      <td>C. Kral</td>
-      <td>Added comment on version number and date, see
+      <td valign=\"top\">3.x.x</td>
+      <td valign=\"top\">2017-07-04</td>
+      <td valign=\"top\">C. Kral</td>
+      <td valign=\"top\">Added comment on version number and date, see
       <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/2219\">#2219</a></td>
     </tr>
     <tr>
-      <td>1.1.0</td>
-      <td>2010-04-22</td>
-      <td>C. Kral</td>
-      <td>Migrated Conventions to UsersGuide of MSL</td>
+      <td valign=\"top\">1.1.0</td>
+      <td valign=\"top\">2010-04-22</td>
+      <td valign=\"top\">C. Kral</td>
+      <td valign=\"top\">Migrated Conventions to UsersGuide of MSL</td>
     </tr>
     <tr>
-      <td>1.0.5</td>
-      <td>2010-03-11</td>
-      <td>D. Winkler</td>
-      <td>Updated image links guide to new 'modelica://' URIs, added contact details</td>
+      <td valign=\"top\">1.0.5</td>
+      <td valign=\"top\">2010-03-11</td>
+      <td valign=\"top\">D. Winkler</td>
+      <td valign=\"top\">Updated image links guide to new 'modelica://' URIs, added contact details</td>
     </tr>
     <tr>
-      <td>1.0.4</td>
-      <td>2009-09-28</td>
-      <td>C. Kral</td>
-      <td>Applied new rules for equations as discussed on the 63rd Modelica Design Meeting</td>
+      <td valign=\"top\">1.0.4</td>
+      <td valign=\"top\">2009-09-28</td>
+      <td valign=\"top\">C. Kral</td>
+      <td valign=\"top\">Applied new rules for equations as discussed on the 63rd Modelica Design Meeting</td>
     </tr>
     <tr>
-      <td>1.0.3</td>
-      <td>2008-05-26</td>
-      <td>D. Winkler</td>
-      <td>Layout fixes and enhancements</td>
+      <td valign=\"top\">1.0.3</td>
+      <td valign=\"top\">2008-05-26</td>
+      <td valign=\"top\">D. Winkler</td>
+      <td valign=\"top\">Layout fixes and enhancements</td>
     </tr>
     <tr>
-      <td>1.0.1</td>
-      <td>2008-05-26</td>
-      <td>A. Haumer<br>C. Kral</td>
-      <td>Fixed bug in documentation</td>
+      <td valign=\"top\">1.0.1</td>
+      <td valign=\"top\">2008-05-26</td>
+      <td valign=\"top\">A. Haumer<br>C. Kral</td>
+      <td valign=\"top\">Fixed bug in documentation</td>
     </tr>
     <tr>
-      <td>1.0.0</td>
-      <td>2008-05-21</td>
-      <td>A. Haumer</td>
-      <td>Initial version</td>
+      <td valign=\"top\">1.0.0</td>
+      <td valign=\"top\">2008-05-21</td>
+      <td valign=\"top\">A. Haumer</td>
+      <td valign=\"top\">Initial version</td>
     </tr>
 </table>
 </html>"));
@@ -2337,14 +2337,14 @@ The following <font color=\"blue\"><strong>new libraries</strong></font> have be
 </p>
 
 <table border=\"1\" cellspacing=0 cellpadding=2>
-<tr><td><a href=\"modelica://Modelica.Electrical.PowerConverters\">Modelica.Electrical.PowerConverters</a></td>
-    <td>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Electrical.PowerConverters\">Modelica.Electrical.PowerConverters</a></td>
+    <td valign=\"top\">
     This library offers models for rectifiers, inverters and DC/DC-converters.<br>
     (This library was developed by Christian Kral and Anton Haumer).
     </td></tr>
 
-<tr><td><a href=\"modelica://Modelica.Magnetic.QuasiStatic.FundamentalWave\">Modelica.Magnetic.QuasiStatic.FundamentalWave</a></td>
-    <td>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.QuasiStatic.FundamentalWave\">Modelica.Magnetic.QuasiStatic.FundamentalWave</a></td>
+    <td valign=\"top\">
     This library provides quasi-static models of multiphase machines (induction machines, synchronous machines) in parallel (with the same parameters but different electric connectors)
     to the transient models in <a href=\"modelica://Modelica.Magnetic.FundamentalWave\">Modelica.Magnetic.FundamentalWave</a>.<br>
     Quasistatic means that electric transients are neglected, voltages and currents are supposed to be sinusoidal. Mechanical and thermal transients are taken into account.<br>
@@ -2353,8 +2353,8 @@ The following <font color=\"blue\"><strong>new libraries</strong></font> have be
     (This library was developed by Christian Kral and Anton Haumer).
     </td></tr>
 
-<tr><td>Sublibraries of <a href=\"modelica://Modelica.Magnetic.FluxTubes\">Modelica.Magnetic.FluxTubes</a></td>
-    <td>
+<tr><td valign=\"top\">Sublibraries of <a href=\"modelica://Modelica.Magnetic.FluxTubes\">Modelica.Magnetic.FluxTubes</a></td>
+    <td valign=\"top\">
    New elements for modeling ferromagnetic (static) and eddy current (dynamic) hysteresis effects and permanent magnets have been added.
    The FluxTubes.Material package is also extended to provide hysteresis data for several magnetic materials. These data is partly based on own measurements.
    For modeling of ferromagnetic hysteresis, two different hystereses models have been implemented: The simple Tellinen model and the considerably
@@ -2373,8 +2373,8 @@ The following <font color=\"blue\"><strong>new libraries</strong></font> have be
      The partial financial support by the European Union for this development is highly appreciated.).
     </td></tr>
 
-<tr><td>Sublibraries for <strong>noise</strong> modeling</td>
-    <td>
+<tr><td valign=\"top\">Sublibraries for <strong>noise</strong> modeling</td>
+    <td valign=\"top\">
    Several new sublibraries have been added allowing the modeling of reproducible noise.
    The most important new sublibraries are (for more details see below):
   <ul>
@@ -2387,8 +2387,8 @@ The following <font color=\"blue\"><strong>new libraries</strong></font> have be
   DLR Institute of System Dynamics and Control).
     </td></tr>
 
-<tr><td><a href=\"modelica://Modelica.Utilities\">Modelica.Utilities</a> functions for <strong>matrix read/write</strong></td>
-    <td>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities\">Modelica.Utilities</a> functions for <strong>matrix read/write</strong></td>
+    <td valign=\"top\">
    New functions are provided in the <a href=\"modelica://Modelica.Utilities.Streams\">Modelica.Utilities.Streams</a>
    sublibrary to write matrices in MATLAB MAT format on file and read matrices in this format from file.
    The MATLAB MAT formats v4, v6, v7 and v7.3 (in case the tool supports HDF5) are supported by these functions.
@@ -2398,8 +2398,8 @@ The following <font color=\"blue\"><strong>new libraries</strong></font> have be
    (These extensions have been developed by Thomas Beutlich from ITI GmbH).
     </td></tr>
 
-<tr><td><a href=\"modelica://Modelica.Math\">Modelica.Math</a> sublibrary for <strong>FFT</strong></td>
-    <td>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Math\">Modelica.Math</a> sublibrary for <strong>FFT</strong></td>
+    <td valign=\"top\">
    The new sublibrary <a href=\"modelica://Modelica.Math.FastFourierTransform\">FastFourierTransform</a>
    provides utility and convenience functions to compute the Fast Fourier Transform (FFT).
    Additionally two examples are present to demonstrate how to compute an FFT during continuous-time
@@ -2416,144 +2416,144 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:<br>
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Examples</strong></td></tr>
-<tr><td width=\"150\">NoiseExamples</td>
-    <td> Several examples to demonstrate the usage of the blocks in the
+<tr><td valign=\"top\" width=\"150\">NoiseExamples</td>
+    <td valign=\"top\"> Several examples to demonstrate the usage of the blocks in the
                       new sublibrary Blocks.Noise.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Interfaces</strong></td></tr>
-<tr><td width=\"150\">PartialNoise</td>
-    <td> Partial noise generator (base class of the noise generators in Blocks.Noise)</td></tr>
+<tr><td valign=\"top\" width=\"150\">PartialNoise</td>
+    <td valign=\"top\"> Partial noise generator (base class of the noise generators in Blocks.Noise)</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Math</strong></td></tr>
-<tr><td width=\"150\">ContinuousMean</td>
-    <td> Calculates the empirical expectation (mean) value of its input signal</td></tr>
-<tr><td width=\"150\">Variance</td>
-    <td> Calculates the empirical variance of its input signal</td></tr>
-<tr><td width=\"150\">StandardDeviation</td>
-    <td> Calculates the empirical standard deviation of its input signal</td></tr>
+<tr><td valign=\"top\" width=\"150\">ContinuousMean</td>
+    <td valign=\"top\"> Calculates the empirical expectation (mean) value of its input signal</td></tr>
+<tr><td valign=\"top\" width=\"150\">Variance</td>
+    <td valign=\"top\"> Calculates the empirical variance of its input signal</td></tr>
+<tr><td valign=\"top\" width=\"150\">StandardDeviation</td>
+    <td valign=\"top\"> Calculates the empirical standard deviation of its input signal</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Noise</strong></td></tr>
-<tr><td width=\"150\">GlobalSeed</td>
-    <td> Defines global settings for the blocks of sublibrary Noise,
+<tr><td valign=\"top\" width=\"150\">GlobalSeed</td>
+    <td valign=\"top\"> Defines global settings for the blocks of sublibrary Noise,
                       especially a global seed value is defined</td></tr>
-<tr><td width=\"150\">UniformNoise</td>
-    <td> Noise generator with uniform distribution</td></tr>
-<tr><td width=\"150\">NormalNoise</td>
-    <td> Noise generator with normal distribution</td></tr>
-<tr><td width=\"150\">TruncatedNormalNoise</td>
-    <td> Noise generator with truncated normal distribution</td></tr>
-<tr><td width=\"150\">BandLimitedWhiteNoise</td>
-    <td> Noise generator to produce band-limited white noise with normal distribution</td></tr>
+<tr><td valign=\"top\" width=\"150\">UniformNoise</td>
+    <td valign=\"top\"> Noise generator with uniform distribution</td></tr>
+<tr><td valign=\"top\" width=\"150\">NormalNoise</td>
+    <td valign=\"top\"> Noise generator with normal distribution</td></tr>
+<tr><td valign=\"top\" width=\"150\">TruncatedNormalNoise</td>
+    <td valign=\"top\"> Noise generator with truncated normal distribution</td></tr>
+<tr><td valign=\"top\" width=\"150\">BandLimitedWhiteNoise</td>
+    <td valign=\"top\"> Noise generator to produce band-limited white noise with normal distribution</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.ComplexBlocks.Examples</strong></td></tr>
-<tr><td width=\"150\">ShowTransferFunction</td>
-    <td> Example to demonstrate the usage of the block TransferFunction.</td></tr>
+<tr><td valign=\"top\" width=\"150\">ShowTransferFunction</td>
+    <td valign=\"top\"> Example to demonstrate the usage of the block TransferFunction.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.ComplexBlocks.ComplexMath</strong></td></tr>
-<tr><td width=\"150\">TransferFunction</td>
-    <td> This block allows to define a complex transfer function (depending on frequency input w) to obtain the complex output y.</td></tr>
+<tr><td valign=\"top\" width=\"150\">TransferFunction</td>
+    <td valign=\"top\"> This block allows to define a complex transfer function (depending on frequency input w) to obtain the complex output y.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.ComplexBlocks.Sources</strong></td></tr>
-<tr><td width=\"150\">LogFrequencySweep</td>
-    <td> The logarithm of w performs a linear ramp from log10(wMin) to log10(wMax), the output is the decimal power of this logarithmic ramp.</td></tr>
+<tr><td valign=\"top\" width=\"150\">LogFrequencySweep</td>
+    <td valign=\"top\"> The logarithm of w performs a linear ramp from log10(wMin) to log10(wMax), the output is the decimal power of this logarithmic ramp.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines.Examples</strong></td></tr>
-<tr><td width=\"150\">ControlledDCDrives</td>
-    <td>Current, speed and position controlled DC PM drive</td></tr>
+<tr><td valign=\"top\" width=\"150\">ControlledDCDrives</td>
+    <td valign=\"top\">Current, speed and position controlled DC PM drive</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Rotational.Examples.Utilities.</strong></td></tr>
-<tr><td width=\"150\">SpringDamperNoRelativeStates</td>
-    <td>Introduced to fix ticket <a href=\"https://trac.modelica.org/Modelica/ticket/1375\">1375</a></td></tr>
+<tr><td valign=\"top\" width=\"150\">SpringDamperNoRelativeStates</td>
+    <td valign=\"top\">Introduced to fix ticket <a href=\"https://trac.modelica.org/Modelica/ticket/1375\">1375</a></td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Rotational.Components.</strong></td></tr>
-<tr><td width=\"150\">ElastoBacklash2</td>
-    <td>Alternative model of backlash. The difference to the existing ElastoBacklash
+<tr><td valign=\"top\" width=\"150\">ElastoBacklash2</td>
+    <td valign=\"top\">Alternative model of backlash. The difference to the existing ElastoBacklash
     component is that an event is generated when contact occurs and that the contact torque
     changes discontinuously in this case. For some user models, this variant of a backlash model
     leads to significantly faster simulations.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Fluid.Examples.</strong></td></tr>
-<tr><td width=\"150\">NonCircularPipes</td>
-    <td>Introduced to check the fix of ticket <a href=\"https://trac.modelica.org/Modelica/ticket/1601\">1681</a></td></tr>
+<tr><td valign=\"top\" width=\"150\">NonCircularPipes</td>
+    <td valign=\"top\">Introduced to check the fix of ticket <a href=\"https://trac.modelica.org/Modelica/ticket/1601\">1681</a></td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Media.Examples.</strong></td></tr>
-<tr><td width=\"150\">PsychrometricData</td>
-    <td>Introduced to fix ticket <a href=\"https://trac.modelica.org/Modelica/ticket/1679\">1679</a></td></tr>
+<tr><td valign=\"top\" width=\"150\">PsychrometricData</td>
+    <td valign=\"top\">Introduced to fix ticket <a href=\"https://trac.modelica.org/Modelica/ticket/1679\">1679</a></td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math.Matrices.</strong></td></tr>
-<tr><td width=\"150\">balanceABC</td>
-    <td> Return a balanced form of a system [A,B;C,0]
+<tr><td valign=\"top\" width=\"150\">balanceABC</td>
+    <td valign=\"top\"> Return a balanced form of a system [A,B;C,0]
                       to improve its condition by a state transformation</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math.Random.Generators.</strong></td></tr>
-<tr><td width=\"150\">Xorshift64star</td>
-    <td> Random number generator xorshift64*</td></tr>
-<tr><td width=\"150\">Xorshift128plus </td>
-    <td> Random number generator xorshift128+</td></tr>
-<tr><td width=\"150\">Xorshift1024star</td>
-    <td> Random number generator xorshift1024*</td></tr>
+<tr><td valign=\"top\" width=\"150\">Xorshift64star</td>
+    <td valign=\"top\"> Random number generator xorshift64*</td></tr>
+<tr><td valign=\"top\" width=\"150\">Xorshift128plus </td>
+    <td valign=\"top\"> Random number generator xorshift128+</td></tr>
+<tr><td valign=\"top\" width=\"150\">Xorshift1024star</td>
+    <td valign=\"top\"> Random number generator xorshift1024*</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math.Random.Utilities.</strong></td></tr>
-<tr><td width=\"150\">initialStateWithXorshift64star</td>
-    <td> Return an initial state vector for a random number generator (based on xorshift64star algorithm)</td></tr>
-<tr><td width=\"150\">automaticGlobalSeed </td>
-    <td> Creates an automatic integer seed from the current time and process id (= impure function)</td></tr>
-<tr><td width=\"150\">initializeImpureRandom </td>
-    <td> Initializes the internal state of the impure random number generator</td></tr>
-<tr><td width=\"150\">impureRandom</td>
-    <td> Impure random number generator (with hidden state vector)</td></tr>
-<tr><td width=\"150\">impureRandomInteger </td>
-    <td> Impure random number generator for integer values (with hidden state vector)</td></tr>
+<tr><td valign=\"top\" width=\"150\">initialStateWithXorshift64star</td>
+    <td valign=\"top\"> Return an initial state vector for a random number generator (based on xorshift64star algorithm)</td></tr>
+<tr><td valign=\"top\" width=\"150\">automaticGlobalSeed </td>
+    <td valign=\"top\"> Creates an automatic integer seed from the current time and process id (= impure function)</td></tr>
+<tr><td valign=\"top\" width=\"150\">initializeImpureRandom </td>
+    <td valign=\"top\"> Initializes the internal state of the impure random number generator</td></tr>
+<tr><td valign=\"top\" width=\"150\">impureRandom</td>
+    <td valign=\"top\"> Impure random number generator (with hidden state vector)</td></tr>
+<tr><td valign=\"top\" width=\"150\">impureRandomInteger </td>
+    <td valign=\"top\"> Impure random number generator for integer values (with hidden state vector)</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math.Distributions.</strong></td></tr>
-<tr><td width=\"150\">Uniform</td>
-    <td> Library of uniform distribution functions (functions: density, cumulative, quantile)</td></tr>
-<tr><td width=\"150\">Normal</td>
-    <td> Library of normal distribution functions (functions: density, cumulative, quantile)</td></tr>
-<tr><td width=\"150\">TruncatedNormal </td>
-    <td> Library of truncated normal distribution functions (functions: density, cumulative, quantile)</td></tr>
-<tr><td width=\"150\">Weibull</td>
-    <td> Library of Weibull distribution functions (functions: density, cumulative, quantile)</td></tr>
-<tr><td width=\"150\">TruncatedWeibull </td>
-    <td> Library of truncated Weibull distribution functions (functions: density, cumulative, quantile)</td></tr>
+<tr><td valign=\"top\" width=\"150\">Uniform</td>
+    <td valign=\"top\"> Library of uniform distribution functions (functions: density, cumulative, quantile)</td></tr>
+<tr><td valign=\"top\" width=\"150\">Normal</td>
+    <td valign=\"top\"> Library of normal distribution functions (functions: density, cumulative, quantile)</td></tr>
+<tr><td valign=\"top\" width=\"150\">TruncatedNormal </td>
+    <td valign=\"top\"> Library of truncated normal distribution functions (functions: density, cumulative, quantile)</td></tr>
+<tr><td valign=\"top\" width=\"150\">Weibull</td>
+    <td valign=\"top\"> Library of Weibull distribution functions (functions: density, cumulative, quantile)</td></tr>
+<tr><td valign=\"top\" width=\"150\">TruncatedWeibull </td>
+    <td valign=\"top\"> Library of truncated Weibull distribution functions (functions: density, cumulative, quantile)</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math.Special.</strong></td></tr>
-<tr><td width=\"150\">erf</td>
-    <td>Error function erf(u) = 2/sqrt(pi)*Integral_0_u exp(-t^2)*d</td></tr>
-<tr><td width=\"150\">erfc</td>
-    <td>Complementary error function erfc(u) = 1 - erf(u)</td></tr>
-<tr><td width=\"150\">erfInv</td>
-    <td>Inverse error function: u = erf(erfInv(u))</td></tr>
-<tr><td width=\"150\">erfcInv </td>
-    <td>Inverse complementary error function: u = erfc(erfcInv(u))</td></tr>
-<tr><td width=\"150\">sinc </td>
-    <td>Unnormalized sinc function: sinc(u) = sin(u)/u</td></tr>
+<tr><td valign=\"top\" width=\"150\">erf</td>
+    <td valign=\"top\">Error function erf(u) = 2/sqrt(pi)*Integral_0_u exp(-t^2)*d</td></tr>
+<tr><td valign=\"top\" width=\"150\">erfc</td>
+    <td valign=\"top\">Complementary error function erfc(u) = 1 - erf(u)</td></tr>
+<tr><td valign=\"top\" width=\"150\">erfInv</td>
+    <td valign=\"top\">Inverse error function: u = erf(erfInv(u))</td></tr>
+<tr><td valign=\"top\" width=\"150\">erfcInv </td>
+    <td valign=\"top\">Inverse complementary error function: u = erfc(erfcInv(u))</td></tr>
+<tr><td valign=\"top\" width=\"150\">sinc </td>
+    <td valign=\"top\">Unnormalized sinc function: sinc(u) = sin(u)/u</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math.FastFourierTransform.</strong></td></tr>
-<tr><td width=\"150\">realFFTinfo </td>
-    <td>Print information about real FFT for given f_max and f_resolution</td></tr>
-<tr><td width=\"150\">realFFTsamplePoints </td>
-    <td>Return number of sample points for a real FFT</td></tr>
-<tr><td width=\"150\">realFFT</td>
-    <td>Return amplitude and phase vectors for a real FFT</td></tr>
+<tr><td valign=\"top\" width=\"150\">realFFTinfo </td>
+    <td valign=\"top\">Print information about real FFT for given f_max and f_resolution</td></tr>
+<tr><td valign=\"top\" width=\"150\">realFFTsamplePoints </td>
+    <td valign=\"top\">Return number of sample points for a real FFT</td></tr>
+<tr><td valign=\"top\" width=\"150\">realFFT</td>
+    <td valign=\"top\">Return amplitude and phase vectors for a real FFT</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Utilities.Streams.</strong></td></tr>
-<tr><td width=\"150\">readMatrixSize</td>
-    <td>Read dimensions of a Real matrix from a MATLAB MAT file</td></tr>
-<tr><td width=\"150\">readRealMatrix</td>
-    <td>Read Real matrix from MATLAB MAT file</td></tr>
-<tr><td width=\"150\">writeRealMatrix</td>
-    <td>Write Real matrix to a MATLAB MAT file</td></tr>
+<tr><td valign=\"top\" width=\"150\">readMatrixSize</td>
+    <td valign=\"top\">Read dimensions of a Real matrix from a MATLAB MAT file</td></tr>
+<tr><td valign=\"top\" width=\"150\">readRealMatrix</td>
+    <td valign=\"top\">Read Real matrix from MATLAB MAT file</td></tr>
+<tr><td valign=\"top\" width=\"150\">writeRealMatrix</td>
+    <td valign=\"top\">Write Real matrix to a MATLAB MAT file</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Utilities.Strings.</strong></td></tr>
-<tr><td width=\"150\">hashString</td>
-    <td>Creates a hash value of a String</td></tr>
+<tr><td valign=\"top\" width=\"150\">hashString</td>
+    <td valign=\"top\">Creates a hash value of a String</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Utilities.System.</strong></td></tr>
-<tr><td width=\"150\">getTime</td>
-    <td>Retrieves the local time (in the local time zone)</td></tr>
-<tr><td width=\"150\">getPid</td>
-    <td>Retrieves the current process id</td></tr>
+<tr><td valign=\"top\" width=\"150\">getTime</td>
+    <td valign=\"top\">Retrieves the local time (in the local time zone)</td></tr>
+<tr><td valign=\"top\" width=\"150\">getPid</td>
+    <td valign=\"top\">Retrieves the current process id</td></tr>
 </table>
 
 <p><br>
@@ -2562,12 +2562,12 @@ The following <font color=\"blue\"><strong>existing components</strong></font> h
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Electrical.Analog.Semiconductors.</strong></td></tr>
-<tr><td> HeatingDiode </td>
-          <td> Removed protected variable k \"Boltzmann's constant\".<br>
+<tr><td valign=\"top\"> HeatingDiode </td>
+          <td valign=\"top\"> Removed protected variable k \"Boltzmann's constant\".<br>
                             Calculate protected constant q \"Electron charge\" from already known constants instead of defining a protected variable q.</td></tr>
-<tr><td> HeatingNPN<br>
+<tr><td valign=\"top\"> HeatingNPN<br>
                       HeatingPNP </td>
-          <td> Removed parameter K \"Boltzmann's constant\" and q \"Elementary electronic charge\".<br>
+          <td valign=\"top\"> Removed parameter K \"Boltzmann's constant\" and q \"Elementary electronic charge\".<br>
                             Calculate instead protected constant q \"Electron charge\" from already known constants.<br>
                             Users that have used these parameters might have broken their models;
                             the (although formal non-backwards compatible) change offers the users a safer use.</td></tr>
@@ -2735,105 +2735,105 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Logical.</strong></td></tr>
-<tr><td width=\"150\"> RSFlipFlop</td>
-    <td> Basic RS flip flop</td></tr>
+<tr><td valign=\"top\" width=\"150\"> RSFlipFlop</td>
+    <td valign=\"top\"> Basic RS flip flop</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Math.</strong></td></tr>
-<tr><td width=\"150\"> MinMax</td>
-    <td>Output the minimum and the maximum element of the input vector </td></tr>
-<tr><td width=\"150\"> LinearDependency </td>
-    <td>Output a linear combination of the two inputs </td></tr>
+<tr><td valign=\"top\" width=\"150\"> MinMax</td>
+    <td valign=\"top\">Output the minimum and the maximum element of the input vector </td></tr>
+<tr><td valign=\"top\" width=\"150\"> LinearDependency </td>
+    <td valign=\"top\">Output a linear combination of the two inputs </td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Nonlinear.</strong></td></tr>
-<tr><td width=\"150\"> SlewRateLimiter</td>
-    <td> Limit the slew rate of a signal </td></tr>
+<tr><td valign=\"top\" width=\"150\"> SlewRateLimiter</td>
+    <td valign=\"top\"> Limit the slew rate of a signal </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Digital.Memories</strong></td></tr>
-<tr><td width=\"150\"> DLATRAM</td>
-    <td> Level sensitive Random Access Memory </td></tr>
-<tr><td width=\"150\"> DLATROM</td>
-    <td> Level sensitive Read Only Memory </td></tr>
+<tr><td valign=\"top\" width=\"150\"> DLATRAM</td>
+    <td valign=\"top\"> Level sensitive Random Access Memory </td></tr>
+<tr><td valign=\"top\" width=\"150\"> DLATROM</td>
+    <td valign=\"top\"> Level sensitive Read Only Memory </td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Digital.Multiplexers</strong></td></tr>
-<tr><td width=\"150\"> MUX2x1</td>
-    <td> A two inputs MULTIPLEXER for multiple value logic (2 data inputs, 1 select input, 1 output) </td></tr>
+<tr><td valign=\"top\" width=\"150\"> MUX2x1</td>
+    <td valign=\"top\"> A two inputs MULTIPLEXER for multiple value logic (2 data inputs, 1 select input, 1 output) </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines.Examples.AsynchronousInductionMachines.</strong></td></tr>
-<tr><td width=\"150\"> AIMC_Initialize </td>
-    <td> Steady-State Initialization example of AsynchronousInductionMachineSquirrelCage </td></tr>
+<tr><td valign=\"top\" width=\"150\"> AIMC_Initialize </td>
+    <td valign=\"top\"> Steady-State Initialization example of AsynchronousInductionMachineSquirrelCage </td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines.Examples.SynchronousInductionMachines.</strong></td></tr>
-<tr><td width=\"150\"> SMPM_VoltageSource </td>
-    <td> PermanentMagnetSynchronousInductionMachine example fed by FOC </td></tr>
+<tr><td valign=\"top\" width=\"150\"> SMPM_VoltageSource </td>
+    <td valign=\"top\"> PermanentMagnetSynchronousInductionMachine example fed by FOC </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.MultiPhase.Examples.</strong></td></tr>
-<tr><td width=\"150\"> TestSensors </td>
-    <td> Example for multiphase quasiRMS sensors: A sinusoidal source feeds a load consisting of resistor and inductor </td></tr>
+<tr><td valign=\"top\" width=\"150\"> TestSensors </td>
+    <td valign=\"top\"> Example for multiphase quasiRMS sensors: A sinusoidal source feeds a load consisting of resistor and inductor </td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.MultiPhase.Sensors.</strong></td></tr>
-<tr><td width=\"150\"> VoltageQuasiRMSSensor </td>
-    <td> Continuous quasi voltage RMS sensor for multi phase system </td></tr>
-<tr><td width=\"150\"> CurrentQuasiRMSSensor </td>
-    <td> Continuous quasi current RMS sensor for multi phase system </td></tr>
+<tr><td valign=\"top\" width=\"150\"> VoltageQuasiRMSSensor </td>
+    <td valign=\"top\"> Continuous quasi voltage RMS sensor for multi phase system </td></tr>
+<tr><td valign=\"top\" width=\"150\"> CurrentQuasiRMSSensor </td>
+    <td valign=\"top\"> Continuous quasi current RMS sensor for multi phase system </td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.MultiPhase.Blocks.</strong></td></tr>
-<tr><td width=\"150\"> QuasiRMS </td>
-    <td> Determine quasi RMS value of a multi-phase system </td></tr>
+<tr><td valign=\"top\" width=\"150\"> QuasiRMS </td>
+    <td valign=\"top\"> Determine quasi RMS value of a multi-phase system </td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.MultiPhase.Functions.</strong></td></tr>
-<tr><td width=\"150\"> quasiRMS </td>
-    <td> Calculate continuous quasi RMS value of input </td></tr>
-<tr><td width=\"150\"> activePower </td>
-    <td> Calculate active power of voltage and current input </td></tr>
-<tr><td width=\"150\"> symmetricOrientation </td>
-    <td> Orientations of the resulting fundamental wave field phasors </td></tr>
+<tr><td valign=\"top\" width=\"150\"> quasiRMS </td>
+    <td valign=\"top\"> Calculate continuous quasi RMS value of input </td></tr>
+<tr><td valign=\"top\" width=\"150\"> activePower </td>
+    <td valign=\"top\"> Calculate active power of voltage and current input </td></tr>
+<tr><td valign=\"top\" width=\"150\"> symmetricOrientation </td>
+    <td valign=\"top\"> Orientations of the resulting fundamental wave field phasors </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Spice3.Examples.</strong></td></tr>
-<tr><td width=\"150\"> CoupledInductors<br>
+<tr><td valign=\"top\" width=\"150\"> CoupledInductors<br>
                                       CascodeCircuit<br>
                                       Spice3BenchmarkDifferentialPair<br>
                                       Spice3BenchmarkMosfetCharacterization<br>
                                       Spice3BenchmarkRtlInverter<br>
                                       Spice3BenchmarkFourBitBinaryAdder</td>
-    <td> Spice3 examples and benchmarks from the SPICE3 Version e3 User's Manual </td></tr>
+    <td valign=\"top\"> Spice3 examples and benchmarks from the SPICE3 Version e3 User's Manual </td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Spice3.Basic.</strong></td></tr>
-<tr><td width=\"150\"> K_CoupledInductors</td>
-    <td> Inductive coupling via coupling factor K </td></tr>
+<tr><td valign=\"top\" width=\"150\"> K_CoupledInductors</td>
+    <td valign=\"top\"> Inductive coupling via coupling factor K </td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Spice3.Semiconductors.</strong></td></tr>
-<tr><td width=\"150\"> M_NMOS2<br>
+<tr><td valign=\"top\" width=\"150\"> M_NMOS2<br>
                                       M_PMOS2<br>
                                       ModelcardMOS2</td>
-    <td>  N/P channel MOSFET transistor with fixed level 2 </td></tr>
-<tr><td width=\"150\"> J_NJFJFE<br>
+    <td valign=\"top\">  N/P channel MOSFET transistor with fixed level 2 </td></tr>
+<tr><td valign=\"top\" width=\"150\"> J_NJFJFE<br>
                                       J_PJFJFE<br>
                                       ModelcardJFET</td>
-    <td>  N/P-channel junction field-effect transistor </td></tr>
-<tr><td width=\"150\"> C_Capacitor<br>
+    <td valign=\"top\">  N/P-channel junction field-effect transistor </td></tr>
+<tr><td valign=\"top\" width=\"150\"> C_Capacitor<br>
                                       ModelcardCAPACITOR</td>
-    <td>  Semiconductor capacitor model </td></tr>
+    <td valign=\"top\">  Semiconductor capacitor model </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Magnetic.FundamentalWave.Examples.BasicMachines.</strong></td></tr>
-<tr><td width=\"150\"> AIMC_DOL_MultiPhase<br>
+<tr><td valign=\"top\" width=\"150\"> AIMC_DOL_MultiPhase<br>
                                       AIMS_Start_MultiPhase<br>
                                       SMPM_Inverter_MultiPhase<br>
                                       SMEE_Generator_MultiPhase<br>
                                       SMR_Inverter_MultiPhase</td>
-    <td> Multi-phase machine examples </td></tr>
+    <td valign=\"top\"> Multi-phase machine examples </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Fluid.Sensors.</strong></td></tr>
-<tr><td width=\"150\"> MassFractions<br>
+<tr><td valign=\"top\" width=\"150\"> MassFractions<br>
                                       MassFractionsTwoPort</td>
-    <td> Ideal mass fraction sensors </td></tr>
+    <td valign=\"top\"> Ideal mass fraction sensors </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Media.</strong></td></tr>
-<tr><td width=\"150\">R134a</td>
-    <td> R134a (Tetrafluoroethane) medium model in the range (0.0039 bar .. 700 bar,
+<tr><td valign=\"top\" width=\"150\">R134a</td>
+    <td valign=\"top\"> R134a (Tetrafluoroethane) medium model in the range (0.0039 bar .. 700 bar,
     169.85 K .. 455 K)</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Media.Air.</strong></td></tr>
-<tr><td width=\"150\"> ReferenceAir</td>
-    <td> Detailed dry air model with a large operating range (130 ... 2000 K, 0 ... 2000 MPa)
+<tr><td valign=\"top\" width=\"150\"> ReferenceAir</td>
+    <td valign=\"top\"> Detailed dry air model with a large operating range (130 ... 2000 K, 0 ... 2000 MPa)
                         based on Helmholtz equations of state</td></tr>
-<tr><td width=\"150\"> ReferenceMoistAir</td>
-    <td> Detailed moist air model (143.15 ... 2000 K)</td></tr>
-<tr><td width=\"150\"> MoistAir</td>
-    <td> Temperature range of functions of MoistAir medium enlarged from
+<tr><td valign=\"top\" width=\"150\"> ReferenceMoistAir</td>
+    <td valign=\"top\"> Detailed moist air model (143.15 ... 2000 K)</td></tr>
+<tr><td valign=\"top\" width=\"150\"> MoistAir</td>
+    <td valign=\"top\"> Temperature range of functions of MoistAir medium enlarged from
                         240 - 400 K to  190 - 647 K.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Media.Air.MoistAir.</strong></td></tr>
-<tr><td width=\"150\"> velocityOfSound<br>
+<tr><td valign=\"top\" width=\"150\"> velocityOfSound<br>
                                       isobaricExpansionCoefficient<br>
                                       isothermalCompressibility<br>
                                       density_derp_h<br>
@@ -2847,58 +2847,58 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
                                       s_pTX<br>
                                       s_pTX_der<br>
                                       isentropicEnthalpy</td>
-    <td> Functions returning additional properties of the moist air medium model</td></tr>
+    <td valign=\"top\"> Functions returning additional properties of the moist air medium model</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Thermal.HeatTransfer.Components.</strong></td></tr>
-<tr><td width=\"150\"> ThermalResistor</td>
-    <td> Lumped thermal element transporting heat without storing it (dT = R*Q_flow) </td></tr>
-<tr><td width=\"150\"> ConvectiveResistor</td>
-    <td> Lumped thermal element for heat convection (dT = Rc*Q_flow) </td></tr>
+<tr><td valign=\"top\" width=\"150\"> ThermalResistor</td>
+    <td valign=\"top\"> Lumped thermal element transporting heat without storing it (dT = R*Q_flow) </td></tr>
+<tr><td valign=\"top\" width=\"150\"> ConvectiveResistor</td>
+    <td valign=\"top\"> Lumped thermal element for heat convection (dT = Rc*Q_flow) </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.MultiBody.Examples.Constraints.</strong></td></tr>
-<tr><td width=\"150\"> PrismaticConstraint<br>
+<tr><td valign=\"top\" width=\"150\"> PrismaticConstraint<br>
                         RevoluteConstraint<br>
                         SphericalConstraint<br>
                         UniversalConstraint</td>
-    <td> Demonstrates the use of the new Joints.Constraints joints by comparing
+    <td valign=\"top\"> Demonstrates the use of the new Joints.Constraints joints by comparing
                         them with the standard joints.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.MultiBody.Joints.Constraints.</strong></td></tr>
-<tr><td width=\"150\"> Prismatic<br>
+<tr><td valign=\"top\" width=\"150\"> Prismatic<br>
                         Revolute<br>
                         Spherical<br>
                         Universal</td>
-    <td> Joint elements formulated as kinematic constraints. These elements are
+    <td valign=\"top\"> Joint elements formulated as kinematic constraints. These elements are
                         designed to break kinematic loops and result usually in numerically more
                         efficient and reliable loop handling as the (standard) automatic handling.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Rotational.</strong></td></tr>
-<tr><td width=\"150\"> MultiSensor</td>
-    <td> Ideal sensor to measure the torque and power between two flanges and the absolute angular velocity </td></tr>
+<tr><td valign=\"top\" width=\"150\"> MultiSensor</td>
+    <td valign=\"top\"> Ideal sensor to measure the torque and power between two flanges and the absolute angular velocity </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Translational.</strong></td></tr>
-<tr><td width=\"150\"> MultiSensor</td>
-    <td> Ideal sensor to measure the absolute velocity, force and power between two flanges </td></tr>
+<tr><td valign=\"top\" width=\"150\"> MultiSensor</td>
+    <td valign=\"top\"> Ideal sensor to measure the absolute velocity, force and power between two flanges </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math.</strong></td></tr>
-<tr><td width=\"150\"> isPowerOf2</td>
-    <td> Determine if the integer input is a power of 2 </td></tr>
+<tr><td valign=\"top\" width=\"150\"> isPowerOf2</td>
+    <td valign=\"top\"> Determine if the integer input is a power of 2 </td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Math.Vectors.</strong></td></tr>
-<tr><td width=\"150\"> normalizedWithAssert</td>
-    <td> Return normalized vector such that length = 1 (trigger an assert for zero vector) </td></tr>
+<tr><td valign=\"top\" width=\"150\"> normalizedWithAssert</td>
+    <td valign=\"top\"> Return normalized vector such that length = 1 (trigger an assert for zero vector) </td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Math.BooleanVectors.</strong></td></tr>
-<tr><td width=\"150\"> countTrue</td>
-    <td> Returns the number of true entries in a Boolean vector  </td></tr>
-<tr><td width=\"150\"> enumerate</td>
-    <td> Enumerates the true entries in a Boolean vector (0 for false entries) </td></tr>
-<tr><td width=\"150\"> index</td>
-    <td> Returns the indices of the true entries of a Boolean vector</td></tr>
+<tr><td valign=\"top\" width=\"150\"> countTrue</td>
+    <td valign=\"top\"> Returns the number of true entries in a Boolean vector  </td></tr>
+<tr><td valign=\"top\" width=\"150\"> enumerate</td>
+    <td valign=\"top\"> Enumerates the true entries in a Boolean vector (0 for false entries) </td></tr>
+<tr><td valign=\"top\" width=\"150\"> index</td>
+    <td valign=\"top\"> Returns the indices of the true entries of a Boolean vector</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Utilities.Files.</strong></td></tr>
-<tr><td width=\"150\"> loadResource</td>
-    <td> Return the absolute path name of a URI or local file name  </td></tr>
+<tr><td valign=\"top\" width=\"150\"> loadResource</td>
+    <td valign=\"top\"> Return the absolute path name of a URI or local file name  </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.SIunits.</strong></td></tr>
-<tr><td width=\"150\"> PressureDifference<br>
+<tr><td valign=\"top\" width=\"150\"> PressureDifference<br>
                         MolarDensity<br>
                         MolarEnergy<br>
                         MolarEnthalpy<br>
@@ -2907,7 +2907,7 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
                         PerUnit<br>
                         DerPressureByDensity<br>
                         DerPressureByTemperature</td>
-    <td> New SI unit types </td></tr>
+    <td valign=\"top\"> New SI unit types </td></tr>
 </table>
 </html>"));
 end Version_3_2_1;
@@ -2983,8 +2983,8 @@ The following <font color=\"blue\"><strong>new libraries</strong></font> have be
 </p>
 
 <table border=\"1\" cellspacing=0 cellpadding=2>
-<tr><td><a href=\"modelica://Complex\">Complex</a></td>
-    <td>
+<tr><td valign=\"top\"><a href=\"modelica://Complex\">Complex</a></td>
+    <td valign=\"top\">
     This is a top-level record outside of the Modelica Standard Library.
     It is used for complex numbers and contains overloaded operators.
     From a users point of view, Complex is used in a similar way as the
@@ -2998,8 +2998,8 @@ The following <font color=\"blue\"><strong>new libraries</strong></font> have be
     (This library was developed by Marcus Baur, DLR).
     </td></tr>
 
-<tr><td><a href=\"modelica://Modelica.ComplexBlocks\">Modelica.ComplexBlocks</a></td>
-    <td>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.ComplexBlocks\">Modelica.ComplexBlocks</a></td>
+    <td valign=\"top\">
     Library of basic input/output control blocks with Complex signals.<br>
     This library is especially useful in combination with the new
     <a href=\"modelica://Modelica.Electrical.QuasiStationary\">Modelica.Electrical.QuasiStationary</a>
@@ -3008,8 +3008,8 @@ The following <font color=\"blue\"><strong>new libraries</strong></font> have be
     (This library was developed by Anton Haumer).
     </td></tr>
 
-<tr><td><a href=\"modelica://Modelica.Electrical.QuasiStationary\">Modelica.Electrical.QuasiStationary</a></td>
-    <td>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Electrical.QuasiStationary\">Modelica.Electrical.QuasiStationary</a></td>
+    <td valign=\"top\">
     Library for quasi-stationary electrical singlephase and multiphase AC simulation.<br>
     This library allows very fast simulations of electrical circuits with sinusoidal
     currents and voltages by only taking into account the quasi-stationary, periodic part
@@ -3017,8 +3017,8 @@ The following <font color=\"blue\"><strong>new libraries</strong></font> have be
     (This library was developed by Anton Haumer and Christian Kral).
     </td></tr>
 
-<tr><td><a href=\"modelica://Modelica.Electrical.Spice3\">Modelica.Electrical.Spice3</a></td>
-    <td>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Electrical.Spice3\">Modelica.Electrical.Spice3</a></td>
+    <td valign=\"top\">
     Library with components of the Berkeley
     <a href=\"http://bwrc.eecs.berkeley.edu/Classes/IcBook/SPICE/\">SPICE3</a>
     simulator:<br>
@@ -3036,8 +3036,8 @@ The following <font color=\"blue\"><strong>new libraries</strong></font> have be
     (This library was developed by Fraunhofer Gesellschaft, Dresden).
     </td></tr>
 
-<tr><td><a href=\"modelica://Modelica.Magnetic.FundamentalWave\">Modelica.Magnetic.FundamentalWave</a></td>
-    <td>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.FundamentalWave\">Modelica.Magnetic.FundamentalWave</a></td>
+    <td valign=\"top\">
      Library for magnetic fundamental wave effects in electric machines for the
      application in three phase electric machines.
      The library is an alternative approach to the Modelica.Electrical.Machines library.
@@ -3051,15 +3051,15 @@ The following <font color=\"blue\"><strong>new libraries</strong></font> have be
      ideas and source code of a library from Michael Beuschel from 2000).
     </td></tr>
 
-<tr><td><a href=\"modelica://Modelica.Fluid.Dissipation\">Modelica.Fluid.Dissipation</a></td>
-    <td>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Fluid.Dissipation\">Modelica.Fluid.Dissipation</a></td>
+    <td valign=\"top\">
      Library with functions to compute convective heat transfer and pressure loss characteristics.<br>
      (This library was developed by Thorben Vahlenkamp and Stefan Wischhusen from
      XRG Simulation GmbH).
     </td></tr>
 
-<tr><td><a href=\"modelica://Modelica.ComplexMath\">Modelica.ComplexMath</a></td>
-    <td>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.ComplexMath\">Modelica.ComplexMath</a></td>
+    <td valign=\"top\">
     Library of complex mathematical functions (e.g., sin, cos) and of functions operating
     on complex vectors.<br>
     (This library was developed by Marcus Baur from DLR-RM, Anton Haumer, and
@@ -3074,12 +3074,12 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Modelica.UsersGuide</strong></td></tr>
-<tr><td> Conventions
+<tr><td valign=\"top\"> Conventions
                       </td>
-    <td> Considerably improved 'Conventions' for the Modelica Standard Library.</td></tr>
+    <td valign=\"top\"> Considerably improved 'Conventions' for the Modelica Standard Library.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Examples</strong></td></tr>
-<tr><td> Filter<br>
+<tr><td valign=\"top\"> Filter<br>
                       FilterWithDifferentation<br>
                       FilterWithRiseTime<br>
                       RealNetwork1<br>
@@ -3087,21 +3087,21 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
                       BooleanNetwork1<br>
                       Interaction1
                       </td>
-    <td> Examples for the newly introduced block components.</td></tr>
+    <td valign=\"top\"> Examples for the newly introduced block components.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Continuous</strong></td></tr>
-<tr><td> Filter </td>
-    <td> Continuous low pass, high pass, band pass and band stop
+<tr><td valign=\"top\"> Filter </td>
+    <td valign=\"top\"> Continuous low pass, high pass, band pass and band stop
                       IIR-filter of type CriticalDamping, Bessel, Butterworth and Chebyshev I.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Interaction.Show</strong></td></tr>
-<tr><td> RealValue<br>
+<tr><td valign=\"top\"> RealValue<br>
                       IntegerValue<br>
                       BooleanValue</td>
-    <td> Blocks to show the values of variables in a diagram animation.</td></tr>
+    <td valign=\"top\"> Blocks to show the values of variables in a diagram animation.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Interfaces</strong></td></tr>
-<tr><td> RealVectorInput<br>
+<tr><td valign=\"top\"> RealVectorInput<br>
                       IntegerVectorInput<br>
                       BooleanVectorInput<br>
                       PartialRealMISO<br>
@@ -3110,25 +3110,25 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
                       PartialBooleanSISO_small<br>
                       PartialBooleanMISO
                       </td>
-    <td> Interfaces and partial blocks for the new block components.</td></tr>
+    <td valign=\"top\"> Interfaces and partial blocks for the new block components.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Math</strong></td></tr>
-<tr><td> MultiSum<br>
+<tr><td valign=\"top\"> MultiSum<br>
                       MultiProduct<br>
                       MultiSwitch </td>
-    <td> Sum, product and switch blocks with 1,2,...,N inputs
+    <td valign=\"top\"> Sum, product and switch blocks with 1,2,...,N inputs
                       (based on connectorSizing annotation to handle vectors of
                        connectors in a convenient way).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.MathInteger</strong></td></tr>
-<tr><td> MultiSwitch<br>
+<tr><td valign=\"top\"> MultiSwitch<br>
                       Sum<br>
                       Product<br>
                       TriggeredAdd</td>
-    <td> Mathematical blocks for Integer signals.</td></tr>
+    <td valign=\"top\"> Mathematical blocks for Integer signals.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Boolean</strong></td></tr>
-<tr><td> MultiSwitch<br>
+<tr><td valign=\"top\"> MultiSwitch<br>
                       And<br>
                       Or<br>
                       Xor<br>
@@ -3139,7 +3139,7 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
                       FallingEdge<br>
                       ChangingEdge<br>
                       OnDelay</td>
-    <td> Mathematical blocks for Boolean signals.
+    <td valign=\"top\"> Mathematical blocks for Boolean signals.
                       Some of these blocks are available also in library
                       <a href=\"modelica://Modelica.Blocks.Logical\">Logical</a>.
                       The new design is based on the connectorSizing annotation that allows
@@ -3150,30 +3150,30 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
                       better utilized</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Sources</strong></td></tr>
-<tr><td> RadioButtonSource</td>
-    <td> Boolean signal source that mimics a radio button.</td></tr>
-<tr><td> IntegerTable</td>
-    <td> Generate an Integer output signal based on a table matrix
+<tr><td valign=\"top\"> RadioButtonSource</td>
+    <td valign=\"top\"> Boolean signal source that mimics a radio button.</td></tr>
+<tr><td valign=\"top\"> IntegerTable</td>
+    <td valign=\"top\"> Generate an Integer output signal based on a table matrix
                       with [time, yi] values.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Examples</strong></td></tr>
-<tr><td> SimpleTriacCircuit,<br>
+<tr><td valign=\"top\"> SimpleTriacCircuit,<br>
                       IdealTriacCircuit,<br>
                       AD_DA_conversion </td>
-    <td> Examples for the newly introduced Analog components.</td></tr>
+    <td valign=\"top\"> Examples for the newly introduced Analog components.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Ideal</strong></td></tr>
-<tr><td> IdealTriac,<br>
+<tr><td valign=\"top\"> IdealTriac,<br>
                       AD_Converter,<br>
                       DA_Converter </td>
-    <td> AD and DA converter, ideal triac (based on ideal thyristor).</td></tr>
+    <td valign=\"top\"> AD and DA converter, ideal triac (based on ideal thyristor).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Semiconductors</strong></td></tr>
-<tr><td> SimpleTriac </td>
-    <td> Simple triac based on semiconductor thyristor model.</td></tr>
+<tr><td valign=\"top\"> SimpleTriac </td>
+    <td valign=\"top\"> Simple triac based on semiconductor thyristor model.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Digital.Examples</strong></td></tr>
-<tr><td>  Delay_example,<br>
+<tr><td valign=\"top\">  Delay_example,<br>
                        DFFREG_example,<br>
                        DFFREGL_example,<br>
                        DFFREGSRH_example,<br>
@@ -3187,16 +3187,16 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
                        BUF3S_example,<br>
                        INV3S_example,<br>
                        WiredX_example </td>
-    <td> Examples for the newly introduced Digital components.</td></tr>
+    <td valign=\"top\"> Examples for the newly introduced Digital components.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Digital.Interfaces</strong></td></tr>
-<tr><td> UX01,<br>
+<tr><td valign=\"top\"> UX01,<br>
                       Strength,<br>
                       MIMO </td>
-    <td> Interfaces for the newly introduced Digital components.</td></tr>
+    <td valign=\"top\"> Interfaces for the newly introduced Digital components.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Digital.Tables</strong></td></tr>
-<tr><td> ResolutionTable,<br>
+<tr><td valign=\"top\"> ResolutionTable,<br>
                       StrengthMap,<br>
                       NXferTable,<br>
                       NRXferTable,<br>
@@ -3204,14 +3204,14 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
                       PRXferTable,<br>
                       Buf3sTable,<br>
                       Buf3slTable </td>
-    <td> New Digital table components.</td></tr>
+    <td valign=\"top\"> New Digital table components.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Digital.Delay</strong></td></tr>
-<tr><td> InertialDelaySensitiveVector </td>
-    <td> New Digital delay component.</td></tr>
+<tr><td valign=\"top\"> InertialDelaySensitiveVector </td>
+    <td valign=\"top\"> New Digital delay component.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Digital.Registers</strong></td></tr>
-<tr><td> DFFR,<br>
+<tr><td valign=\"top\"> DFFR,<br>
                       DFFREG,<br>
                       DFFREGL,<br>
                       DFFSR,<br>
@@ -3223,11 +3223,11 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
                       DLATSR,<br>
                       DLATREGSRH,<br>
                       DLATREGSRL </td>
-    <td> Various register components (collection of flipflops and latches)
+    <td valign=\"top\"> Various register components (collection of flipflops and latches)
                       according to the VHDL standard.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Digital.Tristates</strong></td></tr>
-<tr><td> NXFERGATE,<br>
+<tr><td valign=\"top\"> NXFERGATE,<br>
                       NRXFERGATE,<br>
                       PXFERGATE,<br>
                       PRXFERGATE,<br>
@@ -3236,220 +3236,220 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
                       INV3S,<br>
                       INV3SL,<br>
                       WiredX </td>
-    <td> Transfer gates, buffers, inverters and wired node.</td></tr>
+    <td valign=\"top\"> Transfer gates, buffers, inverters and wired node.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.MultiPhase.Basic</strong></td></tr>
-<tr><td> MutualInductor </td>
-    <td> Multi phase inductor providing a mutual inductance matrix model.</td></tr>
-<tr><td> ZeroInductor </td>
-    <td> Multi phase zero sequence inductor.</td></tr>
+<tr><td valign=\"top\"> MutualInductor </td>
+    <td valign=\"top\"> Multi phase inductor providing a mutual inductance matrix model.</td></tr>
+<tr><td valign=\"top\"> ZeroInductor </td>
+    <td valign=\"top\"> Multi phase zero sequence inductor.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines</strong></td></tr>
-<tr><td> Examples </td>
-    <td> Structured according to machine types:<br>
+<tr><td valign=\"top\"> Examples </td>
+    <td valign=\"top\"> Structured according to machine types:<br>
                       AsynchronousInductionMachines<br>
                       SynchronousInductionMachines<br>
                       DCMachines<br>
                       Transformers </td></tr>
-<tr><td> Losses.* </td>
-    <td> Parameter records and models for losses in electrical machines and transformers (where applicable):<br>
+<tr><td valign=\"top\"> Losses.* </td>
+    <td valign=\"top\"> Parameter records and models for losses in electrical machines and transformers (where applicable):<br>
                       Friction losses<br>
                       Brush losses<br>
                       Stray Load losses<br>
                       Core losses (only eddy current losses but no hysteresis losses; not for transformers) </td></tr>
-<tr><td> Thermal.* </td>
-    <td> Simple thermal ambients, to be connected to the thermal ports of machines,<br>
+<tr><td valign=\"top\"> Thermal.* </td>
+    <td valign=\"top\"> Simple thermal ambients, to be connected to the thermal ports of machines,<br>
                       as well as material constants and utility functions.</td></tr>
-<tr><td> Icons.* </td>
-    <td> Icons for transient and quasistationary electrical machines and transformers.</td></tr>
+<tr><td valign=\"top\"> Icons.* </td>
+    <td valign=\"top\"> Icons for transient and quasistationary electrical machines and transformers.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines.Examples.AsynchronousInductionMachines.</strong></td></tr>
-<tr><td> AIMC_withLosses </td>
-    <td> Asynchronous induction machine with squirrel cage with losses </td></tr>
-<tr><td> AIMC_Transformer </td>
-    <td> Asynchronous induction machine with squirrel cage - transformer starting </td></tr>
-<tr><td> AIMC_withLosses </td>
-    <td> Test example of an asynchronous induction machine with squirrel cage with losses </td></tr>
+<tr><td valign=\"top\"> AIMC_withLosses </td>
+    <td valign=\"top\"> Asynchronous induction machine with squirrel cage with losses </td></tr>
+<tr><td valign=\"top\"> AIMC_Transformer </td>
+    <td valign=\"top\"> Asynchronous induction machine with squirrel cage - transformer starting </td></tr>
+<tr><td valign=\"top\"> AIMC_withLosses </td>
+    <td valign=\"top\"> Test example of an asynchronous induction machine with squirrel cage with losses </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines.Examples.SynchronousInductionMachines.</strong></td></tr>
-<tr><td> SMPM_CurrentSource </td>
-    <td> Permanent magnet synchronous induction machine fed by a current source </td></tr>
-<tr><td> SMEE_LoadDump </td>
-    <td> Electrical excited synchronous induction machine with voltage controller </td></tr>
+<tr><td valign=\"top\"> SMPM_CurrentSource </td>
+    <td valign=\"top\"> Permanent magnet synchronous induction machine fed by a current source </td></tr>
+<tr><td valign=\"top\"> SMEE_LoadDump </td>
+    <td valign=\"top\"> Electrical excited synchronous induction machine with voltage controller </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines.Examples.DCMachines.</strong></td></tr>
-<tr><td> DCSE_SinglePhase </td>
-    <td> Series excited DC machine, fed by sinusoidal voltage </td></tr>
-<tr><td> DCPM_Temperature </td>
-    <td> Permanent magnet DC machine, demonstration of varying temperature </td></tr>
-<tr><td> DCPM_Cooling </td>
-    <td> Permanent magnet DC machine, coupled with a simple thermal model </td></tr>
-<tr><td> DCPM_QuasiStationary </td>
-    <td> Permanent magnet DC machine, comparison between transient and quasistationary model </td></tr>
-<tr><td> DCPM_Losses </td>
-    <td> Permanent magnet DC machine, comparison between model with and without losses </td></tr>
+<tr><td valign=\"top\"> DCSE_SinglePhase </td>
+    <td valign=\"top\"> Series excited DC machine, fed by sinusoidal voltage </td></tr>
+<tr><td valign=\"top\"> DCPM_Temperature </td>
+    <td valign=\"top\"> Permanent magnet DC machine, demonstration of varying temperature </td></tr>
+<tr><td valign=\"top\"> DCPM_Cooling </td>
+    <td valign=\"top\"> Permanent magnet DC machine, coupled with a simple thermal model </td></tr>
+<tr><td valign=\"top\"> DCPM_QuasiStationary </td>
+    <td valign=\"top\"> Permanent magnet DC machine, comparison between transient and quasistationary model </td></tr>
+<tr><td valign=\"top\"> DCPM_Losses </td>
+    <td valign=\"top\"> Permanent magnet DC machine, comparison between model with and without losses </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines.BasicMachines.QuasiStationaryDCMachines.</strong></td></tr>
-<tr><td> DC_PermanentMagnet<br>
+<tr><td valign=\"top\"> DC_PermanentMagnet<br>
                       DC_ElectricalExcited<br>
                       DC_SeriesExcited </td>
-    <td> QuasiStationary DC machines, i.e., neglecting electrical transients </td></tr>
+    <td valign=\"top\"> QuasiStationary DC machines, i.e., neglecting electrical transients </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines.BasicMachines.Components.</strong></td></tr>
-<tr><td> InductorDC </td>
-    <td> Inductor model which neglects der(i) if Boolean parameter quasiStationary = true </td></tr>
+<tr><td valign=\"top\"> InductorDC </td>
+    <td valign=\"top\"> Inductor model which neglects der(i) if Boolean parameter quasiStationary = true </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines.Interfaces.</strong></td></tr>
-<tr><td>  ThermalPortTransformer<br>
+<tr><td valign=\"top\">  ThermalPortTransformer<br>
                        PowerBalanceTransformer </td>
-    <td> Thermal ports and power balances for electrical machines and transformers.</td></tr>
+    <td valign=\"top\"> Thermal ports and power balances for electrical machines and transformers.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines.Utilities</strong></td></tr>
-<tr><td> SwitchedRheostat </td>
-    <td> Switched rheostat, used for starting asynchronous induction motors with slipring rotor.</td></tr>
-<tr><td> RampedRheostat </td>
-    <td> Ramped rheostat, used for starting asynchronous induction motors with slipring rotor.</td></tr>
-<tr><td> SynchronousMachineData </td>
-    <td> The parameters of the synchronous machine model with electrical excitation (and damper) are calculated
+<tr><td valign=\"top\"> SwitchedRheostat </td>
+    <td valign=\"top\"> Switched rheostat, used for starting asynchronous induction motors with slipring rotor.</td></tr>
+<tr><td valign=\"top\"> RampedRheostat </td>
+    <td valign=\"top\"> Ramped rheostat, used for starting asynchronous induction motors with slipring rotor.</td></tr>
+<tr><td valign=\"top\"> SynchronousMachineData </td>
+    <td valign=\"top\"> The parameters of the synchronous machine model with electrical excitation (and damper) are calculated
                       from parameters normally given in a technical description,
                       according to the standard EN 60034-4:2008 Appendix C.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.Examples.Elementary.</strong></td></tr>
-<tr><td> HeatLosses </td>
-    <td> Demonstrate the modeling of heat losses.</td></tr>
-<tr><td> UserDefinedGravityField </td>
-    <td> Demonstrate the modeling of a user-defined gravity field.</td></tr>
-<tr><td> Surfaces </td>
-    <td> Demonstrate the visualization of a sine surface,<br>
+<tr><td valign=\"top\"> HeatLosses </td>
+    <td valign=\"top\"> Demonstrate the modeling of heat losses.</td></tr>
+<tr><td valign=\"top\"> UserDefinedGravityField </td>
+    <td valign=\"top\"> Demonstrate the modeling of a user-defined gravity field.</td></tr>
+<tr><td valign=\"top\"> Surfaces </td>
+    <td valign=\"top\"> Demonstrate the visualization of a sine surface,<br>
                       as well as a torus and a wheel constructed from a surface.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.Joints.</strong></td></tr>
-<tr><td> FreeMotionScalarInit </td>
-    <td> Free motion joint that allows initialization and state selection<br>
+<tr><td valign=\"top\"> FreeMotionScalarInit </td>
+    <td valign=\"top\"> Free motion joint that allows initialization and state selection<br>
                       of single elements of the relevant vectors<br>
                       (e.g., initialize r_rel_a[2] but not the other elements of r_rel_a;<br>
                       this new component fixes ticket
                       <a href=\"https://trac.modelica.org/Modelica/ticket/274\">#274</a>) </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.Visualizers.</strong></td></tr>
-<tr><td> Torus </td>
-    <td> Visualizing a torus.</td></tr>
-<tr><td> VoluminousWheel </td>
-    <td> Visualizing a voluminous wheel.</td></tr>
-<tr><td> PipeWithScalarField </td>
-    <td> Visualizing a pipe with scalar field quantities along the pipe axis.</td></tr>
+<tr><td valign=\"top\"> Torus </td>
+    <td valign=\"top\"> Visualizing a torus.</td></tr>
+<tr><td valign=\"top\"> VoluminousWheel </td>
+    <td valign=\"top\"> Visualizing a voluminous wheel.</td></tr>
+<tr><td valign=\"top\"> PipeWithScalarField </td>
+    <td valign=\"top\"> Visualizing a pipe with scalar field quantities along the pipe axis.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.Visualizers.ColorMaps.</strong></td></tr>
-<tr><td> jet<br>
+<tr><td valign=\"top\"> jet<br>
                       hot<br>
                       gray<br>
                       spring<br>
                       summer<br>
                       autumn<br>
                       winter </td>
-    <td> Functions returning different color maps.</td></tr>
+    <td valign=\"top\"> Functions returning different color maps.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.Visualizers.Colors.</strong></td></tr>
-<tr><td> colorMapToSvg </td>
-    <td> Save a color map on file in svg (scalable vector graphics) format.</td></tr>
-<tr><td> scalarToColor </td>
-    <td> Map a scalar to a color using a color map.</td></tr>
+<tr><td valign=\"top\"> colorMapToSvg </td>
+    <td valign=\"top\"> Save a color map on file in svg (scalable vector graphics) format.</td></tr>
+<tr><td valign=\"top\"> scalarToColor </td>
+    <td valign=\"top\"> Map a scalar to a color using a color map.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.Visualizers.Advanced.</strong></td></tr>
-<tr><td> Surface </td>
-    <td> Visualizing a moveable, parameterized surface;<br>
+<tr><td valign=\"top\"> Surface </td>
+    <td valign=\"top\"> Visualizing a moveable, parameterized surface;<br>
                       the surface characteristic is provided by a function<br>
                       (this new component fixes ticket
                        <a href=\"https://trac.modelica.org/Modelica/ticket/181\">#181</a>)</td></tr>
-<tr><td> PipeWithScalarField </td>
-    <td> Visualizing a pipe with a scalar field.</td></tr>
+<tr><td valign=\"top\"> PipeWithScalarField </td>
+    <td valign=\"top\"> Visualizing a pipe with a scalar field.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.Visualizers.Advanced.SurfaceCharacteristics.</strong></td></tr>
-<tr><td> torus </td>
-    <td> Function defining the surface characteristic of a torus.</td></tr>
-<tr><td> pipeWithScalarField </td>
-    <td> Function defining the surface characteristic of a pipe<br>
+<tr><td valign=\"top\"> torus </td>
+    <td valign=\"top\"> Function defining the surface characteristic of a torus.</td></tr>
+<tr><td valign=\"top\"> pipeWithScalarField </td>
+    <td valign=\"top\"> Function defining the surface characteristic of a pipe<br>
                       where a scalar field value is displayed with color along the pipe axis.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Rotational.Examples.</strong></td></tr>
-<tr><td> HeatLosses </td>
-    <td> Demonstrate the modeling of heat losses.</td></tr>
+<tr><td valign=\"top\"> HeatLosses </td>
+    <td valign=\"top\"> Demonstrate the modeling of heat losses.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Translational.Examples.</strong></td></tr>
-<tr><td> HeatLosses </td>
-    <td> Demonstrate the modeling of heat losses.</td></tr>
+<tr><td valign=\"top\"> HeatLosses </td>
+    <td valign=\"top\"> Demonstrate the modeling of heat losses.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Fluid.Fittings.Bends</strong></td></tr>
-<tr><td> CurvedBend<br>
+<tr><td valign=\"top\"> CurvedBend<br>
                       EdgedBend</td>
-    <td> New fitting (pressure loss) components.</td></tr>
+    <td valign=\"top\"> New fitting (pressure loss) components.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Fluid.Fittings.Orifices.</strong></td></tr>
-<tr><td> ThickEdgedOrifice</td>
-    <td> New fitting (pressure loss) component.</td></tr>
+<tr><td valign=\"top\"> ThickEdgedOrifice</td>
+    <td valign=\"top\"> New fitting (pressure loss) component.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Fluid.Fittings.GenericResistances.</strong></td></tr>
-<tr><td> VolumeFlowRate</td>
-    <td> New fitting (pressure loss) component.</td></tr>
+<tr><td valign=\"top\"> VolumeFlowRate</td>
+    <td valign=\"top\"> New fitting (pressure loss) component.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math</strong></td></tr>
-<tr><td> isEqual </td>
-    <td> Determine if two Real scalars are numerically identical.</td></tr>
+<tr><td valign=\"top\"> isEqual </td>
+    <td valign=\"top\"> Determine if two Real scalars are numerically identical.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math.Vectors</strong></td></tr>
-<tr><td> find </td>
-    <td> Find element in vector.</td></tr>
-<tr><td> toString </td>
-    <td> Convert a real vector to a string.</td></tr>
-<tr><td> interpolate </td>
-    <td> Interpolate in a vector.</td></tr>
-<tr><td> relNodePositions </td>
-    <td> Return vector of relative node positions (0..1).</td></tr>
+<tr><td valign=\"top\"> find </td>
+    <td valign=\"top\"> Find element in vector.</td></tr>
+<tr><td valign=\"top\"> toString </td>
+    <td valign=\"top\"> Convert a real vector to a string.</td></tr>
+<tr><td valign=\"top\"> interpolate </td>
+    <td valign=\"top\"> Interpolate in a vector.</td></tr>
+<tr><td valign=\"top\"> relNodePositions </td>
+    <td valign=\"top\"> Return vector of relative node positions (0..1).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math.Vectors.Utilities</strong></td></tr>
-<tr><td> householderVector<br>
+<tr><td valign=\"top\"> householderVector<br>
                       householderReflection<br>
                       roots </td>
-    <td> Utility functions for vectors that are used by the newly introduced functions,
+    <td valign=\"top\"> Utility functions for vectors that are used by the newly introduced functions,
                       but are only of interest for a specialist.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math.Matrices</strong></td></tr>
-<tr><td> continuousRiccati<br>
+<tr><td valign=\"top\"> continuousRiccati<br>
                       discreteRiccati </td>
-    <td> Return solution of continuous-time and discrete-time
+    <td valign=\"top\"> Return solution of continuous-time and discrete-time
                       algebraic Riccati equation respectively.</td></tr>
-<tr><td> continuousSylvester<br>
+<tr><td valign=\"top\"> continuousSylvester<br>
                       discreteSylvester </td>
-    <td> Return solution of continuous-time and discrete-time
+    <td valign=\"top\"> Return solution of continuous-time and discrete-time
                       Sylvester equation respectively.</td></tr>
-<tr><td> continuousLyapunov<br>
+<tr><td valign=\"top\"> continuousLyapunov<br>
                       discreteLyapunov </td>
-    <td> Return solution of continuous-time and discrete-time
+    <td valign=\"top\"> Return solution of continuous-time and discrete-time
                       Lyapunov equation respectively.</td></tr>
-<tr><td> trace </td>
-    <td> Return the trace of a matrix.</td></tr>
-<tr><td> conditionNumber </td>
-    <td> Compute the condition number of a matrix.</td></tr>
-<tr><td> rcond </td>
-    <td> Estimate the reciprocal condition number of a matrix.</td></tr>
-<tr><td> nullSpace </td>
-    <td> Return a orthonormal basis for the null space of a matrix.</td></tr>
-<tr><td> toString </td>
-    <td> Convert a matrix into its string representation.</td></tr>
-<tr><td> flipLeftRight </td>
-    <td> Flip the columns of a matrix in left/right direction.</td></tr>
-<tr><td> flipUpDown </td>
-    <td> Flip the rows of a matrix in up/down direction.</td></tr>
-<tr><td> cholesky </td>
-    <td> Perform Cholesky factorization of a real symmetric positive definite matrix.</td></tr>
-<tr><td> hessenberg </td>
-    <td> Transform a matrix to upper Hessenberg form.</td></tr>
-<tr><td> realSchur </td>
-    <td> Computes the real Schur form of a matrix.</td></tr>
-<tr><td> frobeniusNorm </td>
-    <td> Return the Frobenius norm of a matrix.</td></tr>
+<tr><td valign=\"top\"> trace </td>
+    <td valign=\"top\"> Return the trace of a matrix.</td></tr>
+<tr><td valign=\"top\"> conditionNumber </td>
+    <td valign=\"top\"> Compute the condition number of a matrix.</td></tr>
+<tr><td valign=\"top\"> rcond </td>
+    <td valign=\"top\"> Estimate the reciprocal condition number of a matrix.</td></tr>
+<tr><td valign=\"top\"> nullSpace </td>
+    <td valign=\"top\"> Return a orthonormal basis for the null space of a matrix.</td></tr>
+<tr><td valign=\"top\"> toString </td>
+    <td valign=\"top\"> Convert a matrix into its string representation.</td></tr>
+<tr><td valign=\"top\"> flipLeftRight </td>
+    <td valign=\"top\"> Flip the columns of a matrix in left/right direction.</td></tr>
+<tr><td valign=\"top\"> flipUpDown </td>
+    <td valign=\"top\"> Flip the rows of a matrix in up/down direction.</td></tr>
+<tr><td valign=\"top\"> cholesky </td>
+    <td valign=\"top\"> Perform Cholesky factorization of a real symmetric positive definite matrix.</td></tr>
+<tr><td valign=\"top\"> hessenberg </td>
+    <td valign=\"top\"> Transform a matrix to upper Hessenberg form.</td></tr>
+<tr><td valign=\"top\"> realSchur </td>
+    <td valign=\"top\"> Computes the real Schur form of a matrix.</td></tr>
+<tr><td valign=\"top\"> frobeniusNorm </td>
+    <td valign=\"top\"> Return the Frobenius norm of a matrix.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Math.Matrices.LAPACK.</strong></td></tr>
-<tr><td> dtrevc<br>
+<tr><td valign=\"top\"> dtrevc<br>
                       dpotrf<br>
                       dtrsm<br>
                       dgees<br>
@@ -3468,11 +3468,11 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
                       dormhr<br>
                       dormqr<br>
                       dorghr</td>
-    <td> New interface functions for LAPACK
+    <td valign=\"top\"> New interface functions for LAPACK
                       (should usually not directly be used but only indirectly via
                       Modelica.Math.Matrices).</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Math.Matrices.Utilities.</strong></td></tr>
-<tr><td> reorderRSF<br>
+<tr><td valign=\"top\"> reorderRSF<br>
                       continuousRiccatiIterative<br>
                       discreteRiccatiIterative<br>
                       eigenvaluesHessenberg<br>
@@ -3480,37 +3480,37 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
                       householderReflection<br>
                       householderSimilarityTransformation<br>
                       findLokal_tk</td>
-    <td> Utility functions for matrices that are used by the newly introduced functions,
+    <td valign=\"top\"> Utility functions for matrices that are used by the newly introduced functions,
                       but are only of interest for a specialist.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math.Nonlinear</strong></td></tr>
-<tr><td> quadratureLobatto </td>
-    <td> Return the integral of an integrand function using an adaptive Lobatto rule.</td></tr>
-<tr><td> solveOneNonlinearEquation </td>
-    <td> Solve f(u) = 0 in a very reliable and efficient way
+<tr><td valign=\"top\"> quadratureLobatto </td>
+    <td valign=\"top\"> Return the integral of an integrand function using an adaptive Lobatto rule.</td></tr>
+<tr><td valign=\"top\"> solveOneNonlinearEquation </td>
+    <td valign=\"top\"> Solve f(u) = 0 in a very reliable and efficient way
                       (f(u_min) and f(u_max) must have different signs).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math.Nonlinear.Examples.</strong></td></tr>
-<tr><td> quadratureLobatto1<br>
+<tr><td valign=\"top\"> quadratureLobatto1<br>
                       quadratureLobatto2<br>
                       solveNonlinearEquations1<br>
                       solveNonlinearEquations2 </td>
-    <td> Examples that demonstrate the usage of the Modelica.Math.Nonlinear functions
+    <td valign=\"top\"> Examples that demonstrate the usage of the Modelica.Math.Nonlinear functions
                       to integrate over functions and to solve scalar nonlinear equations.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math.BooleanVectors.</strong></td></tr>
-<tr><td> allTrue </td>
-    <td> Returns true, if all elements of the Boolean input vector are true.</td></tr>
-<tr><td> anyTrue </td>
-    <td> Returns true, if at least on element of the Boolean input vector is true.</td></tr>
-<tr><td> oneTrue </td>
-    <td> Returns true, if exactly one element of the Boolean input vector is true.</td></tr>
-<tr><td> firstTrueIndex </td>
-    <td> Returns the index of the first element of the Boolean vector that
+<tr><td valign=\"top\"> allTrue </td>
+    <td valign=\"top\"> Returns true, if all elements of the Boolean input vector are true.</td></tr>
+<tr><td valign=\"top\"> anyTrue </td>
+    <td valign=\"top\"> Returns true, if at least on element of the Boolean input vector is true.</td></tr>
+<tr><td valign=\"top\"> oneTrue </td>
+    <td valign=\"top\"> Returns true, if exactly one element of the Boolean input vector is true.</td></tr>
+<tr><td valign=\"top\"> firstTrueIndex </td>
+    <td valign=\"top\"> Returns the index of the first element of the Boolean vector that
                       is true and returns 0, if no element is true </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Icons.</strong></td></tr>
-<tr><td> Information<br>
+<tr><td valign=\"top\"> Information<br>
                       Contact<br>
                       ReleaseNotes<br>
                       References<br>
@@ -3524,11 +3524,11 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
                       SensorsPackage<br>
                       MaterialPropertiesPackage<br>
                       MaterialProperty </td>
-    <td> New icons to get a unified view on different categories
+    <td valign=\"top\"> New icons to get a unified view on different categories
                       of packages.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.SIunits.</strong></td></tr>
-<tr><td> ComplexCurrent<br>
+<tr><td valign=\"top\"> ComplexCurrent<br>
                       ComplexCurrentSlope<br>
                       ComplexCurrentDensity<br>
                       ComplexElectricPotential<br>
@@ -3548,12 +3548,12 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
                       ComplexImpedance<br>
                       ComplexAdmittance<br>
                       ComplexPower</td>
-    <td> SIunits to be used in physical models using complex variables, e.g.,<br>
+    <td valign=\"top\"> SIunits to be used in physical models using complex variables, e.g.,<br>
                       <a href=\"modelica://Modelica.Electrical.QuasiStationary\">Modelica.Electrical.QuasiStationary</a>,
                       <a href=\"modelica://Modelica.Magnetic.FundamentalWave\">Modelica.Magnetic.FundamentalWave</a> </td></tr>
-<tr><td> ImpulseFlowRate<br>
+<tr><td valign=\"top\"> ImpulseFlowRate<br>
                       AngularImpulseFlowRate</td>
-    <td> New SIunits for mechanics.</td></tr>
+    <td valign=\"top\"> New SIunits for mechanics.</td></tr>
 </table>
 
 <p><br>
@@ -3564,18 +3564,18 @@ have been <font color=\"blue\"><strong>improved</strong></font> in a
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Sources.</strong></td></tr>
-<tr><td> Pulse<br>
+<tr><td valign=\"top\"> Pulse<br>
                       SawTooth </td>
-    <td> New parameter \"nperiod\" introduced to define the number of periods
+    <td valign=\"top\"> New parameter \"nperiod\" introduced to define the number of periods
                       for the signal type. Default is \"infinite number of periods
                       (nperiods=-1).</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.</strong></td></tr>
-<tr><td> MultiPhase.*</td>
-    <td> All dissipative components have now an optional heatPort connector
+<tr><td valign=\"top\"> MultiPhase.*</td>
+    <td valign=\"top\"> All dissipative components have now an optional heatPort connector
                       to which the dissipated losses are transported in form of heat.
                        </td></tr>
-<tr><td> Machines.*</td>
-    <td> To all electric machines (asynchronous and synchronous induction machines, DC machines)
+<tr><td valign=\"top\"> Machines.*</td>
+    <td valign=\"top\"> To all electric machines (asynchronous and synchronous induction machines, DC machines)
                       and transformers loss models have been added (where applicable):<br>
                       Temperature dependent resistances (ohmic losses)<br>
                       Friction losses<br>
@@ -3592,10 +3592,10 @@ have been <font color=\"blue\"><strong>improved</strong></font> in a
                       a \"powerBalance\" result record has been added, summarizing converted power and losses.
                        </td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.</strong></td></tr>
-<tr><td> MultiBody.*<br>
+<tr><td valign=\"top\"> MultiBody.*<br>
                       Rotational.*<br>
                       Translational.*</td>
-    <td> All dissipative components in Modelica.Mechanics have now an
+    <td valign=\"top\"> All dissipative components in Modelica.Mechanics have now an
                       optional heatPort connector to which the dissipated energy is
                       transported in form of heat.<br>
                       All icons in Modelica.Mechanics are unified according to the
@@ -3604,16 +3604,16 @@ have been <font color=\"blue\"><strong>improved</strong></font> in a
                       other text: height: 30, color: black
                        </td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.</strong></td></tr>
-<tr><td> World </td>
-    <td> Function gravityAcceleration is made replaceable, so that redeclaration
+<tr><td valign=\"top\"> World </td>
+    <td valign=\"top\"> Function gravityAcceleration is made replaceable, so that redeclaration
                       yields user-defined gravity fields.
                        </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Fluid.Valves.</strong></td></tr>
-<tr><td> ValveIncompressible<br>
+<tr><td valign=\"top\"> ValveIncompressible<br>
                       ValveVaporizing<br>
                       ValveCompressible</td>
-    <td> (a) Optional filtering of opening signal introduced to model
+    <td valign=\"top\"> (a) Optional filtering of opening signal introduced to model
                       the delay time of the opening/closing drive. In this case, an optional
                       leakageOpening can be defined to model leakage flow and/or to
                       improve the numerics in certain situations.
@@ -3623,10 +3623,10 @@ have been <font color=\"blue\"><strong>improved</strong></font> in a
                       </tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Fluid.Sources.</strong></td></tr>
-<tr><td> FixedBoundary<br>
+<tr><td valign=\"top\"> FixedBoundary<br>
                       Boundary_pT<br>
                       Boundary_ph</td>
-    <td> Changed the implementation so that no non-linear algebraic
+    <td valign=\"top\"> Changed the implementation so that no non-linear algebraic
                       equation system occurs, if the given variables (e.g. p,T,X) do
                       not correspond to the medium states (e.g. p,h,X). This is
                       achieved by using appropriate \"setState_xxx\" calls to compute the
@@ -3637,8 +3637,8 @@ have been <font color=\"blue\"><strong>improved</strong></font> in a
                       </tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Media.Interfaces.</strong></td></tr>
-<tr><td> PartialMedium </td>
-    <td> The min/max values of types SpecificEnthalpy, SpecificEntropy,
+<tr><td valign=\"top\"> PartialMedium </td>
+    <td valign=\"top\"> The min/max values of types SpecificEnthalpy, SpecificEntropy,
                       SpecificHeatCapacity increased, due to reported user problems.<br>
                       New constant C_nominal introduced to provide nominal values for
                       trace substances (utilized in Modelica.Fluid to avoid numerical problems;
@@ -3647,16 +3647,16 @@ have been <font color=\"blue\"><strong>improved</strong></font> in a
                       </tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Thermal.</strong></td></tr>
-<tr><td> HeatTransfer.*</td>
-    <td> All icons are unified according to the
+<tr><td valign=\"top\"> HeatTransfer.*</td>
+    <td valign=\"top\"> All icons are unified according to the
                       Modelica.Blocks library:<br>
                       \"%name\": width: -150 .. 150, height: 40, color: blue<br>
                       other text: height: 30, color: black
                        </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math.Matrices</strong></td></tr>
-<tr><td> QR </td>
-    <td> A Boolean input \"pivoting\" has been added (now QR(A, pivoting)) to provide QR-decomposition without pivoting (QR(A, false)). Default is pivoting=true.</td></tr>
+<tr><td valign=\"top\"> QR </td>
+    <td valign=\"top\"> A Boolean input \"pivoting\" has been added (now QR(A, pivoting)) to provide QR-decomposition without pivoting (QR(A, false)). Default is pivoting=true.</td></tr>
 </table>
 
 <p><br>
@@ -3666,32 +3666,32 @@ that can lead to wrong simulation results):
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Digital.Delay.</strong></td></tr>
-<tr><td> InertialDelaySensitive </td>
-    <td> In order to decide whether the rising delay (tLH) or
+<tr><td valign=\"top\"> InertialDelaySensitive </td>
+    <td valign=\"top\"> In order to decide whether the rising delay (tLH) or
                       the falling delay (tHL) is used, the \"previous\" value of the
                       output y has to be used and not the \"previous\" value of the
                       input x (delayType = delayTable[y_old, x] and not
                       delayType = delayTable[x_old, x]). This has been corrected.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.Parts.</strong></td></tr>
-<tr><td> BodyBox<br>
+<tr><td valign=\"top\"> BodyBox<br>
                       BodyCylinder </td>
-    <td> Fixes ticket
+    <td valign=\"top\"> Fixes ticket
                       <a href=\"https://trac.modelica.org/Modelica/ticket/373\">#373</a>:
                       The \"Center of Mass\" was calculated as normalize(r)*length/2. This is
                       only correct if the box/cylinder is attached between frame_a and frame_b.
                       If this is not the case, the calculation is wrong.
                       The has been fixed by using the correct formula:<br>
                       r_shape + normalize(lengthDirection)*length/2</td></tr>
-<tr><td> BodyShape<br>
+<tr><td valign=\"top\"> BodyShape<br>
                       BodyBox<br>
                       BodyCylinder </td>
-    <td> Fixes ticket
+    <td valign=\"top\"> Fixes ticket
                       <a href=\"https://trac.modelica.org/Modelica/ticket/300\">#300</a>:
                       If parameter enforceStates=true, an error occurred.
                       This has been fixed.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Rotational.Components.</strong></td></tr>
-<tr><td> LossyGear</td>
-    <td> In cases where the driving flange is not obvious, the component could
+<tr><td valign=\"top\"> LossyGear</td>
+    <td valign=\"top\"> In cases where the driving flange is not obvious, the component could
                       lead to a non-convergent event iteration. This has been fixed
                       (a detailed description is provided in ticket
                       <a href=\"https://trac.modelica.org/Modelica/ticket/108\">#108</a>
@@ -3699,28 +3699,28 @@ that can lead to wrong simulation results):
                       <a href=\"modelica://Modelica/Resources/Documentation/Mechanics/Lossy-Gear-Bug_Solution.pdf\">attachment</a>
                       of this ticket).</td></tr>
 
-<tr><td> Gearbox</td>
-    <td> If useSupport=false, the support flange of the internal LossyGear
+<tr><td valign=\"top\"> Gearbox</td>
+    <td valign=\"top\"> If useSupport=false, the support flange of the internal LossyGear
                       model was connected to the (disabled) support connector. As a result, the
                       LossyGear was \"free floating\". This has been corrected.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Fluid.Pipes.</strong></td></tr>
-<tr><td> DynamicPipe</td>
-    <td> Bug fix for dynamic mass, energy and momentum balances
+<tr><td valign=\"top\"> DynamicPipe</td>
+    <td valign=\"top\"> Bug fix for dynamic mass, energy and momentum balances
                       for pipes with nParallel&gt;1.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Fluid.Pipes.BaseClasses.HeatTransfer.</strong></td></tr>
-<tr><td> PartialPipeFlowHeatTransfer</td>
-    <td> Calculation of Reynolds numbers for the heat transfer through
+<tr><td valign=\"top\"> PartialPipeFlowHeatTransfer</td>
+    <td valign=\"top\"> Calculation of Reynolds numbers for the heat transfer through
                       walls corrected, if nParallel&gt;1.
                       This partial model is used by LocalPipeFlowHeatTransfer
                       for laminar and turbulent forced convection in pipes.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Media.Interfaces.PartialLinearFluid</strong></td></tr>
-<tr><td> setState_psX</td>
-    <td> Sign error fixed.</td></tr>
+<tr><td valign=\"top\"> setState_psX</td>
+    <td valign=\"top\"> Sign error fixed.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Media.CompressibleLiquids.</strong></td></tr>
-<tr><td> LinearColdWater</td>
-    <td> Fixed wrong values for thermal conductivity and viscosity.</td></tr>
+<tr><td valign=\"top\"> LinearColdWater</td>
+    <td valign=\"top\"> Fixed wrong values for thermal conductivity and viscosity.</td></tr>
 
 </table>
 
@@ -3731,7 +3731,7 @@ units are wrong or errors in documentation):
 </p>
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Modelica.Math.Matrices.LAPACK</strong></td></tr>
-<tr><td> dgesv_vec<br>
+<tr><td valign=\"top\"> dgesv_vec<br>
                         dgesv<br>
                         dgetrs<br>
                         dgetrf<br>
@@ -3741,7 +3741,7 @@ units are wrong or errors in documentation):
                         dorgqr<br>
                         dgesvx<br>
                         dtrsyl</td>
-    <td> Integer inputs to specify leading dimensions of matrices have got a lower bound 1 (e.g., lda=max(1,n))
+    <td valign=\"top\"> Integer inputs to specify leading dimensions of matrices have got a lower bound 1 (e.g., lda=max(1,n))
                       to avoid incorrect values (e.g., lda=0) in the case of empty matrices.<br>
                       The Integer variable \"info\" to indicate the successful call of a LAPACK routine has been converted to an output where it had been a protected variable.</td></tr>
 </table>
@@ -3754,385 +3754,385 @@ have been fixed:
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Modelica</strong></td></tr>
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/155\">#155</a></td>
-    <td>Wrong usage of \"fillColor\" and \"fillPattern\" annotations for lines</td>
+    <td valign=\"top\">Wrong usage of \"fillColor\" and \"fillPattern\" annotations for lines</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/211\">#211</a></td>
-    <td>Undefined function realString used in MSL</td>
+    <td valign=\"top\">Undefined function realString used in MSL</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/216\">#216</a></td>
-    <td>Make MSL version 3.2 more Modelica 3.1 conform</td>
+    <td valign=\"top\">Make MSL version 3.2 more Modelica 3.1 conform</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/218\">#218</a></td>
-    <td>Replace `Modelica://`-URIs by `modelica://`-URIs</td>
+    <td valign=\"top\">Replace `Modelica://`-URIs by `modelica://`-URIs</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/271\">#271</a></td>
-    <td>Documentation URI errors in MSL 3.1</td>
+    <td valign=\"top\">Documentation URI errors in MSL 3.1</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/292\">#292</a></td>
-    <td>Remove empty \"\" annotations\"</td>
+    <td valign=\"top\">Remove empty \"\" annotations\"</td>
 </tr>
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/294\">#294</a></td>
-    <td>Typo 'w.r.t' --> 'w.r.t.'</td>
+    <td valign=\"top\">Typo 'w.r.t' --> 'w.r.t.'</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/296\">#296</a></td>
-    <td>Unify disclaimer message and improve bad style \"here\" links</td>
+    <td valign=\"top\">Unify disclaimer message and improve bad style \"here\" links</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/333\">#333</a></td>
-    <td>Fix real number formats of the form `.[0-9]+`</td>
+    <td valign=\"top\">Fix real number formats of the form `.[0-9]+`</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/347\">#347</a></td>
-    <td>invalid URI in MSL 3.2</td>
+    <td valign=\"top\">invalid URI in MSL 3.2</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/355\">#355</a></td>
-    <td>Non-standard annotations</td>
+    <td valign=\"top\">Non-standard annotations</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>Modelica.Blocks</strong></td></tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/227\">#227</a></td>
-    <td>Enhance unit deduction functionality by adding 'unit=\"1\"' to some blocks\"</td>
+    <td valign=\"top\">Enhance unit deduction functionality by adding 'unit=\"1\"' to some blocks\"</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/349\">#349</a></td>
-    <td>Incorrect annotation in Blocks/Continuous.mo</td>
+    <td valign=\"top\">Incorrect annotation in Blocks/Continuous.mo</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/374\">#374</a></td>
-    <td>Parameter with no value at all in Modelica.Blocks.Continuous.TransferFunction</td>
+    <td valign=\"top\">Parameter with no value at all in Modelica.Blocks.Continuous.TransferFunction</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>Modelica.Constants</strong></td></tr>
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/356\">#356</a></td>
-    <td>Add Euler-Mascheroni constant to Modelica.Constants</td>
+    <td valign=\"top\">Add Euler-Mascheroni constant to Modelica.Constants</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>Modelica.Electrical.Analog</strong></td></tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/346\">#346</a></td>
-    <td>Multiple text in Modelica.Electrical.Analog.Basic.Conductor</td>
+    <td valign=\"top\">Multiple text in Modelica.Electrical.Analog.Basic.Conductor</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/363\">#363</a></td>
-    <td>Mixture of Real and Integer in index expressions in Modelica.Electrical.Analog.Lines</td>
+    <td valign=\"top\">Mixture of Real and Integer in index expressions in Modelica.Electrical.Analog.Lines</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/384\">#384</a></td>
-    <td>Incomplete annotations in some examples</td>
+    <td valign=\"top\">Incomplete annotations in some examples</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/396\">#396</a></td>
-    <td>Bug in Modelica.Electrical.Analog.Ideal.ControlledIdealIntermediateSwitch</td>
+    <td valign=\"top\">Bug in Modelica.Electrical.Analog.Ideal.ControlledIdealIntermediateSwitch</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>Modelica.Machines</strong></td></tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/276\">#276</a></td>
-    <td>Improve/fix documentation of Modelica.Electrical.Machines</td>
+    <td valign=\"top\">Improve/fix documentation of Modelica.Electrical.Machines</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/288\">#288</a></td>
-    <td>Describe thermal concept of machines</td>
+    <td valign=\"top\">Describe thermal concept of machines</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/301\">#301</a></td>
-    <td>Documentation of Electrical.Machines.Examples needs update</td>
+    <td valign=\"top\">Documentation of Electrical.Machines.Examples needs update</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/306\">#306</a></td>
-    <td>Merge content of `Modelica.Electrical.Machines.Icons` into `Modelica.Icons`</td>
+    <td valign=\"top\">Merge content of `Modelica.Electrical.Machines.Icons` into `Modelica.Icons`</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/362\">#362</a></td>
-    <td>Incomplete example model for DC machines</td>
+    <td valign=\"top\">Incomplete example model for DC machines</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/375\">#375</a></td>
-    <td>Strangeness with final parameters with no value but a start value</td>
+    <td valign=\"top\">Strangeness with final parameters with no value but a start value</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>Modelica.Electrical.MultiPhase</strong></td></tr>
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/173\">#173</a></td>
-    <td>m-phase mutual inductor</td>
+    <td valign=\"top\">m-phase mutual inductor</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/200\">#200</a></td>
-    <td>adjust Multiphase to Analog</td>
+    <td valign=\"top\">adjust Multiphase to Analog</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/277\">#277</a></td>
-    <td>Improve/fix documentation of Modelica.Electrical.Multiphase</td>
+    <td valign=\"top\">Improve/fix documentation of Modelica.Electrical.Multiphase</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/352\">#352</a></td>
-    <td>Odd annotation in Modelica.Electrical.MultiPhase.Sources.SignalVoltage</td>
+    <td valign=\"top\">Odd annotation in Modelica.Electrical.MultiPhase.Sources.SignalVoltage</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>Modelica.Fluid</strong></td></tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/215\">#215</a></td>
-    <td>Bug in Modelica.Fluid.Pipes.DynamicPipe</td>
+    <td valign=\"top\">Bug in Modelica.Fluid.Pipes.DynamicPipe</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/219\">#219</a></td>
-    <td>Fluid.Examples.HeatExchanger: Heat transfer is switched off and cannot be enabled</td>
+    <td valign=\"top\">Fluid.Examples.HeatExchanger: Heat transfer is switched off and cannot be enabled</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>Modelica.Math</strong></td></tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/348\">#348</a></td>
-    <td>Small error in documentation</td>
+    <td valign=\"top\">Small error in documentation</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/371\">#371</a></td>
-    <td>Modelica.Math functions declared as \"C\" not \"builtin\"\"</td>
+    <td valign=\"top\">Modelica.Math functions declared as \"C\" not \"builtin\"\"</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>Modelica.Mechanics.MultiBody</strong></td></tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/50\">#50</a></td>
-    <td>Error in LineForce handling of potential root</td>
+    <td valign=\"top\">Error in LineForce handling of potential root</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/71\">#71</a></td>
-    <td>Make MultiBody.World replaceable</td>
+    <td valign=\"top\">Make MultiBody.World replaceable</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/181\">#181</a></td>
-    <td>3d surface visualisation</td>
+    <td valign=\"top\">3d surface visualisation</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/210\">#210</a></td>
-    <td>Description of internal gear wheel missing</td>
+    <td valign=\"top\">Description of internal gear wheel missing</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/242\">#242</a></td>
-    <td>Missing each qualifier for modifiers in MultiBody.</td>
+    <td valign=\"top\">Missing each qualifier for modifiers in MultiBody.</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/251\">#251</a></td>
-    <td>Using enforceStates=true for BodyShape causes errors</td>
+    <td valign=\"top\">Using enforceStates=true for BodyShape causes errors</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/255\">#255</a></td>
-    <td>Error in Revolute's handling of non-normalized axis of rotations</td>
+    <td valign=\"top\">Error in Revolute's handling of non-normalized axis of rotations</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/268\">#268</a></td>
-    <td>Non-standard annotation in MultiBody,Examples.Systems.RobotR3</td>
+    <td valign=\"top\">Non-standard annotation in MultiBody,Examples.Systems.RobotR3</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/269\">#269</a></td>
-    <td>What is the purpose of MultiBody.Examples.Systems.RobotR3.Components.InternalConnectors?</td>
+    <td valign=\"top\">What is the purpose of MultiBody.Examples.Systems.RobotR3.Components.InternalConnectors?</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/272\">#272</a></td>
-    <td>Function World.gravityAcceleration should not be protected</td>
+    <td valign=\"top\">Function World.gravityAcceleration should not be protected</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/274\">#274</a></td>
-    <td>Convenient and mighty  initialization of frame kinematics</td>
+    <td valign=\"top\">Convenient and mighty  initialization of frame kinematics</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/286\">#286</a></td>
-    <td>Typo in Multibody/Frames.mo</td>
+    <td valign=\"top\">Typo in Multibody/Frames.mo</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/300\">#300</a></td>
-    <td>enforceStates parameter managed incorrectly in BodyShape, BodyBox, BodyCylinder</td>
+    <td valign=\"top\">enforceStates parameter managed incorrectly in BodyShape, BodyBox, BodyCylinder</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/320\">#320</a></td>
-    <td>Replace non-standard annotation by `showStartAttribute`</td>
+    <td valign=\"top\">Replace non-standard annotation by `showStartAttribute`</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/373\">#373</a></td>
-    <td>Error in Modelica Mechanics</td>
+    <td valign=\"top\">Error in Modelica Mechanics</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/389\">#389</a></td>
-    <td>Shape.rxvisobj wrongly referenced in Arrow/DoubleArrow</td>
+    <td valign=\"top\">Shape.rxvisobj wrongly referenced in Arrow/DoubleArrow</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>Modelica.Mechanics.Rotational</strong></td></tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/108\">#108</a></td>
-    <td>Problem with model \"Lossy Gear\" and approach to a solution</td>
+    <td valign=\"top\">Problem with model \"Lossy Gear\" and approach to a solution</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/278\">#278</a></td>
-    <td>Improve/fix documentation of Modelica.Mechanics.Rotational</td>
+    <td valign=\"top\">Improve/fix documentation of Modelica.Mechanics.Rotational</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/381\">#381</a></td>
-    <td>Bug in Modelica.Mechanics.Rotational.Gearbox</td>
+    <td valign=\"top\">Bug in Modelica.Mechanics.Rotational.Gearbox</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>Modelica.Mechanics.Translational</strong></td></tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/279\">#279</a></td>
-    <td>Improve/fix documentation of Modelica.Mechanics.Translational</td>
+    <td valign=\"top\">Improve/fix documentation of Modelica.Mechanics.Translational</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/310\">#310</a></td>
-    <td>Erroneous image links in `Modelica.Mechanics.Translational`</td>
+    <td valign=\"top\">Erroneous image links in `Modelica.Mechanics.Translational`</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>Modelica.Media</strong></td></tr>
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/72\">#72</a></td>
-    <td>PartialMedium functions not provided for all media in  Modelica.Media</td>
+    <td valign=\"top\">PartialMedium functions not provided for all media in  Modelica.Media</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/217\">#217</a></td>
-    <td>Missing image file Air.png</td>
+    <td valign=\"top\">Missing image file Air.png</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/224\">#224</a></td>
-    <td>dpT calculation in waterBaseProp_dT</td>
+    <td valign=\"top\">dpT calculation in waterBaseProp_dT</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/393\">#393</a></td>
-    <td>Provide C_nominal in Modelica.Media to allow propagating
+    <td valign=\"top\">Provide C_nominal in Modelica.Media to allow propagating
                      value and avoid wrong numerical results</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>Modelica.StateGraph</strong></td></tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/206\">#206</a></td>
-    <td>Syntax error in StateGraph.mo</td>
+    <td valign=\"top\">Syntax error in StateGraph.mo</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/261\">#261</a></td>
-    <td>Modelica.StateGraph should mention the availability of Modelica_StateGraph2</td>
+    <td valign=\"top\">Modelica.StateGraph should mention the availability of Modelica_StateGraph2</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/354\">#354</a></td>
-    <td>Bad annotation in Modelica.StateGraph.Temporary.NumericValue</td>
+    <td valign=\"top\">Bad annotation in Modelica.StateGraph.Temporary.NumericValue</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>Modelica.Thermal.FluidHeatFlow</strong></td></tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/280\">#280</a></td>
-    <td>Improve/fix documentation of Modelica.Thermal.FluidHeatFlow</td>
+    <td valign=\"top\">Improve/fix documentation of Modelica.Thermal.FluidHeatFlow</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>Modelica.Thermal.HeatTransfer</strong></td></tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/281\">#281</a></td>
-    <td>Improve/fix documentation of Modelica.Thermal.HeatTransfer</td>
+    <td valign=\"top\">Improve/fix documentation of Modelica.Thermal.HeatTransfer</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>Modelica.UsersGuide</strong></td></tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/198\">#198</a></td>
-    <td>Name of components in MSL not according to naming conventions</td>
+    <td valign=\"top\">Name of components in MSL not according to naming conventions</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/204\">#204</a></td>
-    <td>Minor correction to User's Guide's section on version management</td>
+    <td valign=\"top\">Minor correction to User's Guide's section on version management</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/244\">#244</a></td>
-    <td>Update the contacts section of the User's Guide</td>
+    <td valign=\"top\">Update the contacts section of the User's Guide</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/267\">#267</a></td>
-    <td>MSL-Documentation: Shouldn't equations be numbered on the right hand side?</td>
+    <td valign=\"top\">MSL-Documentation: Shouldn't equations be numbered on the right hand side?</td>
 </tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/299\">#299</a></td>
-    <td>SVN keyword expansion messed up the User's guide section on version management</td>
+    <td valign=\"top\">SVN keyword expansion messed up the User's guide section on version management</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>Modelica.Utilities</strong></td></tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/249\">#249</a></td>
-    <td>Documentation error in ModelicaUtilities.h</td>
+    <td valign=\"top\">Documentation error in ModelicaUtilities.h</td>
 </tr>
 
 <tr><td colspan=\"2\"><br><strong>ModelicaServices</strong></td></tr>
 
-<tr><td>
+<tr><td valign=\"top\">
     <a href=\"https://trac.modelica.org/Modelica/ticket/248\">#248</a></td>
-    <td>No uses statement on ModelicaServices in MSL 3.1</td>
+    <td valign=\"top\">No uses statement on ModelicaServices in MSL 3.1</td>
 </tr>
 
 </table>
@@ -4192,8 +4192,8 @@ the following new language elements (compared to Modelica Specification 3.0):
 The following <font color=\"blue\"><strong>new libraries</strong></font> have been added:
 </p>
 <table border=\"1\" cellspacing=0 cellpadding=2>
-<tr><td><a href=\"modelica://Modelica.Fluid\">Modelica.Fluid</a></td>
-    <td>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Fluid\">Modelica.Fluid</a></td>
+    <td valign=\"top\">
      Components to model 1-dim. thermo-fluid flow in networks of vessels, pipes,
      fluid machines, valves and fittings. All media from the
      Modelica.Media library can be used (so incompressible or compressible,
@@ -4201,8 +4201,8 @@ The following <font color=\"blue\"><strong>new libraries</strong></font> have be
     The library is using the stream-concept from Modelica Specification 3.1.
     </td></tr>
 
-<tr><td><a href=\"modelica://Modelica.Magnetic.FluxTubes\">Modelica.Magnetic.FluxTubes</a></td>
-    <td>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.FluxTubes\">Modelica.Magnetic.FluxTubes</a></td>
+    <td valign=\"top\">
      Components to model magnetic devices based on the magnetic flux tubes concepts.
      Especially to model
      electro-magnetic actuators. Nonlinear shape, force, leakage, and
@@ -4210,8 +4210,8 @@ The following <font color=\"blue\"><strong>new libraries</strong></font> have be
      Cobalt iron, Nickel iron, NdFeB, Sm2Co17, and more.
     </td></tr>
 
-<tr><td><a href=\"modelica://ModelicaServices\">ModelicaServices</a></td>
-    <td>
+<tr><td valign=\"top\"><a href=\"modelica://ModelicaServices\">ModelicaServices</a></td>
+    <td valign=\"top\">
      New top level package that shall contain functions and models to be used in the
      Modelica Standard Library that requires a tool specific implementation.
      ModelicaServices is then used in the Modelica package.
@@ -4228,136 +4228,136 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Modelica.</strong></td></tr>
-<tr><td> versionBuild<br>versionDate<br>dateModified<br>revisionId </td>
-    <td> New annotations from Modelica 3.1 for version handling added.</td></tr>
+<tr><td valign=\"top\"> versionBuild<br>versionDate<br>dateModified<br>revisionId </td>
+    <td valign=\"top\"> New annotations from Modelica 3.1 for version handling added.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.UsersGuide.ReleaseNotes.</strong></td></tr>
-<tr><td> VersionManagement </td>
-    <td> Copied from info layer of previous ReleaseNotes (to make it more
+<tr><td valign=\"top\"> VersionManagement </td>
+    <td valign=\"top\"> Copied from info layer of previous ReleaseNotes (to make it more
                       visible) and adapted it to the new possibilities in
                       Modelica Specification 3.1.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Math.</strong></td></tr>
-<tr><td> RectangularToPolar<br>
+<tr><td valign=\"top\"> RectangularToPolar<br>
                       PolarToRectangular </td>
-    <td> New blocks to convert between rectangular and polar form
+    <td valign=\"top\"> New blocks to convert between rectangular and polar form
                       of space phasors.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Routing.</strong></td></tr>
-<tr><td> Replicator </td>
-    <td> New block to replicate an input signal to many output signals.</td></tr>
+<tr><td valign=\"top\"> Replicator </td>
+    <td valign=\"top\"> New block to replicate an input signal to many output signals.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Examples.</strong></td></tr>
-<tr><td> AmplifierWithOpAmpDetailed<br>
+<tr><td valign=\"top\"> AmplifierWithOpAmpDetailed<br>
                       HeatingResistor<br>
                       CompareTransformers<br>
                       OvervoltageProtection<br>
                       ControlledSwitchWithArc<br>
                       SwitchWithArc<br>
                       ThyristorBehaviourTest</td>
-    <td> New examples to demonstrate the usage of new components.</td></tr>
+    <td valign=\"top\"> New examples to demonstrate the usage of new components.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Basic.</strong></td></tr>
-<tr><td> OpAmpDetailed<br>
+<tr><td valign=\"top\"> OpAmpDetailed<br>
                       TranslationalEMF<br>
                       M_Transformer</td>
-    <td> New detailed model of an operational amplifier.<br>
+    <td valign=\"top\"> New detailed model of an operational amplifier.<br>
                       New electromotoric force from electrical energy into mechanical translational energy.<br>
                       Generic transformer with choosable number of inductors</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Ideal.</strong></td></tr>
-<tr><td> OpenerWithArc<br>
+<tr><td valign=\"top\"> OpenerWithArc<br>
                       CloserWithArc<br>
                       ControlledOpenerWithArc<br>
                       ControlledCloserWithArc</td>
-    <td> New switches with simple arc model.</td></tr>
+    <td valign=\"top\"> New switches with simple arc model.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Interfaces.</strong></td></tr>
-<tr><td> ConditionalHeatPort</td>
-    <td> New partial model to add a conditional HeatPort to
+<tr><td valign=\"top\"> ConditionalHeatPort</td>
+    <td valign=\"top\"> New partial model to add a conditional HeatPort to
                       an electrical component.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Lines.</strong></td></tr>
-<tr><td> M_Oline</td>
-    <td> New multiple line model, both the number of lines and the number of segments choosable.</td></tr>
+<tr><td valign=\"top\"> M_Oline</td>
+    <td valign=\"top\"> New multiple line model, both the number of lines and the number of segments choosable.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Semiconductors.</strong></td></tr>
-<tr><td> ZDiode<br>Thyristor</td>
-    <td> Zener Diode with 3 working areas and simple thyristor model.</td></tr>
+<tr><td valign=\"top\"> ZDiode<br>Thyristor</td>
+    <td valign=\"top\"> Zener Diode with 3 working areas and simple thyristor model.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.MultiPhase.Ideal.</strong></td></tr>
-<tr><td> OpenerWithArc<br>CloserWithArc</td>
-    <td> New switches with simple arc model (as in Modelica.Electrical.Analog.Ideal.</td></tr>
+<tr><td valign=\"top\"> OpenerWithArc<br>CloserWithArc</td>
+    <td valign=\"top\"> New switches with simple arc model (as in Modelica.Electrical.Analog.Ideal.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.Examples.Elementary.</strong></td></tr>
-<tr><td> RollingWheel<br>
+<tr><td valign=\"top\"> RollingWheel<br>
                       RollingWheelSetDriving<br>
                       RollingWheelSetPulling</td>
-    <td> New examples to demonstrate the usage of new components.</td></tr>
+    <td valign=\"top\"> New examples to demonstrate the usage of new components.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.Joints.</strong></td></tr>
-<tr><td> RollingWheel<br>
+<tr><td valign=\"top\"> RollingWheel<br>
                       RollingWheelSet</td>
-    <td> New joints (no mass, no inertia) that describe an
+    <td valign=\"top\"> New joints (no mass, no inertia) that describe an
                       ideal rolling wheel and a ideal rolling wheel set consisting
                       of two wheels rolling on the plane z=0.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.Parts.</strong></td></tr>
-<tr><td> RollingWheel<br>
+<tr><td valign=\"top\"> RollingWheel<br>
                       RollingWheelSet</td>
-    <td> New ideal rolling wheel and ideal rolling wheel set consisting
+    <td valign=\"top\"> New ideal rolling wheel and ideal rolling wheel set consisting
                       of two wheels rolling on the plane z=0.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.Visualizers.</strong></td></tr>
-<tr><td> Ground</td>
-    <td> New model to visualize the ground (box at z=0).</td></tr>
+<tr><td valign=\"top\"> Ground</td>
+    <td valign=\"top\"> New model to visualize the ground (box at z=0).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Rotational.Interfaces.</strong></td></tr>
-<tr><td> PartialElementaryOneFlangeAndSupport2<br>
+<tr><td valign=\"top\"> PartialElementaryOneFlangeAndSupport2<br>
                       PartialElementaryTwoFlangesAndSupport2</td>
-    <td> New partial model with one and two flanges and the support flange
+    <td valign=\"top\"> New partial model with one and two flanges and the support flange
                       with a much simpler implementation as previously.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Translational.Interfaces.</strong></td></tr>
-<tr><td> PartialElementaryOneFlangeAndSupport2<br>
+<tr><td valign=\"top\"> PartialElementaryOneFlangeAndSupport2<br>
                       PartialElementaryTwoFlangesAndSupport2</td>
-    <td> New partial model with one and two flanges and the support flange
+    <td valign=\"top\"> New partial model with one and two flanges and the support flange
                       with a much simpler implementation as previously.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Media.IdealGases.Common.MixtureGasNasa.</strong></td></tr>
-<tr><td> setSmoothState</td>
-    <td> Return thermodynamic state so that it smoothly approximates:
+<tr><td valign=\"top\"> setSmoothState</td>
+    <td valign=\"top\"> Return thermodynamic state so that it smoothly approximates:
                       if x &gt; 0 then state_a else state_b.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Utilities.Internal.</strong></td></tr>
-<tr><td> PartialModelicaServices</td>
-    <td> New package containing the interface description of
+<tr><td valign=\"top\"> PartialModelicaServices</td>
+    <td valign=\"top\"> New package containing the interface description of
                       models and functions that require a tool dependent
                       implementation (currently only \"Shape\" for 3-dim. animation,
                       but will be extended in the future)</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Thermal.HeatTransfer.Components.</strong></td></tr>
-<tr><td> ThermalCollector</td>
-    <td> New auxiliary model to collect the heat flows
+<tr><td valign=\"top\"> ThermalCollector</td>
+    <td valign=\"top\"> New auxiliary model to collect the heat flows
                       from m heatports to a single heatport;
                       useful for multiphase resistors (with heatports)
                       as a junction of the m heatports.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Icons.</strong></td></tr>
-<tr><td> VariantLibrary<br>
+<tr><td valign=\"top\"> VariantLibrary<br>
                       BaseClassLibrary<br>
                       ObsoleteModel</td>
-    <td> New icons (VariantLibrary and BaseClassLibrary have been moved
+    <td valign=\"top\"> New icons (VariantLibrary and BaseClassLibrary have been moved
                       from Modelica_Fluid.Icons to this place).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.SIunits.</strong></td></tr>
-<tr><td> ElectricalForceConstant </td>
-    <td> New type added (#190).</td></tr>
+<tr><td valign=\"top\"> ElectricalForceConstant </td>
+    <td valign=\"top\"> New type added (#190).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.SIunits.Conversions.</strong></td></tr>
-<tr><td> from_Hz<br>
+<tr><td valign=\"top\"> from_Hz<br>
                       to_Hz</td>
-    <td> New functions to convert between frequency [Hz] and
+    <td valign=\"top\"> New functions to convert between frequency [Hz] and
                       angular velocity [1/s]. (#156) </td></tr>
 
 </table>
@@ -4370,51 +4370,51 @@ have been <font color=\"blue\"><strong>improved</strong></font> in a
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Modelica.</strong></td></tr>
-<tr><td> Blocks<br>Mechanics<br>StateGraph </td>
-    <td> Provided missing parameter values for examples
+<tr><td valign=\"top\"> Blocks<br>Mechanics<br>StateGraph </td>
+    <td valign=\"top\"> Provided missing parameter values for examples
                       (these parameters had only start values)</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Basic</strong></td></tr>
-<tr><td> Resistor, Conductor, VariableResistor, VariableConductor</td>
-    <td> Conditional heatport added for coupling to thermal network.</td></tr>
+<tr><td valign=\"top\"> Resistor, Conductor, VariableResistor, VariableConductor</td>
+    <td valign=\"top\"> Conditional heatport added for coupling to thermal network.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Ideal</strong></td></tr>
-<tr><td> Thyristors, Switches, IdealDiode</td>
-    <td> Conditional heatport added for coupling to thermal network.</td></tr>
+<tr><td valign=\"top\"> Thyristors, Switches, IdealDiode</td>
+    <td valign=\"top\"> Conditional heatport added for coupling to thermal network.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Semiconductors</strong></td></tr>
-<tr><td> Diode, ZDiode, PMOS, NMOS, NPN, PNP</td>
-    <td> Conditional heatport added for coupling to thermal network.</td></tr>
+<tr><td valign=\"top\"> Diode, ZDiode, PMOS, NMOS, NPN, PNP</td>
+    <td valign=\"top\"> Conditional heatport added for coupling to thermal network.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.MultiPhase.Basic</strong></td></tr>
-<tr><td> Resistor, Conductor, VariableResistor, VariableConductor</td>
-    <td> Conditional heatport added for coupling to thermal network (as in Modelica.Electrical.Analog).</td></tr>
+<tr><td valign=\"top\"> Resistor, Conductor, VariableResistor, VariableConductor</td>
+    <td valign=\"top\"> Conditional heatport added for coupling to thermal network (as in Modelica.Electrical.Analog).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.MultiPhase.Ideal</strong></td></tr>
-<tr><td> Thyristors, Switches, IdealDiode</td>
-    <td> Conditional heatport added for coupling to thermal network (as in Modelica.Electrical.Analog).</td></tr>
+<tr><td valign=\"top\"> Thyristors, Switches, IdealDiode</td>
+    <td valign=\"top\"> Conditional heatport added for coupling to thermal network (as in Modelica.Electrical.Analog).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.Visualizers.Advanced.</strong></td></tr>
-<tr><td> Shape </td>
-    <td> New implementation by inheriting from ModelicaServices. This allows a
+<tr><td valign=\"top\"> Shape </td>
+    <td valign=\"top\"> New implementation by inheriting from ModelicaServices. This allows a
                       tool vendor to provide its own implementation of Shape.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.StateGraph.</strong></td></tr>
-<tr><td> Examples </td>
-    <td> Introduced \"StateGraphRoot\" on the top level of all example models.</td></tr>
+<tr><td valign=\"top\"> Examples </td>
+    <td valign=\"top\"> Introduced \"StateGraphRoot\" on the top level of all example models.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.StateGraph.Interfaces.</strong></td></tr>
-<tr><td> StateGraphRoot<br>PartialCompositeStep<br>CompositeStepState </td>
-    <td> Replaced the wrong Modelica code \"flow output Real xxx\"
+<tr><td valign=\"top\"> StateGraphRoot<br>PartialCompositeStep<br>CompositeStepState </td>
+    <td valign=\"top\"> Replaced the wrong Modelica code \"flow output Real xxx\"
                       by \"Real dummy; flow Real xxx;\".
                       As a side effect, several \"blocks\" had to be changed to \"models\".</td></tr>
-<tr><td> PartialStep </td>
-    <td> Changed model by packing the protected outer connector in to a model.
+<tr><td valign=\"top\"> PartialStep </td>
+    <td valign=\"top\"> Changed model by packing the protected outer connector in to a model.
                       Otherwise, there might be differences in the sign of the flow variable
                       in Modelica 3.0 and 3.1.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Utilities.Examples.</strong></td></tr>
-<tr><td> expression </td>
-    <td> Changed local variable \"operator\" to \"opString\" since \"operator\"
+<tr><td valign=\"top\"> expression </td>
+    <td valign=\"top\"> Changed local variable \"operator\" to \"opString\" since \"operator\"
                       is a reserved keyword in Modelica 3.1 </td></tr>
 </table>
 
@@ -4425,26 +4425,26 @@ units are wrong or errors in documentation):
 </p>
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Modelica.</strong></td></tr>
-<tr><td> Many models</td>
-    <td> Removed wrong usages of annotations fillColor and fillPattern
+<tr><td valign=\"top\"> Many models</td>
+    <td valign=\"top\"> Removed wrong usages of annotations fillColor and fillPattern
                       in text annotations (#155, #185).</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines</strong></td></tr>
-<tr><td> All machine models</td>
-    <td> The conditional heatports of the instantiated resistors
+<tr><td valign=\"top\"> All machine models</td>
+    <td valign=\"top\"> The conditional heatports of the instantiated resistors
                         (which are new in Modelica.Electrical.Analog and Modelica.Electrical.MultiPhase)
                         are finally switched off until a thermal connector design for machines is implemented.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Media.Air.MoistAir</strong></td></tr>
-<tr><td> saturationPressureLiquid<br>
+<tr><td valign=\"top\"> saturationPressureLiquid<br>
                       sublimationPressureIce<br>
                       saturationPressure</td>
-          <td> For these three functions, an error in the <code>derivative</code> annotation was corrected. However, the effect of
+          <td valign=\"top\"> For these three functions, an error in the <code>derivative</code> annotation was corrected. However, the effect of
                             this bug was minor, as a Modelica tool was allowed to compute derivatives automatically via
                             the <code>smoothOrder</code> annotation.</td>
 </tr>
 <tr><td colspan=\"2\"><strong>Modelica.Math.Matrices.</strong></td></tr>
-<tr><td> eigenValues</td>
-    <td> Wrong documentation corrected (#162)</td></tr>
+<tr><td valign=\"top\"> eigenValues</td>
+    <td valign=\"top\"> Wrong documentation corrected (#162)</td></tr>
 </table>
 
 </html>"));
@@ -4498,46 +4498,46 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Electrical.Analog.Basic.</strong></td></tr>
-<tr><td>M_Transformer</td>
-          <td> Transformer, with the possibility to
+<tr><td valign=\"top\">M_Transformer</td>
+          <td valign=\"top\"> Transformer, with the possibility to
         choose the number of inductors. The inductances and the coupled inductances
         can be chosen arbitrarily.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Analog.Lines.</strong></td></tr>
-<tr><td>M_OLine</td>
-          <td> Segmented line model that enables the use of
+<tr><td valign=\"top\">M_OLine</td>
+          <td valign=\"top\"> Segmented line model that enables the use of
         multiple lines, that means, the number of segments and the number of
         single lines can be chosen by the user. The model allows to investigate
         phenomena at multiple lines like mutual magnetic or capacitive influence.</td></tr>
 <tr><td colspan=\"2\"><strong>Mechanics.Translational.Components.Examples.</strong></td></tr>
-<tr><td>Brake</td>
-          <td> Demonstrates the usage of the translational brake component.</td></tr>
+<tr><td valign=\"top\">Brake</td>
+          <td valign=\"top\"> Demonstrates the usage of the translational brake component.</td></tr>
 <tr><td colspan=\"2\"><strong>Media.Interfaces.PartialMedium.</strong></td></tr>
-<tr><td>ThermoStates</td>
-          <td> Enumeration type for independent variables to identify the independent
+<tr><td valign=\"top\">ThermoStates</td>
+          <td valign=\"top\"> Enumeration type for independent variables to identify the independent
                                                 variables of the medium (pT, ph, phX, pTX, dTX).<br>
                                                 An implementation of this enumeration is provided for every medium.
                                                 (This is useful for fluid libraries that do not use the
                                                 PartialMedium.BaseProperties model).</td></tr>
-<tr><td>setSmoothState</td>
-          <td> Function that returns the thermodynamic state which smoothly approximates:
+<tr><td valign=\"top\">setSmoothState</td>
+          <td valign=\"top\"> Function that returns the thermodynamic state which smoothly approximates:
                                                 if x > 0 then state_a else state_b.<br>
                                                 (This is useful for pressure drop components in fluid libraries
                                                  where the upstream density and/or viscosity has to be computed
                                                  and these properties should be smooth a zero mass flow rate)<br>
                                                 An implementation of this function is provided for every medium.</td></tr>
 <tr><td colspan=\"2\"><strong>Media.Common.</strong></td></tr>
-<tr><td>smoothStep</td>
-          <td> Approximation of a general step, such that the characteristic
+<tr><td valign=\"top\">smoothStep</td>
+          <td valign=\"top\"> Approximation of a general step, such that the characteristic
                                                 is continuous and differentiable.</td></tr>
 <tr><td colspan=\"2\"><strong>Media.UsersGuide.</strong></td></tr>
-<tr><td>Future</td>
-          <td> Short description of goals and changes of upcoming release of Modelica.Media.</td></tr>
+<tr><td valign=\"top\">Future</td>
+          <td valign=\"top\"> Short description of goals and changes of upcoming release of Modelica.Media.</td></tr>
 <tr><td colspan=\"2\"><strong>Media.Media.Air.MoistAir.</strong></td></tr>
-<tr><td>isentropicExponent</td>
-          <td> Implemented Missing Function from interface.</td></tr>
-<tr><td>isentropicEnthalpyApproximation</td>
-<td> Implemented function that approximates the isentropic enthalpy change.
+<tr><td valign=\"top\">isentropicExponent</td>
+          <td valign=\"top\"> Implemented Missing Function from interface.</td></tr>
+<tr><td valign=\"top\">isentropicEnthalpyApproximation</td>
+<td valign=\"top\"> Implemented function that approximates the isentropic enthalpy change.
 This is only correct as long as there is no liquid in the stream.</td></tr>
 </table>
 
@@ -4549,51 +4549,51 @@ have been <font color=\"blue\"><strong>changed</strong></font> (in a
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Mechanics.Rotational.Interfaces.</strong></td></tr>
-<tr><td> PartialFriction </td>
-          <td> Improvement of friction model so that in certain situations
+<tr><td valign=\"top\"> PartialFriction </td>
+          <td valign=\"top\"> Improvement of friction model so that in certain situations
                                                 the number of iterations is much smaller.</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Translational.Components.Examples.</strong></td></tr>
-<tr><td> Friction </td>
-          <td> Added a third variant, where friction is modelled with
+<tr><td valign=\"top\"> Friction </td>
+          <td valign=\"top\"> Added a third variant, where friction is modelled with
                                                 the SupportFriction component.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Translational.Components.</strong></td></tr>
-<tr><td> MassWithStopAndFriction </td>
-          <td> Improvement of friction model so that in certain situations
+<tr><td valign=\"top\"> MassWithStopAndFriction </td>
+          <td valign=\"top\"> Improvement of friction model so that in certain situations
                                                 the number of iterations is much smaller.</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Translational.Interfaces.</strong></td></tr>
-<tr><td> PartialFriction </td>
-          <td> Improvement of friction model so that in certain situations
+<tr><td valign=\"top\"> PartialFriction </td>
+          <td valign=\"top\"> Improvement of friction model so that in certain situations
                                                 the number of iterations is much smaller.</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Examples.</strong></td></tr>
-<tr><td> SimpleLiquidWater<br>
+<tr><td valign=\"top\"> SimpleLiquidWater<br>
                                                 IdealGasH20<br>
                                                 WaterIF97<br>
                                                 MixtureGases<br>
                                                 MoistAir </td>
-          <td> Added equations to test the new setSmoothState(..) functions
+          <td valign=\"top\"> Added equations to test the new setSmoothState(..) functions
                                                 including the analytic derivatives of these functions.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Media.Interfaces.PartialLinearFluid.</strong></td></tr>
-<tr><td> setState_pTX<br>
+<tr><td valign=\"top\"> setState_pTX <br>
                                                 setState_phX<br>
                                                 setState_psX<br>
                                                 setState_dTX </td>
-          <td> Rewritten function in one statement so that it is usually inlined.</td></tr>
+          <td valign=\"top\"> Rewritten function in one statement so that it is usually inlined.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Media.Interfaces.PartialLinearFluid.</strong></td></tr>
-<tr><td> consistent use of reference_d instead of density(state </td>
-          <td> Change was done to achieve consistency with analytic inverse functions.</td></tr>
+<tr><td valign=\"top\"> consistent use of reference_d instead of density(state </td>
+          <td valign=\"top\"> Change was done to achieve consistency with analytic inverse functions.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Media.Air.MoistAir.</strong></td></tr>
-<tr><td> T_phX </td>
-          <td> Interval of nonlinear solver to compute T from p,h,X changed
+<tr><td valign=\"top\"> T_phX </td>
+          <td valign=\"top\"> Interval of nonlinear solver to compute T from p,h,X changed
                                                 from 200..6000 to 240 ..400 K.</td></tr>
 
 </table>
@@ -4605,13 +4605,13 @@ that can lead to wrong simulation results):
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Forces</strong></td></tr>
-<tr><td> WorldTorque </td>
-          <td> Parameter \"ResolveInFrame\" was not propagated and therefore
+<tr><td valign=\"top\"> WorldTorque </td>
+          <td valign=\"top\"> Parameter \"ResolveInFrame\" was not propagated and therefore
                                                 always the default (resolved in world frame) was used, independently
                                                 of the setting of this parameter.</td>
 </tr>
-<tr><td> WorldForceAndTorque </td>
-          <td> Parameter \"ResolveInFrame\" was not propagated and therefore
+<tr><td valign=\"top\"> WorldForceAndTorque </td>
+          <td valign=\"top\"> Parameter \"ResolveInFrame\" was not propagated and therefore
                                                 always the default (resolved in world frame) was used, independently
                                                 of the setting of this parameter.<br>
                                                 Furthermore, internally WorldTorque was used instead of
@@ -4619,50 +4619,50 @@ that can lead to wrong simulation results):
                                                 worldTorque was performed twice.</td>
 </tr>
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Sensors</strong></td></tr>
-<tr><td> AbsoluteSensor </td>
-          <td> Velocity, acceleration and angular acceleration were computed
+<tr><td valign=\"top\"> AbsoluteSensor </td>
+          <td valign=\"top\"> Velocity, acceleration and angular acceleration were computed
                                                   by differentiating in the resolveInFrame frame. This has been corrected, by
                                                   first transforming the vectors in to the world frame, differentiating here
                                                   and then transforming into resolveInFrame. The parameter in the Advanced menu
                                                   resolveInFrameAfterDifferentiation is then superfluous and was removed .</td>
 </tr>
-<tr><td> AbsoluteVelocity </td>
-          <td> The velocity was computed
+<tr><td valign=\"top\"> AbsoluteVelocity </td>
+          <td valign=\"top\"> The velocity was computed
                                                   by differentiating in the resolveInFrame frame. This has been corrected, by
                                                   first transforming the velocity in to the world frame, differentiating here
                                                   and then transforming into resolveInFrame </td>
 </tr>
-<tr><td> RelativeSensor </td>
-          <td> If resolveInFrame &lt;&gt; frame_resolve and
+<tr><td valign=\"top\"> RelativeSensor </td>
+          <td valign=\"top\"> If resolveInFrame &lt;&gt; frame_resolve and
                                                    resolveInFrameAfterDifferentiation = frame_resolve, a translation
                                                 error occurred, since frame_resolve was not enabled in this situation.
                                                 This has been corrected.</td>
 </tr>
-<tr><td> RelativeVelocity </td>
-          <td> The velocity has have been computed
+<tr><td valign=\"top\"> RelativeVelocity </td>
+          <td valign=\"top\"> The velocity has have been computed
                                                   by differentiating in the resolveInFrame frame. This has been corrected, by
                                                   first transforming the relative position in to frame_a, differentiating here
                                                   and then transforming into resolveInFrame </td>
 </tr>
-<tr><td> TransformRelativeVector </td>
-          <td> The transformation was wrong, since the parameters frame_r_in and frame_r_out
+<tr><td valign=\"top\"> TransformRelativeVector </td>
+          <td valign=\"top\"> The transformation was wrong, since the parameters frame_r_in and frame_r_out
                                                 have not been propagated to the submodel that performs the transformation.
                                                 This has been corrected.</td>
 </tr>
 <tr><td colspan=\"2\"><strong>Mechanics.Translational.Components.</strong></td></tr>
-<tr><td> SupportFriction<br>
+<tr><td valign=\"top\"> SupportFriction<br>
                                                 Brake </td>
-          <td> The sign of the friction force was wrong and therefore friction accelerated
+          <td valign=\"top\"> The sign of the friction force was wrong and therefore friction accelerated
                                                 instead of decelerated. This was fixed.</td>
 </tr>
-<tr><td> SupportFriction</td>
-          <td> The component was only correct for fixed support.
+<tr><td valign=\"top\"> SupportFriction</td>
+          <td valign=\"top\"> The component was only correct for fixed support.
                                                 This was corrected.</td>
 </tr>
 <tr><td colspan=\"2\"><strong>Media.Interfaces.</strong></td></tr>
-<tr><td> PartialSimpleMedium<br>
+<tr><td valign=\"top\"> PartialSimpleMedium<br>
                                                 PartialSimpleIdealGasMedium </td>
-          <td> BaseProperties.p was not defined as preferred state and BaseProperties.T was
+          <td valign=\"top\"> BaseProperties.p was not defined as preferred state and BaseProperties.T was
                                                 always defined as preferred state. This has been fixed by
                                                 Defining p,T as preferred state if parameter preferredMediumState = true.
                                                 This error had the effect that mass m is selected as state instead of p
@@ -4682,41 +4682,41 @@ units are wrong or errors in documentation):
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Blocks.Math.</strong></td></tr>
-<tr><td> InverseBlockConstraint </td>
-          <td> Changed annotation preserveAspectRatio from true to false.</td>
+<tr><td valign=\"top\"> InverseBlockConstraint </td>
+          <td valign=\"top\"> Changed annotation preserveAspectRatio from true to false.</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Blocks.Sources.</strong></td></tr>
-<tr><td> RealExpression<br>
+<tr><td valign=\"top\"> RealExpression<br>
                                                 IntegerExpression<br>
                                                 BooleanExpression </td>
-          <td> Changed annotation preserveAspectRatio from true to false.</td>
+          <td valign=\"top\"> Changed annotation preserveAspectRatio from true to false.</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Analog.Basic.</strong></td></tr>
-<tr><td> SaturatingInductor</td>
-          <td> Replaced non-standard \"arctan\" by \"atan\" function.</td>
+<tr><td valign=\"top\"> SaturatingInductor</td>
+          <td valign=\"top\"> Replaced non-standard \"arctan\" by \"atan\" function.</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Digital.</strong></td></tr>
-<tr><td> UsersGuide</td>
-          <td> Removed empty documentation placeholders and added the missing
+<tr><td valign=\"top\"> UsersGuide</td>
+          <td valign=\"top\"> Removed empty documentation placeholders and added the missing
                                                   release comment for version 1.0.7</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Translational.Components.</strong></td></tr>
-<tr><td> MassWithStopAndFriction </td>
-          <td> Changed usage of reinit(..), in order that it appears
+<tr><td valign=\"top\"> MassWithStopAndFriction </td>
+          <td valign=\"top\"> Changed usage of reinit(..), in order that it appears
                                                 only once for one variable according to the language specification
                                                 (if a tool could simulate the model, there is no difference).</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Interfaces.PartialSimpleMedium</strong></td></tr>
-<tr><td> pressure<br>
+<tr><td valign=\"top\"> pressure<br>
                                                 temperature<br>
                                                 density<br>
                                                 specificEnthalpy </td>
-          <td> Missing functions added.</td>
+          <td valign=\"top\"> Missing functions added.</td>
 </tr>
 
 </table>
@@ -4858,30 +4858,30 @@ are the new sublibrary names that are introduced in version 3.0):
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Blocks.Examples.</strong></td></tr>
-<tr><td>InverseModel</td>
-          <td> Demonstrates the construction of an inverse model.</td></tr>
+<tr><td valign=\"top\">InverseModel</td>
+          <td valign=\"top\"> Demonstrates the construction of an inverse model.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Blocks.Math.</strong></td></tr>
-<tr><td>InverseBlockConstraints</td>
-          <td> Construct inverse model by requiring that two inputs
+<tr><td valign=\"top\">InverseBlockConstraints</td>
+          <td valign=\"top\"> Construct inverse model by requiring that two inputs
                                                 and two outputs are identical (replaces the previously,
                                                 unbalanced, TwoInputs and TwoOutputs blocks).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Machines.Utilities</strong></td></tr>
-<tr><td>TransformerData</td>
-          <td> A record that calculates required impedances (parameters) from nominal data of transformers.</td></tr>
+<tr><td valign=\"top\">TransformerData</td>
+          <td valign=\"top\"> A record that calculates required impedances (parameters) from nominal data of transformers.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Examples.Rotational3DEffects</strong></td></tr>
-<tr><td> GyroscopicEffects<br>
+<tr><td valign=\"top\"> GyroscopicEffects<br>
                                                 ActuatedDrive<br>
                                                 MovingActuatedDrive<br>
                                                 GearConstraint </td>
-          <td> New examples to demonstrate the usage of the Rotational library
+          <td valign=\"top\"> New examples to demonstrate the usage of the Rotational library
                                                 in combination with multi-body components.</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Sensors</strong></td></tr>
-<tr><td> AbsolutePosition<br>
+<tr><td valign=\"top\"> AbsolutePosition<br>
                                                 AbsoluteVelocity<br>
                                                 AbsoluteAngles<br>
                                                 AbsoluteAngularVelocity<br>
@@ -4889,34 +4889,34 @@ are the new sublibrary names that are introduced in version 3.0):
                                                 RelativeVelocity<br>
                                                 RelativeAngles<br>
                                                 RelativeAngularVelocity</td>
-          <td> New sensors to measure one vector.</td>
+          <td valign=\"top\"> New sensors to measure one vector.</td>
 </tr>
-<tr><td> TransformAbsoluteVector<br>
+<tr><td valign=\"top\"> TransformAbsoluteVector<br>
                                                 TransformRelativeVector</td>
-          <td> Transform absolute and/or relative vector into another frame.</td>
+          <td valign=\"top\"> Transform absolute and/or relative vector into another frame.</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Rotational.(Components)</strong></td></tr>
-<tr><td> Disc </td>
-          <td> Right flange is rotated by a fixed angle with respect to left flange</td></tr>
-<tr><td> IdealRollingWheel </td>
-          <td> Simple 1-dim. model of an ideal rolling wheel without inertia</td></tr>
+<tr><td valign=\"top\"> Disc </td>
+          <td valign=\"top\"> Right flange is rotated by a fixed angle with respect to left flange</td></tr>
+<tr><td valign=\"top\"> IdealRollingWheel </td>
+          <td valign=\"top\"> Simple 1-dim. model of an ideal rolling wheel without inertia</td></tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Translational.Sensors</strong></td></tr>
-<tr><td>RelPositionSensor<br>RelSpeedSensor<br>RelAccSensor<br>PowerSensor</td>
-          <td> Relative position sensor, i.e., distance between two flanges<br>
+<tr><td valign=\"top\">RelPositionSensor<br>RelSpeedSensor<br>RelAccSensor<br>PowerSensor</td>
+          <td valign=\"top\"> Relative position sensor, i.e., distance between two flanges<br>
                                                 Relative speed sensor<br>
                                                 Relative acceleration sensor<br>
                                                 Ideal power sensor</td></tr>
 <tr><td colspan=\"2\"><strong>Mechanics.Translational(.Components)</strong></td></tr>
-<tr><td>SupportFriction<br>Brake<br>InitializeFlange</td>
-          <td> Model of friction due to support<br>
+<tr><td valign=\"top\">SupportFriction<br>Brake<br>InitializeFlange</td>
+          <td valign=\"top\"> Model of friction due to support<br>
                                                 Model of a brake, base on Coulomb friction<br>
                                                 Initializes a flange with pre-defined position, speed and acceleration .</td></tr>
 <tr><td colspan=\"2\"><strong>Mechanics.Translational(.Sources)</strong></td></tr>
-<tr><td>Force2<br>LinearSpeedDependentForce<br>QuadraticSpeedDependentForce<br>
+<tr><td valign=\"top\">Force2<br>LinearSpeedDependentForce<br>QuadraticSpeedDependentForce<br>
                                            ConstantForce<br>ConstantSpeed<br>ForceStep</td>
-          <td> Force acting on 2 flanges<br>
+          <td valign=\"top\"> Force acting on 2 flanges<br>
                                                 Force linearly dependent on flange speed<br>
                                                 Force quadratic dependent on flange speed<br>
                                                 Constant force source<br>
@@ -4935,68 +4935,68 @@ should be automatic):
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Blocks.Continuous.</strong></td></tr>
-<tr><td> CriticalDamping </td>
-          <td> New parameter \"normalized\" to define whether filter is provided
+<tr><td valign=\"top\"> CriticalDamping </td>
+          <td valign=\"top\"> New parameter \"normalized\" to define whether filter is provided
                                                 in normalized or non-normalized form. Default is \"normalized = true\".
                                                 The previous implementation was a non-normalized filter.
                                                 The conversion script automatically introduces the modifier
                                                 \"normalized=false\" for existing models.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Blocks.Interfaces.</strong></td></tr>
-<tr><td> RealInput<br>
+<tr><td valign=\"top\"> RealInput<br>
                                                 RealOutput</td>
-          <td> Removed \"SignalType\", since extending from a replaceable class
+          <td valign=\"top\"> Removed \"SignalType\", since extending from a replaceable class
                                                 and this is not allowed in Modelica 3.<br>The conversion script
                                                 removes modifiers to SignalType.</td></tr>
 
-<tr><td> RealSignal<br>
+<tr><td valign=\"top\"> RealSignal<br>
                                                 IntegerSignal<br>
                                                 BooleanSignal</td>
-          <td> Moved to library ObsoleteModelica3, since these connectors
+          <td valign=\"top\"> Moved to library ObsoleteModelica3, since these connectors
                                                 are no longer allowed in Modelica 3<br>
                                                 (prefixes input and/or output are required).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Blocks.Interfaces.Adaptors.</strong></td></tr>
-<tr><td> AdaptorReal<br>
+<tr><td valign=\"top\"> AdaptorReal<br>
                                                 AdaptorBoolean<br>
                                                 AdaptorInteger</td>
-          <td> Moved to library ObsoleteModelica3, since the models are not \"balanced\".
+          <td valign=\"top\"> Moved to library ObsoleteModelica3, since the models are not \"balanced\".
                                                 These are completely obsolete adaptors<br>between the Real, Boolean, Integer
                                                 signal connectors of version 1.6 and version &ge; 2.1 of the Modelica
                                                 Standard Library.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Blocks.Math.</strong></td></tr>
-<tr><td> ConvertAllUnits</td>
-          <td> Moved to library ObsoleteModelica3, since extending from a replaceable class
+<tr><td valign=\"top\"> ConvertAllUnits</td>
+          <td valign=\"top\"> Moved to library ObsoleteModelica3, since extending from a replaceable class
                                                 and this is not allowed in Modelica 3.<br> It would be possible to rewrite this
                                                 model to use a replaceable component. However, the information about the
                                                 conversion<br> cannot be visualized in the icon in this case.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Blocks.Math.UnitConversions.</strong></td></tr>
-<tr><td> TwoInputs<br>
+<tr><td valign=\"top\"> TwoInputs<br>
                                                 TwoOutputs</td>
-          <td> Moved to library ObsoleteModelica3, since the models are not \"balanced\".
+          <td valign=\"top\"> Moved to library ObsoleteModelica3, since the models are not \"balanced\".
                                                 A new component<br>\"InverseBlockConstraints\"
                                                 is provided instead that has the same feature, but is \"balanced\".</td></tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Analog.Baisc.</strong></td></tr>
-<tr><td> HeatingResistor</td>
-          <td> The heatPort has to be connected; otherwise the component Resistor (without heatPort) has to be used.<br>
+<tr><td valign=\"top\"> HeatingResistor</td>
+          <td valign=\"top\"> The heatPort has to be connected; otherwise the component Resistor (without heatPort) has to be used.<br>
                                                 cardinality() is only used to check whether the heatPort is connected.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.MultiPhase.Examples.</strong></td></tr>
-<tr><td> </td>
-          <td> Changed the instance names of components used in the examples to more up-to-date style.</td></tr>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Changed the instance names of components used in the examples to more up-to-date style.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Machines.</strong></td></tr>
-<tr><td> </td>
-          <td> Moved package <code>Machines.Examples.Utilities</code> to <code>Machines.Utilities</code></td></tr>
-<tr><td> </td>
-          <td> Removed all nonSIunits; especially in DCMachines<br>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Moved package <code>Machines.Examples.Utilities</code> to <code>Machines.Utilities</code></td></tr>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Removed all nonSIunits; especially in DCMachines<br>
                                                 parameter NonSIunits.AngularVelocity_rpm rpmNominal was replaced by<br>
                                                 parameter SIunits.AngularVelocity wNominal</td></tr>
-<tr><td> </td>
-          <td> Changed the following component variable and parameter names to be more concise:<br>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Changed the following component variable and parameter names to be more concise:<br>
                                                 Removed suffix \"DamperCage\" from all synchronous induction machines
                                                 since the user can choose whether the damper cage is present or not.<br><code>
                                                 RotorAngle ... RotorDisplacementAngle<br>
@@ -5015,52 +5015,52 @@ should be automatic):
                                                 V0 ............... VsOpenCicuit  (SMPM)<br>
                                                 Ie0 .............. IeOpenCicuit  (SMEE)
                                                 </code></td></tr>
-<tr><td>Interfaces.</td>
-          <td> Moved as much code as possible from specific machine models to partials to reduce redundant code.</td></tr>
-<tr><td>Interfaces.Adapter</td>
-          <td> Removed to avoid cardinality; instead, the following solution has been implemented:</td></tr>
-<tr><td>Sensors.RotorDisplacementAngle<br>Interfaces.PartialBasicMachine</td>
-          <td> Introduced <code>parameter Boolean useSupport=false \"enable / disable (=fixed stator) support\"</code><br>
+<tr><td valign=\"top\">Interfaces.</td>
+          <td valign=\"top\"> Moved as much code as possible from specific machine models to partials to reduce redundant code.</td></tr>
+<tr><td valign=\"top\">Interfaces.Adapter</td>
+          <td valign=\"top\"> Removed to avoid cardinality; instead, the following solution has been implemented:</td></tr>
+<tr><td valign=\"top\">Sensors.RotorDisplacementAngle<br>Interfaces.PartialBasicMachine</td>
+          <td valign=\"top\"> Introduced <code>parameter Boolean useSupport=false \"enable / disable (=fixed stator) support\"</code><br>
                                                 The rotational support connector is only present with <code>useSupport = true;</code><br>
                                                 otherwise the stator is fixed internally.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Machines.Examples.</strong></td></tr>
-<tr><td> </td>
-          <td> Changed the names of the examples to more meaningful names.<br>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Changed the names of the examples to more meaningful names.<br>
                                                 Changed the instance names of components used in the examples to more up-to-date style.</td></tr>
-<tr><td>SMEE_Generator</td>
-          <td> Initialization of <code>smee.phiMechanical</code> with <code>fixed=true</code></td></tr>
+<tr><td valign=\"top\">SMEE_Generator</td>
+          <td valign=\"top\"> Initialization of <code>smee.phiMechanical</code> with <code>fixed=true</code></td></tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.</strong></td></tr>
-<tr><td> World</td>
-          <td> Changed default value of parameter driveTrainMechanics3D from false to true.<br>
+<tr><td valign=\"top\"> World</td>
+          <td valign=\"top\"> Changed default value of parameter driveTrainMechanics3D from false to true.<br>
                                                 3-dim. effects in Rotor1D, Mounting1D and BevelGear1D are therefore taken<br>
                                                 into account by default (previously this was only the case, if
                                                 world.driveTrainMechanics3D was explicitly set).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Forces.</strong></td></tr>
-<tr><td> FrameForce<br>
+<tr><td valign=\"top\"> FrameForce<br>
                                                 FrameTorque<br>
                                                 FrameForceAndTorque</td>
-          <td> Models removed, since functionality now available via Force, Torque, ForceAndTorque</td></tr>
-<tr><td> WorldForce<br>
+          <td valign=\"top\"> Models removed, since functionality now available via Force, Torque, ForceAndTorque</td></tr>
+<tr><td valign=\"top\"> WorldForce<br>
                                                 WorldTorque<br>
                                                 WorldForceAndTorque<br>
                                                 Force<br>
                                                 Torque<br>
                                                 ForceAndTorque</td>
-          <td> Connector frame_resolve is optionally enabled via parameter resolveInFrame<br>.
+          <td valign=\"top\"> Connector frame_resolve is optionally enabled via parameter resolveInFrame<br>.
                                                 Forces and torques and be resolved in all meaningful frames defined
                                                 by enumeration resolveInFrame.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Frames.</strong></td></tr>
-<tr><td> length<br>
+<tr><td valign=\"top\"> length<br>
                                                 normalize</td>
-          <td> Removed functions, since available also in Modelica.Math.Vectors
+          <td valign=\"top\"> Removed functions, since available also in Modelica.Math.Vectors
                                                 <br>The conversion script changes the references correspondingly.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Joints.</strong></td></tr>
-<tr><td> Prismatic<br>
+<tr><td valign=\"top\"> Prismatic<br>
                                                 ActuatedPrismatic<br>
                                                 Revolute<br>
                                                 ActuatedRevolute<br>
@@ -5069,7 +5069,7 @@ should be automatic):
                                                 Planar<br>
                                                 Spherical<br>
                                                 FreeMotion</td>
-          <td> Changed initialization, by replacing initial value parameters with
+          <td valign=\"top\"> Changed initialization, by replacing initial value parameters with
                                                 start/fixed attributes.<br>
                                                 When start/fixed attributes are properly supported
                                                 in the parameter menu by a Modelica tool,<br>
@@ -5079,9 +5079,9 @@ should be automatic):
                                                 built-in enumeration stateSelect=StateSelection.xxx.<br>
                                                 The conversion script automatically
                                                 transforms from the \"old\" to the \"new\" forms.</td></tr>
-<tr><td> Revolute<br>
+<tr><td valign=\"top\"> Revolute<br>
                                                 ActuatedRevolute</td>
-          <td> Parameter \"planarCutJoint\" in the \"Advanced\" menu of \"Revolute\" and of
+          <td valign=\"top\"> Parameter \"planarCutJoint\" in the \"Advanced\" menu of \"Revolute\" and of
                                                 \"ActuatedRevolute\" removed.<br>
                                                 A new joint \"RevolutePlanarLoopConstraint\" introduced that defines the constraints
                                                 of a revolute joint<br> as cut-joint in a planar loop.
@@ -5089,19 +5089,19 @@ should be automatic):
                                                 properly used<br>in advanced model checking.<br>
                                                 ActuatedRevolute joint removed. Flange connectors of Revolute joint<br>
                                                 can be enabled with parameter useAxisFlange.</td></tr>
-<tr><td> Prismatic<br>
+<tr><td valign=\"top\"> Prismatic<br>
                                                 ActuatedPrismatic</td>
-          <td> ActuatedPrismatic joint removed. Flange connectors of Prismatic joint<br>
+          <td valign=\"top\"> ActuatedPrismatic joint removed. Flange connectors of Prismatic joint<br>
                                                 can be enabled with parameter useAxisFlange.</td></tr>
-<tr><td> Assemblies</td>
-          <td> Assembly joint implementation slightly changed, so that
+<tr><td valign=\"top\"> Assemblies</td>
+          <td valign=\"top\"> Assembly joint implementation slightly changed, so that
                                                 annotation \"structurallyIncomplete\"<br>could be removed
                                                 (all Assembly joint models are now \"balanced\").</td></tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Joints.Internal</strong></td></tr>
-<tr><td> RevoluteWithLengthConstraint<br>
+<tr><td valign=\"top\"> RevoluteWithLengthConstraint<br>
                                                 PrismaticWithLengthConstraint</td>
-          <td> These joints should not be used by a user of the MultiBody library.
+          <td valign=\"top\"> These joints should not be used by a user of the MultiBody library.
                                                 They are only provided to built-up the
                                                 MultiBody.Joints.Assemblies.JointXYZ joints.
                                                 These two joints have been changed in a slightly not backward compatible
@@ -5122,18 +5122,18 @@ should be automatic):
                                                 via the new parameter \"constraintResidue\".</td></tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Parts.</strong></td></tr>
-<tr><td> BodyBox<br>
+<tr><td valign=\"top\"> BodyBox<br>
                                                 BodyCylinder</td>
-          <td> Changed unit of parameter density from g/cm3 to the SI unit kg/m3
+          <td valign=\"top\"> Changed unit of parameter density from g/cm3 to the SI unit kg/m3
                                                 in order to allow stricter unit checking.<br>The conversion script multiplies
                                                 previous density values with 1000.</td></tr>
-<tr><td> Body<br>
+<tr><td valign=\"top\"> Body<br>
                                                 BodyShape<br>
                                                 BodyBox<br>
                                                 BodyCylinder<br>
                                                 PointMass
                                                 Rotor1D</td>
-          <td> Changed initialization, by replacing initial value parameters with
+          <td valign=\"top\"> Changed initialization, by replacing initial value parameters with
                                                 start/fixed attributes.<br>
                                                 When start/fixed attributes are properly supported
                                                 in the parameter menu by a Modelica tool,<br>
@@ -5142,27 +5142,27 @@ should be automatic):
                                                 transforms from the \"old\" to the \"new\" form of initialization.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Sensors.</strong></td></tr>
-<tr><td> AbsoluteSensor<br>
+<tr><td valign=\"top\"> AbsoluteSensor<br>
                                                 RelativeSensor<br>
                                                 CutForceAndTorque</td>
-          <td> New design of sensor components: Via Boolean parameters<br>
+          <td valign=\"top\"> New design of sensor components: Via Boolean parameters<br>
                                                 signal connectors for the respective vectors are enabled/disabled.<br>
                                                 It is not possible to automatically convert models to this new design.<br>
                                                 Instead, references in existing models are changed to ObsoleteModelice3.<br>
                                                 This means that these models must be manually adapted.</td></tr>
-<tr><td> CutForce<br>
+<tr><td valign=\"top\"> CutForce<br>
                                                 CutTorque</td>
-          <td> Slightly new design. The force and/or torque component can be
+          <td valign=\"top\"> Slightly new design. The force and/or torque component can be
                                                 resolved in world, frame_a, or frame_resolved.<br>
                                                 Existing models are automatically converted.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Rotational.</strong></td></tr>
-<tr><td> </td>
-          <td> Moved components to structured sub-packages (Sources, Components)</td></tr>
-<tr><td> Inertia<br>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Moved components to structured sub-packages (Sources, Components)</td></tr>
+<tr><td valign=\"top\"> Inertia<br>
                                                 SpringDamper<br>
                                                 RelativeStates</td>
-          <td> Changed initialization, by replacing initial value parameters with
+          <td valign=\"top\"> Changed initialization, by replacing initial value parameters with
                                                 start/fixed attributes.<br>
                                                 When start/fixed attributes are properly supported
                                                 in the parameter menu by a Modelica tool,<br>
@@ -5173,16 +5173,16 @@ should be automatic):
                                                 Introduced the \"stateSelect\" enumeration in \"RelativeStates\".<br>
                                                 The conversion script automatically
                                                 transforms from the \"old\" to the \"new\" forms.</td></tr>
-<tr><td> LossyGear<br>
+<tr><td valign=\"top\"> LossyGear<br>
                                                 GearBox</td>
-          <td> Renamed gear ratio parameter \"i\" to \"ratio\", in order to have a
+          <td valign=\"top\"> Renamed gear ratio parameter \"i\" to \"ratio\", in order to have a
                                                 consistent naming convention.<br>
                                                 Existing models are automatically converted.</td></tr>
-<tr><td> SpringDamper<br>
+<tr><td valign=\"top\"> SpringDamper<br>
                                                 ElastoBacklash<br>
                                                 Clutch<br>
                                                 OneWayClutch</td>
-          <td> Relative quantities (phi_rel, w_rel) are used as states, if possible
+          <td valign=\"top\"> Relative quantities (phi_rel, w_rel) are used as states, if possible
                                                 (due to StateSelect.prefer).<br>
                                                 In most cases, relative states in drive trains are better suited as
                                                 absolute states.<br> This change might give changes in the selected states
@@ -5192,48 +5192,48 @@ should be automatic):
                                                 initialization heuristic may give different initial values.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Translational.</strong></td></tr>
-<tr><td> </td>
-          <td> Moved components to structured sub-packages (Sources, Components)</td></tr>
-<tr><td> </td>
-          <td> Adaptions corresponding to Rotational</td></tr>
-<tr><td> Stop</td>
-          <td> Renamed to Components.MassWithStopAndFriction to be more concise.<br>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Moved components to structured sub-packages (Sources, Components)</td></tr>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Adaptions corresponding to Rotational</td></tr>
+<tr><td valign=\"top\"> Stop</td>
+          <td valign=\"top\"> Renamed to Components.MassWithStopAndFriction to be more concise.<br>
                                                 MassWithStopAndFriction is not available with a support connector,<br>
                                                 since the reaction force can't be modeled in a meaningful way due to reinit of velocity v.<br>
                                                 Until a sound implementation of a hard stop is available, the old model may be used.</td></tr>
 <tr><td colspan=\"2\"><strong>Media.</strong></td></tr>
-<tr><td> constant nX<br>
+<tr><td valign=\"top\"> constant nX<br>
                                                 constant nXi<br>
                                                 constant reference_X<br>
                                                 BaseProperties</td>
-          <td> The package constant nX = nS, now always, even for single species media. This also allows to define mixtures with only 1 element. The package constant nXi=if fixedX then 0 else if reducedX or nS==1 then nS - 1 else nS. This required that all BaseProperties for single species media get an additional equation to define the composition X as {1.0} (or reference_X, which is {1.0} for single species). This will also mean that all user defined single species media need to be updated by that equation.</td></tr>
+          <td valign=\"top\"> The package constant nX = nS, now always, even for single species media. This also allows to define mixtures with only 1 element. The package constant nXi=if fixedX then 0 else if reducedX or nS==1 then nS - 1 else nS. This required that all BaseProperties for single species media get an additional equation to define the composition X as {1.0} (or reference_X, which is {1.0} for single species). This will also mean that all user defined single species media need to be updated by that equation.</td></tr>
 
 <tr><td colspan=\"2\"><strong>SIunits.</strong></td></tr>
-<tr><td> CelsiusTemperature </td>
-          <td> Removed, since no SI unit. The conversion script changes references to
+<tr><td valign=\"top\"> CelsiusTemperature </td>
+          <td valign=\"top\"> Removed, since no SI unit. The conversion script changes references to
                                                 SIunits.Conversions.NonSIunits.Temperature_degC </td></tr>
-<tr><td> ThermodynamicTemperature<br>
+<tr><td valign=\"top\"> ThermodynamicTemperature<br>
                                                 TemperatureDifference</td>
-          <td> Added annotation \"absoluteValue=true/false\"
+          <td valign=\"top\"> Added annotation \"absoluteValue=true/false\"
                                                 in order that unit checking is possible<br>
                                                 (the unit checker needs to know for a unit that has an offset,
                                                 whether it is used as absolute or as a relative number)</td></tr>
 
 <tr><td colspan=\"2\"><strong>SIunits.Conversions.NonSIunits.</strong></td></tr>
-<tr><td> Temperature_degC<br>
+<tr><td valign=\"top\"> Temperature_degC<br>
                                                 Temperature_degF<br>
                                                 Temperature_degRk </td>
-          <td> Added annotation \"absoluteValue=true\"
+          <td valign=\"top\"> Added annotation \"absoluteValue=true\"
                                                 in order that unit checking is possible<br>
                                                 (the unit checker needs to know for a unit that has an offset,
                                                 whether it is used as absolute or as a relative number)</td></tr>
 
 <tr><td colspan=\"2\"><strong>StateGraph.Examples.</strong></td></tr>
-<tr><td> ControlledTanks </td>
-          <td> The connectors of the ControlledTanks did not fulfill the new
+<tr><td valign=\"top\"> ControlledTanks </td>
+          <td valign=\"top\"> The connectors of the ControlledTanks did not fulfill the new
                                                 restrictions of Modelica 3. This has been fixed.</td></tr>
-<tr><td> Utilities </td>
-          <td> Replacing inflow, outflow by connectors inflow1, inflow2,
+<tr><td valign=\"top\"> Utilities </td>
+          <td valign=\"top\"> Replacing inflow, outflow by connectors inflow1, inflow2,
                                                 outflow1, outflow2 with appropriate input/output prefixes in
                                                 order to fulfill the restrictions of Modelica 3 to arrive
                                                 at balanced models. No conversion is provided, since
@@ -5241,47 +5241,47 @@ should be automatic):
                                                 an example.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Thermal.FluidHeatFlow.Sensors.</strong></td></tr>
-<tr><td><br>
+<tr><td valign=\"top\"><br>
                                                 pSensor<br>TSensor<br>dpSensor<br>dTSensor<br>m_flowSensor<br>V_flowSensor<br>H_flowSensor</td>
-          <td> renamed to:<br>
+          <td valign=\"top\"> renamed to:<br>
                                                 PressureSensor<br>TemperatureSensor<br>RelPressureSensor<br>RelTemperatureSensor<br>MassFlowSensor<br>VolumeFlowSensor<br>EnthalpyFlowSensor
                                                 </td></tr>
 
 <tr><td colspan=\"2\"><strong>Thermal.FluidHeatFlow.Sources.</strong></td></tr>
-<tr><td> Ambient<br>PrescribedAmbient</td>
-          <td> available as one combined component Ambient<br>
+<tr><td valign=\"top\"> Ambient<br>PrescribedAmbient</td>
+          <td valign=\"top\"> available as one combined component Ambient<br>
                                                 Boolean parameters usePressureInput and useTemperatureInput decide
                                                 whether pressure and/or temperature are constant or prescribed</td></tr>
-<tr><td> ConstantVolumeFlow<br>PrescribedVolumeFlow</td>
-          <td> available as one combined component VolumeFlow<br>
+<tr><td valign=\"top\"> ConstantVolumeFlow<br>PrescribedVolumeFlow</td>
+          <td valign=\"top\"> available as one combined component VolumeFlow<br>
                                                 Boolean parameter useVolumeFlowInput decides
                                                 whether volume flow is constant or prescribed</td></tr>
-<tr><td> ConstantPressureIncrease<br>PrescribedPressureIncrease</td>
-          <td> available as one combined component PressureIncrease<br>
+<tr><td valign=\"top\"> ConstantPressureIncrease<br>PrescribedPressureIncrease</td>
+          <td valign=\"top\"> available as one combined component PressureIncrease<br>
                                                 Boolean parameter usePressureIncreaseInput decides
                                                 whether pressure increase is constant or prescribed</td></tr>
 
 <tr><td colspan=\"2\"><strong>Thermal.FluidHeatFlow.Examples.</strong></td></tr>
-<tr><td> </td>
-          <td> Changed the instance names of components used in the examples to more up-to-date style.</td></tr>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Changed the instance names of components used in the examples to more up-to-date style.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Thermal.HeatTransfer.(Components)</strong></td></tr>
-<tr><td> HeatCapacitor</td>
-          <td> Initialization changed: SteadyStateStart removed. Instead
+<tr><td valign=\"top\"> HeatCapacitor</td>
+          <td valign=\"top\"> Initialization changed: SteadyStateStart removed. Instead
                                                 start/fixed values for T and der_T<br>(initial temperature and its derivative).</td></tr>
 
-<tr><td><br><br>HeatCapacitor<br>ThermalConductor<br>ThermalConvection<br>BodyRadiation<br><br>
+<tr><td valign=\"top\"><br><br>HeatCapacitor<br>ThermalConductor<br>ThermalConvection<br>BodyRadiation<br><br>
                                                 TemperatureSensor<br>RelTemperatureSensor<br>HeatFlowSensor<br><br>
                                                 FixedTemperature<br>PrescribedTemperature<br>FixedHeatFlow<br>PrescribedHeatFlow</td>
-          <td> Moved components to sub-packages:<br><br>
+          <td valign=\"top\"> Moved components to sub-packages:<br><br>
                                                 Components.HeatCapacitor<br>Components.ThermalConductor<br>Components.ThermalConvection<br>Components.BodyRadiation<br><br>
                                                 Sensors.TemperatureSensor<br>Sensors.RelTemperatureSensor<br>Sensors.HeatFlowSensor<br><br>
                                                 Sources.FixedTemperature<br>Sources.PrescribedTemperature<br>Sources.FixedHeatFlow<br>Sources.PrescribedHeatFlow
                                                 </td></tr>
 
 <tr><td colspan=\"2\"><strong>Thermal.FluidHeatFlow.Examples.</strong></td></tr>
-<tr><td> </td>
-          <td> Changed the instance names of components used in the examples to more up-to-date style.</td></tr>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Changed the instance names of components used in the examples to more up-to-date style.</td></tr>
 </table>
 
 <p><br>
@@ -5291,70 +5291,70 @@ have been <font color=\"blue\"><strong>improved</strong></font> in a
 </p>
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
-<tr><td> <strong>Modelica.*</strong> </td>
-          <td> Parameter declarations, input and output function arguments without description
+<tr><td valign=\"top\"> <strong>Modelica.*</strong> </td>
+          <td valign=\"top\"> Parameter declarations, input and output function arguments without description
                                                 strings improved<br> by providing meaningful description texts.
                                                 </td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Continuous.</strong></td></tr>
-<tr><td> TransferFunction </td>
-          <td> Internal scaling of the controller canonical states introduced
+<tr><td valign=\"top\"> TransferFunction </td>
+          <td valign=\"top\"> Internal scaling of the controller canonical states introduced
                                                 in order to enlarge the range of transfer functions where the default
                                                 relative tolerance of the simulator is sufficient.</td>
 </tr>
 
-<tr><td> Butterworth<br>CriticalDamping </td>
-          <td> Documentation improved and plots of the filter characteristics added.</td></tr>
+<tr><td valign=\"top\"> Butterworth<br>CriticalDamping </td>
+          <td valign=\"top\"> Documentation improved and plots of the filter characteristics added.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Analog.Basic.</strong></td></tr>
-<tr><td> EMF </td>
-          <td> New parameter \"useSupport\" to optionally enable a support connector.</td></tr>
+<tr><td valign=\"top\"> EMF </td>
+          <td valign=\"top\"> New parameter \"useSupport\" to optionally enable a support connector.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Icons.</strong></td></tr>
-<tr><td> TranslationalSensor<br>
+<tr><td valign=\"top\"> TranslationalSensor<br>
                                                 RotationalSensor</td>
-          <td> Removed drawing from the diagram layer (kept drawing only in
+          <td valign=\"top\"> Removed drawing from the diagram layer (kept drawing only in
                                                 icon layer),<br> in order that this icon can be used in situations
                                                 where components are dragged in the diagram layer.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Math.Vectors.</strong></td></tr>
-<tr><td> normalize</td>
-          <td> Implementation changed, so that the result is awalys continuous<br>
+<tr><td valign=\"top\"> normalize</td>
+          <td valign=\"top\"> Implementation changed, so that the result is awalys continuous<br>
                                                 (previously, this was not the case for small vectors: normalize(eps,eps)).
                                                 </td></tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.</strong></td></tr>
-<tr><td> </td>
-          <td> Renamed non-standard keywords defineBranch, defineRoot, definePotentialRoot,
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Renamed non-standard keywords defineBranch, defineRoot, definePotentialRoot,
                                                 isRooted to the standard names:<br>
                                                 Connections.branch/.root/.potentialRoot/.isRooted.</td></tr>
-<tr><td> Frames </td>
-          <td> Added annotation \"Inline=true\" to all one-line functions
+<tr><td valign=\"top\"> Frames </td>
+          <td valign=\"top\"> Added annotation \"Inline=true\" to all one-line functions
                                                 (which should be all inlined).</td></tr>
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Parts.</strong></td></tr>
-<tr><td> Mounting1D<br>
+<tr><td valign=\"top\"> Mounting1D<br>
                                                 Rotor1D<br>
                                                 BevelGear1D</td>
-          <td> Changed implementation so that no longer modifiers for connector
+          <td valign=\"top\"> Changed implementation so that no longer modifiers for connector
                                                 variables are used,<br>because this violates the restrictions on
                                                 \"balanced models\" of Modelica 3.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Rotational.</strong></td></tr>
-<tr><td> InitializeFlange</td>
-          <td> Changed implementation so that counting unknowns and
+<tr><td valign=\"top\"> InitializeFlange</td>
+          <td valign=\"top\"> Changed implementation so that counting unknowns and
                                                 equations is possible without actual values of parameters.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Thermal.FluidHeatFlow.Interfaces.Partials.</strong></td></tr>
-<tr><td>TwoPort</td>
-          <td> Introduced <code>parameter Real tapT(final min=0, final max=1)=1</code><br> that defines the temperature of the heatPort
+<tr><td valign=\"top\">TwoPort</td>
+          <td valign=\"top\"> Introduced <code>parameter Real tapT(final min=0, final max=1)=1</code><br> that defines the temperature of the heatPort
                                                 between inlet and outlet.</td></tr>
 
 <tr><td colspan=\"2\"><strong>StateGraph.</strong></td></tr>
-<tr><td> InitialStep<br>
+<tr><td valign=\"top\"> InitialStep<br>
                                                 InitialStepWithSignal<br>
                                                 Step<br>
                                                 StepWithSignal</td>
-          <td> Changed implementation so that no longer modifiers for output
+          <td valign=\"top\"> Changed implementation so that no longer modifiers for output
                                                 variables are used,<br>because this violates the restrictions on
                                                 \"balanced models\" of Modelica 3.</td></tr>
 
@@ -5367,22 +5367,22 @@ that can lead to wrong simulation results):
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Electrical.Analog.Examples.</strong></td></tr>
-<tr><td> CauerLowPassSC </td>
-          <td> Wrong calculation of Capacitor1 both in Rn and Rp corrected
+<tr><td valign=\"top\"> CauerLowPassSC </td>
+          <td valign=\"top\"> Wrong calculation of Capacitor1 both in Rn and Rp corrected
                                                 (C=clock/R instead of C=clock*R) </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Parts.</strong></td></tr>
-<tr><td> Rotor1D </td>
-          <td> The 3D reaction torque was not completely correct and gave in
+<tr><td valign=\"top\"> Rotor1D </td>
+          <td valign=\"top\"> The 3D reaction torque was not completely correct and gave in
                                                 some situations a wrong result. This bug should not influence the
                                                 movement of a multi-body system, but only the constraint torques
                                                 are sometimes not correct.</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Rotational.</strong></td></tr>
-<tr><td> ElastoBacklash </td>
-          <td> If the damping torque was too large, the reaction torque
+<tr><td valign=\"top\"> ElastoBacklash </td>
+          <td valign=\"top\"> If the damping torque was too large, the reaction torque
                                                 could \"pull\" which is unphysical. The component was
                                                 newly written by limiting the damping torque in such a case
                                                 so that \"pulling\" torques can no longer occur. Furthermore,
@@ -5392,8 +5392,8 @@ that can lead to wrong simulation results):
                                                 (StateSelect.prefer), since relative quantities lead usually
                                                 to better behavior.  </td>
 </tr>
-<tr><td> Position<br>Speed<br>Accelerate<br>Move</td>
-          <td> The movement of the flange was wrongly defined as absolute;
+<tr><td valign=\"top\"> Position<br>Speed<br>Accelerate<br>Move</td>
+          <td valign=\"top\"> The movement of the flange was wrongly defined as absolute;
                                                 this is corrected as relative to connector support.<br>
                                                 For Accelerate, it was necessary to rename
                                                 RealInput a to a_ref, as well as the start values
@@ -5402,19 +5402,19 @@ that can lead to wrong simulation results):
                                                 existing models automatically.</td>
 </tr>
 <tr><td colspan=\"2\"><strong>Media.Interfaces.</strong></td></tr>
-<tr><td> PartialSimpleIdealGasMedium </td>
-          <td> Inconsistency in reference temperature corrected. This may give
+<tr><td valign=\"top\"> PartialSimpleIdealGasMedium </td>
+          <td valign=\"top\"> Inconsistency in reference temperature corrected. This may give
                                                 different results for functions:<br>
                                                 specificEnthalpy, specificInternalEnergy, specificGibbsEnergy,
                                                 specificHelmholtzEnergy.</td>
 </tr>
 <tr><td colspan=\"2\"><strong>Media.Air.</strong></td></tr>
-<tr><td> specificEntropy </td>
-          <td> Small bug in entropy computation of ideal gas mixtures corrected.</td>
+<tr><td valign=\"top\"> specificEntropy </td>
+          <td valign=\"top\"> Small bug in entropy computation of ideal gas mixtures corrected.</td>
 </tr>
 <tr><td colspan=\"2\"><strong>Media.IdealGases.Common.MixtureGasNasa</strong></td></tr>
-<tr><td> specificEntropy </td>
-          <td> Small bug in entropy computation of ideal gas mixtures corrected.</td>
+<tr><td valign=\"top\"> specificEntropy </td>
+          <td valign=\"top\"> Small bug in entropy computation of ideal gas mixtures corrected.</td>
 </tr>
 </table>
 
@@ -5426,51 +5426,51 @@ units are wrong or errors in documentation):
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Blocks.Tables.</strong></td></tr>
-<tr><td> CombiTable2D</td>
-          <td> Documentation improved.</td>
+<tr><td valign=\"top\"> CombiTable2D</td>
+          <td valign=\"top\"> Documentation improved.</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrica.Digital.Gates</strong></td></tr>
-<tr><td> AndGate<br>
+<tr><td valign=\"top\"> AndGate<br>
                                                 NandGate<br>
                                                 OrGate<br>
                                                 NorGate<br>
                                                 XorGate<br>
                                                 XnorGate</td>
-          <td> The number of inputs was not correctly propagated
+          <td valign=\"top\"> The number of inputs was not correctly propagated
                                                 to the included base model.<br>
                                                 This gave a translation error, if the number
                                                 of inputs was changed (and not the default used).</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrica.Digital.Sources</strong></td></tr>
-<tr><td> Pulse </td>
-          <td> Model differently implemented, so that
+<tr><td valign=\"top\"> Pulse </td>
+          <td valign=\"top\"> Model differently implemented, so that
                                                 warning message about \"cannot properly initialize\" is gone.</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Rotational.</strong></td></tr>
-<tr><td> BearingFriction<br>
+<tr><td valign=\"top\"> BearingFriction<br>
                                                 Clutch<br>
                                                 OneWayClutch<br>
                                                 Brake<br>
                                                 Gear </td>
-          <td> Declaration of table parameter changed from
+          <td valign=\"top\"> Declaration of table parameter changed from
                                                 table[:,:] to table[:,2].</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.Examples.Loops.Utilities.</strong></td></tr>
-<tr><td> GasForce </td>
-          <td> Unit of variable \"press\" corrected (from Pa to bar)</td>
+<tr><td valign=\"top\"> GasForce </td>
+          <td valign=\"top\"> Unit of variable \"press\" corrected (from Pa to bar)</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>StateGraph.Examples.</strong></td></tr>
-<tr><td>SimpleFriction</td>
-          <td> The internal parameter k is defined and calculated with the appropriate unit.</td></tr>
+<tr><td valign=\"top\">SimpleFriction</td>
+          <td valign=\"top\"> The internal parameter k is defined and calculated with the appropriate unit.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Thermal.FluidHeatFlow.Interfaces.Partials.</strong></td></tr>
-<tr><td>SimpleFriction</td>
-          <td> The internal parameter k is defined and calculated with the appropriate unit.</td></tr>
+<tr><td valign=\"top\">SimpleFriction</td>
+          <td valign=\"top\"> The internal parameter k is defined and calculated with the appropriate unit.</td></tr>
 
 </table>
 
@@ -5518,218 +5518,218 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Blocks.Logical.</strong></td></tr>
-<tr><td> TerminateSimulation</td>
-          <td> Terminate a simulation by a given condition.</td>
+<tr><td valign=\"top\"> TerminateSimulation</td>
+          <td valign=\"top\"> Terminate a simulation by a given condition.</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Blocks.Routing.</strong></td></tr>
-<tr><td> RealPassThrough<br>
+<tr><td valign=\"top\"> RealPassThrough<br>
                    IntegerPassThrough<br>
                    BooleanPassThrough</td>
-          <td> Pass a signal from input to output
+          <td valign=\"top\"> Pass a signal from input to output
                    (useful in combination with a bus due to restrictions
                    of expandable connectors).</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Blocks.Sources.</strong></td></tr>
-<tr><td> KinematicPTP2 </td>
-          <td> Directly gives q,qd,qdd as output (and not just qdd as KinematicPTP).
+<tr><td valign=\"top\"> KinematicPTP2 </td>
+          <td valign=\"top\"> Directly gives q,qd,qdd as output (and not just qdd as KinematicPTP).
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Machines.Examples.</strong></td></tr>
-<tr><td> TransformerTestbench </td>
-          <td> Transformer Testbench
+<tr><td valign=\"top\"> TransformerTestbench </td>
+          <td valign=\"top\"> Transformer Testbench
           </td></tr>
-<tr><td> Rectifier6pulse </td>
-          <td> 6-pulse rectifier with 1 transformer
+<tr><td valign=\"top\"> Rectifier6pulse </td>
+          <td valign=\"top\"> 6-pulse rectifier with 1 transformer
           </td>
 </tr>
-<tr><td> Rectifier12pulse </td>
-          <td> 12-pulse rectifier with 2 transformers
+<tr><td valign=\"top\"> Rectifier12pulse </td>
+          <td valign=\"top\"> 12-pulse rectifier with 2 transformers
           </td>
 </tr>
-<tr><td> AIMC_Steinmetz </td>
-          <td> Asynchronous induction machine squirrel cage with Steinmetz connection
+<tr><td valign=\"top\"> AIMC_Steinmetz </td>
+          <td valign=\"top\"> Asynchronous induction machine squirrel cage with Steinmetz connection
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Machines.BasicMachines.Components.</strong></td></tr>
-<tr><td> BasicAIM </td>
-          <td> Partial model for asynchronous induction machine
+<tr><td valign=\"top\"> BasicAIM </td>
+          <td valign=\"top\"> Partial model for asynchronous induction machine
           </td></tr>
-<tr><td> BasicSM </td>
-          <td> Partial model for synchronous induction machine
+<tr><td valign=\"top\"> BasicSM </td>
+          <td valign=\"top\"> Partial model for synchronous induction machine
           </td></tr>
-<tr><td> PartialAirGap </td>
-          <td> Partial airgap model
+<tr><td valign=\"top\"> PartialAirGap </td>
+          <td valign=\"top\"> Partial airgap model
           </td></tr>
-<tr><td> BasicDCMachine </td>
-          <td> Partial model for DC machine
+<tr><td valign=\"top\"> BasicDCMachine </td>
+          <td valign=\"top\"> Partial model for DC machine
           </td></tr>
-<tr><td> PartialAirGapDC </td>
-          <td> Partial airgap model of a DC machine
+<tr><td valign=\"top\"> PartialAirGapDC </td>
+          <td valign=\"top\"> Partial airgap model of a DC machine
           </td></tr>
-<tr><td> BasicTransformer </td>
-          <td> Partial model of threephase transformer
+<tr><td valign=\"top\"> BasicTransformer </td>
+          <td valign=\"top\"> Partial model of threephase transformer
           </td></tr>
-<tr><td> PartialCore </td>
-          <td> Partial model of transformer core with 3 windings
+<tr><td valign=\"top\"> PartialCore </td>
+          <td valign=\"top\"> Partial model of transformer core with 3 windings
           </td></tr>
-<tr><td> IdealCore </td>
-          <td> Ideal transformer with 3 windings
+<tr><td valign=\"top\"> IdealCore </td>
+          <td valign=\"top\"> Ideal transformer with 3 windings
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Machines.BasicMachines.</strong></td></tr>
-<tr><td> Transformers </td>
-          <td> Sub-Library for technical 3phase transformers
+<tr><td valign=\"top\"> Transformers </td>
+          <td valign=\"top\"> Sub-Library for technical 3phase transformers
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Machines.Interfaces.</strong></td></tr>
-<tr><td> Adapter </td>
-          <td> Adapter to model housing of electrical machine
+<tr><td valign=\"top\"> Adapter </td>
+          <td valign=\"top\"> Adapter to model housing of electrical machine
           </td>
 </tr>
 <tr><td colspan=\"2\"><strong>Math.</strong></td></tr>
-<tr><td> Vectors </td>
-          <td> New library of functions operating on vectors
+<tr><td valign=\"top\"> Vectors </td>
+          <td valign=\"top\"> New library of functions operating on vectors
           </td>
 </tr>
-<tr><td> atan3 </td>
-          <td> Four quadrant inverse tangent (select solution that is closest to given angle y0)
+<tr><td valign=\"top\"> atan3 </td>
+          <td valign=\"top\"> Four quadrant inverse tangent (select solution that is closest to given angle y0)
           </td>
 </tr>
-<tr><td> asinh </td>
-          <td> Inverse of sinh (area hyperbolic sine)
+<tr><td valign=\"top\"> asinh </td>
+          <td valign=\"top\"> Inverse of sinh (area hyperbolic sine)
           </td>
 </tr>
-<tr><td> acosh </td>
-          <td> Inverse of cosh (area hyperbolic cosine)
+<tr><td valign=\"top\"> acosh </td>
+          <td valign=\"top\"> Inverse of cosh (area hyperbolic cosine)
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Math.Vectors</strong></td></tr>
-<tr><td> isEqual </td>
-          <td> Determine if two Real vectors are numerically identical
+<tr><td valign=\"top\"> isEqual </td>
+          <td valign=\"top\"> Determine if two Real vectors are numerically identical
           </td>
 </tr>
-<tr><td> norm </td>
-          <td> Return the p-norm of a vector
+<tr><td valign=\"top\"> norm </td>
+          <td valign=\"top\"> Return the p-norm of a vector
           </td></tr>
-<tr><td> length </td>
-          <td> Return length of a vector (better as norm(), if further symbolic processing is performed)
+<tr><td valign=\"top\"> length </td>
+          <td valign=\"top\"> Return length of a vector (better as norm(), if further symbolic processing is performed)
           </td></tr>
-<tr><td> normalize </td>
-          <td> Return normalized vector such that length = 1 and prevent zero-division for zero vector
+<tr><td valign=\"top\"> normalize </td>
+          <td valign=\"top\"> Return normalized vector such that length = 1 and prevent zero-division for zero vector
           </td></tr>
-<tr><td> reverse </td>
-          <td> Reverse vector elements (e.g., v[1] becomes last element)
+<tr><td valign=\"top\"> reverse </td>
+          <td valign=\"top\"> Reverse vector elements (e.g., v[1] becomes last element)
           </td></tr>
-<tr><td> sort </td>
-          <td> Sort elements of vector in ascending or descending order
+<tr><td valign=\"top\"> sort </td>
+          <td valign=\"top\"> Sort elements of vector in ascending or descending order
           </td></tr>
 
 <tr><td colspan=\"2\"><strong>Math.Matrices</strong></td></tr>
-<tr><td> solve2 </td>
-          <td> Solve real system of linear equations A*X=B with a B matrix
+<tr><td valign=\"top\"> solve2 </td>
+          <td valign=\"top\"> Solve real system of linear equations A*X=B with a B matrix
                    (Gaussian elimination with partial pivoting)
           </td>
 </tr>
-<tr><td> LU_solve2 </td>
-          <td> Solve real system of linear equations P*L*U*X=B with a B matrix
+<tr><td valign=\"top\"> LU_solve2 </td>
+          <td valign=\"top\"> Solve real system of linear equations P*L*U*X=B with a B matrix
                    and an LU decomposition (from LU(..))
           </td></tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Rotational.</strong></td></tr>
-<tr><td> InitializeFlange </td>
-          <td> Initialize a flange according to given signals
+<tr><td valign=\"top\"> InitializeFlange </td>
+          <td valign=\"top\"> Initialize a flange according to given signals
                    (useful if initialization signals are provided by a signal bus).
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Interfaces.PartialMedium.</strong></td></tr>
-<tr><td> density_pTX </td>
-          <td> Return density from p, T, and X or Xi
+<tr><td valign=\"top\"> density_pTX </td>
+          <td valign=\"top\"> Return density from p, T, and X or Xi
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Interfaces.PartialTwoPhaseMedium.</strong></td></tr>
-<tr><td> BaseProperties </td>
-          <td> Base properties (p, d, T, h, u, R, MM, x) of a two phase medium
+<tr><td valign=\"top\"> BaseProperties </td>
+          <td valign=\"top\"> Base properties (p, d, T, h, u, R, MM, x) of a two phase medium
           </td>
 </tr>
-<tr><td> molarMass </td>
-          <td> Return the molar mass of the medium
+<tr><td valign=\"top\"> molarMass </td>
+          <td valign=\"top\"> Return the molar mass of the medium
           </td>
 </tr>
-<tr><td> saturationPressure_sat </td>
-          <td> Return saturation pressure
+<tr><td valign=\"top\"> saturationPressure_sat </td>
+          <td valign=\"top\"> Return saturation pressure
           </td>
 </tr>
-<tr><td> saturationTemperature_sat </td>
-          <td> Return saturation temperature
+<tr><td valign=\"top\"> saturationTemperature_sat </td>
+          <td valign=\"top\"> Return saturation temperature
           </td>
 </tr>
-<tr><td> saturationTemperature_derp_sat </td>
-          <td> Return derivative of saturation temperature w.r.t. pressure
+<tr><td valign=\"top\"> saturationTemperature_derp_sat </td>
+          <td valign=\"top\"> Return derivative of saturation temperature w.r.t. pressure
           </td>
-</tr>  <tr><td> setState_px </td>
-          <td> Return thermodynamic state from pressure and vapour quality
+</tr>  <tr><td valign=\"top\"> setState_px </td>
+          <td valign=\"top\"> Return thermodynamic state from pressure and vapour quality
           </td>
-</tr>  <tr><td> setState_Tx </td>
-          <td> Return thermodynamic state from temperature and vapour quality
+</tr>  <tr><td valign=\"top\"> setState_Tx </td>
+          <td valign=\"top\"> Return thermodynamic state from temperature and vapour quality
           </td>
-</tr>  <tr><td> vapourQuality </td>
-          <td> Return vapour quality
+</tr>  <tr><td valign=\"top\"> vapourQuality </td>
+          <td valign=\"top\"> Return vapour quality
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Interfaces.</strong></td></tr>
-<tr><td> PartialLinearFluid </td>
-          <td> Generic pure liquid model with constant cp,
+<tr><td valign=\"top\"> PartialLinearFluid </td>
+          <td valign=\"top\"> Generic pure liquid model with constant cp,
                    compressibility and thermal expansion coefficients
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Air.MoistAir.</strong></td></tr>
-<tr><td> massFraction_pTphi </td>
-          <td> Return the steam mass fraction from relative humidity and T
+<tr><td valign=\"top\"> massFraction_pTphi </td>
+          <td valign=\"top\"> Return the steam mass fraction from relative humidity and T
           </td>
 </tr>
-<tr><td> saturationTemperature </td>
-          <td> Return saturation temperature from (partial) pressure
+<tr><td valign=\"top\"> saturationTemperature </td>
+          <td valign=\"top\"> Return saturation temperature from (partial) pressure
                    via numerical inversion of function saturationPressure
           </td>
 </tr>
-<tr><td> enthalpyOfWater </td>
-          <td> Return specific enthalpy of water (solid/liquid) near
+<tr><td valign=\"top\"> enthalpyOfWater </td>
+          <td valign=\"top\"> Return specific enthalpy of water (solid/liquid) near
                    atmospheric pressure from temperature
           </td>
 </tr>
-<tr><td> enthalpyOfWater_der </td>
-          <td> Return derivative of enthalpyOfWater()\" function
+<tr><td valign=\"top\"> enthalpyOfWater_der </td>
+          <td valign=\"top\"> Return derivative of enthalpyOfWater()\" function
           </td>
 </tr>
-<tr><td> PsychrometricData </td>
-          <td> Model to generate plot data for psychrometric chart
+<tr><td valign=\"top\"> PsychrometricData </td>
+          <td valign=\"top\"> Model to generate plot data for psychrometric chart
           </td>
 </tr>
 <tr><td colspan=\"2\"><strong>Media.CompressibleLiquids.</strong><br>
           New sub-library for simple compressible liquid models</td></tr>
-<tr><td> LinearColdWater </td>
-          <td> Cold water model with linear compressibility
+<tr><td valign=\"top\"> LinearColdWater </td>
+          <td valign=\"top\"> Cold water model with linear compressibility
           </td>
 </tr>
-<tr><td> LinearWater_pT_Ambient </td>
-          <td> Liquid, linear compressibility water model at 1.01325 bar
+<tr><td valign=\"top\"> LinearWater_pT_Ambient </td>
+          <td valign=\"top\"> Liquid, linear compressibility water model at 1.01325 bar
                    and 25 degree Celsius
           </td>
 </tr>
 <tr><td colspan=\"2\"><strong>SIunits.</strong></td></tr>
-<tr><td> TemperatureDifference </td>
-          <td> Type for temperature difference
+<tr><td valign=\"top\"> TemperatureDifference </td>
+          <td valign=\"top\"> Type for temperature difference
           </td>
 </tr>
 </table>
@@ -5741,53 +5741,53 @@ have been <font color=\"blue\"><strong>improved</strong></font>:
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Blocks.Examples.</strong></td></tr>
-<tr><td> BusUsage</td>
-          <td> Example changed from the \"old\" to the \"new\" bus concept with
+<tr><td valign=\"top\"> BusUsage</td>
+          <td valign=\"top\"> Example changed from the \"old\" to the \"new\" bus concept with
                    expandable connectors.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Blocks.Discrete.</strong></td></tr>
-<tr><td> ZeroOrderHold</td>
-          <td> Sample output ySample moved from \"protected\" to \"public\"
+<tr><td valign=\"top\"> ZeroOrderHold</td>
+          <td valign=\"top\"> Sample output ySample moved from \"protected\" to \"public\"
                    section with new attributes (start=0, fixed=true).
           </td>
 </tr>
-<tr><td> TransferFunction</td>
-          <td> Discrete state x with new attributes (each start=0, each fixed=0).
+<tr><td valign=\"top\"> TransferFunction</td>
+          <td valign=\"top\"> Discrete state x with new attributes (each start=0, each fixed=0).
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.</strong></td></tr>
-<tr><td> Analog<br>MultiPhase</td>
-          <td> Improved some icons.
+<tr><td valign=\"top\"> Analog<br>MultiPhase</td>
+          <td valign=\"top\"> Improved some icons.
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Digital.Interfaces.</strong></td></tr>
-<tr><td> MISO</td>
-          <td> Removed \"algorithm\" from this partial block.
+<tr><td valign=\"top\"> MISO</td>
+          <td valign=\"top\"> Removed \"algorithm\" from this partial block.
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Digital.Delay.</strong></td></tr>
-<tr><td> DelayParams</td>
-          <td> Removed \"algorithm\" from this partial block.
+<tr><td valign=\"top\"> DelayParams</td>
+          <td valign=\"top\"> Removed \"algorithm\" from this partial block.
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Digital.Delay.</strong></td></tr>
-<tr><td> DelayParams</td>
-          <td> Removed \"algorithm\" from this partial block.
+<tr><td valign=\"top\"> DelayParams</td>
+          <td valign=\"top\"> Removed \"algorithm\" from this partial block.
           </td>
 </tr>
-<tr><td> TransportDelay</td>
-          <td>  If delay time is zero, an infinitely small delay is
+<tr><td valign=\"top\"> TransportDelay</td>
+          <td valign=\"top\">  If delay time is zero, an infinitely small delay is
                         introduced via pre(x) (previously \"x\" was used).
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Digital.Sources.</strong></td></tr>
-<tr><td> Clock<br>Step</td>
-          <td> Changed if-conditions from \"xxx < time\" to \"time >= xxx\"
+<tr><td valign=\"top\"> Clock<br>Step</td>
+          <td valign=\"top\"> Changed if-conditions from \"xxx < time\" to \"time >= xxx\"
                    (according to the Modelica specification, in the second case
                    a time event should be triggered, i.e., this change leads
                    potentially to a faster simulation).
@@ -5795,46 +5795,46 @@ have been <font color=\"blue\"><strong>improved</strong></font>:
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Digital.Converters.</strong></td></tr>
-<tr><td> BooleanToLogic<br>
+<tr><td valign=\"top\"> BooleanToLogic<br>
                    LogicToBoolean<br>
                    RealToLogic<br>
                    LogicToReal</td>
-          <td> Changed from \"algorithm\" to \"equation\" section
+          <td valign=\"top\"> Changed from \"algorithm\" to \"equation\" section
                    to allow better symbolic preprocessing
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.</strong></td></tr>
-<tr><td> Machines</td>
-          <td> Slightly improved documentation, typos in
+<tr><td valign=\"top\"> Machines</td>
+          <td valign=\"top\"> Slightly improved documentation, typos in
                    documentation corrected
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Machines.Examples.</strong></td></tr>
-<tr><td> AIMS_start</td>
-          <td> Changed QuadraticLoadTorque1(TorqueDirection=true) to
+<tr><td valign=\"top\"> AIMS_start</td>
+          <td valign=\"top\"> Changed QuadraticLoadTorque1(TorqueDirection=true) to
                    QuadraticLoadTorque1(TorqueDirection=false) since more realistic
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Machines.Interfaces.</strong></td></tr>
-<tr><td> PartialBasicMachine</td>
-          <td> Introduced support flange to model the
+<tr><td valign=\"top\"> PartialBasicMachine</td>
+          <td valign=\"top\"> Introduced support flange to model the
                    reaction torque to the housing
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Machines.Sensors.</strong></td></tr>
-<tr><td> Rotorangle</td>
-          <td> Introduced support flange to model the
+<tr><td valign=\"top\"> Rotorangle</td>
+          <td valign=\"top\"> Introduced support flange to model the
                    reaction torque to the housing
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Examples.Elementary.</strong></td></tr>
-<tr><td> PointMassesWithGravity</td>
-          <td> Added two point masses connected by a line force to demonstrate
+<tr><td valign=\"top\"> PointMassesWithGravity</td>
+          <td valign=\"top\"> Added two point masses connected by a line force to demonstrate
                    additionally how this works. Connections of point masses
                    with 3D-elements are demonstrated in the new example
                    PointMassesWithGravity (there is the difficulty that the orientation
@@ -5845,16 +5845,16 @@ have been <font color=\"blue\"><strong>improved</strong></font>:
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Examples.Systems.</strong></td></tr>
-<tr><td> RobotR3</td>
-          <td> Changed from the \"old\" to the \"new\" bus concept with expandable connectors.
+<tr><td valign=\"top\"> RobotR3</td>
+          <td valign=\"top\"> Changed from the \"old\" to the \"new\" bus concept with expandable connectors.
                    Replaced the non-standard Modelica function \"constrain()\" by
                    standard Modelica components. As a result, the non-standard function
                    constrain() is no longer used in the Modelica Standard Library.</td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Frames.Orientation.</strong></td></tr>
-<tr><td> equalityConstraint</td>
-          <td> Use a better residual for the equalityConstraint function.
+<tr><td valign=\"top\"> equalityConstraint</td>
+          <td valign=\"top\"> Use a better residual for the equalityConstraint function.
                    As a result, the non-linear equation system of a kinematic
                    loop is formulated in a better way (the range where the
                    desired result is a unique solution of the non-linear
@@ -5862,15 +5862,15 @@ have been <font color=\"blue\"><strong>improved</strong></font>:
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.</strong></td></tr>
-<tr><td> Visualizers.</td>
-          <td> Removed (misleading) annotation \"structurallyIncomplete\"
+<tr><td valign=\"top\"> Visualizers.</td>
+          <td valign=\"top\"> Removed (misleading) annotation \"structurallyIncomplete\"
                    in the models of this sub-library
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Rotational.</strong></td></tr>
-<tr><td> Examples</td>
-          <td> For all models in this sub-library:
+<tr><td valign=\"top\"> Examples</td>
+          <td valign=\"top\"> For all models in this sub-library:
                    <ul>
                    <li> Included a housing object in all examples to compute
                                 all support torques.</li>
@@ -5883,56 +5883,56 @@ have been <font color=\"blue\"><strong>improved</strong></font>:
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Rotational.Interfaces.</strong></td></tr>
-<tr><td> FrictionBase</td>
-          <td> Introduced \"fixed=true\" for Boolean variables startForward,
+<tr><td valign=\"top\"> FrictionBase</td>
+          <td valign=\"top\"> Introduced \"fixed=true\" for Boolean variables startForward,
                    startBackward, mode.
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Translational.Interfaces.</strong></td></tr>
-<tr><td> FrictionBase</td>
-          <td> Introduced \"fixed=true\" for Boolean variables startForward,
+<tr><td valign=\"top\"> FrictionBase</td>
+          <td valign=\"top\"> Introduced \"fixed=true\" for Boolean variables startForward,
                    startBackward, mode.
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.UsersGuide.MediumUsage.</strong></td></tr>
-<tr><td> TwoPhase</td>
-          <td> Improved documentation and demonstrating the newly introduced functions
+<tr><td valign=\"top\"> TwoPhase</td>
+          <td valign=\"top\"> Improved documentation and demonstrating the newly introduced functions
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Examples.</strong></td></tr>
-<tr><td> WaterIF97</td>
-          <td> Provided (missing) units for variables V, dV, H_flow_ext, m, U.
+<tr><td valign=\"top\"> WaterIF97</td>
+          <td valign=\"top\"> Provided (missing) units for variables V, dV, H_flow_ext, m, U.
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong> Media.Interfaces.</strong></td></tr>
-<tr><td> PartialMedium</td>
-          <td> Final modifiers are removed from nX and nXi, to allow
+<tr><td valign=\"top\"> PartialMedium</td>
+          <td valign=\"top\"> Final modifiers are removed from nX and nXi, to allow
                    customized medium models such as mixtures of refrigerants with oil, etc.
           </td>
 </tr>
-<tr><td> PartialCondensingGases</td>
-          <td> Included attributes \"min=1, max=2\" for input argument FixedPhase
+<tr><td valign=\"top\"> PartialCondensingGases</td>
+          <td valign=\"top\"> Included attributes \"min=1, max=2\" for input argument FixedPhase
                    for functions setDewState and setBubbleState (in order to guarantee
                    that input arguments are correct).
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong> Media.Interfaces.PartialMedium.</strong></td></tr>
-<tr><td> BaseProperties</td>
-          <td> New Boolean parameter \"standardOrderComponents\".
+<tr><td valign=\"top\"> BaseProperties</td>
+          <td valign=\"top\"> New Boolean parameter \"standardOrderComponents\".
                    If true, last element vector X is computed from 1-sum(Xi) (= default)
                    otherwise, no equation is provided for it in PartialMedium.
           </td>
 </tr>
-<tr><td> IsentropicExponent</td>
-          <td> \"max\" value changed from 1.7 to 500000
+<tr><td valign=\"top\"> IsentropicExponent</td>
+          <td valign=\"top\"> \"max\" value changed from 1.7 to 500000
           </td>
 </tr>
-<tr><td> setState_pTX<br>
+<tr><td valign=\"top\"> setState_pTX<br>
                    setState_phX<br>
                    setState_psX<br>
                    setState_dTX<br>
@@ -5942,105 +5942,105 @@ have been <font color=\"blue\"><strong>improved</strong></font>:
                    temperature_psX<br>
                    density_psX<br>
                    specificEnthalpy_psX</td>
-          <td> Introduced default value \"reference_X\" for input argument \"X\".
+          <td valign=\"top\"> Introduced default value \"reference_X\" for input argument \"X\".
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong> Media.Interfaces.PartialSimpleMedium.</strong></td></tr>
-<tr><td> setState_pTX<br>
+<tr><td valign=\"top\"> setState_pTX<br>
                    setState_phX<br>
                    setState_psX<br>
                    setState_dTX</td>
-          <td> Introduced default value \"reference_X\" for input argument \"X\".
+          <td valign=\"top\"> Introduced default value \"reference_X\" for input argument \"X\".
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong> Media.Interfaces.PartialSimpleIdealGasMedium.</strong></td></tr>
-<tr><td> setState_pTX<br>
+<tr><td valign=\"top\"> setState_pTX<br>
                    setState_phX<br>
                    setState_psX<br>
                    setState_dTX</td>
-          <td> Introduced default value \"reference_X\" for input argument \"X\".
+          <td valign=\"top\"> Introduced default value \"reference_X\" for input argument \"X\".
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong> Media.Air.MoistAir.</strong></td></tr>
-<tr><td> setState_pTX<br>
+<tr><td valign=\"top\"> setState_pTX<br>
                    setState_phX<br>
                    setState_dTX</td>
-          <td> Introduced default value \"reference_X\" for input argument \"X\".
+          <td valign=\"top\"> Introduced default value \"reference_X\" for input argument \"X\".
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong> Media.IdealGases.Common.SingleGasNasa.</strong></td></tr>
-<tr><td> setState_pTX<br>
+<tr><td valign=\"top\"> setState_pTX<br>
                    setState_phX<br>
                    setState_psX<br>
                    setState_dTX</td>
-          <td> Introduced default value \"reference_X\" for input argument \"X\".
+          <td valign=\"top\"> Introduced default value \"reference_X\" for input argument \"X\".
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong> Media.IdealGases.Common.MixtureGasNasa.</strong></td></tr>
-<tr><td> setState_pTX<br>
+<tr><td valign=\"top\"> setState_pTX<br>
                    setState_phX<br>
                    setState_psX<br>
                    setState_dTX<br>
                    h_TX</td>
-          <td> Introduced default value \"reference_X\" for input argument \"X\".
+          <td valign=\"top\"> Introduced default value \"reference_X\" for input argument \"X\".
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong> Media.Common.</strong></td></tr>
-<tr><td> IF97PhaseBoundaryProperties<br>
+<tr><td valign=\"top\"> IF97PhaseBoundaryProperties<br>
                    gibbsToBridgmansTables </td>
-          <td> Introduced unit for variables vt, vp.
+          <td valign=\"top\"> Introduced unit for variables vt, vp.
           </td>
 </tr>
-<tr><td> SaturationProperties</td>
-          <td> Introduced unit for variable dpT.
+<tr><td valign=\"top\"> SaturationProperties</td>
+          <td valign=\"top\"> Introduced unit for variable dpT.
           </td>
 </tr>
-<tr><td> BridgmansTables</td>
-          <td> Introduced unit for dfs, dgs.
+<tr><td valign=\"top\"> BridgmansTables</td>
+          <td valign=\"top\"> Introduced unit for dfs, dgs.
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong> Media.Common.ThermoFluidSpecial.</strong></td></tr>
-<tr><td> gibbsToProps_ph<br>
+<tr><td valign=\"top\"> gibbsToProps_ph<br>
                    gibbsToProps_ph<br>
                    gibbsToBoundaryProps<br>
                    gibbsToProps_dT<br>
                    gibbsToProps_pT</td>
-          <td> Introduced unit for variables vt, vp.
+          <td valign=\"top\"> Introduced unit for variables vt, vp.
           </td></tr>
-<tr><td> TwoPhaseToProps_ph</td>
-          <td> Introduced unit for variables dht, dhd, detph.
+<tr><td valign=\"top\"> TwoPhaseToProps_ph</td>
+          <td valign=\"top\"> Introduced unit for variables dht, dhd, detph.
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong> Media.</strong></td></tr>
-<tr><td> MoistAir</td>
-          <td> Documentation of moist air model significantly improved.
+<tr><td valign=\"top\"> MoistAir</td>
+          <td valign=\"top\"> Documentation of moist air model significantly improved.
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong> Media.MoistAir.</strong></td></tr>
-<tr><td> enthalpyOfVaporization</td>
-          <td> Replaced by linear correlation since simpler and more
+<tr><td valign=\"top\"> enthalpyOfVaporization</td>
+          <td valign=\"top\"> Replaced by linear correlation since simpler and more
                    accurate in the entire region.
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong> Media.Water.IF97_Utilities.BaseIF97.Regions.</strong></td></tr>
-<tr><td> drhovl_dp</td>
-          <td> Introduced unit for variable dd_dp.
+<tr><td valign=\"top\"> drhovl_dp</td>
+          <td valign=\"top\"> Introduced unit for variable dd_dp.
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong> Thermal.</strong></td></tr>
-<tr><td> FluidHeatFlow</td>
-          <td> Introduced new parameter tapT (0..1) to define the
+<tr><td valign=\"top\"> FluidHeatFlow</td>
+          <td valign=\"top\"> Introduced new parameter tapT (0..1) to define the
                    temperature of the HeatPort as linear combination of the
                    flowPort_a (tapT=0) and flowPort_b (tapT=1) temperatures.
           </td>
@@ -6054,16 +6054,16 @@ that can lead to wrong simulation results):
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Electrical.Machines.BasicMachines.Components.</strong></td></tr>
-<tr><td> ElectricalExcitation</td>
-          <td> Excitation voltage ve is calculated as
+<tr><td valign=\"top\"> ElectricalExcitation</td>
+          <td valign=\"top\"> Excitation voltage ve is calculated as
                    \"spacePhasor_r.v_[1]*TurnsRatio*3/2\" instead of
                    \"spacePhasor_r.v_[1]*TurnsRatio
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Parts.</strong></td></tr>
-<tr><td> FixedRotation</td>
-          <td> Bug corrected that the torque balance was wrong in the
+<tr><td valign=\"top\"> FixedRotation</td>
+          <td valign=\"top\"> Bug corrected that the torque balance was wrong in the
                    following cases (since vector r was not transformed
                    from frame_a to frame_b; note this special case occurs very seldom in practice):
                    <ul><li> frame_b is in the spanning tree closer to the root
@@ -6073,8 +6073,8 @@ that can lead to wrong simulation results):
            </td>
 </tr>
 
-<tr><td> PointMass</td>
-         <td> If a PointMass model is connected so that no equations are present
+<tr><td valign=\"top\"> PointMass</td>
+         <td valign=\"top\"> If a PointMass model is connected so that no equations are present
                   to compute its orientation object, the orientation was arbitrarily
                   set to a unit rotation. In some cases this can lead to a wrong overall
                   model, depending on how the PointMass model is used. For this reason,
@@ -6084,51 +6084,51 @@ that can lead to wrong simulation results):
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Interfaces.PartialPureSubstance.</strong></td></tr>
-<tr><td> pressure_dT<br>
+<tr><td valign=\"top\"> pressure_dT<br>
                    specificEnthalpy_dT
           </td>
-          <td> Changed wrong call from \"setState_pTX\" to \"setState_dTX\"
+          <td valign=\"top\"> Changed wrong call from \"setState_pTX\" to \"setState_dTX\"
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Interfaces.PartialTwoPhaseMedium.</strong></td></tr>
-<tr><td> pressure_dT<br>
+<tr><td valign=\"top\"> pressure_dT<br>
                    specificEnthalpy_dT
           </td>
-          <td> Changed wrong call from \"setState_pTX\" to \"setState_dTX\"
+          <td valign=\"top\"> Changed wrong call from \"setState_pTX\" to \"setState_dTX\"
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Common.ThermoFluidSpecial.</strong></td></tr>
-<tr><td> gibbsToProps_dT<br>
+<tr><td valign=\"top\"> gibbsToProps_dT<br>
                    helmholtzToProps_ph<br>
                    helmholtzToProps_pT<br>
                    helmholtzToProps_dT</td>
-          <td> Bugs in equations corrected </td>
+          <td valign=\"top\"> Bugs in equations corrected </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Common.</strong></td></tr>
-<tr><td> helmholtzToBridgmansTables<br>
+<tr><td valign=\"top\"> helmholtzToBridgmansTables<br>
                    helmholtzToExtraDerivs</td>
-          <td> Bugs in equations corrected </td>
+          <td valign=\"top\"> Bugs in equations corrected </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.IdealGases.Common.SingleGasNasa.</strong></td></tr>
-<tr><td> density_derp_T</td>
-          <td> Bug in equation of partial derivative corrected </td>
+<tr><td valign=\"top\"> density_derp_T</td>
+          <td valign=\"top\"> Bug in equation of partial derivative corrected </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Water.IF97_Utilities.</strong></td></tr>
-<tr><td> BaseIF97.Inverses.dtofps3<br>
+<tr><td valign=\"top\"> BaseIF97.Inverses.dtofps3<br>
                    isentropicExponent_props_ph<br>
                    isentropicExponent_props_pT<br>
                    isentropicExponent_props_dT</td>
-          <td> Bugs in equations corrected </td>
+          <td valign=\"top\"> Bugs in equations corrected </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Air.MoistAir.</strong></td></tr>
-<tr><td> h_pTX</td>
-          <td> Bug in setState_phX due to wrong vector size in h_pTX corrected.
+<tr><td valign=\"top\"> h_pTX</td>
+          <td valign=\"top\"> Bug in setState_phX due to wrong vector size in h_pTX corrected.
                    Furthermore, syntactical errors corrected:
                    <ul><li> In function massFractionpTphi an equation
                                         sign is used in an algorithm.</li>
@@ -6138,21 +6138,21 @@ that can lead to wrong simulation results):
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Water.</strong></td></tr>
-<tr><td> waterConstants</td>
-          <td> Bug in equation of criticalMolarVolume corrected.
+<tr><td valign=\"top\"> waterConstants</td>
+          <td valign=\"top\"> Bug in equation of criticalMolarVolume corrected.
           </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Water.IF97_Utilities.BaseIF97.Regions.</strong></td></tr>
-<tr><td> region_ph<br>
+<tr><td valign=\"top\"> region_ph<br>
                    region_ps</td>
-          <td> Bug in region determination corrected.
+          <td valign=\"top\"> Bug in region determination corrected.
           </td>
 </tr>
 
-<tr><td> boilingcurve_p<br>
+<tr><td valign=\"top\"> boilingcurve_p<br>
                    dewcurve_p</td>
-          <td> Bug in equation of plim corrected.
+          <td valign=\"top\"> Bug in equation of plim corrected.
           </td>
 </tr>
 </table>
@@ -6165,104 +6165,104 @@ units are wrong or errors in documentation):
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Blocks.</strong></td></tr>
-<tr><td> Examples</td>
-          <td> Corrected typos in description texts of bus example models.
+<tr><td valign=\"top\"> Examples</td>
+          <td valign=\"top\"> Corrected typos in description texts of bus example models.
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Blocks.Continuous.</strong></td></tr>
-<tr><td> LimIntegrator</td>
-          <td> removed incorrect smooth(0,..) because expression might be discontinuous.
+<tr><td valign=\"top\"> LimIntegrator</td>
+          <td valign=\"top\"> removed incorrect smooth(0,..) because expression might be discontinuous.
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Blocks.Math.UnitConversions.</strong></td></tr>
-<tr><td> block_To_kWh<br>block_From_kWh</td>
-          <td> Corrected unit from \"kWh\" to (syntactically correct) \"kW.h\".
+<tr><td valign=\"top\"> block_To_kWh<br>block_From_kWh</td>
+          <td valign=\"top\"> Corrected unit from \"kWh\" to (syntactically correct) \"kW.h\".
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Analog.Examples.</strong></td></tr>
-<tr><td> HeatingNPN_OrGate</td>
-          <td> Included start values, so that initialization is
+<tr><td valign=\"top\"> HeatingNPN_OrGate</td>
+          <td valign=\"top\"> Included start values, so that initialization is
                                                 successful </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Analog.Lines.</strong></td></tr>
-<tr><td> OLine</td>
-          <td> Corrected unit from \"Siemens/m\" to \"S/m\".
+<tr><td valign=\"top\"> OLine</td>
+          <td valign=\"top\"> Corrected unit from \"Siemens/m\" to \"S/m\".
            </td></tr>
-<tr><td> TLine2</td>
-          <td> Changed wrong type of parameter NL (normalized length) from
+<tr><td valign=\"top\"> TLine2</td>
+          <td valign=\"top\"> Changed wrong type of parameter NL (normalized length) from
                    SIunits.Length to Real.
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Digital.Delay.</strong></td></tr>
-<tr><td> TransportDelay</td>
-          <td> Syntax error corrected
+<tr><td valign=\"top\"> TransportDelay</td>
+          <td valign=\"top\"> Syntax error corrected
                    (\":=\" in equation section is converted by Dymola silently to \"=\").
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.Digital</strong></td></tr>
-<tr><td> Converters</td>
-          <td> Syntax error corrected
+<tr><td valign=\"top\"> Converters</td>
+          <td valign=\"top\"> Syntax error corrected
                    (\":=\" in equation section is converted by Dymola silently to \"=\").
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.MultiPhase.Basic.</strong></td></tr>
-<tr><td> Conductor</td>
-          <td> Changed wrong type of parameter G from SIunits.Resistance to
+<tr><td valign=\"top\"> Conductor</td>
+          <td valign=\"top\"> Changed wrong type of parameter G from SIunits.Resistance to
                    SIunits.Conductance.
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.MultiPhase.Interfaces.</strong></td></tr>
-<tr><td> Plug<br></td>
-          <td> Made used \"pin\" connectors non-graphical (otherwise,
+<tr><td valign=\"top\"> Plug<br></td>
+          <td valign=\"top\"> Made used \"pin\" connectors non-graphical (otherwise,
                    there are difficulties to connect to Plug).
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Electrical.MultiPhase.Sources.</strong></td></tr>
-<tr><td> SineCurrent</td>
-          <td> Changed wrong type of parameter offset from SIunits.Voltage to
+<tr><td valign=\"top\"> SineCurrent</td>
+          <td valign=\"top\"> Changed wrong type of parameter offset from SIunits.Voltage to
                    SIunits.Current.
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Examples.Loops.</strong></td></tr>
-<tr><td> EngineV6</td>
-          <td> Corrected wrong crankAngleOffset of some cylinders
+<tr><td valign=\"top\"> EngineV6</td>
+          <td valign=\"top\"> Corrected wrong crankAngleOffset of some cylinders
                    and improved the example.
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Examples.Loops.Utilities.</strong></td></tr>
-<tr><td> GasForce</td>
-          <td> Wrong units corrected:
+<tr><td valign=\"top\"> GasForce</td>
+          <td valign=\"top\"> Wrong units corrected:
                    \"SIunitsPosition x,y\" to \"Real x,y\";
            \"SIunits.Pressure press\" to \"SIunits.Conversions.NonSIunits.Pressure_bar\"
            </td>
 </tr>
-<tr><td> GasForce2</td>
-          <td> Wrong unit corrected: \"SIunits.Position x\" to \"Real x\".
+<tr><td valign=\"top\"> GasForce2</td>
+          <td valign=\"top\"> Wrong unit corrected: \"SIunits.Position x\" to \"Real x\".
            </td>
 </tr>
-<tr><td> EngineV6_analytic</td>
-          <td> Corrected wrong crankAngleOffset of some cylinders.
+<tr><td valign=\"top\"> EngineV6_analytic</td>
+          <td valign=\"top\"> Corrected wrong crankAngleOffset of some cylinders.
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Interfaces.</strong></td></tr>
-<tr><td> PartialLineForce</td>
-          <td> Corrected wrong unit: \"SIunits.Position eRod_a\" to \"Real eRod_a\";
+<tr><td valign=\"top\"> PartialLineForce</td>
+          <td valign=\"top\"> Corrected wrong unit: \"SIunits.Position eRod_a\" to \"Real eRod_a\";
            </td>
 </tr>
-<tr><td> FlangeWithBearingAdaptor </td>
-          <td> If includeBearingConnector = false, connector \"fr\"
+<tr><td valign=\"top\"> FlangeWithBearingAdaptor </td>
+          <td valign=\"top\"> If includeBearingConnector = false, connector \"fr\"
                            + \"ame\" was not
                    removed. As long as the connecting element to \"frame\" determines
                    the non-flow variables, this is fine. In the corrected version, \"frame\"
@@ -6270,49 +6270,49 @@ units are wrong or errors in documentation):
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Forces.</strong></td></tr>
-<tr><td> ForceAndTorque</td>
-          <td> Corrected wrong unit: \"SIunits.Force t_b_0\" to \"SIunits.Torque t_b_0\".
+<tr><td valign=\"top\"> ForceAndTorque</td>
+          <td valign=\"top\"> Corrected wrong unit: \"SIunits.Force t_b_0\" to \"SIunits.Torque t_b_0\".
            </td>
 </tr>
-<tr><td> LineForceWithTwoMasses</td>
-          <td> Corrected wrong unit: \"SIunits.Position e_rel_0\" to \"Real e_rel_0\".
+<tr><td valign=\"top\"> LineForceWithTwoMasses</td>
+          <td valign=\"top\"> Corrected wrong unit: \"SIunits.Position e_rel_0\" to \"Real e_rel_0\".
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Frames.</strong></td></tr>
-<tr><td> axisRotation</td>
-          <td> Corrected wrong unit: \"SIunits.Angle der_angle\" to
+<tr><td valign=\"top\"> axisRotation</td>
+          <td valign=\"top\"> Corrected wrong unit: \"SIunits.Angle der_angle\" to
                         \"SIunits.AngularVelocity der_angle\".
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Joints.Assemblies.</strong></td></tr>
-<tr><td> JointUSP<br>JointSSP</td>
-          <td> Corrected wrong unit: \"SIunits.Position aux\"  to \"Real\"
+<tr><td valign=\"top\"> JointUSP<br>JointSSP</td>
+          <td valign=\"top\"> Corrected wrong unit: \"SIunits.Position aux\"  to \"Real\"
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Sensors.</strong></td></tr>
-<tr><td> AbsoluteSensor</td>
-          <td> Corrected wrong units: \"SIunits.Acceleration angles\" to
+<tr><td valign=\"top\"> AbsoluteSensor</td>
+          <td valign=\"top\"> Corrected wrong units: \"SIunits.Acceleration angles\" to
                    \"SIunits.Angle angles\" and
                    \"SIunits.Velocity w_abs_0\" to \"SIunits.AngularVelocity w_abs_0\"
            </td>
 </tr>
-<tr><td> RelativeSensor</td>
-          <td> Corrected wrong units: \"SIunits.Acceleration angles\" to
+<tr><td valign=\"top\"> RelativeSensor</td>
+          <td valign=\"top\"> Corrected wrong units: \"SIunits.Acceleration angles\" to
                    \"SIunits.Angle angles\"
            </td>
 </tr>
-<tr><td> Distance</td>
-          <td> Corrected wrong units: \"SIunits.Length L2\" to \"SIunits.Area L2\" and
+<tr><td valign=\"top\"> Distance</td>
+          <td valign=\"top\"> Corrected wrong units: \"SIunits.Length L2\" to \"SIunits.Area L2\" and
                    SIunits.Length s_small2\" to \"SIunits.Area s_small2\"
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.MultiBody.Visualizers.Advanced.</strong></td></tr>
-<tr><td> Shape</td>
-          <td> Changed \"MultiBody.Types.Color color\" to \"Real color[3]\", since
+<tr><td valign=\"top\"> Shape</td>
+          <td valign=\"top\"> Changed \"MultiBody.Types.Color color\" to \"Real color[3]\", since
                    \"Types.Color\" is \"Integer color[3]\" and there have been backward
                    compatibility problems with models using \"color\" before it was changed
                    to \"Types.Color\".
@@ -6320,8 +6320,8 @@ units are wrong or errors in documentation):
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Rotational.Interfaces.</strong></td></tr>
-<tr><td> FrictionBase</td>
-          <td> Rewrote equations with new variables \"unitAngularAcceleration\" and
+<tr><td valign=\"top\"> FrictionBase</td>
+          <td valign=\"top\"> Rewrote equations with new variables \"unitAngularAcceleration\" and
                    \"unitTorque\" in order that the equations are correct with respect
                    to units (previously, variable \"s\" can be both a torque and an
                    angular acceleration and this lead to unit incompatibilities)
@@ -6329,8 +6329,8 @@ units are wrong or errors in documentation):
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Rotational.</strong></td></tr>
-<tr><td> OneWayClutch<br>LossyGear</td>
-          <td> Rewrote equations with new variables \"unitAngularAcceleration\" and
+<tr><td valign=\"top\"> OneWayClutch<br>LossyGear</td>
+          <td valign=\"top\"> Rewrote equations with new variables \"unitAngularAcceleration\" and
                    \"unitTorque\" in order that the equations are correct with respect
                    to units (previously, variable \"s\" can be both a torque and an
                    angular acceleration and this lead to unit incompatibilities)
@@ -6338,8 +6338,8 @@ units are wrong or errors in documentation):
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Translational.Interfaces.</strong></td></tr>
-<tr><td> FrictionBase</td>
-          <td> Rewrote equations with new variables \"unitAngularAcceleration\" and
+<tr><td valign=\"top\"> FrictionBase</td>
+          <td valign=\"top\"> Rewrote equations with new variables \"unitAngularAcceleration\" and
                    \"unitTorque\" in order that the equations are correct with respect
                    to units (previously, variable \"s\" can be both a torque and an
                    angular acceleration and this lead to unit incompatibilities)
@@ -6347,66 +6347,66 @@ units are wrong or errors in documentation):
 </tr>
 
 <tr><td colspan=\"2\"><strong>Mechanics.Translational.</strong></td></tr>
-<tr><td> Speed</td>
-          <td> Corrected unit of v_ref from SIunits.Position to SIunits.Velocity
+<tr><td valign=\"top\"> Speed</td>
+          <td valign=\"top\"> Corrected unit of v_ref from SIunits.Position to SIunits.Velocity
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Examples.Tests.Components.</strong></td></tr>
-<tr><td> PartialTestModel<br>PartialTestModel2</td>
-          <td> Corrected unit of h_start from \"SIunits.Density\" to \"SIunits.SpecificEnthalpy\"
+<tr><td valign=\"top\"> PartialTestModel<br>PartialTestModel2</td>
+          <td valign=\"top\"> Corrected unit of h_start from \"SIunits.Density\" to \"SIunits.SpecificEnthalpy\"
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Examples.SolveOneNonlinearEquation.</strong></td></tr>
-<tr><td> Inverse_sh_T
+<tr><td valign=\"top\"> Inverse_sh_T
                    InverseIncompressible_sh_T<br>
                    Inverse_sh_TX</td>
-          <td> Rewrote equations so that dimensional (unit) analysis is correct\"
+          <td valign=\"top\"> Rewrote equations so that dimensional (unit) analysis is correct\"
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Incompressible.Examples.</strong></td></tr>
-<tr><td> TestGlycol</td>
-          <td> Rewrote equations so that dimensional (unit) analysis is correct\"
+<tr><td valign=\"top\"> TestGlycol</td>
+          <td valign=\"top\"> Rewrote equations so that dimensional (unit) analysis is correct\"
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Interfaces.PartialTwoPhaseMedium.</strong></td></tr>
-<tr><td> dBubbleDensity_dPressure<br>dDewDensity_dPressure</td>
-          <td> Changed wrong type of ddldp from \"DerDensityByEnthalpy\"
+<tr><td valign=\"top\"> dBubbleDensity_dPressure<br>dDewDensity_dPressure</td>
+          <td valign=\"top\"> Changed wrong type of ddldp from \"DerDensityByEnthalpy\"
                    to \"DerDensityByPressure\".
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Common.ThermoFluidSpecial.</strong></td></tr>
-<tr><td> ThermoProperties</td>
-          <td> Changed wrong units:
+<tr><td valign=\"top\"> ThermoProperties</td>
+          <td valign=\"top\"> Changed wrong units:
                    \"SIunits.DerEnergyByPressure dupT\" to \"Real dupT\" and
                    \"SIunits.DerEnergyByDensity dudT\" to \"Real dudT\"
            </td>
 </tr>
-<tr><td> ThermoProperties_ph</td>
-          <td> Changed wrong unit from \"SIunits.DerEnergyByPressure duph\" to \"Real duph\"
+<tr><td valign=\"top\"> ThermoProperties_ph</td>
+          <td valign=\"top\"> Changed wrong unit from \"SIunits.DerEnergyByPressure duph\" to \"Real duph\"
            </td>
 </tr>
-<tr><td> ThermoProperties_pT</td>
-          <td> Changed wrong unit from \"SIunits.DerEnergyByPressure dupT\" to \"Real dupT\"
+<tr><td valign=\"top\"> ThermoProperties_pT</td>
+          <td valign=\"top\"> Changed wrong unit from \"SIunits.DerEnergyByPressure dupT\" to \"Real dupT\"
            </td>
 </tr>
-<tr><td> ThermoProperties_dT</td>
-          <td>  Changed wrong unit from \"SIunits.DerEnergyByDensity dudT\" to \"Real dudT\"
+<tr><td valign=\"top\"> ThermoProperties_dT</td>
+          <td valign=\"top\">  Changed wrong unit from \"SIunits.DerEnergyByDensity dudT\" to \"Real dudT\"
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.IdealGases.Common.SingleGasNasa.</strong></td></tr>
-<tr><td> cp_Tlow_der</td>
-          <td> Changed wrong unit from \"SIunits.Temperature dT\" to \"Real dT\".
+<tr><td valign=\"top\"> cp_Tlow_der</td>
+          <td valign=\"top\"> Changed wrong unit from \"SIunits.Temperature dT\" to \"Real dT\".
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Water.IF97_Utilities.BaseIF97.Basic.</strong></td></tr>
-<tr><td> p1_hs<br>
+<tr><td valign=\"top\"> p1_hs<br>
                    h2ab_s<br>
                    p2a_hs<br>
                    p2b_hs<br>
@@ -6420,36 +6420,36 @@ units are wrong or errors in documentation):
                    T3b_ps<br>
                    v3a_ps<br>
                    v3b_ps</td>
-          <td> Changed wrong unit of variables h/hstar, s, sstar from
+          <td valign=\"top\"> Changed wrong unit of variables h/hstar, s, sstar from
                    \"SIunits.Enthalpy\" to \"SIunits.SpecificEnthalpy\",
                    \"SIunits.SpecificEntropy\", \"SIunits.SpecificEntropy
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Water.IF97_Utilities.BaseIF97.Transport.</strong></td></tr>
-<tr><td> cond_dTp</td>
-          <td> Changed wrong unit of TREL, rhoREL, lambdaREL from
+<tr><td valign=\"top\"> cond_dTp</td>
+          <td valign=\"top\"> Changed wrong unit of TREL, rhoREL, lambdaREL from
                    \"SIunits.Temperature\", \"SIunit.Density\", \"SIunits.ThermalConductivity\"
                    to \"Real\".
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Water.IF97_Utilities.BaseIF97.Inverses.</strong></td></tr>
-<tr><td> tofps5<br>tofpst5</td>
-          <td> Changed wrong unit of pros from \"SIunits.SpecificEnthalpy\" to
+<tr><td valign=\"top\"> tofps5<br>tofpst5</td>
+          <td valign=\"top\"> Changed wrong unit of pros from \"SIunits.SpecificEnthalpy\" to
                    \"SIunits.SpecificEntropy\".
            </td>
 </tr>
 
 <tr><td colspan=\"2\"><strong>Media.Water.IF97_Utilities.</strong></td></tr>
-<tr><td> waterBaseProp_ph</td>
-          <td> Improved calculation at the limits of the validity.
+<tr><td valign=\"top\"> waterBaseProp_ph</td>
+          <td valign=\"top\"> Improved calculation at the limits of the validity.
            </td>
 </tr>
 
         <tr><td colspan=\"2\"><strong>Thermal.</strong></td></tr>
-<tr><td> FluidHeatFlow<br>HeatTransfer</td>
-          <td> Corrected wrong unit \"SIunits.Temperature\" of difference temperature
+<tr><td valign=\"top\"> FluidHeatFlow<br>HeatTransfer</td>
+          <td valign=\"top\"> Corrected wrong unit \"SIunits.Temperature\" of difference temperature
                         variables with \"SIunits.TemperatureDifference\".
            </td>
 </tr>
@@ -6512,112 +6512,112 @@ The following <strong>new components</strong> have been added to <strong>existin
 
 <table border=\"1\" cellspacing=0 cellpadding=2>
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Examples.</strong></td></tr>
-<tr><td> PID_Controller</td>
-          <td> Example to demonstrate the usage of the
+<tr><td valign=\"top\"> PID_Controller</td>
+          <td valign=\"top\"> Example to demonstrate the usage of the
                    Blocks.Continuous.LimPID block.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Math.</strong></td></tr>
-<tr><td> UnitConversions.*</td>
-          <td> New package that provides blocks for unit conversions.
+<tr><td valign=\"top\"> UnitConversions.*</td>
+          <td valign=\"top\"> New package that provides blocks for unit conversions.
                    UnitConversions.ConvertAllBlocks allows to select all
                    available conversions from a menu.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines.BasicMachines.SynchronousInductionMachines.</strong></td></tr>
-<tr><td> SM_ElectricalExcitedDamperCage</td>
-          <td> Electrical excited synchronous induction machine with damper cage</td></tr>
+<tr><td valign=\"top\"> SM_ElectricalExcitedDamperCage</td>
+          <td valign=\"top\"> Electrical excited synchronous induction machine with damper cage</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines.BasicMachines.Components.</strong></td></tr>
-<tr><td> ElectricalExcitation </td>
-          <td> Electrical excitation for electrical excited synchronous
+<tr><td valign=\"top\"> ElectricalExcitation </td>
+          <td valign=\"top\"> Electrical excitation for electrical excited synchronous
                    induction machines</td></tr>
-<tr><td> DamperCage</td>
-          <td> Unsymmetrical damper cage for electrical excited synchronous
+<tr><td valign=\"top\"> DamperCage</td>
+          <td valign=\"top\"> Unsymmetrical damper cage for electrical excited synchronous
                    induction machines. At least the user has to specify the dampers
                    resistance and stray inductance in d-axis; if he omits the
                    parameters of the q-axis, the same values as for the d.axis
                    are used, assuming a symmetrical damper.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines.Examples.</strong></td></tr>
-<tr><td> SMEE_Gen </td>
-          <td> Test example 7: ElectricalExcitedSynchronousInductionMachine
+<tr><td valign=\"top\"> SMEE_Gen </td>
+          <td valign=\"top\"> Test example 7: ElectricalExcitedSynchronousInductionMachine
                    as Generator</td></tr>
-<tr><td> Utilities.TerminalBox</td>
-          <td> Terminal box for three-phase induction machines to choose
+<tr><td valign=\"top\"> Utilities.TerminalBox</td>
+          <td valign=\"top\"> Terminal box for three-phase induction machines to choose
                    either star (wye) ? or delta ? connection</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math.Matrices.</strong></td></tr>
-<tr><td> equalityLeastSquares</td>
-          <td> Solve a linear equality constrained least squares problem:<br>
+<tr><td valign=\"top\"> equalityLeastSquares</td>
+          <td valign=\"top\"> Solve a linear equality constrained least squares problem:<br>
                   min|A*x-a|^2 subject to B*x=b</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.</strong></td></tr>
-<tr><td> Parts.PointMass</td>
-          <td> Point mass, i.e., body where inertia tensor is neglected.</td></tr>
-<tr><td> Interfaces.FlangeWithBearing</td>
-          <td> Connector consisting of 1-dim. rotational flange and its
+<tr><td valign=\"top\"> Parts.PointMass</td>
+          <td valign=\"top\"> Point mass, i.e., body where inertia tensor is neglected.</td></tr>
+<tr><td valign=\"top\"> Interfaces.FlangeWithBearing</td>
+          <td valign=\"top\"> Connector consisting of 1-dim. rotational flange and its
                    3-dim. bearing frame.</td></tr>
-<tr><td> Interfaces.FlangeWithBearingAdaptor</td>
-          <td> Adaptor to allow direct connections to the sub-connectors
+<tr><td valign=\"top\"> Interfaces.FlangeWithBearingAdaptor</td>
+          <td valign=\"top\"> Adaptor to allow direct connections to the sub-connectors
                    of FlangeWithBearing.</td></tr>
-<tr><td> Types.SpecularCoefficient</td>
-          <td> New type to define a specular coefficient.</td></tr>
-<tr><td> Types.ShapeExtra</td>
-          <td> New type to define the extra data for visual shape objects and to
+<tr><td valign=\"top\"> Types.SpecularCoefficient</td>
+          <td valign=\"top\"> New type to define a specular coefficient.</td></tr>
+<tr><td valign=\"top\"> Types.ShapeExtra</td>
+          <td valign=\"top\"> New type to define the extra data for visual shape objects and to
                    have a central place for the documentation of this data.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.Examples.Elementary</strong></td></tr>
-<tr><td> PointGravityWithPointMasses</td>
-          <td> Example of two point masses in a central gravity field.</td></tr>
+<tr><td valign=\"top\"> PointGravityWithPointMasses</td>
+          <td valign=\"top\"> Example of two point masses in a central gravity field.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Rotational.</strong></td></tr>
-<tr><td>UsersGuide</td>
-          <td> A User's Guide has been added by using the documentation previously
+<tr><td valign=\"top\">UsersGuide</td>
+          <td valign=\"top\"> A User's Guide has been added by using the documentation previously
                    present in the package documentation of Rotational.</td></tr>
-<tr><td>Sensors.PowerSensor</td>
-          <td> New component to measure the energy flow between two connectors
+<tr><td valign=\"top\">Sensors.PowerSensor</td>
+          <td valign=\"top\"> New component to measure the energy flow between two connectors
                    of the Rotational library.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Translational.</strong></td></tr>
-<tr><td>Speed</td>
-          <td> New component to move a translational flange
+<tr><td valign=\"top\">Speed</td>
+          <td valign=\"top\"> New component to move a translational flange
                    according to a reference speed</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Media.Interfaces.PartialMedium.</strong></td></tr>
-<tr><td>specificEnthalpy_pTX</td>
-          <td> New function to compute specific enthalpy from pressure, temperature
+<tr><td valign=\"top\">specificEnthalpy_pTX</td>
+          <td valign=\"top\"> New function to compute specific enthalpy from pressure, temperature
                    and mass fractions.</td></tr>
-<tr><td>temperature_phX</td>
-          <td> New function to compute temperature from pressure, specific enthalpy,
+<tr><td valign=\"top\">temperature_phX</td>
+          <td valign=\"top\"> New function to compute temperature from pressure, specific enthalpy,
                    and mass fractions.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Icons.</strong></td></tr>
-<tr><td> SignalBus</td>
-          <td> Icon for signal bus</td></tr>
-<tr><td> SignalSubBus</td>
-          <td> Icon for signal sub-bus</td></tr>
+<tr><td valign=\"top\"> SignalBus</td>
+          <td valign=\"top\"> Icon for signal bus</td></tr>
+<tr><td valign=\"top\"> SignalSubBus</td>
+          <td valign=\"top\"> Icon for signal sub-bus</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.SIunits.</strong></td></tr>
-<tr><td>UsersGuide</td>
-          <td> A User's Guide has been added that describes unit handling.</td></tr>
-<tr><td> Resistance<br>
+<tr><td valign=\"top\">UsersGuide</td>
+          <td valign=\"top\"> A User's Guide has been added that describes unit handling.</td></tr>
+<tr><td valign=\"top\"> Resistance<br>
                    Conductance</td>
-          <td> Attribute 'min=0' removed from these types.</td></tr>
+          <td valign=\"top\"> Attribute 'min=0' removed from these types.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Thermal.FluidHeatFlow.</strong></td></tr>
-<tr><td> Components.Valve</td>
-          <td> Simple controlled valve with either linear or
+<tr><td valign=\"top\"> Components.Valve</td>
+          <td valign=\"top\"> Simple controlled valve with either linear or
                    exponential characteristic.</td></tr>
-<tr><td> Sources. IdealPump </td>
-          <td> Simple ideal pump (resp. fan)  dependent on the shaft's speed;
+<tr><td valign=\"top\"> Sources. IdealPump </td>
+          <td valign=\"top\"> Simple ideal pump (resp. fan)  dependent on the shaft's speed;
                    pressure increase versus volume flow is defined as a linear
                    function. Torque * Speed = Pressure increase * Volume flow
                    (without losses).</td></tr>
-<tr><td> Examples.PumpAndValve </td>
-          <td> Test example for valves.</td></tr>
-<tr><td> Examples.PumpDropOut </td>
-          <td> Drop out of 1 pump to test behavior of semiLinear.</td></tr>
-<tr><td> Examples.ParallelPumpDropOut </td>
-          <td> Drop out of 2 parallel pumps to test behavior of semiLinear.</td></tr>
-<tr><td> Examples.OneMass </td>
-          <td> Cooling of 1 hot mass to test behavior of semiLinear.</td></tr>
-<tr><td> Examples.TwoMass </td>
-          <td> Cooling of 2 hot masses to test behavior of semiLinear.</td></tr>
+<tr><td valign=\"top\"> Examples.PumpAndValve </td>
+          <td valign=\"top\"> Test example for valves.</td></tr>
+<tr><td valign=\"top\"> Examples.PumpDropOut </td>
+          <td valign=\"top\"> Drop out of 1 pump to test behavior of semiLinear.</td></tr>
+<tr><td valign=\"top\"> Examples.ParallelPumpDropOut </td>
+          <td valign=\"top\"> Drop out of 2 parallel pumps to test behavior of semiLinear.</td></tr>
+<tr><td valign=\"top\"> Examples.OneMass </td>
+          <td valign=\"top\"> Cooling of 1 hot mass to test behavior of semiLinear.</td></tr>
+<tr><td valign=\"top\"> Examples.TwoMass </td>
+          <td valign=\"top\"> Cooling of 2 hot masses to test behavior of semiLinear.</td></tr>
 </table>
 
 <p>
@@ -6626,62 +6626,62 @@ The following <strong>components</strong> have been improved:
 
 <table border=\"1\" cellspacing=0 cellpadding=2>
 <tr><td colspan=\"2\"><strong>Modelica.</strong></td></tr>
-<tr><td> UsersGuide</td>
-          <td> User's Guide and package description of Modelica Standard Library improved.</td></tr>
+<tr><td valign=\"top\"> UsersGuide</td>
+          <td valign=\"top\"> User's Guide and package description of Modelica Standard Library improved.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Interfaces.</strong></td></tr>
-<tr><td> RealInput<br>
+<tr><td valign=\"top\"> RealInput<br>
                    BooleanInput<br>
                    IntegerInput</td>
-          <td> When dragging one of these connectors the width and height
+          <td valign=\"top\"> When dragging one of these connectors the width and height
                    is a factor of 2 larger as a standard icon. Previously,
                    these connectors have been dragged and then manually enlarged
                    by a factor of 2 in the Modelica standard library.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.</strong></td></tr>
-<tr><td> Continuous.*</td>
-          <td> Initialization options added to all blocks
+<tr><td valign=\"top\"> Continuous.*</td>
+          <td valign=\"top\"> Initialization options added to all blocks
                    (NoInit, SteadyState, InitialState, InitialOutput).
                    New parameter limitsAtInit to switch off the limits
                    of LimIntegrator or LimPID during initialization</td></tr>
-<tr><td> Continuous.LimPID</td>
-          <td> Option to select P, PI, PD, PID controller.
+<tr><td valign=\"top\"> Continuous.LimPID</td>
+          <td valign=\"top\"> Option to select P, PI, PD, PID controller.
                    Documentation significantly improved.</td></tr>
-<tr><td> Nonlinear.Limiter<br>
+<tr><td valign=\"top\"> Nonlinear.Limiter<br>
                    Nonlinear.VariableLimiter<br>
                    Nonlinear.Deadzone</td>
-          <td> New parameter limitsAtInit/deadZoneAtInit to switch off the limits
+          <td valign=\"top\"> New parameter limitsAtInit/deadZoneAtInit to switch off the limits
                    or the dead zone during initialization</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog. </strong></td></tr>
-<tr><td> Sources</td>
-          <td> Icon improved (+/- added to voltage sources, arrow added to
+<tr><td valign=\"top\"> Sources</td>
+          <td valign=\"top\"> Icon improved (+/- added to voltage sources, arrow added to
                    current sources).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Semiconductors. </strong></td></tr>
-<tr><td> Diode</td>
-          <td> smooth() operator included to improve numerics.</td></tr>
+<tr><td valign=\"top\"> Diode</td>
+          <td valign=\"top\"> smooth() operator included to improve numerics.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines.BasicMachines.SynchronousInductionMachines. </strong></td></tr>
-<tr><td> SM_PermanentMagnetDamperCage<br>
+<tr><td valign=\"top\"> SM_PermanentMagnetDamperCage<br>
                    SM_ElectricalExcitedDamperCage<br>
                    SM_ReluctanceRotorDamperCage</td>
-          <td> The user can choose \"DamperCage = false\" (default: true)
+          <td valign=\"top\"> The user can choose \"DamperCage = false\" (default: true)
                    to remove all equations for the damper cage from the model.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines.BasicMachines.AsynchronousInductionMachines. </strong></td></tr>
-<tr><td> AIM_SlipRing</td>
-          <td> Easier parameterization: if the user selects \"useTurnsRatio = false\"
+<tr><td valign=\"top\"> AIM_SlipRing</td>
+          <td valign=\"top\"> Easier parameterization: if the user selects \"useTurnsRatio = false\"
                    (default: true, this is the same behavior as before),
                         parameter TurnsRatio is calculated internally from
                         Nominal stator voltage and Locked-rotor voltage.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Math.Matrices.</strong></td></tr>
-<tr><td>leastSquares</td>
-          <td>The A matrix in the least squares problem might be rank deficient.
+<tr><td valign=\"top\">leastSquares</td>
+          <td valign=\"top\">The A matrix in the least squares problem might be rank deficient.
                   Previously, it was required that A has full rank.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.</strong></td></tr>
-<tr><td>all models</td>
-          <td> <ul>
+<tr><td valign=\"top\">all models</td>
+          <td valign=\"top\"> <ul>
                    <li> All components with animation information have a new variable
                                 <strong>specularCoefficient</strong> to define the reflection of ambient light.
                                 The default value is world.defaultSpecularCoefficient which has
@@ -6711,21 +6711,21 @@ The following <strong>components</strong> have been improved:
                                 dimension 0 or 1.</li>
                    </ul></td></tr>
 
-<tr><td>Frames.resolveRelative</td>
-          <td> The derivative of this function added as function and defined via
+<tr><td valign=\"top\">Frames.resolveRelative</td>
+          <td valign=\"top\"> The derivative of this function added as function and defined via
                    an annotation. In certain situations, tools had previously
                    difficulties to differentiate the inlined function automatically.</td></tr>
 
-<tr><td>Forces.*</td>
-          <td> The scaling factors N_to_m and Nm_to_m have no longer a default
+<tr><td valign=\"top\">Forces.*</td>
+          <td valign=\"top\"> The scaling factors N_to_m and Nm_to_m have no longer a default
                    value of 1000 but a default value of world.defaultN_to_m (=1000)
                    and world.defaultNm_to_m (=1000). This allows to change the
                    scaling factors for all forces and torques in the world
                    object.</td></tr>
-<tr><td>Interfaces.Frame.a<br>
+<tr><td valign=\"top\">Interfaces.Frame.a<br>
                   Interfaces.Frame.b<br>
                   Interfaces.Frame_resolve</td>
-          <td> The Frame connectors are now centered around the origin to ease
+          <td valign=\"top\"> The Frame connectors are now centered around the origin to ease
                    the usage. The shape was changed, such that the icon is a factor
                    of 1.6 larger as a standard icon (previously, the icon had a
                    standard size when dragged and then the icon was manually enlarged
@@ -6734,54 +6734,54 @@ The following <strong>components</strong> have been improved:
                    The double line width of the border in icon and diagram layer was changed
                    to a single line width and when making a connection the connection
                    line is dark grey and no longer black which looks better.</td></tr>
-<tr><td>Joints.Assemblies.*</td>
-          <td> When dragging an assembly joint, the icon is a factor of 2
+<tr><td valign=\"top\">Joints.Assemblies.*</td>
+          <td valign=\"top\"> When dragging an assembly joint, the icon is a factor of 2
                    larger as a standard icon. Icon texts and connectors have a
                    standard size in this enlarged icon (and are not a factor of 2
                    larger as previously).</td></tr>
-<tr><td>Types.*</td>
-          <td> All types have a corresponding icon now to visualize the content
+<tr><td valign=\"top\">Types.*</td>
+          <td valign=\"top\"> All types have a corresponding icon now to visualize the content
                    in the package browser (previously, the types did not have an icon).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Rotational.</strong></td></tr>
-<tr><td> Inertia</td>
-          <td> Initialization and state selection added.</td></tr>
-<tr><td> SpringDamper</td>
-          <td> Initialization and state selection added.</td></tr>
-<tr><td> Move</td>
-          <td> New implementation based solely on Modelica 2.2 language
+<tr><td valign=\"top\"> Inertia</td>
+          <td valign=\"top\"> Initialization and state selection added.</td></tr>
+<tr><td valign=\"top\"> SpringDamper</td>
+          <td valign=\"top\"> Initialization and state selection added.</td></tr>
+<tr><td valign=\"top\"> Move</td>
+          <td valign=\"top\"> New implementation based solely on Modelica 2.2 language
                    (previously, the Dymola specific constrain(..) function was used).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Translational.</strong></td></tr>
-<tr><td> Move</td>
-          <td> New implementation based solely on Modelica 2.2 language
+<tr><td valign=\"top\"> Move</td>
+          <td valign=\"top\"> New implementation based solely on Modelica 2.2 language
                    (previously, the Dymola specific constrain(..) function was used).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Thermal.FluidHeatFlow.Interfaces.Partials.</strong></td></tr>
-<tr><td> SimpleFriction</td>
-          <td> Calculates friction losses from pressure drop and volume flow.</td></tr>
+<tr><td valign=\"top\"> SimpleFriction</td>
+          <td valign=\"top\"> Calculates friction losses from pressure drop and volume flow.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Thermal.FluidHeatFlow.Components.</strong></td></tr>
-<tr><td> IsolatedPipe<br>
+<tr><td valign=\"top\"> IsolatedPipe<br>
                    HeatedPipe</td>
-          <td> Added geodetic height as a source of pressure change;
+          <td valign=\"top\"> Added geodetic height as a source of pressure change;
                    feeds friction losses as calculated by simple friction to
                    the energy balance of the medium.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Media.Interfaces.PartialMedium.FluidConstants.</strong></td></tr>
-<tr><td>HCRIT0</td><td>Critical specific enthalpy of the fundamental
+<tr><td valign=\"top\">HCRIT0</td><td valign=\"top\">Critical specific enthalpy of the fundamental
                   equation (base formulation of the fluid medium model).</td></tr>
-<tr><td>SCRIT0</td><td>Critical specific entropy of the fundamental
+<tr><td valign=\"top\">SCRIT0</td><td valign=\"top\">Critical specific entropy of the fundamental
                   equation (base formulation of the fluid medium model).</td></tr>
-<tr><td>deltah</td><td>Enthalpy offset (default: 0) between the
+<tr><td valign=\"top\">deltah</td><td valign=\"top\">Enthalpy offset (default: 0) between the
                   specific enthalpy of the fluid model and the user-visible
                   specific enthalpy in the model: deltah = h_model - h_fundamentalEquation.
 </td></tr>
-<tr><td>deltas</td><td>Entropy offset (default: 0) between the
+<tr><td valign=\"top\">deltas</td><td valign=\"top\">Entropy offset (default: 0) between the
                   specific entropy of the fluid model and the user-visible
                   specific entropy in the model: deltas = s_model - s_fundamentalEquation.</td></tr>
-<tr><td>T_default</td><td>Default value for temperature of medium (for initialization)</td></tr>
-<tr><td>h_default</td><td>Default value for specific enthalpy of medium (for initialization)</td></tr>
-<tr><td>p_default</td><td>Default value for pressure of medium (for initialization)</td></tr>
-<tr><td>X_default</td><td>Default value for mass fractions of medium (for initialization)</td></tr>
+<tr><td valign=\"top\">T_default</td><td valign=\"top\">Default value for temperature of medium (for initialization)</td></tr>
+<tr><td valign=\"top\">h_default</td><td valign=\"top\">Default value for specific enthalpy of medium (for initialization)</td></tr>
+<tr><td valign=\"top\">p_default</td><td valign=\"top\">Default value for pressure of medium (for initialization)</td></tr>
+<tr><td valign=\"top\">X_default</td><td valign=\"top\">Default value for mass fractions of medium (for initialization)</td></tr>
 </table>
 <p>
 The following <strong>errors</strong> have been fixed:
@@ -6789,10 +6789,10 @@ The following <strong>errors</strong> have been fixed:
 
 <table border=\"1\" cellspacing=0 cellpadding=2>
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Tables.</strong></td></tr>
-<tr><td>CombiTable1D<br>
+<tr><td valign=\"top\">CombiTable1D<br>
                   CombiTable1Ds<br>
                   CombiTable2D</td>
-          <td> Parameter \"tableOnFile\" determines now whether a table is read from
+          <td valign=\"top\"> Parameter \"tableOnFile\" determines now whether a table is read from
                    file or used from parameter \"table\". Previously, if \"fileName\" was not
                    \"NoName\", a table was always read from file \"fileName\", independently
                    of the setting of \"tableOnFile\". This has been corrected.<br>
@@ -6803,16 +6803,16 @@ The following <strong>errors</strong> have been fixed:
                    (and occupies also more memory).</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Sources.</strong></td></tr>
-<tr><td>CombiTimeTable</td>
-          <td> Same bug fix/improvement as for the tables from Modelica.Blocks.Tables
+<tr><td valign=\"top\">CombiTimeTable</td>
+          <td valign=\"top\"> Same bug fix/improvement as for the tables from Modelica.Blocks.Tables
                    as outlined above.</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Semiconductors. </strong></td></tr>
-<tr><td> PMOS<br>
+<tr><td valign=\"top\"> PMOS<br>
                    NMOS<br>
                    HeatingPMOS<br>
                    HeatingNMOS</td>
-          <td> The Drain-Source-Resistance RDS had actually a resistance of
+          <td valign=\"top\"> The Drain-Source-Resistance RDS had actually a resistance of
                    RDS/v, with v=Beta*(W+dW)/(L+dL). The correct formula is without
                    the division by \"v\". This has now been corrected.<br>
                    This bug fix should not have an essential effect in most applications.
@@ -6822,13 +6822,13 @@ The following <strong>errors</strong> have been fixed:
                    was that this resistance had practically no effect.</td></tr>
 
 <tr><td colspan=\"2\"> <strong>Modelica.Media.IdealGases.Common.SingleGasNasa.</strong></td></tr>
-<tr><td> dynamicViscosityLowPressure</td>
-          <td> Viscosity and thermal conductivity (which needs viscosity as input)
+<tr><td valign=\"top\"> dynamicViscosityLowPressure</td>
+          <td valign=\"top\"> Viscosity and thermal conductivity (which needs viscosity as input)
                    were computed wrong for polar gases and gas mixtures
                    (i.e., if dipole moment not 0.0). This has been fixed in version 2.2.1.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Utilities.Streams.</strong></td></tr>
-<tr><td>readLine</td>
-          <td> Depending on the C-implementation, the stream was not correctly closed.
+<tr><td valign=\"top\">readLine</td>
+          <td valign=\"top\"> Depending on the C-implementation, the stream was not correctly closed.
                    This has been corrected by adding a \"Streams.close(..)\"
                    after reading the file content.</td></tr>
 
@@ -6850,8 +6850,8 @@ The following <strong>new libraries</strong> have been added:
 </p>
 
 <table border=\"1\" cellspacing=0 cellpadding=2>
-<tr><td><a href=\"modelica://Modelica.Media\">Modelica.Media</a></td>
-          <td> Property models of liquids and gases, especially
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Media\">Modelica.Media</a></td>
+          <td valign=\"top\"> Property models of liquids and gases, especially
                    <ul>
                    <li>1241 detailed gas models,</li>
                    <li> moist air,</li>
@@ -6875,8 +6875,8 @@ The following <strong>new libraries</strong> have been added:
                                 dynamic simulation.</li>
                    </ul>
           </td></tr>
-<tr><td><a href=\"modelica://Modelica.Thermal.FluidHeatFlow\">Modelica.Thermal.FluidHeatFlow</a></td>
-          <td> Simple components for 1-dim., incompressible thermo-fluid flow
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Thermal.FluidHeatFlow\">Modelica.Thermal.FluidHeatFlow</a></td>
+          <td valign=\"top\"> Simple components for 1-dim., incompressible thermo-fluid flow
                    to model coolant flows, e.g., of electrical machines.
                    Components can be connected arbitrarily together (= ideal mixing
                    at connection points) and fluid may reverse direction of flow.
@@ -6946,28 +6946,28 @@ before automatic conversion is performed.
 The following <strong>new libraries</strong> have been added:
 </p>
 <table border=\"1\" cellspacing=0 cellpadding=2>
-<tr><td><a href=\"modelica://Modelica.Electrical.Digital\">Modelica.Electrical.Digital</a></td>
-          <td>Digital electrical components based on 2-,3-,4-, and 9-valued logic<br>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Electrical.Digital\">Modelica.Electrical.Digital</a></td>
+          <td valign=\"top\">Digital electrical components based on 2-,3-,4-, and 9-valued logic<br>
                   according to the VHDL standard</td></tr>
-<tr><td><a href=\"modelica://Modelica.Electrical.Machines\">Modelica.Electrical.Machines</a></td>
-          <td>Asynchronous, synchronous and DC motor and generator models</td></tr>
-<tr><td><a href=\"modelica://Modelica.Math.Matrices\">Modelica.Math.Matrices</a></td>
-          <td>Functions operating on matrices such as solve() (A*x=b), leastSquares(),<br>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Electrical.Machines\">Modelica.Electrical.Machines</a></td>
+          <td valign=\"top\">Asynchronous, synchronous and DC motor and generator models</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Math.Matrices\">Modelica.Math.Matrices</a></td>
+          <td valign=\"top\">Functions operating on matrices such as solve() (A*x=b), leastSquares(),<br>
                   norm(), LU(), QR(),  eigenValues(), singularValues(), exp(), ...</td></tr>
-<tr><td><a href=\"modelica://Modelica.StateGraph\">Modelica.StateGraph</a></td>
-          <td> Modeling of <strong>discrete event</strong> and <strong>reactive</strong> systems in a convenient way using<br>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.StateGraph\">Modelica.StateGraph</a></td>
+          <td valign=\"top\"> Modeling of <strong>discrete event</strong> and <strong>reactive</strong> systems in a convenient way using<br>
                    <strong>hierarchical state machines</strong> and <strong>Modelica</strong> as <strong>action language</strong>.<br>
                    It is based on JGrafchart and Grafcet and  has a similar modeling power as<br>
                    StateCharts. It avoids deficiencies of usually used action languages.<br>
                    This library makes the ModelicaAdditions.PetriNets library obsolete.</td></tr>
-<tr><td><a href=\"modelica://Modelica.Utilities.Files\">Modelica.Utilities.Files</a></td>
-          <td>Functions to operate on files and directories (copy, move, remove files etc.)</td></tr>
-<tr><td><a href=\"modelica://Modelica.Utilities.Streams\">Modelica.Utilities.Streams</a></td>
-          <td>Read from files and write to files (print, readLine, readFile, error, ...)</td></tr>
-<tr><td><a href=\"modelica://Modelica.Utilities.Strings\">Modelica.Utilities.Strings</a></td>
-          <td>Operations on strings (substring, find, replace, sort, scanToken, ...)</td></tr>
-<tr><td><a href=\"modelica://Modelica.Utilities.System\">Modelica.Utilities.System</a></td>
-          <td>Get/set current directory, get/set environment variable, execute shell command, etc.</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Files\">Modelica.Utilities.Files</a></td>
+          <td valign=\"top\">Functions to operate on files and directories (copy, move, remove files etc.)</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Streams\">Modelica.Utilities.Streams</a></td>
+          <td valign=\"top\">Read from files and write to files (print, readLine, readFile, error, ...)</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Strings\">Modelica.Utilities.Strings</a></td>
+          <td valign=\"top\">Operations on strings (substring, find, replace, sort, scanToken, ...)</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.System\">Modelica.Utilities.System</a></td>
+          <td valign=\"top\">Get/set current directory, get/set environment variable, execute shell command, etc.</td></tr>
 </table>
 <p>
 The following existing libraries outside of the Modelica standard library
@@ -6976,23 +6976,23 @@ have been improved and added as <strong>new libraries</strong>
 to the new sublibraries inside package Modelica):
 </p>
 <table border=\"1\" cellspacing=0 cellpadding=2>
-<tr><td><a href=\"modelica://Modelica.Blocks.Discrete\">Modelica.Blocks.Discrete</a></td>
-          <td> Discrete input/output blocks with fixed sample period<br>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Blocks.Discrete\">Modelica.Blocks.Discrete</a></td>
+          <td valign=\"top\"> Discrete input/output blocks with fixed sample period<br>
                    (from ModelicaAdditions.Blocks.Discrete)</td></tr>
-<tr><td><a href=\"modelica://Modelica.Blocks.Logical\">Modelica.Blocks.Logical</a></td>
-          <td> Logical components with Boolean input and output signals<br>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Blocks.Logical\">Modelica.Blocks.Logical</a></td>
+          <td valign=\"top\"> Logical components with Boolean input and output signals<br>
                    (from ModelicaAdditions.Blocks.Logical)</td></tr>
-<tr><td><a href=\"modelica://Modelica.Blocks.Nonlinear\">Modelica.Blocks.Nonlinear</a></td>
-          <td> Discontinuous or non-differentiable algebraic control blocks such as variable limiter,<br>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Blocks.Nonlinear\">Modelica.Blocks.Nonlinear</a></td>
+          <td valign=\"top\"> Discontinuous or non-differentiable algebraic control blocks such as variable limiter,<br>
                    fixed, variable and Pade delay etc. (from ModelicaAdditions.Blocks.Nonlinear)</td></tr>
-<tr><td><a href=\"modelica://Modelica.Blocks.Routing\">Modelica.Blocks.Routing</a></td>
-          <td> Blocks to combine and extract signals, such as multiplexer<br>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Blocks.Routing\">Modelica.Blocks.Routing</a></td>
+          <td valign=\"top\"> Blocks to combine and extract signals, such as multiplexer<br>
                    (from ModelicaAdditions.Blocks.Multiplexer)</td></tr>
-<tr><td><a href=\"modelica://Modelica.Blocks.Tables\">Modelica.Blocks.Tables</a></td>
-          <td> One and two-dimensional interpolation in tables. CombiTimeTable is available<br>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Blocks.Tables\">Modelica.Blocks.Tables</a></td>
+          <td valign=\"top\"> One and two-dimensional interpolation in tables. CombiTimeTable is available<br>
                    in Modelica.Blocks.Sources (from ModelicaAdditions.Tables)</td></tr>
-<tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody\">Modelica.Mechanics.MultiBody</a></td>
-          <td> Components to model the movement of 3-dimensional mechanical systems. Contains<br>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody\">Modelica.Mechanics.MultiBody</a></td>
+          <td valign=\"top\"> Components to model the movement of 3-dimensional mechanical systems. Contains<br>
                    body, joint, force and sensor components, analytic handling of kinematic loops,<br>
                    force elements with mass, series/parallel connection of 3D force elements etc.<br>
                    (from MultiBody 1.0 where the new signal connectors are used;<br>
@@ -7008,69 +7008,69 @@ The following <strong>new components</strong> have been added to <strong>existin
 </p>
 <table border=\"1\" cellspacing=0 cellpadding=2>
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Logical.</strong></td></tr>
-<tr><td>Pre</td>
-          <td>y = pre(u): Breaks algebraic loops by an infinitesimal small<br>
+<tr><td valign=\"top\">Pre</td>
+          <td valign=\"top\">y = pre(u): Breaks algebraic loops by an infinitesimal small<br>
                   time delay (event iteration continues until u = pre(u))</td></tr>
-<tr><td>Edge</td>
-          <td>y = edge(u): Output y is true, if the input u has a rising edge </td></tr>
-<tr><td>FallingEdge</td>
-          <td>y = edge(not u): Output y is true, if the input u has a falling edge </td></tr>
-<tr><td>Change</td>
-          <td>y = change(u): Output y is true, if the input u has a rising or falling edge </td></tr>
-<tr><td>GreaterEqual</td>
-          <td>Output y is true, if input u1 is greater or equal than input u2 </td></tr>
-<tr><td>Less</td>
-          <td>Output y is true, if input u1 is less than input u2 </td></tr>
-<tr><td>LessEqual</td>
-          <td>Output y is true, if input u1 is less or equal than input u2 </td></tr>
-<tr><td>Timer</td>
-          <td>Timer measuring the time from the time instant where the<br>
+<tr><td valign=\"top\">Edge</td>
+          <td valign=\"top\">y = edge(u): Output y is true, if the input u has a rising edge </td></tr>
+<tr><td valign=\"top\">FallingEdge</td>
+          <td valign=\"top\">y = edge(not u): Output y is true, if the input u has a falling edge </td></tr>
+<tr><td valign=\"top\">Change</td>
+          <td valign=\"top\">y = change(u): Output y is true, if the input u has a rising or falling edge </td></tr>
+<tr><td valign=\"top\">GreaterEqual</td>
+          <td valign=\"top\">Output y is true, if input u1 is greater or equal than input u2 </td></tr>
+<tr><td valign=\"top\">Less</td>
+          <td valign=\"top\">Output y is true, if input u1 is less than input u2 </td></tr>
+<tr><td valign=\"top\">LessEqual</td>
+          <td valign=\"top\">Output y is true, if input u1 is less or equal than input u2 </td></tr>
+<tr><td valign=\"top\">Timer</td>
+          <td valign=\"top\">Timer measuring the time from the time instant where the<br>
                   Boolean input became true </td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Math.</strong></td></tr>
-<tr><td>BooleanToReal</td>
-          <td>Convert Boolean to Real signal</td></tr>
-<tr><td>BooleanToInteger</td>
-          <td>Convert Boolean to Integer signal</td></tr>
-<tr><td>RealToBoolean</td>
-          <td>Convert Real to Boolean signal</td></tr>
-<tr><td>IntegerToBoolean</td>
-          <td>Convert Integer to Boolean signal</td></tr>
+<tr><td valign=\"top\">BooleanToReal</td>
+          <td valign=\"top\">Convert Boolean to Real signal</td></tr>
+<tr><td valign=\"top\">BooleanToInteger</td>
+          <td valign=\"top\">Convert Boolean to Integer signal</td></tr>
+<tr><td valign=\"top\">RealToBoolean</td>
+          <td valign=\"top\">Convert Real to Boolean signal</td></tr>
+<tr><td valign=\"top\">IntegerToBoolean</td>
+          <td valign=\"top\">Convert Integer to Boolean signal</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Sources.</strong></td></tr>
-<tr><td>RealExpression</td>
-          <td>Set output signal to a time varying Real expression</td></tr>
-<tr><td>IntegerExpression</td>
-          <td>Set output signal to a time varying Integer expression</td></tr>
-<tr><td>BooleanExpression</td>
-          <td>Set output signal to a time varying Boolean expression</td></tr>
-<tr><td>BooleanTable</td>
-          <td>Generate a Boolean output signal based on a vector of time instants</td></tr>
+<tr><td valign=\"top\">RealExpression</td>
+          <td valign=\"top\">Set output signal to a time varying Real expression</td></tr>
+<tr><td valign=\"top\">IntegerExpression</td>
+          <td valign=\"top\">Set output signal to a time varying Integer expression</td></tr>
+<tr><td valign=\"top\">BooleanExpression</td>
+          <td valign=\"top\">Set output signal to a time varying Boolean expression</td></tr>
+<tr><td valign=\"top\">BooleanTable</td>
+          <td valign=\"top\">Generate a Boolean output signal based on a vector of time instants</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.</strong></td></tr>
-<tr><td>Frames.from_T2</td>
-          <td>Return orientation object R from transformation matrix T and its derivative der(T)</td></tr>
+<tr><td valign=\"top\">Frames.from_T2</td>
+          <td valign=\"top\">Return orientation object R from transformation matrix T and its derivative der(T)</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Rotational.</strong></td></tr>
-<tr><td>LinearSpeedDependentTorque</td>
-          <td>Linear dependency of torque versus speed (acts as load torque)</td></tr>
-<tr><td>QuadraticSpeedDependentTorque</td>
-          <td>Quadratic dependency of torque versus speed (acts as load torque)</td></tr>
-<tr><td>ConstantTorque</td>
-          <td>Constant torque, not dependent on speed (acts as load torque)</td></tr>
-<tr><td>ConstantSpeed</td>
-          <td>Constant speed, not dependent on torque (acts as load torque)</td></tr>
-<tr><td>TorqueStep</td>
-          <td>Constant torque, not dependent on speed (acts as load torque)</td></tr>
+<tr><td valign=\"top\">LinearSpeedDependentTorque</td>
+          <td valign=\"top\">Linear dependency of torque versus speed (acts as load torque)</td></tr>
+<tr><td valign=\"top\">QuadraticSpeedDependentTorque</td>
+          <td valign=\"top\">Quadratic dependency of torque versus speed (acts as load torque)</td></tr>
+<tr><td valign=\"top\">ConstantTorque</td>
+          <td valign=\"top\">Constant torque, not dependent on speed (acts as load torque)</td></tr>
+<tr><td valign=\"top\">ConstantSpeed</td>
+          <td valign=\"top\">Constant speed, not dependent on torque (acts as load torque)</td></tr>
+<tr><td valign=\"top\">TorqueStep</td>
+          <td valign=\"top\">Constant torque, not dependent on speed (acts as load torque)</td></tr>
 </table>
 <p>
 The following <strong>bugs</strong> have been <strong>corrected</strong>:
 </p>
 <table border=\"1\" cellspacing=0 cellpadding=2>
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.MultiBody.Forces.</strong></td></tr>
-<tr><td>LineForceWithMass<br>
+<tr><td valign=\"top\">LineForceWithMass<br>
                   Spring</td>
-          <td>If mass of the line force or spring component is not zero, the<br>
+          <td valign=\"top\">If mass of the line force or spring component is not zero, the<br>
                   mass was (implicitly) treated as \"mass*mass\" instead of as \"mass\"</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Rotational.</strong></td></tr>
-<tr><td>Speed</td>
-          <td>If parameter exact=<strong>false</strong>, the filter was wrong<br>
+<tr><td valign=\"top\">Speed</td>
+          <td valign=\"top\">If parameter exact=<strong>false</strong>, the filter was wrong<br>
                   (position was filtered and not the speed input signal)</td></tr>
 </table>
 <p>
@@ -7113,27 +7113,27 @@ class Version_1_6 "Version 1.6 (June 21, 2004)"
 </p>
 <table border=\"1\" cellspacing=0 cellpadding=2>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Basic.</strong></td></tr>
-<tr><td>SaturatingInductor</td>
-          <td>Simple model of an inductor with saturation</td></tr>
-<tr><td>VariableResistor</td>
-          <td>Ideal linear electrical resistor with variable resistance</td></tr>
-<tr><td>VariableConductor</td>
-          <td>Ideal linear electrical conductor with variable conductance</td></tr>
-<tr><td>VariableCapacitor</td>
-          <td>Ideal linear electrical capacitor with variable capacitance</td></tr>
-<tr><td>VariableInductor</td>
-          <td>Ideal linear electrical inductor with variable inductance</td></tr>
+<tr><td valign=\"top\">SaturatingInductor</td>
+          <td valign=\"top\">Simple model of an inductor with saturation</td></tr>
+<tr><td valign=\"top\">VariableResistor</td>
+          <td valign=\"top\">Ideal linear electrical resistor with variable resistance</td></tr>
+<tr><td valign=\"top\">VariableConductor</td>
+          <td valign=\"top\">Ideal linear electrical conductor with variable conductance</td></tr>
+<tr><td valign=\"top\">VariableCapacitor</td>
+          <td valign=\"top\">Ideal linear electrical capacitor with variable capacitance</td></tr>
+<tr><td valign=\"top\">VariableInductor</td>
+          <td valign=\"top\">Ideal linear electrical inductor with variable inductance</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Semiconductors.</strong></td></tr>
-<tr><td>HeatingDiode</td>
-          <td>Simple diode with heating port</td></tr>
-<tr><td>HeatingNMOS</td>
-          <td>Simple MOS Transistor with heating port</td></tr>
-<tr><td>HeatingPMOS</td>
-          <td>Simple PMOS Transistor with heating port</td></tr>
-<tr><td>HeatingNPN</td>
-          <td>Simple NPN BJT according to Ebers-Moll with heating port</td></tr>
-<tr><td>HeatingPNP</td>
-          <td>Simple PNP BJT according to Ebers-Moll with heating port</td></tr>
+<tr><td valign=\"top\">HeatingDiode</td>
+          <td valign=\"top\">Simple diode with heating port</td></tr>
+<tr><td valign=\"top\">HeatingNMOS</td>
+          <td valign=\"top\">Simple MOS Transistor with heating port</td></tr>
+<tr><td valign=\"top\">HeatingPMOS</td>
+          <td valign=\"top\">Simple PMOS Transistor with heating port</td></tr>
+<tr><td valign=\"top\">HeatingNPN</td>
+          <td valign=\"top\">Simple NPN BJT according to Ebers-Moll with heating port</td></tr>
+<tr><td valign=\"top\">HeatingPNP</td>
+          <td valign=\"top\">Simple PNP BJT according to Ebers-Moll with heating port</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.MultiPhase</strong><br>
           A new library for multi-phase electrical circuits</td></tr>
 </table>
@@ -7165,12 +7165,12 @@ with not much computational effort.</p>
 <p> In the Modelica.SIunits library, the following changes
         have been made:</p>
 <table border=\"1\" cellspacing=0 cellpadding=2>
-<tr><td>Inductance</td>
-          <td>min=0 removed</td></tr>
-<tr><td>SelfInductance</td>
-          <td>min=0 added</td></tr>
-<tr><td>ThermodynamicTemperature</td>
-          <td>min=0 added</td></tr>
+<tr><td valign=\"top\">Inductance</td>
+          <td valign=\"top\">min=0 removed</td></tr>
+<tr><td valign=\"top\">SelfInductance</td>
+          <td valign=\"top\">min=0 added</td></tr>
+<tr><td valign=\"top\">ThermodynamicTemperature</td>
+          <td valign=\"top\">min=0 added</td></tr>
 </table>
 </html>"));
 end Version_1_6;
@@ -7192,81 +7192,81 @@ class Version_1_5 "Version 1.5 (Dec. 16, 2002)"
 </p>
 <table border=\"1\" cellspacing=0 cellpadding=2>
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.</strong></td></tr>
-<tr><td>Continuous.Der</td><td>Derivative of input (= analytic differentiations)</td></tr>
-<tr><td><strong><em>Examples</em></strong></td><td>Demonstration examples of the components of this package</td></tr>
-<tr><td>Nonlinear.VariableLimiter</td><td>Limit the range of a signal with variable limits</td></tr>
+<tr><td valign=\"top\">Continuous.Der</td><td valign=\"top\">Derivative of input (= analytic differentiations)</td></tr>
+<tr><td valign=\"top\"><strong><em>Examples</em></strong></td><td valign=\"top\">Demonstration examples of the components of this package</td></tr>
+<tr><td valign=\"top\">Nonlinear.VariableLimiter</td><td valign=\"top\">Limit the range of a signal with variable limits</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Interfaces.</strong></td></tr>
-<tr><td>RealPort</td><td>Real port (both input/output possible)</td></tr>
-<tr><td>IntegerPort</td><td>Integer port (both input/output possible)</td></tr>
-<tr><td>BooleanPort</td><td>Boolean port (both input/output possible)</td></tr>
-<tr><td>SIMO</td><td>Single Input Multiple Output continuous control block</td></tr>
-<tr><td>IntegerBlockIcon</td><td>Basic graphical layout of Integer block</td></tr>
-<tr><td>IntegerMO</td><td>Multiple Integer Output continuous control block</td></tr>
-<tr><td>IntegerSignalSource</td><td>Base class for continuous Integer signal source</td></tr>
-<tr><td>IntegerMIBooleanMOs</td><td>Multiple Integer Input Multiple Boolean Output continuous control block with same number of inputs and outputs</td></tr>
-<tr><td>BooleanMIMOs</td><td>Multiple Input Multiple Output continuous control block with same number of inputs and outputs of Boolean type</td></tr>
-<tr><td><strong><em>BusAdaptors</em></strong></td><td>Components to send signals to the bus or receive signals from the bus</td></tr>
+<tr><td valign=\"top\">RealPort</td><td valign=\"top\">Real port (both input/output possible)</td></tr>
+<tr><td valign=\"top\">IntegerPort</td><td valign=\"top\">Integer port (both input/output possible)</td></tr>
+<tr><td valign=\"top\">BooleanPort</td><td valign=\"top\">Boolean port (both input/output possible)</td></tr>
+<tr><td valign=\"top\">SIMO</td><td valign=\"top\">Single Input Multiple Output continuous control block</td></tr>
+<tr><td valign=\"top\">IntegerBlockIcon</td><td valign=\"top\">Basic graphical layout of Integer block</td></tr>
+<tr><td valign=\"top\">IntegerMO</td><td valign=\"top\">Multiple Integer Output continuous control block</td></tr>
+<tr><td valign=\"top\">IntegerSignalSource</td><td valign=\"top\">Base class for continuous Integer signal source</td></tr>
+<tr><td valign=\"top\">IntegerMIBooleanMOs</td><td valign=\"top\">Multiple Integer Input Multiple Boolean Output continuous control block with same number of inputs and outputs</td></tr>
+<tr><td valign=\"top\">BooleanMIMOs</td><td valign=\"top\">Multiple Input Multiple Output continuous control block with same number of inputs and outputs of Boolean type</td></tr>
+<tr><td valign=\"top\"><strong><em>BusAdaptors</em></strong></td><td valign=\"top\">Components to send signals to the bus or receive signals from the bus</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Math.</strong></td></tr>
-<tr><td>RealToInteger</td><td>Convert real to integer signals</td></tr>
-<tr><td>IntegerToReal</td><td>Convert integer to real signals</td></tr>
-<tr><td>Max</td><td>Pass through the largest signal</td></tr>
-<tr><td>Min</td><td>Pass through the smallest signal</td></tr>
-<tr><td>Edge</td><td>Indicates rising edge of Boolean signal</td></tr>
-<tr><td>BooleanChange</td><td>Indicates Boolean signal changing</td></tr>
-<tr><td>IntegerChange</td><td>Indicates integer signal changing</td></tr>
+<tr><td valign=\"top\">RealToInteger</td><td valign=\"top\">Convert real to integer signals</td></tr>
+<tr><td valign=\"top\">IntegerToReal</td><td valign=\"top\">Convert integer to real signals</td></tr>
+<tr><td valign=\"top\">Max</td><td valign=\"top\">Pass through the largest signal</td></tr>
+<tr><td valign=\"top\">Min</td><td valign=\"top\">Pass through the smallest signal</td></tr>
+<tr><td valign=\"top\">Edge</td><td valign=\"top\">Indicates rising edge of Boolean signal</td></tr>
+<tr><td valign=\"top\">BooleanChange</td><td valign=\"top\">Indicates Boolean signal changing</td></tr>
+<tr><td valign=\"top\">IntegerChange</td><td valign=\"top\">Indicates integer signal changing</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Blocks.Sources.</strong></td></tr>
-<tr><td>IntegerConstant</td><td>Generate constant signals of type Integer</td></tr>
-<tr><td>IntegerStep</td><td>Generate step signals of type Integer</td></tr>
+<tr><td valign=\"top\">IntegerConstant</td><td valign=\"top\">Generate constant signals of type Integer</td></tr>
+<tr><td valign=\"top\">IntegerStep</td><td valign=\"top\">Generate step signals of type Integer</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Basic.</strong></td></tr>
-<tr><td>HeatingResistor</td><td>Temperature dependent electrical resistor</td></tr>
-<tr><td>OpAmp</td><td>Simple nonideal model of an OpAmp with limitation</td></tr>
+<tr><td valign=\"top\">HeatingResistor</td><td valign=\"top\">Temperature dependent electrical resistor</td></tr>
+<tr><td valign=\"top\">OpAmp</td><td valign=\"top\">Simple nonideal model of an OpAmp with limitation</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Ideal.</strong></td></tr>
-<tr><td>IdealCommutingSwitch</td><td>Ideal commuting switch</td></tr>
-<tr><td>IdealIntermediateSwitch</td><td>Ideal intermediate switch</td></tr>
-<tr><td>ControlledIdealCommutingSwitch</td><td>Controlled ideal commuting switch</td></tr>
-<tr><td>ControlledIdealIntermediateSwitch</td><td>Controlled ideal intermediate switch</td></tr>
-<tr><td>IdealOpAmpLimited</td><td>Ideal operational amplifier with limitation</td></tr>
-<tr><td>IdealOpeningSwitch</td><td>Ideal opener</td></tr>
-<tr><td>IdealClosingSwitch</td><td>Ideal closer</td></tr>
-<tr><td>ControlledIdealOpeningSwitch</td><td>Controlled ideal opener</td></tr>
-<tr><td>ControlledIdealClosingSwitch</td><td>Controlled ideal closer</td></tr>
+<tr><td valign=\"top\">IdealCommutingSwitch</td><td valign=\"top\">Ideal commuting switch</td></tr>
+<tr><td valign=\"top\">IdealIntermediateSwitch</td><td valign=\"top\">Ideal intermediate switch</td></tr>
+<tr><td valign=\"top\">ControlledIdealCommutingSwitch</td><td valign=\"top\">Controlled ideal commuting switch</td></tr>
+<tr><td valign=\"top\">ControlledIdealIntermediateSwitch</td><td valign=\"top\">Controlled ideal intermediate switch</td></tr>
+<tr><td valign=\"top\">IdealOpAmpLimited</td><td valign=\"top\">Ideal operational amplifier with limitation</td></tr>
+<tr><td valign=\"top\">IdealOpeningSwitch</td><td valign=\"top\">Ideal opener</td></tr>
+<tr><td valign=\"top\">IdealClosingSwitch</td><td valign=\"top\">Ideal closer</td></tr>
+<tr><td valign=\"top\">ControlledIdealOpeningSwitch</td><td valign=\"top\">Controlled ideal opener</td></tr>
+<tr><td valign=\"top\">ControlledIdealClosingSwitch</td><td valign=\"top\">Controlled ideal closer</td></tr>
 
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Analog.Lines.</strong></td></tr>
-<tr><td>TLine1</td><td>Lossless transmission line (Z0, TD)</td></tr>
-<tr><td>TLine2</td><td>Lossless transmission line (Z0, F, NL)</td></tr>
-<tr><td>TLine2</td><td>Lossless transmission line (Z0, F)</td></tr>
+<tr><td valign=\"top\">TLine1</td><td valign=\"top\">Lossless transmission line (Z0, TD)</td></tr>
+<tr><td valign=\"top\">TLine2</td><td valign=\"top\">Lossless transmission line (Z0, F, NL)</td></tr>
+<tr><td valign=\"top\">TLine2</td><td valign=\"top\">Lossless transmission line (Z0, F)</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Icons.</strong></td></tr>
-<tr><td>Function</td><td>Icon for a function</td></tr>
-<tr><td>Record</td><td>Icon for a record</td></tr>
-<tr><td>Enumeration</td><td>Icon for an enumeration</td></tr>
+<tr><td valign=\"top\">Function</td><td valign=\"top\">Icon for a function</td></tr>
+<tr><td valign=\"top\">Record</td><td valign=\"top\">Icon for a record</td></tr>
+<tr><td valign=\"top\">Enumeration</td><td valign=\"top\">Icon for an enumeration</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Math.</strong></td></tr>
-<tr><td>tempInterpol2</td><td>temporary routine for vectorized linear interpolation (will be removed)</td></tr>
+<tr><td valign=\"top\">tempInterpol2</td><td valign=\"top\">temporary routine for vectorized linear interpolation (will be removed)</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Mechanics.Rotational.</strong></td></tr>
-<tr><td>Examples.LossyGearDemo1</td><td>Example to show that gear efficiency may lead to stuck motion</td></tr>
-<tr><td>Examples.LossyGearDemo2</td><td>Example to show combination of LossyGear and BearingFriction</td></tr>
-<tr><td>LossyGear</td><td>Gear with mesh efficiency and bearing friction (stuck/rolling possible)</td></tr>
-<tr><td>Gear2</td><td>Realistic model of a gearbox (based on LossyGear)</td></tr>
+<tr><td valign=\"top\">Examples.LossyGearDemo1</td><td valign=\"top\">Example to show that gear efficiency may lead to stuck motion</td></tr>
+<tr><td valign=\"top\">Examples.LossyGearDemo2</td><td valign=\"top\">Example to show combination of LossyGear and BearingFriction</td></tr>
+<tr><td valign=\"top\">LossyGear</td><td valign=\"top\">Gear with mesh efficiency and bearing friction (stuck/rolling possible)</td></tr>
+<tr><td valign=\"top\">Gear2</td><td valign=\"top\">Realistic model of a gearbox (based on LossyGear)</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.SIunits.</strong></td></tr>
-<tr><td><strong><em>Conversions</em></strong></td><td>Conversion functions to/from non SI units and type definitions of non SI units</td></tr>
-<tr><td>EnergyFlowRate</td><td>Same definition as <em>Power</em></td></tr>
-<tr><td>EnthalpyFlowRate</td><td><code>Real (final quantity=\"EnthalpyFlowRate\", final unit=\"W\")</code></td></tr>
+<tr><td valign=\"top\"><strong><em>Conversions</em></strong></td><td valign=\"top\">Conversion functions to/from non SI units and type definitions of non SI units</td></tr>
+<tr><td valign=\"top\">EnergyFlowRate</td><td valign=\"top\">Same definition as <em>Power</em></td></tr>
+<tr><td valign=\"top\">EnthalpyFlowRate</td><td valign=\"top\"><code>Real (final quantity=\"EnthalpyFlowRate\", final unit=\"W\")</code></td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.</strong></td></tr>
-<tr><td><strong><em>Thermal.HeatTransfer</em></strong></td><td>1-dimensional heat transfer with lumped elements</td></tr>
+<tr><td valign=\"top\"><strong><em>Thermal.HeatTransfer</em></strong></td><td valign=\"top\">1-dimensional heat transfer with lumped elements</td></tr>
 <tr><td colspan=\"2\"><strong>ModelicaAdditions.Blocks.Discrete.</strong></td></tr>
-<tr><td>TriggeredSampler</td><td>Triggered sampling of continuous signals</td></tr>
-<tr><td>TriggeredMax</td><td>Compute maximum, absolute value of continuous signal at trigger instants</td></tr>
+<tr><td valign=\"top\">TriggeredSampler</td><td valign=\"top\">Triggered sampling of continuous signals</td></tr>
+<tr><td valign=\"top\">TriggeredMax</td><td valign=\"top\">Compute maximum, absolute value of continuous signal at trigger instants</td></tr>
 <tr><td colspan=\"2\"><strong>ModelicaAdditions.Blocks.Logical.Interfaces.</strong></td></tr>
-<tr><td>BooleanMIRealMOs</td><td>Multiple Boolean Input Multiple Real Output continuous control block with same number of inputs and outputs</td></tr>
-<tr><td>RealMIBooleanMOs</td><td>Multiple Real Input Multiple Boolean Output continuous control block with same number of inputs and outputs</td></tr>
+<tr><td valign=\"top\">BooleanMIRealMOs</td><td valign=\"top\">Multiple Boolean Input Multiple Real Output continuous control block with same number of inputs and outputs</td></tr>
+<tr><td valign=\"top\">RealMIBooleanMOs</td><td valign=\"top\">Multiple Real Input Multiple Boolean Output continuous control block with same number of inputs and outputs</td></tr>
 <tr><td colspan=\"2\"><strong>ModelicaAdditions.Blocks.Logical.</strong></td></tr>
-<tr><td>TriggeredTrapezoid</td><td>Triggered trapezoid generator</td></tr>
-<tr><td>Hysteresis</td><td>Transform Real to Boolean with Hysteresis</td></tr>
-<tr><td>OnOffController</td><td>On-off controller</td></tr>
-<tr><td>Compare</td><td>True, if signal of inPort1 is larger than signal of inPort2</td></tr>
-<tr><td>ZeroCrossing</td><td>Trigger zero crossing of input signal</td></tr>
+<tr><td valign=\"top\">TriggeredTrapezoid</td><td valign=\"top\">Triggered trapezoid generator</td></tr>
+<tr><td valign=\"top\">Hysteresis</td><td valign=\"top\">Transform Real to Boolean with Hysteresis</td></tr>
+<tr><td valign=\"top\">OnOffController</td><td valign=\"top\">On-off controller</td></tr>
+<tr><td valign=\"top\">Compare</td><td valign=\"top\">True, if signal of inPort1 is larger than signal of inPort2</td></tr>
+<tr><td valign=\"top\">ZeroCrossing</td><td valign=\"top\">Trigger zero crossing of input signal</td></tr>
 <tr><td colspan=\"2\"><strong>ModelicaAdditions.</strong></td></tr>
-<tr><td>Blocks.Multiplexer.Extractor</td><td>Extract scalar signal out of signal vector dependent on IntegerRealInput index</td></tr>
-<tr><td>Tables.CombiTable1Ds</td><td>Table look-up in one dimension (matrix/file) with only single input</td></tr>
+<tr><td valign=\"top\">Blocks.Multiplexer.Extractor</td><td valign=\"top\">Extract scalar signal out of signal vector dependent on IntegerRealInput index</td></tr>
+<tr><td valign=\"top\">Tables.CombiTable1Ds</td><td valign=\"top\">Table look-up in one dimension (matrix/file) with only single input</td></tr>
 </table>
 <p>
 <strong>Package-specific Changes</strong>
@@ -7456,20 +7456,20 @@ main version number is not changed.
 </p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_2_3\">Version 3.2.3</a></td><td>August 1, 2018</td></tr>
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_2_2\">Version 3.2.2</a></td><td>April 3, 2016</td></tr>
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_2_1\">Version 3.2.1</a></td><td>August 14, 2013</td></tr>
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_2\">Version 3.2</a></td><td>Oct. 25, 2010</td></tr>
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_1\">Version 3.1</a></td><td>August 14, 2009</td></tr>
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_0_1\">Version 3.0.1</a></td><td>Jan. 27, 2009</td></tr>
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_0\">Version 3.0</a></td><td>March 1, 2008</td></tr>
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_2_2_2\">Version 2.2.2</a></td><td>Aug. 31, 2007</td></tr>
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_2_2_1\">Version 2.2.1</a></td><td>March 24, 2006</td></tr>
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_2_2\">Version 2.2</a></td><td>April 6, 2005</td></tr>
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_2_1\">Version 2.1</a></td><td>Nov. 11, 2004</td></tr>
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_1_6\">Version 1.6</a></td><td>June 21, 2004</td></tr>
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_1_5\">Version 1.5</a></td><td>Dec. 16, 2002</td></tr>
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_1_4\">Version 1.4</a></td><td>June 28, 2001</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_2_3\">Version 3.2.3</a></td><td>August 1, 2018</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_2_2\">Version 3.2.2</a></td><td>April 3, 2016</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_2_1\">Version 3.2.1</a></td><td>August 14, 2013</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_2\">Version 3.2</a></td><td>Oct. 25, 2010</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_1\">Version 3.1</a></td><td>August 14, 2009</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_0_1\">Version 3.0.1</a></td><td>Jan. 27, 2009</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_0\">Version 3.0</a></td><td>March 1, 2008</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_2_2_2\">Version 2.2.2</a></td><td>Aug. 31, 2007</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_2_2_1\">Version 2.2.1</a></td><td>March 24, 2006</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_2_2\">Version 2.2</a></td><td>April 6, 2005</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_2_1\">Version 2.1</a></td><td>Nov. 11, 2004</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_1_6\">Version 1.6</a></td><td>June 21, 2004</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_1_5\">Version 1.5</a></td><td>Dec. 16, 2002</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_1_4\">Version 1.4</a></td><td>June 28, 2001</td></tr>
 </table>
 </html>"));
 end ReleaseNotes;
@@ -7515,8 +7515,8 @@ class Contact "Contact"
 <p>As of March 21st, 2018, the following library officers are assigned:</p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-<tr><td><strong>Sublibraries</strong> </td>
-   <td><strong>Library officers</strong></td>
+<tr><td valign=\"top\"><strong>Sublibraries</strong> </td>
+   <td valign=\"top\"><strong>Library officers</strong></td>
 </tr>
 
 <tr>
@@ -7667,61 +7667,61 @@ of the Modelica package (many more people have contributed to the design):
 </p>
 
 <table border=1 cellspacing=0 cellpadding=2>
-<tr><td><strong>Marcus Baur</strong></td>
-   <td>Institute of System Dynamics and Control<br>
+<tr><td valign=\"top\"><strong>Marcus Baur</strong></td>
+   <td valign=\"top\">Institute of System Dynamics and Control<br>
      DLR, German Aerospace Center,<br>
      Oberpfaffenhofen, Germany</td>
-   <td>Complex<br>
+   <td valign=\"top\">Complex<br>
                       Modelica.Math.Vectors<br>
                       Modelica.Math.Matrices</td>
 </tr>
 
-<tr><td><strong>Peter Beater</strong></td>
-   <td>University of Paderborn, Germany</td>
-   <td>Modelica.Mechanics.Translational</td>
+<tr><td valign=\"top\"><strong>Peter Beater</strong></td>
+   <td valign=\"top\">University of Paderborn, Germany</td>
+   <td valign=\"top\">Modelica.Mechanics.Translational</td>
 </tr>
 
-<tr><td><strong>Thomas Beutlich</strong></td>
-   <td>ESI ITI GmbH, Germany</td>
-   <td>Modelica.Blocks.Sources.CombiTimeTable<br>
+<tr><td valign=\"top\"><strong>Thomas Beutlich</strong></td>
+   <td valign=\"top\">ESI ITI GmbH, Germany</td>
+   <td valign=\"top\">Modelica.Blocks.Sources.CombiTimeTable<br>
                       Modelica.Blocks.Tables</td>
 </tr>
 
-<tr><td><strong>Thomas B&ouml;drich</strong></td>
-   <td>Dresden University of Technology, Germany</td>
-   <td>Modelica.Magnetic.FluxTubes</td>
+<tr><td valign=\"top\"><strong>Thomas B&ouml;drich</strong></td>
+   <td valign=\"top\">Dresden University of Technology, Germany</td>
+   <td valign=\"top\">Modelica.Magnetic.FluxTubes</td>
 </tr>
 
-<tr><td><strong>Dag Br&uuml;ck</strong></td>
-   <td>Dassault Syst&egrave;mes AB, Lund, Sweden</td>
-   <td>Modelica.Utilities</td>
+<tr><td valign=\"top\"><strong>Dag Br&uuml;ck</strong></td>
+   <td valign=\"top\">Dassault Syst&egrave;mes AB, Lund, Sweden</td>
+   <td valign=\"top\">Modelica.Utilities</td>
 </tr>
 
-<tr><td><strong>Francesco Casella</strong></td>
-   <td>Politecnico di Milano, Milano, Italy</td>
-   <td>Modelica.Fluid<br>
+<tr><td valign=\"top\"><strong>Francesco Casella</strong></td>
+   <td valign=\"top\">Politecnico di Milano, Milano, Italy</td>
+   <td valign=\"top\">Modelica.Fluid<br>
                       Modelica.Media</td>
 </tr>
 
-<tr><td><strong>Christoph Clauss</strong></td>
-   <td>until 2016:<br>
+<tr><td valign=\"top\"><strong>Christoph Clauss</strong></td>
+   <td valign=\"top\">until 2016:<br>
      Fraunhofer Institute for Integrated Circuits,<br>
      Dresden, Germany</td>
-   <td>Modelica.Electrical.Analog<br>
+   <td valign=\"top\">Modelica.Electrical.Analog<br>
                       Modelica.Electrical.Digital<br>
                       Modelica.Electrical.Spice3</td>
 </tr>
 
-<tr><td><strong>Jonas Eborn</strong></td>
-   <td>Modelon AB, Lund, Sweden</td>
-   <td>Modelica.Media</td>
+<tr><td valign=\"top\"><strong>Jonas Eborn</strong></td>
+   <td valign=\"top\">Modelon AB, Lund, Sweden</td>
+   <td valign=\"top\">Modelica.Media</td>
 </tr>
 
-<tr><td><strong>Hilding Elmqvist</strong></td>
-   <td>Mogram AB, Lund, Sweden<br>
+<tr><td valign=\"top\"><strong>Hilding Elmqvist</strong></td>
+   <td valign=\"top\">Mogram AB, Lund, Sweden<br>
      until 2015:<br>
      Dassault Syst&egrave;mes AB, Lund, Sweden</td>
-   <td>Modelica.Mechanics.MultiBody<br>
+   <td valign=\"top\">Modelica.Mechanics.MultiBody<br>
                       Modelica.Fluid<br>
                       Modelica.Media<br>
                       Modelica.StateGraph<br>
@@ -7729,21 +7729,21 @@ of the Modelica package (many more people have contributed to the design):
                       Conversion from 1.6 to 2.0</td>
 </tr>
 
-<tr><td><strong>R&uuml;diger Franke</strong></td>
-   <td>ABB Corporate Research,<br>Ladenburg, Germany</td>
-   <td>Modelica.Fluid<br>
+<tr><td valign=\"top\"><strong>R&uuml;diger Franke</strong></td>
+   <td valign=\"top\">ABB Corporate Research,<br>Ladenburg, Germany</td>
+   <td valign=\"top\">Modelica.Fluid<br>
                       Modelica.Media</td>
 </tr>
 
-<tr><td><strong>Manuel Gr&auml;ber</strong></td>
-   <td>Institut f&uuml;r Thermodynamik,<br>
+<tr><td valign=\"top\"><strong>Manuel Gr&auml;ber</strong></td>
+   <td valign=\"top\">Institut f&uuml;r Thermodynamik,<br>
      Technische Universit&auml;t Braunschweig, Germany</td>
-   <td>Modelica.Fluid</td>
+   <td valign=\"top\">Modelica.Fluid</td>
 </tr>
 
-<tr><td><strong>Anton Haumer</strong></td>
-   <td>Consultant, St.Andrae-Woerdern,<br>Austria</td>
-   <td>Modelica.ComplexBlocks<br>
+<tr><td valign=\"top\"><strong>Anton Haumer</strong></td>
+   <td valign=\"top\">Consultant, St.Andrae-Woerdern,<br>Austria</td>
+   <td valign=\"top\">Modelica.ComplexBlocks<br>
                       Modelica.Electrical.Machines<br>
                       Modelica.Electrical.Multiphase<br>
                       Modelica.Electrical.QuasiStationary<br>
@@ -7757,17 +7757,17 @@ of the Modelica package (many more people have contributed to the design):
                       Conversion from 2.2 to 3.0</td>
 </tr>
 
-<tr><td><strong>Hans-Dieter Joos</strong></td>
-   <td>Institute of System Dynamics and Control<br>
+<tr><td valign=\"top\"><strong>Hans-Dieter Joos</strong></td>
+   <td valign=\"top\">Institute of System Dynamics and Control<br>
      DLR, German Aerospace Center,<br>
      Oberpfaffenhofen, Germany</td>
-   <td>Modelica.Math.Matrices</td>
+   <td valign=\"top\">Modelica.Math.Matrices</td>
 </tr>
 
-<tr><td><strong>Christian Kral</strong></td>
-   <td>Modeling and Simulation of Electric Machines, Drives and Mechatronic Systems,<br>
+<tr><td valign=\"top\"><strong>Christian Kral</strong></td>
+   <td valign=\"top\">Modeling and Simulation of Electric Machines, Drives and Mechatronic Systems,<br>
      Vienna, Austria</td>
-   <td>Modelica.ComplexBlocks<br>
+   <td valign=\"top\">Modelica.ComplexBlocks<br>
                       Modelica.Electrical.Machines<br>
                       Modelica.Electrical.MultiPhase<br>
                       Modelica.Electrical.QuasiStationary<br>
@@ -7780,26 +7780,26 @@ of the Modelica package (many more people have contributed to the design):
   </td>
 </tr>
 
-<tr><td><strong>Sven Erik Mattsson</strong></td>
-   <td>until 2015:<br>
+<tr><td valign=\"top\"><strong>Sven Erik Mattsson</strong></td>
+   <td valign=\"top\">until 2015:<br>
      Dassault Syst&egrave;mes AB, Lund, Sweden</td>
-   <td>Modelica.Mechanics.MultiBody</td>
+   <td valign=\"top\">Modelica.Mechanics.MultiBody</td>
 </tr>
 
-<tr><td><strong>Hans Olsson</strong></td>
-   <td>Dassault Syst&egrave;mes AB, Lund, Sweden</td>
-   <td>Modelica.Blocks<br>
+<tr><td valign=\"top\"><strong>Hans Olsson</strong></td>
+   <td valign=\"top\">Dassault Syst&egrave;mes AB, Lund, Sweden</td>
+   <td valign=\"top\">Modelica.Blocks<br>
                       Modelica.Math.Matrices<br>
                       Modelica.Utilities<br>
                       Conversion from 1.6 to 2.0<br>
                       Conversion from 2.2 to 3.0</td>
 </tr>
 
-<tr><td><strong>Martin Otter</strong></td>
-   <td>Institute of System Dynamics and Control<br>
+<tr><td valign=\"top\"><strong>Martin Otter</strong></td>
+   <td valign=\"top\">Institute of System Dynamics and Control<br>
      DLR, German Aerospace Center,<br>
      Oberpfaffenhofen, Germany</td>
-   <td>Complex<br>
+   <td valign=\"top\">Complex<br>
                       Modelica.Blocks<br>
                       Modelica.Fluid<br>
                       Modelica.Mechanics.MultiBody<br>
@@ -7817,91 +7817,91 @@ of the Modelica package (many more people have contributed to the design):
                       Conversion from 2.2 to 3.0</td>
 </tr>
 
-<tr><td><strong>Katrin Pr&ouml;l&szlig;</strong></td>
-   <td>Modelon Deutschland GmbH, Hamburg, Germany<br>
+<tr><td valign=\"top\"><strong>Katrin Pr&ouml;l&szlig;</strong></td>
+   <td valign=\"top\">Modelon Deutschland GmbH, Hamburg, Germany<br>
      until 2008:<br>
      Department of Technical Thermodynamics,<br>
      Technical University Hamburg-Harburg,<br>Germany</td>
-   <td>Modelica.Fluid<br>
+   <td valign=\"top\">Modelica.Fluid<br>
                             Modelica.Media</td>
 </tr>
 
-<tr><td><strong>Christoph C. Richter</strong></td>
-   <td>until 2009:<br>
+<tr><td valign=\"top\"><strong>Christoph C. Richter</strong></td>
+   <td valign=\"top\">until 2009:<br>
      Institut f&uuml;r Thermodynamik,<br>
      Technische Universit&auml;t Braunschweig,<br>
      Germany</td>
-   <td>Modelica.Fluid<br>
+   <td valign=\"top\">Modelica.Fluid<br>
                       Modelica.Media</td>
 </tr>
 
-<tr><td><strong>Andr&eacute; Schneider</strong></td>
-   <td>Fraunhofer Institute for Integrated Circuits,<br>Dresden, Germany</td>
-   <td>Modelica.Electrical.Analog<br>
+<tr><td valign=\"top\"><strong>Andr&eacute; Schneider</strong></td>
+   <td valign=\"top\">Fraunhofer Institute for Integrated Circuits,<br>Dresden, Germany</td>
+   <td valign=\"top\">Modelica.Electrical.Analog<br>
      Modelica.Electrical.Digital</td>
 </tr>
-<tr><td><strong>Christian Schweiger</strong></td>
-   <td>until 2006:<br>
+<tr><td valign=\"top\"><strong>Christian Schweiger</strong></td>
+   <td valign=\"top\">until 2006:<br>
      Institute of System Dynamics and Control,<br>
      DLR, German Aerospace Center,<br>
      Oberpfaffenhofen, Germany</td>
-   <td>Modelica.Mechanics.Rotational<br>
+   <td valign=\"top\">Modelica.Mechanics.Rotational<br>
                       ModelicaReference<br>
                       Conversion from 1.6 to 2.0</td>
 </tr>
 
-<tr><td><strong>Michael Sielemann</strong></td>
-   <td>Modelon Deutschland GmbH, Munich, Germany<br>
+<tr><td valign=\"top\"><strong>Michael Sielemann</strong></td>
+   <td valign=\"top\">Modelon Deutschland GmbH, Munich, Germany<br>
      previously at:<br>
      Institute of System Dynamics and Control<br>
      DLR, German Aerospace Center,<br>
      Oberpfaffenhofen, Germany</td>
-   <td>Modelica.Fluid<br>
+   <td valign=\"top\">Modelica.Fluid<br>
                       Modelica.Media</td>
 </tr>
 
-<tr><td><strong>Michael Tiller</strong></td>
-   <td>Xogeny Inc., Canton, MI, U.S.A.<br>
+<tr><td valign=\"top\"><strong>Michael Tiller</strong></td>
+   <td valign=\"top\">Xogeny Inc., Canton, MI, U.S.A.<br>
      previously at:<br>
      Emmeskay, Inc., Dearborn, MI, U.S.A.<br>
      previously at:<br>
      Ford Motor Company, Dearborn, MI, U.S.A.</td>
-   <td>Modelica.Media<br>
+   <td valign=\"top\">Modelica.Media<br>
                       Modelica.Thermal.HeatTransfer</td>
 </tr>
 
-<tr><td><strong>Hubertus Tummescheit</strong></td>
-   <td>Modelon, Inc., Hartford, CT, U.S.A.</td>
-   <td>Modelica.Media<br>
+<tr><td valign=\"top\"><strong>Hubertus Tummescheit</strong></td>
+   <td valign=\"top\">Modelon, Inc., Hartford, CT, U.S.A.</td>
+   <td valign=\"top\">Modelica.Media<br>
                       Modelica.Thermal.HeatTransfer</td>
 </tr>
 
-<tr><td><strong>Thorsten Vahlenkamp</strong></td>
-   <td>until 2010:<br>
+<tr><td valign=\"top\"><strong>Thorsten Vahlenkamp</strong></td>
+   <td valign=\"top\">until 2010:<br>
                      XRG Simulation GmbH, Hamburg, Germany</td>
-   <td>Modelica.Fluid.Dissipation</td>
+   <td valign=\"top\">Modelica.Fluid.Dissipation</td>
 </tr>
 
-<tr><td><strong>Nico Walter</strong></td>
-   <td>Master thesis at HTWK Leipzig<br>
+<tr><td valign=\"top\"><strong>Nico Walter</strong></td>
+   <td valign=\"top\">Master thesis at HTWK Leipzig<br>
      (Prof. R. M&uuml;ller) and<br>
      DLR Oberpfaffenhofen, Germany</td>
-   <td>Modelica.Math.Matrices</td>
+   <td valign=\"top\">Modelica.Math.Matrices</td>
 </tr>
 
-<tr><td><strong>Michael Wetter</strong></td>
-   <td>Lawrence Berkeley National Laboratory, Berkeley, CA, U.S.A.</td>
-   <td>Modelica.Fluid</td>
+<tr><td valign=\"top\"><strong>Michael Wetter</strong></td>
+   <td valign=\"top\">Lawrence Berkeley National Laboratory, Berkeley, CA, U.S.A.</td>
+   <td valign=\"top\">Modelica.Fluid</td>
 </tr>
 
-<tr><td><strong>Hans-J&uuml;rg Wiesmann</strong></td>
-   <td>Switzerland</td>
-   <td>Modelica.ComplexMath</td>
+<tr><td valign=\"top\"><strong>Hans-J&uuml;rg Wiesmann</strong></td>
+   <td valign=\"top\">Switzerland</td>
+   <td valign=\"top\">Modelica.ComplexMath</td>
 </tr>
 
-<tr><td><strong>Stefan Wischhusen</strong></td>
-   <td>XRG Simulation GmbH, Hamburg, Germany</td>
-   <td>Modelica.Fluid.Dissipation<br>
+<tr><td valign=\"top\"><strong>Stefan Wischhusen</strong></td>
+   <td valign=\"top\">XRG Simulation GmbH, Hamburg, Germany</td>
+   <td valign=\"top\">Modelica.Fluid.Dissipation<br>
                       Modelica.Media</td>
 </tr>
 </table>
@@ -7928,102 +7928,102 @@ User's Guides that can be accessed by the following links:
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr>
-  <td><a href=\"modelica://Modelica.ComplexBlocks.UsersGuide\">ComplexBlocks</a></td>
-  <td>Library of basic input/output control blocks with Complex signals</td>
+  <td valign=\"top\"><a href=\"modelica://Modelica.ComplexBlocks.UsersGuide\">ComplexBlocks</a></td>
+  <td valign=\"top\">Library of basic input/output control blocks with Complex signals</td>
 </tr>
 
-<tr><td><a href=\"modelica://Modelica.Electrical.Digital.UsersGuide\">Digital</a>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Electrical.Digital.UsersGuide\">Digital</a>
    </td>
-   <td>Library for digital electrical components based on the VHDL standard
+   <td valign=\"top\">Library for digital electrical components based on the VHDL standard
    (2-,3-,4-,9-valued logic)</td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Fluid.Dissipation.UsersGuide\">Dissipation</a></td>
-  <td>Library of functions for convective heat transfer and pressure loss characteristics</td>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Fluid.Dissipation.UsersGuide\">Dissipation</a></td>
+  <td valign=\"top\">Library of functions for convective heat transfer and pressure loss characteristics</td>
 </tr>
 
-<tr><td><a href=\"modelica://Modelica.Fluid.UsersGuide\">Fluid</a></td>
-    <td>Library of 1-dim. thermo-fluid flow models using the Modelica.Media media description</td>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Fluid.UsersGuide\">Fluid</a></td>
+    <td valign=\"top\">Library of 1-dim. thermo-fluid flow models using the Modelica.Media media description</td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Thermal.FluidHeatFlow.UsersGuide\">FluidHeatFlow</a></td>
-  <td>Library of simple components for 1-dimensional incompressible thermo-fluid flow models</td>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Thermal.FluidHeatFlow.UsersGuide\">FluidHeatFlow</a></td>
+  <td valign=\"top\">Library of simple components for 1-dimensional incompressible thermo-fluid flow models</td>
 </tr>
 
-<tr><td><a href=\"modelica://Modelica.Magnetic.FluxTubes.UsersGuide\">FluxTubes</a>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.FluxTubes.UsersGuide\">FluxTubes</a>
     </td>
-   <td>Library for modelling of electromagnetic devices with lumped magnetic networks</td>
+   <td valign=\"top\">Library for modelling of electromagnetic devices with lumped magnetic networks</td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Magnetic.FundamentalWave.UsersGuide\">FundamentalWave</a></td>
-  <td>Library for magnetic fundamental wave effects in electric machines</td>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.FundamentalWave.UsersGuide\">FundamentalWave</a></td>
+  <td valign=\"top\">Library for magnetic fundamental wave effects in electric machines</td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Magnetic.QuasiStatic.FundamentalWave.UsersGuide\">FundamentalWave</a></td>
-  <td>Library for quasi static fundamental wave electric machines</td>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.QuasiStatic.FundamentalWave.UsersGuide\">FundamentalWave</a></td>
+  <td valign=\"top\">Library for quasi static fundamental wave electric machines</td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Electrical.Machines.UsersGuide\">Machines</a></td>
-  <td>Library for electric machines</td>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.Machines.UsersGuide\">Machines</a></td>
+  <td valign=\"top\">Library for electric machines</td>
 </tr>
 
-<tr><td><a href=\"modelica://Modelica.Media.UsersGuide\">Media</a>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Media.UsersGuide\">Media</a>
     </td>
-   <td>Library of media property models</td>
+   <td valign=\"top\">Library of media property models</td>
 </tr>
 
-<tr><td><a href=\"modelica://Modelica.Mechanics.MultiBody.UsersGuide\">MultiBody</a>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.UsersGuide\">MultiBody</a>
     </td>
-   <td>Library to model 3-dimensional mechanical systems</td>
+   <td valign=\"top\">Library to model 3-dimensional mechanical systems</td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Electrical.MultiPhase.UsersGuide\">MultiPhase</a></td>
-  <td>Library for electrical components of one or more phases</td>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.MultiPhase.UsersGuide\">MultiPhase</a></td>
+  <td valign=\"top\">Library for electrical components of one or more phases</td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Electrical.PowerConverters.UsersGuide\">PowerConverters</a></td>
-  <td>Library for rectifiers, inverters and DC/DC converters</td>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.PowerConverters.UsersGuide\">PowerConverters</a></td>
+  <td valign=\"top\">Library for rectifiers, inverters and DC/DC converters</td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Electrical.QuasiStationary.UsersGuide\">QuasiStationary</a></td>
-  <td>Library for quasi-stationary electrical singlephase and multiphase AC simulation</td>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.QuasiStationary.UsersGuide\">QuasiStationary</a></td>
+  <td valign=\"top\">Library for quasi-stationary electrical singlephase and multiphase AC simulation</td>
 </tr>
 
-<tr><td><a href=\"modelica://Modelica.Mechanics.Rotational.UsersGuide\">Rotational</a>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Rotational.UsersGuide\">Rotational</a>
     </td>
-   <td>Library to model 1-dimensional, rotational mechanical systems</td>
+   <td valign=\"top\">Library to model 1-dimensional, rotational mechanical systems</td>
 </tr>
 
-<tr><td><a href=\"modelica://Modelica.SIunits.UsersGuide\">SIunits</a> </td>
-   <td>Library of type definitions based on SI units according to ISO 31-1992</td>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.SIunits.UsersGuide\">SIunits</a> </td>
+   <td valign=\"top\">Library of type definitions based on SI units according to ISO 31-1992</td>
 </tr>
 
 <tr>
-  <td><a href=\"modelica://Modelica.Electrical.Spice3.UsersGuide\">Spice3</a></td>
-  <td>Library for components of the Berkeley SPICE3 simulator</td>
+  <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.Spice3.UsersGuide\">Spice3</a></td>
+  <td valign=\"top\">Library for components of the Berkeley SPICE3 simulator</td>
 </tr>
 
-<tr><td><a href=\"modelica://Modelica.StateGraph.UsersGuide\">StateGraph</a>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.StateGraph.UsersGuide\">StateGraph</a>
     </td>
-   <td>Library to model discrete event and reactive systems by hierarchical state machines</td>
+   <td valign=\"top\">Library to model discrete event and reactive systems by hierarchical state machines</td>
 </tr>
 
-<tr><td><a href=\"modelica://Modelica.Mechanics.Translational.UsersGuide\">Translational</a>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Translational.UsersGuide\">Translational</a>
     </td>
-   <td>Library to model 1-dimensional, translational mechanical systems</td>
+   <td valign=\"top\">Library to model 1-dimensional, translational mechanical systems</td>
 </tr>
 
-<tr><td><a href=\"modelica://Modelica.Utilities.UsersGuide\">Utilities</a>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.UsersGuide\">Utilities</a>
     </td>
-   <td>Library of utility functions especially for scripting (Files, Streams, Strings, System)</td>
+   <td valign=\"top\">Library of utility functions especially for scripting (Files, Streams, Strings, System)</td>
 </tr>
 </table>
 

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -6952,10 +6952,10 @@ It is based on the
       <th>Comment</th>
     </tr>
     <tr>
-      <td></td>
-      <td>2017-09-22</td>
-      <td><a href=\"https://github.com/HansOlsson\">Hans Olsson</a></td>
-      <td>
+      <td valign=\"top\"></td>
+      <td valign=\"top\">2017-09-22</td>
+      <td valign=\"top\"><a href=\"https://github.com/HansOlsson\">Hans Olsson</a></td>
+      <td valign=\"top\">
       <ul>
       <li>Changed grammar to have colon emphasized as well, since it may otherwise look like a dot after 't' due to lack of kerning.</li>
       <li>Annotation inverse moved to annotations.</li>
@@ -6964,11 +6964,11 @@ It is based on the
       </ul>
       </td>
      <tr>
-      <td></td>
-      <td>2013-07-26</td>
-      <td><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a>,<br>
+      <td valign=\"top\"></td>
+      <td valign=\"top\">2013-07-26</td>
+      <td valign=\"top\"><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a>,<br>
                          <a href=\"http://www.robotic.dlr.de/Martin.Otter/\">Martin Otter</a></td>
-      <td>
+      <td valign=\"top\">
 <ul>
 <li> Update of grammar from Maplesoft which reflects changes from
      <a href=\"http://trac.modelica.org/Modelica/ticket/1140\">#1140</a></li>
@@ -7004,62 +7004,62 @@ It is based on the
      </tr>
 
      <tr>
-      <td><a href=\"http://trac.modelica.org/Modelica/changeset/4781/Modelica\">r4781</a></td>
-      <td>2011-12-15</td>
-      <td><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a></td>
-      <td>Use quoted class names for function descriptions (closes ticket <a href=\"http://trac.modelica.org/Modelica/ticket/565\">#565</a>)</td>
+      <td valign=\"top\"><a href=\"http://trac.modelica.org/Modelica/changeset/4781/Modelica\">r4781</a></td>
+      <td valign=\"top\">2011-12-15</td>
+      <td valign=\"top\"><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a></td>
+      <td valign=\"top\">Use quoted class names for function descriptions (closes ticket <a href=\"http://trac.modelica.org/Modelica/ticket/565\">#565</a>)</td>
     </tr>
     <tr>
-      <td><a href=\"http://trac.modelica.org/Modelica/changeset/4256/Modelica\">r4256</a></td>
-      <td>2010-10-06</td>
-      <td><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a></td>
-      <td>Removed 'uses' annotation and added icons so it can be used with multiple versions of the MSL (closes ticket <a href=\"http://trac.modelica.org/Modelica/ticket/425\">#425</a>)</td>
+      <td valign=\"top\"><a href=\"http://trac.modelica.org/Modelica/changeset/4256/Modelica\">r4256</a></td>
+      <td valign=\"top\">2010-10-06</td>
+      <td valign=\"top\"><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a></td>
+      <td valign=\"top\">Removed 'uses' annotation and added icons so it can be used with multiple versions of the MSL (closes ticket <a href=\"http://trac.modelica.org/Modelica/ticket/425\">#425</a>)</td>
     </tr>
     <tr>
-      <td><a href=\"http://trac.modelica.org/Modelica/changeset/4218/Modelica\">r4218</a></td>
-      <td>2010-09-25</td>
-      <td><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a></td>
-      <td>Major clean up of the documentation by use of <a href=\"http://linkchecker.sourceforge.net\"> LinkChecker</a> (closes ticket <a href=\"http://trac.modelica.org/Modelica/ticket/228\">#228</a>)</td>
+      <td valign=\"top\"><a href=\"http://trac.modelica.org/Modelica/changeset/4218/Modelica\">r4218</a></td>
+      <td valign=\"top\">2010-09-25</td>
+      <td valign=\"top\"><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a></td>
+      <td valign=\"top\">Major clean up of the documentation by use of <a href=\"http://linkchecker.sourceforge.net\"> LinkChecker</a> (closes ticket <a href=\"http://trac.modelica.org/Modelica/ticket/228\">#228</a>)</td>
     </tr>
     <tr>
-      <td><a href=\"http://trac.modelica.org/Modelica/changeset/4145/Modelica\">r4145</a></td>
-      <td>2010-09-07</td>
-      <td><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a></td>
-      <td>Added an update of the <a href=\"modelica://ModelicaReference.ModelicaGrammar\">Modelica 3.2 grammar</a>
+      <td valign=\"top\"><a href=\"http://trac.modelica.org/Modelica/changeset/4145/Modelica\">r4145</a></td>
+      <td valign=\"top\">2010-09-07</td>
+      <td valign=\"top\"><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a></td>
+      <td valign=\"top\">Added an update of the <a href=\"modelica://ModelicaReference.ModelicaGrammar\">Modelica 3.2 grammar</a>
                        from Stefan Vorkoetter (Maplesoft).</td>
     </tr>
     <tr>
-      <td><a href=\"http://trac.modelica.org/Modelica/changeset/3742/Modelica\">r3742</a></td>
-      <td>2010-04-13</td>
-      <td><a href=\"http://www.robotic.dlr.de/Martin.Otter/\">Martin Otter</a></td>
-      <td>Added the <a href=\"modelica://ModelicaReference.ModelicaGrammar\">Modelica 3.2 grammar</a>
+      <td valign=\"top\"><a href=\"http://trac.modelica.org/Modelica/changeset/3742/Modelica\">r3742</a></td>
+      <td valign=\"top\">2010-04-13</td>
+      <td valign=\"top\"><a href=\"http://www.robotic.dlr.de/Martin.Otter/\">Martin Otter</a></td>
+      <td valign=\"top\">Added the <a href=\"modelica://ModelicaReference.ModelicaGrammar\">Modelica 3.2 grammar</a>
                        from Stefan Vorkoetter (Maplesoft).<br>
                        Introduced a \"Contact\" subpackage with updated contact and
                        acknowledgment information.</td>
     </tr>
     <tr>
-      <td><a href=\"http://trac.modelica.org/Modelica/changeset/3598/Modelica\">r3598</a></td>
-      <td>2010-03-10</td>
-      <td><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a></td>
-      <td>Added some annotations from Modelica language version 3.1 and 3.2 (see ticket <a href=\"http://trac.modelica.org/Modelica/ticket/228\">#228</a>)</td>
+      <td valign=\"top\"><a href=\"http://trac.modelica.org/Modelica/changeset/3598/Modelica\">r3598</a></td>
+      <td valign=\"top\">2010-03-10</td>
+      <td valign=\"top\"><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a></td>
+      <td valign=\"top\">Added some annotations from Modelica language version 3.1 and 3.2 (see ticket <a href=\"http://trac.modelica.org/Modelica/ticket/228\">#228</a>)</td>
     </tr>
     <tr>
-      <td><a href=\"http://trac.modelica.org/Modelica/changeset/948/Modelica\">r948</a></td>
-      <td>2008-01-02</td>
-      <td><a href=\"http://www.robotic.dlr.de/Martin.Otter/\">Martin Otter</a></td>
-      <td>Adapted to Modelica language version 3.0</td>
+      <td valign=\"top\"><a href=\"http://trac.modelica.org/Modelica/changeset/948/Modelica\">r948</a></td>
+      <td valign=\"top\">2008-01-02</td>
+      <td valign=\"top\"><a href=\"http://www.robotic.dlr.de/Martin.Otter/\">Martin Otter</a></td>
+      <td valign=\"top\">Adapted to Modelica language version 3.0</td>
     </tr>
     <tr>
-      <td></td>
-      <td>2004-09-30</td>
-      <td><a href=\"http://www.robotic.dlr.de/Martin.Otter/\">Martin Otter</a></td>
-      <td>Moved the content of \"Functions\" into \"Operators\" and updated \"Operators\" according to Modelica 2.1</td>
+      <td valign=\"top\"></td>
+      <td valign=\"top\">2004-09-30</td>
+      <td valign=\"top\"><a href=\"http://www.robotic.dlr.de/Martin.Otter/\">Martin Otter</a></td>
+      <td valign=\"top\">Moved the content of \"Functions\" into \"Operators\" and updated \"Operators\" according to Modelica 2.1</td>
     </tr>
     <tr>
-      <td></td>
-      <td>2003-07-10</td>
-      <td>Christian Schweiger</td>
-      <td>Implemented.</td>
+      <td valign=\"top\"></td>
+      <td valign=\"top\">2003-07-10</td>
+      <td valign=\"top\">Christian Schweiger</td>
+      <td valign=\"top\">Implemented.</td>
     </tr>
 </table>
 </html>"));

--- a/ModelicaTest/Math.mo
+++ b/ModelicaTest/Math.mo
@@ -923,11 +923,11 @@ extends Modelica.Icons.ExamplesPackage;
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1008,11 +1008,11 @@ extends Modelica.Icons.ExamplesPackage;
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1093,11 +1093,11 @@ extends Modelica.Icons.ExamplesPackage;
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1191,11 +1191,11 @@ extends Modelica.Icons.ExamplesPackage;
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1351,11 +1351,11 @@ Implementation is according to Abramowitz and Stegun
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1424,11 +1424,11 @@ The relative error is less than 1e-9.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1453,11 +1453,11 @@ The relative error is less than 1e-9.
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1504,11 +1504,11 @@ For more details of this distribution see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1543,11 +1543,11 @@ For more details of this distribution see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1581,11 +1581,11 @@ For more details of this distribution see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by
@@ -1601,11 +1601,11 @@ For more details of this distribution see
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>
 
-<tr><td> June 22, 2015 </td>
-    <td>
+<tr><td valign=\"top\"> June 22, 2015 </td>
+    <td valign=\"top\">
 
 <table border=0>
-<tr><td>
+<tr><td valign=\"top\">
          <img src=\"modelica://Modelica/Resources/Images/Blocks/Noise/dlr_logo.png\">
 </td><td valign=\"bottom\">
          Initial version implemented by

--- a/ObsoleteModelica3.mo
+++ b/ObsoleteModelica3.mo
@@ -2119,21 +2119,21 @@ Exact definition of the returned quantities:
       <th><strong><em>resolveInFrame_a =</em></strong></th>
       <th><strong><em>vector is resolved in</em></strong></th>
   </tr>
-  <tr><td>connected</td>
-      <td>true</td>
-      <td><strong>frame_resolve</strong></td>
+  <tr><td valign=\"top\">connected</td>
+      <td valign=\"top\">true</td>
+      <td valign=\"top\"><strong>frame_resolve</strong></td>
   </tr>
-  <tr><td>connected</td>
-      <td>false</td>
-      <td><strong>frame_resolve</strong></td>
+  <tr><td valign=\"top\">connected</td>
+      <td valign=\"top\">false</td>
+      <td valign=\"top\"><strong>frame_resolve</strong></td>
   </tr>
-  <tr><td>not connected</td>
-      <td>true</td>
-      <td><strong>frame_a</strong></td>
+  <tr><td valign=\"top\">not connected</td>
+      <td valign=\"top\">true</td>
+      <td valign=\"top\"><strong>frame_a</strong></td>
   </tr>
-  <tr><td>not connected</td>
-      <td>false</td>
-      <td><strong>world frame</strong></td>
+  <tr><td valign=\"top\">not connected</td>
+      <td valign=\"top\">false</td>
+      <td valign=\"top\"><strong>world frame</strong></td>
   </tr>
 </table><br>
 </html>"));
@@ -2530,21 +2530,21 @@ and resolved in the following frame
       <th><strong><em>resolveInFrame_a =</em></strong></th>
       <th><strong><em>vector is resolved in</em></strong></th>
   </tr>
-  <tr><td>connected</td>
-      <td>true</td>
-      <td><strong>frame_resolve</strong></td>
+  <tr><td valign=\"top\">connected</td>
+      <td valign=\"top\">true</td>
+      <td valign=\"top\"><strong>frame_resolve</strong></td>
   </tr>
-  <tr><td>connected</td>
-      <td>false</td>
-      <td><strong>frame_resolve</strong></td>
+  <tr><td valign=\"top\">connected</td>
+      <td valign=\"top\">false</td>
+      <td valign=\"top\"><strong>frame_resolve</strong></td>
   </tr>
-  <tr><td>not connected</td>
-      <td>true</td>
-      <td><strong>frame_a</strong></td>
+  <tr><td valign=\"top\">not connected</td>
+      <td valign=\"top\">true</td>
+      <td valign=\"top\"><strong>frame_a</strong></td>
   </tr>
-  <tr><td>not connected</td>
-      <td>false</td>
-      <td><strong>frame_b</strong></td>
+  <tr><td valign=\"top\">not connected</td>
+      <td valign=\"top\">false</td>
+      <td valign=\"top\"><strong>frame_b</strong></td>
   </tr>
 </table>
 </html>"));
@@ -2725,26 +2725,26 @@ with negative sign at frame_a.
 
 <table border=1 cellspacing=0 cellpadding=2>
 <tr><th><strong>Types.Init.</strong></th><th><strong>Meaning</strong></th></tr>
-<tr><td>Free</td>
-    <td>No initialization</td></tr>
+<tr><td valign=\"top\">Free</td>
+    <td valign=\"top\">No initialization</td></tr>
 
-<tr><td>PositionVelocity</td>
-    <td>Initialize generalized position and velocity variables</td></tr>
+<tr><td valign=\"top\">PositionVelocity</td>
+    <td valign=\"top\">Initialize generalized position and velocity variables</td></tr>
 
-<tr><td>SteadyState</td>
-    <td>Initialize in steady state (velocity and acceleration are zero)</td></tr>
+<tr><td valign=\"top\">SteadyState</td>
+    <td valign=\"top\">Initialize in steady state (velocity and acceleration are zero)</td></tr>
 
-<tr><td>Position </td>
-    <td>Initialize only generalized position variable(s)</td></tr>
+<tr><td valign=\"top\">Position </td>
+    <td valign=\"top\">Initialize only generalized position variable(s)</td></tr>
 
-<tr><td>Velocity</td>
-    <td>Initialize only generalized velocity variable(s)</td></tr>
+<tr><td valign=\"top\">Velocity</td>
+    <td valign=\"top\">Initialize only generalized velocity variable(s)</td></tr>
 
-<tr><td>VelocityAcceleration</td>
-    <td>Initialize generalized velocity and acceleration variables</td></tr>
+<tr><td valign=\"top\">VelocityAcceleration</td>
+    <td valign=\"top\">Initialize generalized velocity and acceleration variables</td></tr>
 
-<tr><td>PositionVelocityAcceleration</td>
-    <td>Initialize generalized position, velocity and acceleration variables</td></tr>
+<tr><td valign=\"top\">PositionVelocityAcceleration</td>
+    <td valign=\"top\">Initialize generalized position, velocity and acceleration variables</td></tr>
 
 </table>
 


### PR DESCRIPTION
This reverts commit 5591ebcedcb68b55b1c1fec4044dcb070475c9ae.

As stated by https://github.com/modelica/ModelicaStandardLibrary/pull/2517#issuecomment-391805726 there are tables where valign="top" has an effect. As it is rather tedious to figure out all tables with (long or explicit) line breaks, I'd rather propose to revert the changes of #2517.