### PR TITLE
Fix beta.2 regression issue #2542

### DIFF
--- a/ModelicaTest/Media.mo
+++ b/ModelicaTest/Media.mo
@@ -934,6 +934,8 @@ is given to compare the approximation.
           extends Modelica.Icons.Example;
           extends Modelica.Media.Examples.Utilities.PartialTestModel(
               redeclare package Medium = Modelica.Media.Air.SimpleAir);
+          inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyStateInitial)
+            annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
           annotation (Documentation(info="<html>
 
 </html>"), experiment(StopTime=1.01));
@@ -943,6 +945,8 @@ is given to compare the approximation.
           extends Modelica.Icons.Example;
           extends Modelica.Media.Examples.Utilities.PartialTestModel(
               redeclare package Medium = Modelica.Media.Air.DryAirNasa);
+          inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyStateInitial)
+            annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
           annotation (Documentation(info="<html>
 
 </html>"), experiment(StopTime=1.01));
@@ -952,6 +956,8 @@ is given to compare the approximation.
           extends Modelica.Icons.Example;
           extends Modelica.Media.Examples.Utilities.PartialTestModel(
               redeclare package Medium = Modelica.Media.Air.MoistAir);
+          inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyStateInitial)
+            annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
           annotation (Documentation(info="<html>
 
 </html>"), experiment(StopTime=1.01));
@@ -968,6 +974,8 @@ is given to compare the approximation.
           extends Modelica.Icons.Example;
           extends Modelica.Media.Examples.Utilities.PartialTestModel(
               redeclare package Medium = Modelica.Media.Air.DryAirNasa);
+          inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyStateInitial)
+            annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
           annotation (Documentation(info="<html>
 
 </html>"), experiment(StopTime=1.01));
@@ -979,6 +987,8 @@ is given to compare the approximation.
           extends Modelica.Media.Examples.Utilities.PartialTestModel(
               redeclare package Medium =
                 Modelica.Media.IdealGases.SingleGases.N2);
+          inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyStateInitial)
+            annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
           annotation (Documentation(info="<html>
 
 </html>"), experiment(StopTime=1.01));
@@ -990,6 +1000,8 @@ is given to compare the approximation.
           extends Modelica.Media.Examples.Utilities.PartialTestModel(
               redeclare package Medium =
                 Modelica.Media.IdealGases.MixtureGases.SimpleNaturalGas);
+          inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyStateInitial)
+            annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
           annotation (Documentation(info="<html>
 
 </html>"), experiment(StopTime=1.01));
@@ -1001,6 +1013,8 @@ is given to compare the approximation.
           extends Modelica.Media.Examples.Utilities.PartialTestModel(
               redeclare package Medium =
                 Modelica.Media.IdealGases.MixtureGases.SimpleNaturalGasFixedComposition);
+          inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyStateInitial)
+            annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
           annotation (experiment(StopTime=1.01));
         end SimpleNaturalGasFixedComposition;
       end IdealGases;
@@ -1014,6 +1028,8 @@ is given to compare the approximation.
               redeclare package Medium =
                 Modelica.Media.Incompressible.Examples.Glycol47 (final
                   singleState=true, final enthalpyOfT=true));
+          inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyStateInitial)
+            annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
           annotation (Documentation(info="<html>
 
 </html>"), experiment(StopTime=1.01));
@@ -1025,6 +1041,8 @@ is given to compare the approximation.
           extends Modelica.Media.Examples.Utilities.PartialTestModel(
               redeclare package Medium =
                 Modelica.Media.Incompressible.Examples.Essotherm650);
+          inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyStateInitial)
+            annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
           annotation (Documentation(info="<html>
 
 </html>"), experiment(StopTime=1.01));
@@ -1042,6 +1060,8 @@ is given to compare the approximation.
           extends Modelica.Media.Examples.Utilities.PartialTestModel(
               redeclare package Medium =
                 Modelica.Media.Water.ConstantPropertyLiquidWater);
+          inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyStateInitial)
+            annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
           annotation (Documentation(info="<html>
 
 </html>"), experiment(StopTime=1.01));
@@ -1051,6 +1071,8 @@ is given to compare the approximation.
           extends Modelica.Icons.Example;
           extends Modelica.Media.Examples.Utilities.PartialTestModel(
               redeclare package Medium = Modelica.Media.Water.IdealSteam);
+          inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyStateInitial)
+            annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
           annotation (Documentation(info="<html>
 
 </html>"), experiment(StopTime=1.01));
@@ -1061,9 +1083,9 @@ is given to compare the approximation.
           extends Modelica.Icons.Example;
           extends Modelica.Media.Examples.Utilities.PartialTestModel(
             redeclare package Medium =
-                Modelica.Media.Water.WaterIF97OnePhase_ph,
-            system(energyDynamics=Modelica.Fluid.Types.Dynamics.DynamicFreeInitial),
-            volume(medium(h(fixed=true), p(fixed=true))));
+                Modelica.Media.Water.WaterIF97OnePhase_ph);
+          inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.DynamicFreeInitial)
+            annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
 
           annotation (Documentation(info="<html>
 
@@ -1073,9 +1095,9 @@ is given to compare the approximation.
         model WaterIF97_pT "Test Modelica.Media.Water.WaterIF97_pT"
           extends Modelica.Icons.Example;
           extends Modelica.Media.Examples.Utilities.PartialTestModel(
-            redeclare package Medium = Modelica.Media.Water.WaterIF97_pT,
-            system(energyDynamics=Modelica.Fluid.Types.Dynamics.DynamicFreeInitial),
-            volume(medium(T(fixed=true), p(fixed=true))));
+            redeclare package Medium = Modelica.Media.Water.WaterIF97_pT);
+          inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.DynamicFreeInitial)
+            annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
 
           annotation (Documentation(info="<html>
 
@@ -1085,9 +1107,9 @@ is given to compare the approximation.
         model WaterIF97_ph "Test Modelica.Media.Water.WaterIF97_ph"
           extends Modelica.Icons.Example;
           extends Modelica.Media.Examples.Utilities.PartialTestModel(
-            redeclare package Medium = Modelica.Media.Water.WaterIF97_ph,
-            system(energyDynamics=Modelica.Fluid.Types.Dynamics.DynamicFreeInitial),
-            volume(medium(h(fixed=true), p(fixed=true))));
+            redeclare package Medium = Modelica.Media.Water.WaterIF97_ph);
+          inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.DynamicFreeInitial)
+            annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
 
           annotation (Documentation(info="<html>
 


### PR DESCRIPTION
The test models
```
ModelicaTest.Media.TestsWithFluid.MediaTestModels.Water.WaterIF97OnePhase_ph
ModelicaTest.Media.TestsWithFluid.MediaTestModels.Water.WaterIF97_pT
ModelicaTest.Media.TestsWithFluid.MediaTestModels.Water.WaterIF97_ph
```
fail due to regression in #2542. The reason is that the removed `ModelicaTest.Media.TestsWithFluid.Components.PartialTestModel` contained an `inner system` component with modified `energyDynamics`
```mo
        inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyStateInitial)
          annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
```
whereas the other `PartialTestModel` (that was moved from `Modelica.Media.Examples.Tests.Components` to `Modelica.Media.Examples.Utilities`) does not.

This adds an `inner system` to all test models of `ModelicaTest.Media.TestsWithFluid.MediaTestModels`. Also, the fixed start values of `volume.medium.p` and `volume.medium.h` were removed (for the above mentioned three failing models).