### PR TITLE
Fixing Modelica.Math.Matrices.Utilities.toUpperHessenberg

### DIFF
--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -11310,27 +11310,27 @@ This transformation is widely used for transforming non-symmetric matrices to a 
       Integer i;
 
     algorithm
-    if n > 0 then
-      if n == 1 then
-        H := A;
-        V := {{0.0}};
-        tau := zeros(0);
-        info := 0;
-      else
-        (Aout, tau, info) := LAPACK.dgehrd(A, ilo, ihi);
-        H := zeros(size(H, 1), size(H, 2));
-        H[1:2, 1:n] := Aout[1:2, 1:n];
-        for i in 3:n loop
-          H[i, (i - 1):n] := Aout[i, (i - 1):n];
-        end for;
-        V := zeros(size(V, 1), size(V, 2));
-        for i in ilo:min(n - 2, ihi) loop
-          V[i + 1, i] := 1.0;
-          V[(i + 2):n, i] := Aout[(i + 2):n, i];
-        end for;
-        V[n, n - 1] := 1;
+      if n > 0 then
+        if n == 1 then
+          H := A;
+          V := {{0.0}};
+          tau := zeros(0);
+          info := 0;
+        else
+          (Aout, tau, info) := LAPACK.dgehrd(A, ilo, ihi);
+          H := zeros(size(H, 1), size(H, 2));
+          H[1:2, 1:n] := Aout[1:2, 1:n];
+          for i in 3:n loop
+            H[i, (i - 1):n] := Aout[i, (i - 1):n];
+          end for;
+          V := zeros(size(V, 1), size(V, 2));
+          for i in ilo:min(n - 2, ihi) loop
+            V[i + 1, i] := 1.0;
+            V[(i + 2):n, i] := Aout[(i + 2):n, i];
+          end for;
+          V[n, n - 1] := 1;
+        end if;
       end if;
-    end if;
     annotation (Documentation(info="<html>
    <h4>Syntax</h4>
 <blockquote><pre>

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -11311,17 +11311,25 @@ This transformation is widely used for transforming non-symmetric matrices to a 
 
     algorithm
     if n > 0 then
-      (Aout, tau, info) := LAPACK.dgehrd(A, ilo, ihi);
-      H[1:2, 1:n] := Aout[1:2, 1:n];
-      for i in 3:n loop
-        H[i, (i - 1):n] := Aout[i, (i - 1):n];
-        H[i, 1:(i - 2)] := zeros(i - 2);
-      end for;
-      for i in 1:min(n - 2, ihi) loop
-        V[i + 1, i] := 1.0;
-        V[i + 2:n, i] := Aout[i + 2:n, i];
-      end for;
-      V[n, n - 1] := 1;
+      if n == 1 then
+        H := A;
+        V := {{1}};
+        tau := {1.0};
+        info := 0;
+      else
+        (Aout, tau, info) := LAPACK.dgehrd(A, ilo, ihi);
+        H := zeros(size(H, 1), size(H, 2));
+        H[1:2, 1:n] := Aout[1:2, 1:n];
+        for i in 3:n loop
+          H[i, (i - 1):n] := Aout[i, (i - 1):n];
+        end for;
+        V := zeros(size(V, 1), size(V, 2));
+        for i in ilo:min(n - 2, ihi) loop
+          V[i + 1, i] := 1.0;
+          V[(i + 2):n, i] := Aout[(i + 2):n, i];
+        end for;
+        V[n, n - 1] := 1;
+      end if;
     end if;
     annotation (Documentation(info="<html>
    <h4>Syntax</h4>

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -11310,27 +11310,20 @@ This transformation is widely used for transforming non-symmetric matrices to a 
       Integer i;
 
     algorithm
-      if n > 0 then
-        (Aout,tau,info) := LAPACK.dgehrd(
-                A,
-                ilo,
-                ihi);
-        H[1:2, 1:ihi] := Aout[1:2, 1:ihi];
-        H[1:2, ihi + 1:n] := A[1:2, ihi + 1:n];
-
-        for i in 3:n loop
-          H[i, i - 1:ihi] := Aout[i, i - 1:ihi];
-          H[i, ihi + 1:n] := A[i, ihi + 1:n];
-        end for;
-
-        for i in 1:min(n - 2, ihi) loop
-          V[i + 1, i] := 1.0;
-          V[i + 2:n, i] := Aout[i + 2:n, i];
-        end for;
-        V[n, n - 1] := 1;
-      end if;
-
-      annotation (Documentation(info="<html>
+    if n > 0 then
+      (Aout, tau, info) := LAPACK.dgehrd(A, ilo, ihi);
+      H[1:2, 1:n] := Aout[1:2, 1:n];
+      for i in 3:n loop
+        H[i, (i - 1):n] := Aout[i, (i - 1):n];
+        H[i, 1:(i - 2)] := zeros(i - 2);
+      end for;
+      for i in 1:min(n - 2, ihi) loop
+        V[i + 1, i] := 1.0;
+        V[i + 2:n, i] := Aout[i + 2:n, i];
+      end for;
+      V[n, n - 1] := 1;
+    end if;
+    annotation (Documentation(info="<html>
    <h4>Syntax</h4>
 <blockquote><pre>
          H = Matrices.Utilities.<strong>toUpperHessenberg</strong>(A);

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -11313,8 +11313,8 @@ This transformation is widely used for transforming non-symmetric matrices to a 
     if n > 0 then
       if n == 1 then
         H := A;
-        V := {{1}};
-        tau := {1.0};
+        V := {{0.0}};
+        tau := zeros(0);
         info := 0;
       else
         (Aout, tau, info) := LAPACK.dgehrd(A, ilo, ihi);


### PR DESCRIPTION
This addresses a couple of issues with toUpperHessenberg.
First, in the previous implementation, the elements below the subdiagonal of H was never initialized. This is an error by the Modelica Specification 3.4, section 12.4.4.
Second, there is no point in copying different parts of H from A or Aout, it just makes for confusing code. Even if ilo and ihi are set to nontrivial values, the upper Hessenberg matrix will be in Aout's upper triangle and first subdiagonal.