### PR TITLE
Must not touch the include guard of ModelicaUtilities.h to keep backward-compatibility

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaUtilities.h
+++ b/Modelica/Resources/C-Sources/ModelicaUtilities.h
@@ -41,8 +41,8 @@
    this header file is shipped with the Modelica Standard Library.
 */
 
-#ifndef MODELICA_UTILITIES_H_
-#define MODELICA_UTILITIES_H_
+#ifndef MODELICA_UTILITIES_H
+#define MODELICA_UTILITIES_H
 
 #include <stddef.h>
 #include <stdarg.h>


### PR DESCRIPTION
* If a Modelica tool distributes a header file ModelicaUtilities.h from MSL v3.2.2 (or previous), make sure the include guard takes effect if the new ModelicaUtilities.h is utilized with a library.
* As reported by https://github.com/modelica/Modelica_DeviceDrivers/pull/253
* Fix regression d574148e3a53588da9b8303ee1596c217a2ac74c