### PR TITLE
Check file encoding and language standard

### DIFF
--- a/.travis.mos
+++ b/.travis.mos
@@ -1,4 +1,5 @@
 setModelicaPath(".");
+setLanguageStandard("3.2");
 loadModel(ModelicaTest);
 loadModel(ModelicaTestOverdetermined);
 loadModel(ObsoleteModelica3);

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ before_install:
 
 script:
   - docker run -v "$PWD:/repo" -w "/repo" openmodelica/openmodelica:v1.12.0-minimal omc .travis.mos
-  - docker run -v "$PWD:/repo" -w "/repo" openmodelica/moparser:xenial moparser -r Complex.mo Modelica ModelicaReference ModelicaServices ModelicaTest ModelicaTestOverdetermined.mo ObsoleteModelica3.mo
+  - "! find . -name '*.mo' -exec bash -c 'iconv -o /dev/null -f ascii -t ascii \"{}\" |& sed \"s,^,{}: ,\"' ';' | grep '.'"
+  - docker run -v "$PWD:/repo" -w "/repo" openmodelica/moparser:xenial moparser -v 3.2 -r Complex.mo Modelica ModelicaReference ModelicaServices ModelicaTest ModelicaTestOverdetermined.mo ObsoleteModelica3.mo
 
 notifications:
   email: false

--- a/Modelica/ComplexBlocks.mo
+++ b/Modelica/ComplexBlocks.mo
@@ -1,4 +1,4 @@
-﻿within Modelica;
+within Modelica;
 package ComplexBlocks
   "Library of basic input/output control blocks with Complex signals"
   extends Modelica.Icons.Package;

--- a/Modelica/ComplexBlocks.mo
+++ b/Modelica/ComplexBlocks.mo
@@ -1998,8 +1998,8 @@ An error occurs if the elements of the input <code>u</code> is zero.
               lineThickness=0.5,
               fillColor={192,192,192},
               fillPattern=FillPattern.Solid,
-              textString="∠",
-              lineColor={128,128,128}),
+              lineColor={128,128,128},
+              textString="angle"),
             Text(
               visible = useDivisor,
               extent={{-56,94},{94,54}},

--- a/Modelica/Fluid/Examples/DrumBoiler.mo
+++ b/Modelica/Fluid/Examples/DrumBoiler.mo
@@ -1,6 +1,6 @@
 within Modelica.Fluid.Examples;
 package DrumBoiler
-  "Drum boiler example, see Franke, Rode, Krüger: On-line Optimization of Drum Boiler Startup, 3rd International Modelica Conference, Linköping, 2003"
+  "Drum boiler example, see Franke, Rode, Krueger: On-line Optimization of Drum Boiler Startup, 3rd International Modelica Conference, Linkoeping, 2003"
 
   extends Modelica.Icons.ExamplesPackage;
   model DrumBoiler
@@ -171,7 +171,7 @@ package DrumBoiler
     extends Modelica.Icons.BasesPackage;
 
     model EquilibriumDrumBoiler
-      "Simple Evaporator with two states, see Åström, Bell: Drum-boiler dynamics, Automatica 36, 2000, pp.363-378"
+      "Simple Evaporator with two states, see Astrom, Bell: Drum-boiler dynamics, Automatica 36, 2000, pp.363-378"
       extends Modelica.Fluid.Interfaces.PartialTwoPort(
         final port_a_exposesState=true,
         final port_b_exposesState=true,

--- a/Modelica/Fluid/Examples/DrumBoiler.mo
+++ b/Modelica/Fluid/Examples/DrumBoiler.mo
@@ -1,6 +1,6 @@
 within Modelica.Fluid.Examples;
 package DrumBoiler
-  "Drum boiler example, see Franke, Rode, Krueger: On-line Optimization of Drum Boiler Startup, 3rd International Modelica Conference, Linkoeping, 2003"
+  "Drum boiler example, see Franke, Rode, Krueger: On-line Optimization of Drum Boiler Startup, 3rd International Modelica Conference, Linkoping, 2003"
 
   extends Modelica.Icons.ExamplesPackage;
   model DrumBoiler
@@ -171,7 +171,7 @@ package DrumBoiler
     extends Modelica.Icons.BasesPackage;
 
     model EquilibriumDrumBoiler
-      "Simple Evaporator with two states, see Astrom, Bell: Drum-boiler dynamics, Automatica 36, 2000, pp.363-378"
+      "Simple Evaporator with two states, see Astroem, Bell: Drum-boiler dynamics, Automatica 36, 2000, pp.363-378"
       extends Modelica.Fluid.Interfaces.PartialTwoPort(
         final port_a_exposesState=true,
         final port_b_exposesState=true,

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes.mo
@@ -1,4 +1,4 @@
-﻿within Modelica.Magnetic.QuasiStatic;
+within Modelica.Magnetic.QuasiStatic;
 package FluxTubes "Library for modelling of quasi static electromagnetic devices with lumped magnetic networks"
 
   import SI = Modelica.SIunits;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes.mo
@@ -2580,7 +2580,7 @@ This sensor can be used to measure the complex magnetic flux <code>Phi</code> of
         annotation (Icon(coordinateSystem(
                 preserveAspectRatio=false), graphics={
                                         Text(extent={{-29,-11},{30,-70}},
-                textString="μ")}), Diagram(
+                textString="mu")}), Diagram(
               coordinateSystem(preserveAspectRatio=false)),
         Documentation(info="<html>
 <p>
@@ -2633,7 +2633,7 @@ This sensor is used to determined the effective fundamental wave permeability of
                 extent={{60,-60},{-60,60}},
                 fillColor={255,170,85},
                 fillPattern=FillPattern.Solid,
-                textString="μ")}),
+                textString="mu")}),
         Documentation(info="<html>
 <p>This model determines the absolute and relative permeability from two real inputs:</p>
 <ul>


### PR DESCRIPTION
This makes Travis verify that the Modelica files conform to the 3.2
version of the language standard, and that files are encoded in 7-bit
ASCII format (no unicode) to make the library consistent.

At least MSL was released as ASCII in the past; has this changed? (There are some unicode files checked in right now; the CI job should reflect this) If it has changed, I would change this to verify that all files are UTF-8 instead.