### PR TITLE
Improve wording of electrical and magnetic connector descriptions

### DIFF
--- a/Modelica/Electrical/Analog/Interfaces.mo
+++ b/Modelica/Electrical/Analog/Interfaces.mo
@@ -4,7 +4,7 @@ package Interfaces
   extends Modelica.Icons.InterfacesPackage;
 
   connector Pin "Pin of an electrical component"
-    SI.ElectricPotential v "Potential at the pin" annotation (
+    SI.ElectricPotential v "Potential of the pin" annotation (
         unassignedMessage="An electrical potential cannot be uniquely calculated.
 The reason could be that
 - a ground object is missing (Modelica.Electrical.Analog.Basic.Ground)
@@ -44,7 +44,7 @@ The reason could be that
   end Pin;
 
   connector PositivePin "Positive pin of an electric component"
-    SI.ElectricPotential v "Potential at the pin" annotation (
+    SI.ElectricPotential v "Potential of the pin" annotation (
         unassignedMessage="An electrical potential cannot be uniquely calculated.
 The reason could be that
 - a ground object is missing (Modelica.Electrical.Analog.Basic.Ground)
@@ -84,7 +84,7 @@ The reason could be that
   end PositivePin;
 
   connector NegativePin "Negative pin of an electric component"
-    SI.ElectricPotential v "Potential at the pin" annotation (
+    SI.ElectricPotential v "Potential of the pin" annotation (
         unassignedMessage="An electrical potential cannot be uniquely calculated.
 The reason could be that
 - a ground object is missing (Modelica.Electrical.Analog.Basic.Ground)
@@ -124,11 +124,10 @@ The reason could be that
   end NegativePin;
 
   partial model TwoPin "Component with two electrical pins"
-    SI.Voltage v "Voltage drop between the two pins (= p.v - n.v)";
-    PositivePin p
-      "Positive pin (potential p.v > n.v for positive voltage drop v)" annotation (Placement(
+    SI.Voltage v "Voltage drop of the two pins (= p.v - n.v)";
+    PositivePin p "Positive electrical pin" annotation (Placement(
           transformation(extent={{-110,-10},{-90,10}})));
-    NegativePin n "Negative pin" annotation (Placement(transformation(extent={{
+    NegativePin n "Negative electrical pin" annotation (Placement(transformation(extent={{
               90,-10},{110,10}})));
   equation
     v = p.v - n.v;
@@ -170,12 +169,11 @@ The reason could be that
   partial model OnePort
     "Component with two electrical pins p and n and current i from p to n"
 
-    SI.Voltage v "Voltage drop between the two pins (= p.v - n.v)";
+    SI.Voltage v "Voltage drop of the two pins (= p.v - n.v)";
     SI.Current i "Current flowing from pin p to pin n";
-    PositivePin p
-      "Positive pin (potential p.v > n.v for positive voltage drop v)" annotation (Placement(
+    PositivePin p "Positive electrical pin" annotation (Placement(
           transformation(extent={{-110,-10},{-90,10}})));
-    NegativePin n "Negative pin" annotation (Placement(transformation(extent={{
+    NegativePin n "Negative electrical pin" annotation (Placement(transformation(extent={{
               110,-10},{90,10}})));
   equation
     v = p.v - n.v;
@@ -222,19 +220,17 @@ The reason could be that
 
   partial model TwoPort
     "Component with two electrical ports, including current"
-    SI.Voltage v1 "Voltage drop over port 1";
-    SI.Voltage v2 "Voltage drop over port 2";
+    SI.Voltage v1 "Voltage drop of port 1 (= p1.v - n1.v)";
+    SI.Voltage v2 "Voltage drop of port 2 (= p2.v - n2.v)";
     SI.Current i1 "Current flowing from pos. to neg. pin of port 1";
     SI.Current i2 "Current flowing from pos. to neg. pin of port 2";
-    PositivePin p1
-      "Positive pin of port 1 (potential p1.v > n1.v for positive voltage drop v1)" annotation (Placement(
+    PositivePin p1 "Positive electrical pin of port 1" annotation (Placement(
           transformation(extent={{-110,90},{-90,110}}), iconTransformation(extent={{-110,90},{-90,110}})));
-    NegativePin n1 "Negative pin of port 1" annotation (Placement(
+    NegativePin n1 "Negative electrical pin of port 1" annotation (Placement(
           transformation(extent={{-90,-110},{-110,-90}}), iconTransformation(extent={{-90,-110},{-110,-90}})));
-    PositivePin p2
-      "Positive pin of port 2 (potential p2.v > n2.v for positive voltage drop v2)" annotation (Placement(
+    PositivePin p2 "Positive electrical pin of port 2" annotation (Placement(
           transformation(extent={{110,90},{90,110}}), iconTransformation(extent={{110,90},{90,110}})));
-    NegativePin n2 "Negative pin of port 2" annotation (Placement(
+    NegativePin n2 "Negative electrical pin of port 2" annotation (Placement(
           transformation(extent={{90,-110},{110,-90}}), iconTransformation(extent={{90,-110},{110,-90}})));
   equation
     v1 = p1.v - n1.v;
@@ -350,7 +346,7 @@ on the model behaviour.
     "Base class to measure the absolute value of a pin variable"
     extends Modelica.Icons.RotationalSensor;
 
-    Interfaces.PositivePin p "Pin to be measured" annotation (Placement(
+    Interfaces.PositivePin p "Positive electrical pin" annotation (Placement(
           transformation(extent={{-110,-10},{-90,10}})));
     Modelica.Blocks.Interfaces.RealOutput y
       "Measured quantity as Real output signal" annotation (Placement(
@@ -385,9 +381,9 @@ on the model behaviour.
     "Base class to measure a relative variable between two pins"
     extends Modelica.Icons.RotationalSensor;
 
-    Interfaces.PositivePin p "Positive pin" annotation (Placement(
+    Interfaces.PositivePin p "Positive electrical pin" annotation (Placement(
           transformation(extent={{-110,-10},{-90,10}})));
-    Interfaces.NegativePin n "Negative pin" annotation (Placement(
+    Interfaces.NegativePin n "Negative electrical pin" annotation (Placement(
           transformation(extent={{90,-10},{110,10}})));
     Modelica.Blocks.Interfaces.RealOutput y
       "Measured quantity as Real output signal" annotation (Placement(

--- a/Modelica/Electrical/Analog/Interfaces.mo
+++ b/Modelica/Electrical/Analog/Interfaces.mo
@@ -4,7 +4,7 @@ package Interfaces
   extends Modelica.Icons.InterfacesPackage;
 
   connector Pin "Pin of an electrical component"
-    SI.ElectricPotential v "Potential of the pin" annotation (
+    SI.ElectricPotential v "Potential at the pin" annotation (
         unassignedMessage="An electrical potential cannot be uniquely calculated.
 The reason could be that
 - a ground object is missing (Modelica.Electrical.Analog.Basic.Ground)
@@ -44,7 +44,7 @@ The reason could be that
   end Pin;
 
   connector PositivePin "Positive pin of an electric component"
-    SI.ElectricPotential v "Potential of the pin" annotation (
+    SI.ElectricPotential v "Potential at the pin" annotation (
         unassignedMessage="An electrical potential cannot be uniquely calculated.
 The reason could be that
 - a ground object is missing (Modelica.Electrical.Analog.Basic.Ground)
@@ -84,7 +84,7 @@ The reason could be that
   end PositivePin;
 
   connector NegativePin "Negative pin of an electric component"
-    SI.ElectricPotential v "Potential of the pin" annotation (
+    SI.ElectricPotential v "Potential at the pin" annotation (
         unassignedMessage="An electrical potential cannot be uniquely calculated.
 The reason could be that
 - a ground object is missing (Modelica.Electrical.Analog.Basic.Ground)

--- a/Modelica/Electrical/Analog/Interfaces.mo
+++ b/Modelica/Electrical/Analog/Interfaces.mo
@@ -43,7 +43,7 @@ The reason could be that
 </html>"));
   end Pin;
 
-  connector PositivePin "Positive pin of an electric component"
+  connector PositivePin "Positive pin of an electrical component"
     SI.ElectricPotential v "Potential at the pin" annotation (
         unassignedMessage="An electrical potential cannot be uniquely calculated.
 The reason could be that
@@ -83,7 +83,7 @@ The reason could be that
             textString="%name")}));
   end PositivePin;
 
-  connector NegativePin "Negative pin of an electric component"
+  connector NegativePin "Negative pin of an electrical component"
     SI.ElectricPotential v "Potential at the pin" annotation (
         unassignedMessage="An electrical potential cannot be uniquely calculated.
 The reason could be that

--- a/Modelica/Electrical/MultiPhase.mo
+++ b/Modelica/Electrical/MultiPhase.mo
@@ -3933,7 +3933,7 @@ This package contains time-dependent and controlled multiphase voltage and curre
   package Interfaces "Interfaces for electrical multiphase models"
     extends Modelica.Icons.InterfacesPackage;
 
-    connector Plug "Polyphase electric plug with m pins"
+    connector Plug "Polyphase electrical plug with m pins"
       parameter Integer m(final min=1) = 3 "Number of phases";
       Modelica.Electrical.Analog.Interfaces.Pin pin[m] "Pins of the plug";
 
@@ -3953,7 +3953,7 @@ Connector Plug is a composite connector containing m Pins (Modelica.Electrical.A
               textString="%name")}));
     end Plug;
 
-    connector PositivePlug "Positive polyphase electric plug with m pins"
+    connector PositivePlug "Positive polyphase electrical plug with m pins"
       extends Plug;
       annotation (
         Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
@@ -3980,7 +3980,7 @@ Connector Plug is a composite connector containing m Pins (Modelica.Electrical.A
 </html>"));
     end PositivePlug;
 
-    connector NegativePlug "Negative polyphase electric plug with m pins"
+    connector NegativePlug "Negative polyphase electrical plug with m pins"
       extends Plug;
       annotation (
         Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
@@ -4039,13 +4039,13 @@ This partial model provides conditional heat ports for the connection to a therm
 </html>"));
     end ConditionalHeatPort;
 
-    partial model TwoPlug "Component with one m-phase electric port"
+    partial model TwoPlug "Component with one polyphase electrical port"
       parameter Integer m(min=1) = 3 "Number of phases";
       Modelica.SIunits.Voltage v[m] "Voltage drops of the two polyphase plugs";
       Modelica.SIunits.Current i[m] "Currents flowing into positive polyphase plugs";
-      PositivePlug plug_p(final m=m) "Positive polyphase electric plug with m pins" annotation (Placement(transformation(
+      PositivePlug plug_p(final m=m) "Positive polyphase electrical plug with m pins" annotation (Placement(transformation(
               extent={{-110,-10},{-90,10}})));
-      NegativePlug plug_n(final m=m) "Negative polyphase electric plug with m pins" annotation (Placement(transformation(
+      NegativePlug plug_n(final m=m) "Negative polyphase electrical plug with m pins" annotation (Placement(transformation(
               extent={{90,-10},{110,10}})));
     equation
       v = plug_p.pin.v - plug_n.pin.v;
@@ -4075,7 +4075,7 @@ It is assumed that the currents flowing into plug_p are identical to the current
 </html>"));
     end OnePort;
 
-    partial model FourPlug "Component with two polyphase electric ports"
+    partial model FourPlug "Component with two polyphase electrical ports"
       parameter Integer m(final min=1) = 3 "Number of phases";
       Modelica.SIunits.Voltage v1[m] "Voltage drops of port 1";
       Modelica.SIunits.Voltage v2[m] "Voltage drops of port 2";
@@ -4104,7 +4104,7 @@ Superclass of elements which have <strong>four</strong> electrical plugs.
     end FourPlug;
 
     partial model TwoPort
-      "Component with two m-phase electric ports, including currents"
+      "Component with two polyphase electrical ports, including currents"
       extends FourPlug;
     equation
       plug_p1.pin.i + plug_n1.pin.i = zeros(m);

--- a/Modelica/Electrical/MultiPhase.mo
+++ b/Modelica/Electrical/MultiPhase.mo
@@ -3980,7 +3980,7 @@ Connector Plug is a composite connector containing m Pins (Modelica.Electrical.A
 </html>"));
     end PositivePlug;
 
-    connector NegativePlug "Negative electric polyphase plug with m pins"
+    connector NegativePlug "Negative polyphase electric plug with m pins"
       extends Plug;
       annotation (
         Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
@@ -4043,9 +4043,9 @@ This partial model provides conditional heat ports for the connection to a therm
       parameter Integer m(min=1) = 3 "Number of phases";
       Modelica.SIunits.Voltage v[m] "Voltage drops of the two polyphase plugs";
       Modelica.SIunits.Current i[m] "Currents flowing into positive polyphase plugs";
-      PositivePlug plug_p(final m=m) "Positive electric polyphase plug with m pins" annotation (Placement(transformation(
+      PositivePlug plug_p(final m=m) "Positive polyphase electric plug with m pins" annotation (Placement(transformation(
               extent={{-110,-10},{-90,10}})));
-      NegativePlug plug_n(final m=m) "Negative electric polyphase plug with m pins" annotation (Placement(transformation(
+      NegativePlug plug_n(final m=m) "Negative polyphase electric plug with m pins" annotation (Placement(transformation(
               extent={{90,-10},{110,10}})));
     equation
       v = plug_p.pin.v - plug_n.pin.v;

--- a/Modelica/Electrical/MultiPhase.mo
+++ b/Modelica/Electrical/MultiPhase.mo
@@ -3933,9 +3933,9 @@ This package contains time-dependent and controlled multiphase voltage and curre
   package Interfaces "Interfaces for electrical multiphase models"
     extends Modelica.Icons.InterfacesPackage;
 
-    connector Plug "Plug with m pins for an electric component"
+    connector Plug "Polyphase electric plug with m pins"
       parameter Integer m(final min=1) = 3 "Number of phases";
-      Modelica.Electrical.Analog.Interfaces.Pin pin[m];
+      Modelica.Electrical.Analog.Interfaces.Pin pin[m] "Pins of the plug";
 
       annotation (Documentation(info="<html>
 <p>
@@ -3953,7 +3953,7 @@ Connector Plug is a composite connector containing m Pins (Modelica.Electrical.A
               textString="%name")}));
     end Plug;
 
-    connector PositivePlug "Positive plug with m pins"
+    connector PositivePlug "Positive polyphase electric plug with m pins"
       extends Plug;
       annotation (
         Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
@@ -3978,10 +3978,9 @@ connector NegativePlug for the negative plug of an electrical component.<br>
 Connector Plug is a composite connector containing m Pins (Modelica.Electrical.Analog.Interfaces.Pin).
 </p>
 </html>"));
-
     end PositivePlug;
 
-    connector NegativePlug "Negative plug with m pins"
+    connector NegativePlug "Negative electric polyphase plug with m pins"
       extends Plug;
       annotation (
         Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
@@ -4042,11 +4041,11 @@ This partial model provides conditional heat ports for the connection to a therm
 
     partial model TwoPlug "Component with one m-phase electric port"
       parameter Integer m(min=1) = 3 "Number of phases";
-      Modelica.SIunits.Voltage v[m] "Voltage drops between the two plugs";
-      Modelica.SIunits.Current i[m] "Currents flowing into positive plugs";
-      PositivePlug plug_p(final m=m) annotation (Placement(transformation(
+      Modelica.SIunits.Voltage v[m] "Voltage drops of the two polyphase plugs";
+      Modelica.SIunits.Current i[m] "Currents flowing into positive polyphase plugs";
+      PositivePlug plug_p(final m=m) "Positive electric polyphase plug with m pins" annotation (Placement(transformation(
               extent={{-110,-10},{-90,10}})));
-      NegativePlug plug_n(final m=m) annotation (Placement(transformation(
+      NegativePlug plug_n(final m=m) "Negative electric polyphase plug with m pins" annotation (Placement(transformation(
               extent={{90,-10},{110,10}})));
     equation
       v = plug_p.pin.v - plug_n.pin.v;
@@ -4076,21 +4075,21 @@ It is assumed that the currents flowing into plug_p are identical to the current
 </html>"));
     end OnePort;
 
-    partial model FourPlug "Component with two m-phase electric ports"
+    partial model FourPlug "Component with two polyphase electric ports"
       parameter Integer m(final min=1) = 3 "Number of phases";
-      Modelica.SIunits.Voltage v1[m] "Voltage drops over the left port";
-      Modelica.SIunits.Voltage v2[m] "Voltage drops over the right port";
+      Modelica.SIunits.Voltage v1[m] "Voltage drops of port 1";
+      Modelica.SIunits.Voltage v2[m] "Voltage drops of port 2";
       Modelica.SIunits.Current i1[m]
-        "Current flowing into positive plug of the left port";
+        "Currents flowing into positive polyphase plug of port 1";
       Modelica.SIunits.Current i2[m]
-        "Current flowing into positive plug of the right port";
-      PositivePlug plug_p1(final m=m) annotation (Placement(transformation(
+        "Currents flowing into positive polyphase plug of port 2";
+      PositivePlug plug_p1(final m=m) "Positive electrical polyphase plug of port 1 with m pins" annotation (Placement(transformation(
               extent={{-110,90},{-90,110}})));
-      PositivePlug plug_p2(final m=m) annotation (Placement(transformation(
+      PositivePlug plug_p2(final m=m) "Positive electrical polyphase plug of port 2 with m pins" annotation (Placement(transformation(
               extent={{90,90},{110,110}})));
-      NegativePlug plug_n1(final m=m) annotation (Placement(transformation(
+      NegativePlug plug_n1(final m=m) "Negative electrical polyphase plug of port 1 with m pins" annotation (Placement(transformation(
               extent={{-110,-110},{-90,-90}})));
-      NegativePlug plug_n2(final m=m) annotation (Placement(transformation(
+      NegativePlug plug_n2(final m=m) "Negative electrical polyphase plug of port 2 with m pins" annotation (Placement(transformation(
               extent={{90,-110},{110,-90}})));
     equation
       v1 = plug_p1.pin.v - plug_n1.pin.v;

--- a/Modelica/Electrical/QuasiStationary/MultiPhase.mo
+++ b/Modelica/Electrical/QuasiStationary/MultiPhase.mo
@@ -4015,9 +4015,9 @@ Quasi stationary theory can be found in the
   package Interfaces "Interfaces for AC multiphase models"
     extends Modelica.Icons.InterfacesPackage;
 
-    connector Plug "Basic multiphase plug"
-      parameter Integer m=3 "number of phases";
-      QuasiStationary.SinglePhase.Interfaces.Pin pin[m];
+    connector Plug "Quasi static polyphase plug"
+      parameter Integer m=3 "Number of phases";
+      QuasiStationary.SinglePhase.Interfaces.Pin pin[m] "Pins of the plug";
       annotation (Documentation(info="<html>
 
 <p>
@@ -4039,7 +4039,7 @@ derived from this base connector.
 </html>"));
     end Plug;
 
-    connector PositivePlug "Positive multiphase connector"
+    connector PositivePlug "Positive quasi static polyphase plug"
       extends Plug;
       QuasiStationary.Types.Reference reference;
       annotation (
@@ -4075,7 +4075,7 @@ Additionally the reference angle is specified in the connector. The time derivat
 </html>"));
     end PositivePlug;
 
-    connector NegativePlug "Negative multiphase connector"
+    connector NegativePlug "Negative quasi static polyphase plug"
       extends Plug;
       QuasiStationary.Types.Reference reference;
       annotation (
@@ -4144,10 +4144,10 @@ Additionally the reference angle is specified in the connector. The time derivat
         "Angular velocity of reference frame";
 
       PositivePlug plug_p(final m=m)
-        "Positive quasi stationary multi phase plug" annotation (Placement(
+        "Positive quasi static polyphase plug" annotation (Placement(
             transformation(extent={{-110,-10},{-90,10}})));
       NegativePlug plug_n(final m=m)
-        "Negative quasi stationary multi phase plug" annotation (Placement(
+        "Negative quasi static polyphase plug" annotation (Placement(
             transformation(extent={{90,-10},{110,10}})));
       Basic.PlugToPins_p plugToPins_p(final m=m) annotation (Placement(
             transformation(extent={{-80,-10},{-60,10}})));
@@ -4213,10 +4213,10 @@ a <a href=\"modelica://Modelica.Electrical.QuasiStationary.MultiPhase.Basic.Plug
         "Angular velocity of reference frame";
 
       PositivePlug plug_p(final m=m)
-        "Positive quasi stationary multi phase plug" annotation (Placement(
+        "Positive quasi static polyphase plug" annotation (Placement(
             transformation(extent={{-110,-10},{-90,10}})));
       NegativePlug plug_n(final m=m)
-        "Negative quasi stationary multi phase plug" annotation (Placement(
+        "Negative quasi static polyphase plug" annotation (Placement(
             transformation(extent={{90,-10},{110,10}})));
     equation
       Connections.branch(plug_p.reference, plug_n.reference);
@@ -4232,7 +4232,7 @@ a <a href=\"modelica://Modelica.Electrical.QuasiStationary.MultiPhase.Basic.Plug
       parameter Integer m(min=1) = 3 "number of phases";
       Modelica.SIunits.AngularVelocity omega;
       PositivePlug plug_p(final m=m)
-        "Positive quasi stationary multi phase plug" annotation (Placement(
+        "Positive quasi static polyphase plug" annotation (Placement(
             transformation(extent={{-110,-10},{-90,10}})));
     equation
       omega = der(plug_p.reference.gamma);

--- a/Modelica/Electrical/QuasiStationary/MultiPhase.mo
+++ b/Modelica/Electrical/QuasiStationary/MultiPhase.mo
@@ -4015,7 +4015,7 @@ Quasi stationary theory can be found in the
   package Interfaces "Interfaces for AC multiphase models"
     extends Modelica.Icons.InterfacesPackage;
 
-    connector Plug "Quasi static polyphase plug"
+    connector Plug "Quasi-static polyphase plug"
       parameter Integer m=3 "Number of phases";
       QuasiStationary.SinglePhase.Interfaces.Pin pin[m] "Pins of the plug";
       annotation (Documentation(info="<html>
@@ -4039,7 +4039,7 @@ derived from this base connector.
 </html>"));
     end Plug;
 
-    connector PositivePlug "Positive quasi static polyphase plug"
+    connector PositivePlug "Positive quasi-static polyphase plug"
       extends Plug;
       QuasiStationary.Types.Reference reference;
       annotation (
@@ -4075,7 +4075,7 @@ Additionally the reference angle is specified in the connector. The time derivat
 </html>"));
     end PositivePlug;
 
-    connector NegativePlug "Negative quasi static polyphase plug"
+    connector NegativePlug "Negative quasi-static polyphase plug"
       extends Plug;
       QuasiStationary.Types.Reference reference;
       annotation (
@@ -4144,10 +4144,10 @@ Additionally the reference angle is specified in the connector. The time derivat
         "Angular velocity of reference frame";
 
       PositivePlug plug_p(final m=m)
-        "Positive quasi static polyphase plug" annotation (Placement(
+        "Positive quasi-static polyphase plug" annotation (Placement(
             transformation(extent={{-110,-10},{-90,10}})));
       NegativePlug plug_n(final m=m)
-        "Negative quasi static polyphase plug" annotation (Placement(
+        "Negative quasi-static polyphase plug" annotation (Placement(
             transformation(extent={{90,-10},{110,10}})));
       Basic.PlugToPins_p plugToPins_p(final m=m) annotation (Placement(
             transformation(extent={{-80,-10},{-60,10}})));
@@ -4213,10 +4213,10 @@ a <a href=\"modelica://Modelica.Electrical.QuasiStationary.MultiPhase.Basic.Plug
         "Angular velocity of reference frame";
 
       PositivePlug plug_p(final m=m)
-        "Positive quasi static polyphase plug" annotation (Placement(
+        "Positive quasi-static polyphase plug" annotation (Placement(
             transformation(extent={{-110,-10},{-90,10}})));
       NegativePlug plug_n(final m=m)
-        "Negative quasi static polyphase plug" annotation (Placement(
+        "Negative quasi-static polyphase plug" annotation (Placement(
             transformation(extent={{90,-10},{110,10}})));
     equation
       Connections.branch(plug_p.reference, plug_n.reference);
@@ -4232,7 +4232,7 @@ a <a href=\"modelica://Modelica.Electrical.QuasiStationary.MultiPhase.Basic.Plug
       parameter Integer m(min=1) = 3 "number of phases";
       Modelica.SIunits.AngularVelocity omega;
       PositivePlug plug_p(final m=m)
-        "Positive quasi static polyphase plug" annotation (Placement(
+        "Positive quasi-static polyphase plug" annotation (Placement(
             transformation(extent={{-110,-10},{-90,10}})));
     equation
       omega = der(plug_p.reference.gamma);

--- a/Modelica/Electrical/QuasiStationary/MultiPhase.mo
+++ b/Modelica/Electrical/QuasiStationary/MultiPhase.mo
@@ -4017,7 +4017,7 @@ Quasi stationary theory can be found in the
 
     connector Plug "Quasi-static polyphase plug"
       parameter Integer m=3 "Number of phases";
-      QuasiStationary.SinglePhase.Interfaces.Pin pin[m] "Pins of the plug";
+      QuasiStationary.SinglePhase.Interfaces.Pin pin[m] "Pins of plug";
       annotation (Documentation(info="<html>
 
 <p>

--- a/Modelica/Electrical/QuasiStationary/SinglePhase.mo
+++ b/Modelica/Electrical/QuasiStationary/SinglePhase.mo
@@ -2577,9 +2577,9 @@ Quasi stationary theory for single phase circuits can be found in the
   package Interfaces "Interfaces for AC singlephase models"
     extends Modelica.Icons.InterfacesPackage;
 
-    connector Pin "Quasi static single-phase pin"
-      Modelica.SIunits.ComplexElectricPotential v "Complex potential at the quasi static single-phase pin";
-      flow Modelica.SIunits.ComplexCurrent i "Complex current flowing into the quasi static single-phase pin";
+    connector Pin "Quasi-static single-phase pin"
+      Modelica.SIunits.ComplexElectricPotential v "Complex potential at the quasi-static single-phase pin";
+      flow Modelica.SIunits.ComplexCurrent i "Complex current flowing into the quasi-static single-phase pin";
       annotation (Documentation(info="<html>
 <p>
 The potential of this connector is the complex voltage and the flow variable is the complex current.
@@ -2601,7 +2601,7 @@ derived from this base connector.
 </html>"));
     end Pin;
 
-    connector PositivePin "Positive quasi static single-phase pin"
+    connector PositivePin "Positive quasi-static single-phase pin"
       extends Pin;
       QuasiStationary.Types.Reference reference "Reference";
       annotation (
@@ -2637,7 +2637,7 @@ Additionally the reference angle is specified in the connector. The time derivat
 </html>"));
     end PositivePin;
 
-    connector NegativePin "Negative quasi static single-phase pin"
+    connector NegativePin "Negative quasi-static single-phase pin"
       extends Pin;
       QuasiStationary.Types.Reference reference "Reference";
       annotation (
@@ -2690,9 +2690,9 @@ Additionally the reference angle is specified in the connector. The time derivat
       Real pf=cos(Modelica.ComplexMath.arg(Complex(P, Q))) "Power factor";
       Modelica.SIunits.AngularVelocity omega "Angular velocity of reference frame";
 
-      PositivePin pin_p "Positive quasi static single-phase pin" annotation (Placement(transformation(
+      PositivePin pin_p "Positive quasi-static single-phase pin" annotation (Placement(transformation(
               extent={{-110,-10},{-90,10}})));
-      NegativePin pin_n "Negative quasi static single-phase pin" annotation (Placement(transformation(
+      NegativePin pin_n "Negative quasi-static single-phase pin" annotation (Placement(transformation(
               extent={{90,-10},{110,10}})));
     equation
       Connections.branch(pin_p.reference, pin_n.reference);
@@ -2742,7 +2742,7 @@ This model is intended to be used with textual representation of user models.
     partial model AbsoluteSensor "Partial potential sensor"
       extends Modelica.Icons.RotationalSensor;
       Modelica.SIunits.AngularVelocity omega;
-      PositivePin pin "Postivite quasi static single-phase pin" annotation (Placement(transformation(extent={{-110,
+      PositivePin pin "Postivite quasi-static single-phase pin" annotation (Placement(transformation(extent={{-110,
                 -10},{-90,10}})));
     equation
       omega = der(pin.reference.gamma);

--- a/Modelica/Electrical/QuasiStationary/SinglePhase.mo
+++ b/Modelica/Electrical/QuasiStationary/SinglePhase.mo
@@ -2578,7 +2578,7 @@ Quasi stationary theory for single phase circuits can be found in the
     extends Modelica.Icons.InterfacesPackage;
 
     connector Pin "Quasi static single-phase pin"
-      Modelica.SIunits.ComplexElectricPotential v "Complex potential of the quasi static single-phase pin";
+      Modelica.SIunits.ComplexElectricPotential v "Complex potential at the quasi static single-phase pin";
       flow Modelica.SIunits.ComplexCurrent i "Complex current flowing into the quasi static single-phase pin";
       annotation (Documentation(info="<html>
 <p>

--- a/Modelica/Electrical/QuasiStationary/SinglePhase.mo
+++ b/Modelica/Electrical/QuasiStationary/SinglePhase.mo
@@ -2577,9 +2577,9 @@ Quasi stationary theory for single phase circuits can be found in the
   package Interfaces "Interfaces for AC singlephase models"
     extends Modelica.Icons.InterfacesPackage;
 
-    connector Pin "Basic connector"
-      Modelica.SIunits.ComplexElectricPotential v "Complex potential of the pin";
-      flow Modelica.SIunits.ComplexCurrent i "Complex current flowing into the pin";
+    connector Pin "Quasi static single-phase pin"
+      Modelica.SIunits.ComplexElectricPotential v "Complex potential of the quasi static single-phase pin";
+      flow Modelica.SIunits.ComplexCurrent i "Complex current flowing into the quasi static single-phase pin";
       annotation (Documentation(info="<html>
 <p>
 The potential of this connector is the complex voltage and the flow variable is the complex current.
@@ -2601,7 +2601,7 @@ derived from this base connector.
 </html>"));
     end Pin;
 
-    connector PositivePin "Positive connector"
+    connector PositivePin "Positive quasi static single-phase pin"
       extends Pin;
       QuasiStationary.Types.Reference reference "Reference";
       annotation (
@@ -2637,7 +2637,7 @@ Additionally the reference angle is specified in the connector. The time derivat
 </html>"));
     end PositivePin;
 
-    connector NegativePin "Negative Connector"
+    connector NegativePin "Negative quasi static single-phase pin"
       extends Pin;
       QuasiStationary.Types.Reference reference "Reference";
       annotation (
@@ -2690,9 +2690,9 @@ Additionally the reference angle is specified in the connector. The time derivat
       Real pf=cos(Modelica.ComplexMath.arg(Complex(P, Q))) "Power factor";
       Modelica.SIunits.AngularVelocity omega "Angular velocity of reference frame";
 
-      PositivePin pin_p "Positive pin" annotation (Placement(transformation(
+      PositivePin pin_p "Positive quasi static single-phase pin" annotation (Placement(transformation(
               extent={{-110,-10},{-90,10}})));
-      NegativePin pin_n "Negative pin" annotation (Placement(transformation(
+      NegativePin pin_n "Negative quasi static single-phase pin" annotation (Placement(transformation(
               extent={{90,-10},{110,10}})));
     equation
       Connections.branch(pin_p.reference, pin_n.reference);
@@ -2742,7 +2742,7 @@ This model is intended to be used with textual representation of user models.
     partial model AbsoluteSensor "Partial potential sensor"
       extends Modelica.Icons.RotationalSensor;
       Modelica.SIunits.AngularVelocity omega;
-      PositivePin pin "Pin" annotation (Placement(transformation(extent={{-110,
+      PositivePin pin "Postivite quasi static single-phase pin" annotation (Placement(transformation(extent={{-110,
                 -10},{-90,10}})));
     equation
       omega = der(pin.reference.gamma);

--- a/Modelica/Magnetic/FluxTubes.mo
+++ b/Modelica/Magnetic/FluxTubes.mo
@@ -7274,7 +7274,7 @@ Fig. 3 shows the static hysteresis loop library entries for soft magnetic cobalt
     extends Modelica.Icons.InterfacesPackage;
 
     connector MagneticPort "Generic magnetic port"
-      SI.MagneticPotential V_m "Magnetic potential of the port";
+      SI.MagneticPotential V_m "Magnetic potential at the port";
       flow SI.MagneticFlux Phi "Magnetic flux flowing into the port";
 
       annotation (defaultComponentName="mag");

--- a/Modelica/Magnetic/FluxTubes.mo
+++ b/Modelica/Magnetic/FluxTubes.mo
@@ -7274,7 +7274,7 @@ Fig. 3 shows the static hysteresis loop library entries for soft magnetic cobalt
     extends Modelica.Icons.InterfacesPackage;
 
     connector MagneticPort "Generic magnetic port"
-      SI.MagneticPotential V_m "Magnetic potential at the port";
+      SI.MagneticPotential V_m "Magnetic potential of the port";
       flow SI.MagneticFlux Phi "Magnetic flux flowing into the port";
 
       annotation (defaultComponentName="mag");
@@ -7344,11 +7344,11 @@ connector port_n.
     end PartialTwoPortsElementary;
 
     partial model PartialTwoPorts
-      "Partial component with magnetic potential difference between two magnetic ports p and n and magnetic flux Phi from p to n"
+      "Partial component with magnetic potential difference of the two magnetic ports p and n and magnetic flux Phi from p to n"
 
       extends FluxTubes.Interfaces.PartialTwoPortsElementary;
       SI.MagneticPotentialDifference V_m
-        "Magnetic potential difference between both ports";
+        "Magnetic potential difference of the ports";
       SI.MagneticFlux Phi(start=0) "Magnetic flux from port_p to port_n";
 
     equation

--- a/Modelica/Magnetic/FluxTubes.mo
+++ b/Modelica/Magnetic/FluxTubes.mo
@@ -7348,7 +7348,7 @@ connector port_n.
 
       extends FluxTubes.Interfaces.PartialTwoPortsElementary;
       SI.MagneticPotentialDifference V_m
-        "Magnetic potential difference of the ports";
+        "Magnetic potential difference of ports";
       SI.MagneticFlux Phi(start=0) "Magnetic flux from port_p to port_n";
 
     equation

--- a/Modelica/Magnetic/FundamentalWave.mo
+++ b/Modelica/Magnetic/FundamentalWave.mo
@@ -8695,7 +8695,7 @@ This package provides sensors for the magnetic potential difference and the magn
     extends Modelica.Icons.InterfacesPackage;
     connector MagneticPort "Magnetic port of fundamental wave machines"
       Modelica.SIunits.ComplexMagneticPotential V_m
-        "Complex magnetic potential of the port";
+        "Complex magnetic potential at the port";
       flow Modelica.SIunits.ComplexMagneticFlux Phi
         "Complex magnetic flux into the port";
       annotation (Documentation(info="<html>

--- a/Modelica/Magnetic/FundamentalWave.mo
+++ b/Modelica/Magnetic/FundamentalWave.mo
@@ -8693,10 +8693,11 @@ This package provides sensors for the magnetic potential difference and the magn
 
   package Interfaces "Interfaces and partial models"
     extends Modelica.Icons.InterfacesPackage;
-    connector MagneticPort "Complex magnetic port of fundamental wave machines"
+    connector MagneticPort "Magnetic port of fundamental wave machines"
       Modelica.SIunits.ComplexMagneticPotential V_m
-        "Complex magnetic potential of port";
-      flow Modelica.SIunits.ComplexMagneticFlux Phi "Complex magnetic flux into port";
+        "Complex magnetic potential of the port";
+      flow Modelica.SIunits.ComplexMagneticFlux Phi
+        "Complex magnetic flux into the port";
       annotation (Documentation(info="<html>
 <p>
 The potential quantity of the magnetic port is the complex magnetic potential difference <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/V_m.png\">. The corresponding flow quantity is the magnetic flux <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/Phi.png\">.
@@ -8711,7 +8712,7 @@ The potential quantity of the magnetic port is the complex magnetic potential di
 </html>"));
     end MagneticPort;
 
-    connector NegativeMagneticPort "Negative complex magnetic port"
+    connector NegativeMagneticPort "Negative magnetic port of fundamental wave machines"
       extends Modelica.Magnetic.FundamentalWave.Interfaces.MagneticPort;
       annotation (
         defaultComponentName="port_n",
@@ -8743,7 +8744,7 @@ Negative magnetic <a href=\"modelica://Modelica.Magnetic.FundamentalWave.Interfa
 </html>"));
     end NegativeMagneticPort;
 
-    connector PositiveMagneticPort "Positive complex magnetic port"
+    connector PositiveMagneticPort "Positive magnetic port of fundamental wave machines"
       extends Modelica.Magnetic.FundamentalWave.Interfaces.MagneticPort;
       annotation (
         defaultComponentName="port_p",
@@ -8777,9 +8778,9 @@ Positive magnetic <a href=\"modelica://Modelica.Magnetic.FundamentalWave.Interfa
     end PositiveMagneticPort;
 
     partial model PartialTwoPort "Two magnetic ports for graphical modeling"
-      PositiveMagneticPort port_p "Positive complex magnetic port" annotation (
+      PositiveMagneticPort port_p "Positive magnetic port of fundamental wave machines" annotation (
           Placement(transformation(extent={{-110,-10},{-90,10}})));
-      NegativeMagneticPort port_n "Negative complex magnetic port" annotation (
+      NegativeMagneticPort port_n "Negative magnetic port of fundamental wave machines" annotation (
           Placement(transformation(extent={{90,-10},{110,10}})));
       annotation (Documentation(info="<html>
 <p>
@@ -9173,13 +9174,13 @@ i.e., with small derivatives.
     model PositivePortInterface "Positive port interface to FluxTubes"
 
       Modelica.Magnetic.FundamentalWave.Interfaces.PositiveMagneticPort port
-        "FundamentalWave port"
+        "Magnetic port of fundamental wave machines"
         annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
       Modelica.Magnetic.FluxTubes.Interfaces.PositiveMagneticPort port_re
-        "Flux tubes port, real part"
+        "Magnetic port, real part"
         annotation (Placement(transformation(extent={{90,90},{110,110}})));
       Modelica.Magnetic.FluxTubes.Interfaces.PositiveMagneticPort port_im
-        "Flux tubes port, imag part"
+        "Magnetic port, imaginary part"
         annotation (Placement(transformation(extent={{90,-108},{110,-88}})));
     equation
       port.V_m.re = port_re.V_m;
@@ -9208,13 +9209,13 @@ i.e., with small derivatives.
     model NegativePortInterface "Negative port interface to FluxTubes"
 
       Modelica.Magnetic.FundamentalWave.Interfaces.NegativeMagneticPort port
-        "FundamentalWave port"
+        "Magnetic port of fundamental wave machines"
         annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
       Modelica.Magnetic.FluxTubes.Interfaces.NegativeMagneticPort port_re
-        "Flux tubes port, real part"
+        "Magnetic port, real part"
         annotation (Placement(transformation(extent={{90,90},{110,110}})));
       Modelica.Magnetic.FluxTubes.Interfaces.NegativeMagneticPort port_im
-        "Flux tubes port, imag part"
+        "Magnetic port, imaginary part"
         annotation (Placement(transformation(extent={{90,-108},{110,-88}})));
     equation
       port.V_m.re = port_re.V_m;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes.mo
@@ -1937,10 +1937,10 @@ The symbol is also designed such way to look different than the
     partial model PartialTwoPortsElementary
     "Partial component with two magnetic ports p and n for textual programming"
 
-      FluxTubes.Interfaces.PositiveMagneticPort port_p "Positive magnetic port" annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
-      FluxTubes.Interfaces.NegativeMagneticPort port_n "Negative magnetic port" annotation (Placement(transformation(extent={{90,-10},{110,10}})));
+      FluxTubes.Interfaces.PositiveMagneticPort port_p "Positive quasi static magnetic port" annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
+      FluxTubes.Interfaces.NegativeMagneticPort port_n "Negative quasi static magnetic port" annotation (Placement(transformation(extent={{90,-10},{110,10}})));
       Modelica.SIunits.ComplexMagneticPotentialDifference V_m
-      "Magnetic potential difference between both ports";
+      "Magnetic potential difference of both ports";
       Modelica.SIunits.MagneticPotentialDifference abs_V_m = Modelica.ComplexMath.'abs'(V_m)
       "Magnitude of complex magnetic potential difference";
       Modelica.SIunits.Angle arg_V_m=Modelica.ComplexMath.arg(V_m)
@@ -2079,7 +2079,7 @@ for utilisation of this partial model.
     partial model AbsoluteSensor "Partial potential sensor"
       extends Modelica.Icons.RotationalSensor;
       Modelica.SIunits.AngularVelocity omega;
-      FluxTubes.Interfaces.PositiveMagneticPort port "Port" annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
+      FluxTubes.Interfaces.PositiveMagneticPort port "Quasi static magnetic port" annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
     equation
       omega = der(port.reference.gamma);
       port.Phi = Complex(0);

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes.mo
@@ -1827,7 +1827,7 @@ The permeances of all elements of this package are calculated from their geometr
 
     connector MagneticPort "Quasi static magnetic port"
       Modelica.SIunits.ComplexMagneticPotential V_m
-      "Complex magnetic potential of the port";
+      "Complex magnetic potential at the port";
       flow Modelica.SIunits.ComplexMagneticFlux Phi
       "Complex magnetic flux flowing into the port";
       annotation (Documentation(info="<html>

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes.mo
@@ -1825,13 +1825,13 @@ The permeances of all elements of this package are calculated from their geometr
   package Interfaces "Interfaces of magnetic network components"
     extends Modelica.Icons.InterfacesPackage;
 
-    connector MagneticPort "Quasi static magnetic port"
+    connector MagneticPort "Quasi-static magnetic port"
       Modelica.SIunits.ComplexMagneticPotential V_m
       "Complex magnetic potential at the port";
       flow Modelica.SIunits.ComplexMagneticFlux Phi
       "Complex magnetic flux flowing into the port";
       annotation (Documentation(info="<html>
-<p>Base definition of complex quasi static magnetic port.
+<p>Base definition of complex quasi-static magnetic port.
 The potential variable is the complex magnetic potential difference <code>V_m</code> and the flow variable
 is the complex magnetic flux <code>Phi</code>.</p>
 
@@ -1846,7 +1846,7 @@ is the complex magnetic flux <code>Phi</code>.</p>
 </html>"));
     end MagneticPort;
 
-    connector PositiveMagneticPort "Positive quasi static magnetic port"
+    connector PositiveMagneticPort "Positive quasi-static magnetic port"
       extends Modelica.Magnetic.QuasiStatic.FundamentalWave.Interfaces.MagneticPort;
       Modelica.Electrical.QuasiStationary.Types.Reference reference "Reference";
       annotation (
@@ -1875,7 +1875,7 @@ is the complex magnetic flux <code>Phi</code>.</p>
 The positive magnetic port is based on the
 <a href=\"modelica://Modelica.Magnetic.QuasiStatic.FluxTubes.Interfaces.MagneticPort\">MagneticPort</a>.
 Additionally the reference angle is specified in the connector. The time derivative of the
-reference angle is the actual angular frequency of the quasi static magnetic potential and flux.
+reference angle is the actual angular frequency of the quasi-static magnetic potential and flux.
 The symbol is also designed such way to look different than the
 <a href=\"modelica://Modelica.Magnetic.QuasiStatic.FundamentalWave.Interfaces.NegativeMagneticPort\">NegativeMagneticPort</a>.
 </p>
@@ -1890,7 +1890,7 @@ The symbol is also designed such way to look different than the
 </html>"));
     end PositiveMagneticPort;
 
-    connector NegativeMagneticPort "Negative quasi static magnetic port"
+    connector NegativeMagneticPort "Negative quasi-static magnetic port"
       extends Modelica.Magnetic.QuasiStatic.FundamentalWave.Interfaces.MagneticPort;
       Modelica.Electrical.QuasiStationary.Types.Reference reference "Reference";
       annotation (
@@ -1919,7 +1919,7 @@ The symbol is also designed such way to look different than the
 The negative magnetic port is based on the
 <a href=\"modelica://Modelica.Magnetic.QuasiStatic.FluxTubes.Interfaces.MagneticPort\">MagneticPort</a>.
 Additionally the reference angle is specified in the connector. The time derivative of the
-reference angle is the actual angular frequency of the quasi static magnetic potential and flux.
+reference angle is the actual angular frequency of the quasi-static magnetic potential and flux.
 The symbol is also designed such way to look different than the
 <a href=\"modelica://Modelica.Magnetic.QuasiStatic.FluxTubes.Interfaces.PositiveMagneticPort\">PositiveMagneticPort</a>.
 </p>
@@ -1937,8 +1937,8 @@ The symbol is also designed such way to look different than the
     partial model PartialTwoPortsElementary
     "Partial component with two magnetic ports p and n for textual programming"
 
-      FluxTubes.Interfaces.PositiveMagneticPort port_p "Positive quasi static magnetic port" annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
-      FluxTubes.Interfaces.NegativeMagneticPort port_n "Negative quasi static magnetic port" annotation (Placement(transformation(extent={{90,-10},{110,10}})));
+      FluxTubes.Interfaces.PositiveMagneticPort port_p "Positive quasi-static magnetic port" annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
+      FluxTubes.Interfaces.NegativeMagneticPort port_n "Negative quasi-static magnetic port" annotation (Placement(transformation(extent={{90,-10},{110,10}})));
       Modelica.SIunits.ComplexMagneticPotentialDifference V_m
       "Magnetic potential difference of both ports";
       Modelica.SIunits.MagneticPotentialDifference abs_V_m = Modelica.ComplexMath.'abs'(V_m)
@@ -2079,7 +2079,7 @@ for utilisation of this partial model.
     partial model AbsoluteSensor "Partial potential sensor"
       extends Modelica.Icons.RotationalSensor;
       Modelica.SIunits.AngularVelocity omega;
-      FluxTubes.Interfaces.PositiveMagneticPort port "Quasi static magnetic port" annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
+      FluxTubes.Interfaces.PositiveMagneticPort port "Quasi-static magnetic port" annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
     equation
       omega = der(port.reference.gamma);
       port.Phi = Complex(0);

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave.mo
@@ -7328,13 +7328,13 @@ This package provides sensors for the magnetic potential difference and the magn
 
   package Interfaces "Interfaces"
     extends Modelica.Icons.InterfacesPackage;
-    connector MagneticPort "Quasi static magnetic port of fundamental wave machines"
+    connector MagneticPort "Quasi-static magnetic port of fundamental wave machines"
       Modelica.SIunits.ComplexMagneticPotential V_m
         "Complex magnetic potential at the port";
       flow Modelica.SIunits.ComplexMagneticFlux Phi
         "Complex magnetic flux flowing into the port";
       annotation (Documentation(info="<html>
-<p>Base definition of complex quasi static magnetic port. The potential variable is the complex magnetic potential 
+<p>Base definition of complex quasi-static magnetic port. The potential variable is the complex magnetic potential 
 <code>V_m</code> and the flow variable is the complex magnetic flux <code>Phi</code>.</p>
 
 <h4>See also</h4>
@@ -7347,7 +7347,7 @@ This package provides sensors for the magnetic potential difference and the magn
 </html>"));
     end MagneticPort;
 
-    connector PositiveMagneticPort "Positive quasi static magnetic port of fundamental wave machines"
+    connector PositiveMagneticPort "Positive quasi-static magnetic port of fundamental wave machines"
       extends FundamentalWave.Interfaces.MagneticPort;
       Modelica.Electrical.QuasiStationary.Types.Reference reference "Reference";
       annotation (
@@ -7370,7 +7370,7 @@ This package provides sensors for the magnetic potential difference and the magn
 <p>
 The positive port is based on
 <a href=\"modelica://Modelica.Magnetic.QuasiStatic.FundamentalWave.Interfaces.MagneticPort\">MagneticPort</a>.
-Additionally the reference angle is specified in the connector. The time derivative of the reference angle is the actual angular velocity of the quasi static voltage and current. The symbol is also designed such way to look different than the
+Additionally the reference angle is specified in the connector. The time derivative of the reference angle is the actual angular velocity of the quasi-static voltage and current. The symbol is also designed such way to look different than the
 <a href=\"modelica://Modelica.Magnetic.QuasiStatic.FundamentalWave.Interfaces.NegativeMagneticPort\">NegativeMagneticPort</a>.
 </p>
 
@@ -7383,7 +7383,7 @@ Additionally the reference angle is specified in the connector. The time derivat
 </html>"));
     end PositiveMagneticPort;
 
-    connector NegativeMagneticPort "Negative quasi static magnetic port of fundamental wave machines"
+    connector NegativeMagneticPort "Negative quasi-static magnetic port of fundamental wave machines"
       extends FundamentalWave.Interfaces.MagneticPort;
       Modelica.Electrical.QuasiStationary.Types.Reference reference "Reference";
       annotation (
@@ -7405,7 +7405,7 @@ Additionally the reference angle is specified in the connector. The time derivat
 
 <p>
 The negative pin is based on <a href=\"modelica://Modelica.Electrical.QuasiStationary.SinglePhase.Interfaces.Pin\">Pin</a>.
-Additionally the reference angle is specified in the connector. The time derivative of the reference angle is the actual angular velocity of the quasi static voltage and current. The symbol is also designed such way to look different than the <a href=\"modelica://Modelica.Electrical.QuasiStationary.SinglePhase.Interfaces.PositivePin\">positive pin</a>.
+Additionally the reference angle is specified in the connector. The time derivative of the reference angle is the actual angular velocity of the quasi-static voltage and current. The symbol is also designed such way to look different than the <a href=\"modelica://Modelica.Electrical.QuasiStationary.SinglePhase.Interfaces.PositivePin\">positive pin</a>.
 </p>
 
 <h4>See also</h4>
@@ -7421,10 +7421,10 @@ Additionally the reference angle is specified in the connector. The time derivat
       Modelica.SIunits.AngularVelocity omega=der(port_p.reference.gamma)
         "Reference angular velocity (= der(port_p.reference.gamma))";
       FundamentalWave.Interfaces.PositiveMagneticPort port_p
-        "Positive quasi static magnetic port of fundamental wave machines" annotation (Placement(
+        "Positive quasi-static magnetic port of fundamental wave machines" annotation (Placement(
             transformation(extent={{-110,-10},{-90,10}})));
       FundamentalWave.Interfaces.NegativeMagneticPort port_n
-        "Negative quasi static magnetic port of fundamental wave machines" annotation (Placement(
+        "Negative quasi-static magnetic port of fundamental wave machines" annotation (Placement(
             transformation(extent={{90,-10},{110,10}})));
     equation
       Connections.branch(port_p.reference, port_n.reference);

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave.mo
@@ -7330,7 +7330,7 @@ This package provides sensors for the magnetic potential difference and the magn
     extends Modelica.Icons.InterfacesPackage;
     connector MagneticPort "Quasi static magnetic port of fundamental wave machines"
       Modelica.SIunits.ComplexMagneticPotential V_m
-        "Complex magnetic potential of the port";
+        "Complex magnetic potential at the port";
       flow Modelica.SIunits.ComplexMagneticFlux Phi
         "Complex magnetic flux flowing into the port";
       annotation (Documentation(info="<html>

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave.mo
@@ -7347,7 +7347,7 @@ This package provides sensors for the magnetic potential difference and the magn
 </html>"));
     end MagneticPort;
 
-    connector PositiveMagneticPort "Positive quasi static magnetic port"
+    connector PositiveMagneticPort "Positive quasi static magnetic port of fundamental wave machines"
       extends FundamentalWave.Interfaces.MagneticPort;
       Modelica.Electrical.QuasiStationary.Types.Reference reference "Reference";
       annotation (
@@ -7383,7 +7383,7 @@ Additionally the reference angle is specified in the connector. The time derivat
 </html>"));
     end PositiveMagneticPort;
 
-    connector NegativeMagneticPort "Negative quasi static magnetic port"
+    connector NegativeMagneticPort "Negative quasi static magnetic port of fundamental wave machines"
       extends FundamentalWave.Interfaces.MagneticPort;
       Modelica.Electrical.QuasiStationary.Types.Reference reference "Reference";
       annotation (
@@ -7421,10 +7421,10 @@ Additionally the reference angle is specified in the connector. The time derivat
       Modelica.SIunits.AngularVelocity omega=der(port_p.reference.gamma)
         "Reference angular velocity (= der(port_p.reference.gamma))";
       FundamentalWave.Interfaces.PositiveMagneticPort port_p
-        "Positive quasi static magnetic port" annotation (Placement(
+        "Positive quasi static magnetic port of fundamental wave machines" annotation (Placement(
             transformation(extent={{-110,-10},{-90,10}})));
       FundamentalWave.Interfaces.NegativeMagneticPort port_n
-        "Negative quasi static magnetic port" annotation (Placement(
+        "Negative quasi static magnetic port of fundamental wave machines" annotation (Placement(
             transformation(extent={{90,-10},{110,10}})));
     equation
       Connections.branch(port_p.reference, port_n.reference);

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -1096,6 +1096,10 @@ For parameters, connectors, as well as inputs and outputs of function automatic 
       <td>single phase, singlephase, one phase, one-phase, onephase, 1 phase, 1-phase</td>
     </tr>
      <tr>
+      <td><a href=\"http://www.electropedia.org/iev/iev.nsf/display?openform&amp;ievref=113-04-08\">quasi-static</a></td>
+      <td>quasistatic, quasi static</td>
+    </tr>
+     <tr>
       <td><a href=\"http://www.electropedia.org/iev/iev.nsf/display?openform&amp;ievref=811-12-22\">three-phase</a></td>
       <td>three phase, threephase, 3 phase, 3-phase</td>
     </tr>
@@ -1123,6 +1127,10 @@ For parameters, connectors, as well as inputs and outputs of function automatic 
     <tr>
       <td><a href=\"http://www.electropedia.org/iev/iev.nsf/display?openform&amp;ievref=121-11-60\">magnetomotive force</a></td>
       <td>magneto motive force</td>
+    </tr>
+     <tr>
+      <td><a href=\"http://www.electropedia.org/iev/iev.nsf/display?openform&amp;ievref=113-04-08\">quasi-static</a></td>
+      <td>quasistatic, quasi static</td>
     </tr>
 </table>
 


### PR DESCRIPTION
The changes are based on the discussion of #2560. Due to the added and improved doc strings of the connectors, the examples of the MSL (and other user libraries) are much better to understand. The tooltips associated with the connectors now show a much more complete and accurate description of the connectors. 