### PR TITLE
Add missing `each` in Magnetic.FundamentalWave

### DIFF
--- a/Modelica/Magnetic/FundamentalWave.mo
+++ b/Modelica/Magnetic/FundamentalWave.mo
@@ -4075,7 +4075,7 @@ to speed to achieve constant current and torque.</p>
           statorCoreParameters(VRef=100),
           strayLoadParameters(IRef=100),
           brushParameters(ILinear=0.01),
-          ir(fixed=true),
+          ir(each fixed=true),
           wMechanical(fixed=true),
           m=m,
           Rs=smeeData.Rs*m/3,


### PR DESCRIPTION
- `ir` is an array, and so `each` should be used in
  Modelica.Magnetic.FundamentalWave.Examples.BasicMachines.SMEE_DOL.