### PR TITLE
Fix event detection and left extrapolation of CombiTimeTable

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -38,6 +38,10 @@
       Modelica.Blocks.Tables.CombiTable2D
 
    Release Notes:
+      Oct. 04, 2018: by Thomas Beutlich, ESI ITI GmbH
+                     Fixed event detection of CombiTimeTable (ticket #2724)
+                     Fixed left extrapolation of CombiTimeTable (ticket #2724)
+
       Jan. 03, 2018: by Thomas Beutlich, ESI ITI GmbH
                      Improved reentrancy of CombiTimeTable (ticket #2411)
 
@@ -1015,12 +1019,12 @@ double ModelicaStandardTables_CombiTimeTable_getValue(void* _tableID, int iCol,
                                 case CONSTANT_SEGMENTS: {
                                     const double t0 = TABLE_COL0(last);
                                     const double t1 = TABLE_COL0(last + 1);
+                                    const double y0 = TABLE(last, col);
                                     const double y1 = TABLE(last + 1, col);
                                     if (isNearlyEqual(t0, t1)) {
-                                        y = y1;
+                                        y = (extrapolate == RIGHT) ? y1 : y0;
                                     }
                                     else {
-                                        const double y0 = TABLE(last, col);
                                         LINEAR(t, t0, t1, y0, y1);
                                     }
                                     break;
@@ -1591,7 +1595,7 @@ double ModelicaStandardTables_CombiTimeTable_nextTimeEvent(void* _tableID,
                     else {
                         nextTimeEvent = DBL_MAX;
                     }
-                } while (nextTimeEvent < t);
+                } while (nextTimeEvent <= t);
             }
         }
 

--- a/ModelicaTest/Tables/CombiTimeTable.mo
+++ b/ModelicaTest/Tables/CombiTimeTable.mo
@@ -1085,4 +1085,20 @@ double mydummyfunc(double* dummy_in) {
         fileName=loadResource("modelica://ModelicaTest/Resources/Data/Tables/test_utf8.txt")));
     annotation (experiment(StartTime=0, StopTime=100));
   end Test84;
+
+  model Test85 "Single time event at t_min=t_max > startTime = 0 (Ticket #2724)"
+    extends Modelica.Icons.Example;
+    extends Test0_noDer(t_new(
+      table=[1,10;1,11],
+      smoothness=Modelica.Blocks.Types.Smoothness.ConstantSegments));
+    annotation (experiment(StartTime=0, StopTime=3));
+  end Test85;
+
+  model Test86 "Two time events (Ticket #2724)"
+    extends Modelica.Icons.Example;
+    extends Test0_noDer(t_new(
+      table=[1,10;1,11;2,12],
+      smoothness=Modelica.Blocks.Types.Smoothness.ConstantSegments));
+    annotation (experiment(StartTime=0, StopTime=3));
+  end Test86;
 end CombiTimeTable;


### PR DESCRIPTION
This actually fixes two issues that only were discovered when implementation of BooleanTable was switched to utilize CombiTimeTable for #2190.

Close #2724 

Updated MSVC Win binaries, in case you do not want to compile on your own: [T2724.zip](https://github.com/modelica/ModelicaStandardLibrary/files/2447043/T2724.zip)

@HansOlsson Can you please check if this fixes the regression issue on ModelicaTest.Blocks.BooleanTable, that was discovered in MSL v3.2.3-rc.1.
