### PR TITLE
Correct misleading error message when out of string memory for ModelicaInternal_readLine

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaInternal.c
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.c
@@ -30,6 +30,10 @@
 */
 
 /* Release Notes:
+      Jun. 28, 2018: by Hans Olsson, Dassault Systemes
+                     Proper error message when out of string memory 
+                     in ModelicaInternal_readLine (ticket #2676)
+  
       Oct. 23, 2017: by Thomas Beutlich, ESI ITI GmbH
                      Utilized non-fatal hash insertion, called by HASH_ADD_KEYPTR in
                      function CacheFileForReading (ticket #2097)

--- a/Modelica/Resources/C-Sources/ModelicaInternal.c
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.c
@@ -969,6 +969,7 @@ _Ret_z_ const char* ModelicaInternal_readLine(_In_z_ const char* fileName,
     }
     line = ModelicaAllocateStringWithErrorReturn(lineLen);
     if ( line == NULL ) {
+        errno = 0; /* Erase previous error code, treated specially below */
         goto Modelica_ERROR3;
     }
 
@@ -1001,7 +1002,7 @@ Modelica_ERROR3:
     fclose(fp);
     CloseCachedFile(fileName);
     ModelicaFormatError("Error when reading line %i from file\n\"%s\":\n%s",
-        lineNumber, fileName, strerror(errno));
+        lineNumber, fileName, (errno == 0) ? "Not enough memory to allocate string for reading line." : strerror(errno));
     return "";
 }
 


### PR DESCRIPTION
When readLine cannot allocate more string memory it deliberately catches this and uses the same code as for other errors, but the error message will be from the previous operation that set errno - and thus misleading. 

There are two ways of resolving this:

- As in this pull-request. Setting errno is standard; and the other operations should set it as well.
- Don't use ModelicaAllocateStringWithErrorReturn - just let string allocation fail in the normal way (downside is that it will not be clear on what line it occurred on).

(Unfortunately I don't think I can include the model reproducing this. internal id is 613258)