### PR TITLE
Move ModelicaFileType to header ModelicaInternal.h

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaInternal.c
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.c
@@ -229,13 +229,6 @@ void ModelicaInternal_setenv(_In_z_ const char* name,
 #define BUFFER_LENGTH 1024
 #endif
 
-typedef enum {
-    FileType_NoFile = 1,
-    FileType_RegularFile,
-    FileType_Directory,
-    FileType_SpecialFile   /* pipe, FIFO, device, etc. */
-} ModelicaFileType;
-
 /* Convert to Unix directory separators: */
 #if defined(_WIN32)
 static void ModelicaConvertToUnixDirectorySeparator(char* string) {

--- a/Modelica/Resources/C-Sources/ModelicaInternal.h
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.h
@@ -80,6 +80,13 @@
 #define _Ret_z_
 #endif
 
+typedef enum {
+    FileType_NoFile = 1,
+    FileType_RegularFile,
+    FileType_Directory,
+    FileType_SpecialFile   /* pipe, FIFO, device, etc. */
+} ModelicaFileType;
+
 MODELICA_EXPORT void ModelicaInternal_mkdir(_In_z_ const char* directoryName) MODELICA_NONNULLATTR;
 MODELICA_EXPORT void ModelicaInternal_rmdir(_In_z_ const char* directoryName) MODELICA_NONNULLATTR;
 MODELICA_EXPORT int ModelicaInternal_stat(_In_z_ const char* name) MODELICA_NONNULLATTR;


### PR DESCRIPTION
This enables the reuse the ModelicaFileType enum values for return value comparisons of ModelicaInternal_stat.

In addition to #2052.