### PR TITLE
Extend function icon for padeCoefficients2

### DIFF
--- a/Modelica/Blocks/Nonlinear.mo
+++ b/Modelica/Blocks/Nonlinear.mo
@@ -464,6 +464,7 @@ The Input signal is delayed by a given time instant, or more precisely:
     parameter Real s[n-1](each fixed=false) "State scaling";
 
   function padeCoefficients2
+    extends Modelica.Icons.Function;
     input Real T "delay time";
     input Integer n "order of denominator";
     input Integer m "order of numerator";


### PR DESCRIPTION
Add icon to (protected) function Modelica.Blocks.Nonlinear.PadeDelay.padeCoefficients2.