### PR TITLE
Removed min=0 attribute from SIunits.Height

### DIFF
--- a/Modelica/SIunits.mo
+++ b/Modelica/SIunits.mo
@@ -918,7 +918,7 @@ argument):</p>
   type Position = Length;
   type Distance = Length (min=0);
   type Breadth = Length(min=0);
-  type Height = Length(min=0);
+  type Height = Length;
   type Thickness = Length(min=0);
   type Radius = Length(min=0);
   type Diameter = Length(min=0);


### PR DESCRIPTION
Modelica SIunits currently defines Height as 

`type Height = Length(min=0);`

IMO negative height can make sense in a number of cases, e.g.
- height above mean sea level (can be negative in the Netherlands or on the Dead Sea shore)
- hydraulic head of a pump (can be negative if the inlet pressure is greater than the outlet pressure)

In fact, the latter example actually influences the pump models in both Modelica.Fluid and ThermoPower, and unnecessarily introduces the constraint that the head should be positive, which is in general unnecessarily restrictive.

I would then propose to simply remove the `min` attribute (which I consider as a bugfix). As we are not introducing additional constraints, this change should be 100% backwards compatible.