### PR TITLE
Perform syntax check using Travis CI

### DIFF
--- a/.travis.mos
+++ b/.travis.mos
@@ -1,0 +1,18 @@
+setModelicaPath(".");
+loadModel(ModelicaTest);
+loadModel(ModelicaTestOverdetermined);
+loadModel(ObsoleteModelica3);
+
+(numMessages,numError,numWarning):=countMessages();
+print(getErrorString());
+if numError<>0 or numWarning<>0 then
+  exit(1);
+end if;
+
+names := {typeNameString(cl) for cl in getClassNames(sort=true)};
+b := sum(names) == "ComplexModelicaModelicaServicesModelicaTestModelicaTestOverdeterminedObsoleteModelica3";
+
+if b and numError==0 and numWarning==0 then
+  exit(0);
+end if;
+exit(1);

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: generic
+services:
+  - docker
+before_install:
+  - time docker pull openmodelica/openmodelica:v1.12.0-minimal
+  - time docker pull openmodelica/moparser:xenial
+script:
+  - docker run -v "$PWD:/repo" -w "/repo" openmodelica/openmodelica:v1.12.0-minimal omc .travis.mos
+  - docker run -v "$PWD:/repo" -w "/repo" openmodelica/moparser:xenial moparser -r Complex.mo Modelica ModelicaReference ModelicaServices ModelicaTest ModelicaTestOverdetermined.mo ObsoleteModelica3.mo

--- a/ObsoleteModelica3.mo
+++ b/ObsoleteModelica3.mo
@@ -3419,7 +3419,7 @@ to the left and/or the right flange.
       end Gear;
     end Rotational;
   end Mechanics;
-  annotation (uses(Modelica(version="3.2.2")),
+  annotation (uses(Modelica(version="3.2.3")),
               version="3.2.3",
               versionBuild=1,
               versionDate="2018-08-01",


### PR DESCRIPTION
This uses OpenModelica v1.12.0 and Maplesoft's moparser to perform syntax
checking of the library. The OpenModelica job returns error on warnings
when it detects mismatching uses-annotations (which is not foolproof),
bad package.order, etc. The job could be enhanced to perform additional
checks or calculate some statistics such as number of classes in the
future.

close #2572