### PR TITLE
Add start value for RadioButton

### DIFF
--- a/Modelica/Fluid/Examples/ControlledTankSystem.mo
+++ b/Modelica/Fluid/Examples/ControlledTankSystem.mo
@@ -427,7 +427,7 @@ This example is based on
       Modelica.Blocks.Interfaces.BooleanOutput on(start=false, fixed=true)
         annotation (Placement(transformation(extent={{100,-10},{120,10}})));
     protected
-      Modelica.Blocks.Sources.BooleanTable table(table=buttonTimeTable, y(fixed=true));
+      Modelica.Blocks.Sources.BooleanTable table(table=buttonTimeTable, y(start=false, fixed=true));
     initial equation
       pre(reset) = fill(false, size(reset, 1));
     algorithm

--- a/Modelica/Fluid/Examples/ControlledTankSystem.mo
+++ b/Modelica/Fluid/Examples/ControlledTankSystem.mo
@@ -429,6 +429,8 @@ This example is based on
     protected
       Modelica.Blocks.Sources.BooleanTable table(table=buttonTimeTable);
     initial equation
+      // These pre-values are used for the algorithm during initialization
+      pre(table.y) = false;
       pre(reset) = fill(false, size(reset, 1));
     algorithm
       when pre(reset) then

--- a/Modelica/Fluid/Examples/ControlledTankSystem.mo
+++ b/Modelica/Fluid/Examples/ControlledTankSystem.mo
@@ -424,13 +424,11 @@ This example is based on
         "Reset button to false, if an element of reset becomes true"
         annotation (Dialog(group="Time varying expressions"));
 
-      Modelica.Blocks.Interfaces.BooleanOutput on
+      Modelica.Blocks.Interfaces.BooleanOutput on(start=false, fixed=true)
         annotation (Placement(transformation(extent={{100,-10},{120,10}})));
     protected
-      Modelica.Blocks.Sources.BooleanTable table(table=buttonTimeTable);
+      Modelica.Blocks.Sources.BooleanTable table(table=buttonTimeTable, y(fixed=true));
     initial equation
-      // These pre-values are used for the algorithm during initialization
-      pre(table.y) = false;
       pre(reset) = fill(false, size(reset, 1));
     algorithm
       when pre(reset) then


### PR DESCRIPTION
To make a clean translation for ControlledTanks we need start-values for both table.y and reset.
As far as I understand they are not relevant after the initialization (since we have equations) - and not used during initialization (since when-conditions aren't active unless using when initial). 
However, they should not cause any problems.

Close #2243 