### PR TITLE
Reintroduce UTF-8 characters that were removed for v3.2.3 release

### DIFF
--- a/Modelica/ComplexBlocks.mo
+++ b/Modelica/ComplexBlocks.mo
@@ -1987,8 +1987,8 @@ An error occurs if the elements of the input <code>u</code> is zero.
               lineThickness=0.5,
               fillColor={192,192,192},
               fillPattern=FillPattern.Solid,
-              lineColor={128,128,128},
-              textString="angle"),
+              textString="∠",
+              lineColor={128,128,128}),
             Text(
               visible = useDivisor,
               extent={{-56,94},{94,54}},

--- a/Modelica/Fluid/Examples/DrumBoiler.mo
+++ b/Modelica/Fluid/Examples/DrumBoiler.mo
@@ -1,6 +1,6 @@
 within Modelica.Fluid.Examples;
 package DrumBoiler
-  "Drum boiler example, see Franke, Rode, Krueger: On-line Optimization of Drum Boiler Startup, 3rd International Modelica Conference, Linkoping, 2003"
+  "Drum boiler example, see Franke, Rode, Krüger: On-line Optimization of Drum Boiler Startup, 3rd International Modelica Conference, Linköping, 2003"
 
   extends Modelica.Icons.ExamplesPackage;
   model DrumBoiler
@@ -171,7 +171,7 @@ package DrumBoiler
     extends Modelica.Icons.BasesPackage;
 
     model EquilibriumDrumBoiler
-      "Simple Evaporator with two states, see Astroem, Bell: Drum-boiler dynamics, Automatica 36, 2000, pp.363-378"
+      "Simple Evaporator with two states, see Åström, Bell: Drum-boiler dynamics, Automatica 36, 2000, pp.363-378"
       extends Modelica.Fluid.Interfaces.PartialTwoPort(
         final port_a_exposesState=true,
         final port_b_exposesState=true,

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes.mo
@@ -2580,7 +2580,7 @@ This sensor can be used to measure the complex magnetic flux <code>Phi</code> of
         annotation (Icon(coordinateSystem(
                 preserveAspectRatio=false), graphics={
                                         Text(extent={{-29,-11},{30,-70}},
-                textString="mu")}), Diagram(
+                textString="μ")}), Diagram(
               coordinateSystem(preserveAspectRatio=false)),
         Documentation(info="<html>
 <p>
@@ -2633,7 +2633,7 @@ This sensor is used to determined the effective fundamental wave permeability of
                 extent={{60,-60},{-60,60}},
                 fillColor={255,170,85},
                 fillPattern=FillPattern.Solid,
-                textString="mu")}),
+                textString="μ")}),
         Documentation(info="<html>
 <p>This model determines the absolute and relative permeability from two real inputs:</p>
 <ul>


### PR DESCRIPTION
For the v3.2.3 release some non-ASCII characters were removed (as part of #2587) in order to keep the MSL ASCII. The next MAJOR version should allow UTF8 encoding and hence also these characters again.