### PR TITLE
Fix LCC linker warning on mymemcpy

### DIFF
--- a/Modelica/Resources/C-Sources/snprintf.c
+++ b/Modelica/Resources/C-Sources/snprintf.c
@@ -1418,7 +1418,7 @@ mypow10(int exponent)
 
 #if !HAVE_VASPRINTF
 #if NEED_MYMEMCPY
-void *
+static void *
 mymemcpy(void *dst, void *src, size_t len)
 {
     const char *from = (const char *)src;


### PR DESCRIPTION
Avoid LCC Warning snprintf.c: 1421  inconsistent linkage for `mymemcpy' previously declared at snprintf.c 263

See also upstream issue https://github.com/weiss/c99-snprintf/pull/5