### PR TITLE
Use ellipses in Mechanics

### DIFF
--- a/Modelica/Mechanics/MultiBody/Examples/Elementary/LineForceWithTwoMasses.mo
+++ b/Modelica/Mechanics/MultiBody/Examples/Elementary/LineForceWithTwoMasses.mo
@@ -185,7 +185,7 @@ this system and plot the differences of the cut forces at both sides
 of the line force component (\"rod_f_diff\" and \"body_f_diff\").
 Both vectors should be zero
 (depending on the chosen relative tolerance of the integration,
-the difference is in the order of 1e-10 ... 1e-15).
+the difference is in the order of 1e-10&nbsp;&hellip;&nbsp;1e-15).
 </p>
 <p>
 Note, that the implementation with the LineForceWithTwoMasses

--- a/Modelica/Mechanics/MultiBody/Examples/Elementary/RollingWheelSetPulling.mo
+++ b/Modelica/Mechanics/MultiBody/Examples/Elementary/RollingWheelSetPulling.mo
@@ -71,7 +71,7 @@ equation
     Documentation(info="<html>
 <p>
 Demonstrates how a RollingWheelSet (two wheels rigidly coupled together) is rolling
-on ground when pulled by an external force..
+on ground when pulled by an external force.
 </p>
 </html>"));
 end RollingWheelSetPulling;

--- a/Modelica/Mechanics/MultiBody/Frames.mo
+++ b/Modelica/Mechanics/MultiBody/Frames.mo
@@ -1018,7 +1018,7 @@ Computes the orientation object from a transformation matrix T and
 the derivative der(T) of the transformation matrix.
 Usually, it is more efficient to use function \"from_T\" instead, where
 the angular velocity has to be given as input argument. Only if this
-is not possible or too difficult to compute, use function from_T2(..).
+is not possible or too difficult to compute, use function from_T2(&hellip;).
 </p>
 
 <h4>See also</h4>
@@ -3604,7 +3604,7 @@ y = Internal.<strong>maxWithoutEvent</strong>(u1, u2)
 <p>
 Function <strong>maxWithoutEvent</strong> returns the maximum of its two
 input arguments. This functions is used instead of the Modelica
-built-in function \"max\" or an if-statement with \"noEvent(..)\",
+built-in function \"max\" or an if-statement with \"noEvent(&hellip;)\",
 in order that the function can be differentiated by providing
 the first and second derivatives with additional functions.
 Note, from a strict mathematical point of view the derivatives

--- a/Modelica/Mechanics/MultiBody/Parts.mo
+++ b/Modelica/Mechanics/MultiBody/Parts.mo
@@ -3077,8 +3077,8 @@ given in
 <p>
 Colors in all animation parts are defined via parameter <strong>color</strong>.
 This is an Integer vector with 3 elements, {r, g, b}, and specifies the
-color of the shape. {r,g,b} are the \"red\", \"green\" and \"blue\" color parts,
-given in the ranges 0 .. 255, respectively. The predefined type
+color of the shape. {r, g, b} are the \"red\", \"green\" and \"blue\" color parts,
+given in the ranges 0&nbsp;&hellip;&nbsp;255, respectively. The predefined type
 <strong>MultiBody.Types.Color</strong> contains a menu
 definition of the colors used in the MultiBody library
 (this will be replaced by a color editor).

--- a/Modelica/Mechanics/MultiBody/Sensors.mo
+++ b/Modelica/Mechanics/MultiBody/Sensors.mo
@@ -1829,7 +1829,7 @@ signal can be easily obtained by connecting the
 block
 <a href=\"modelica://Modelica.Blocks.Continuous.Der\">Modelica.Blocks.Continuous.Der</a>
 to \"distance\" (this block performs analytic differentiation
-of the input signal using the der(..) operator).
+of the input signal using the der(&hellip;) operator).
 </p>
 <p>
 In the following figure the animation of a Distance

--- a/Modelica/Mechanics/MultiBody/Types.mo
+++ b/Modelica/Mechanics/MultiBody/Types.mo
@@ -153,7 +153,7 @@ Additionally, external shapes can be specified as (not all options might be supp
 </p>
 
 <ul>
-<li> <strong>\"1\", \"2\", &hellip;</strong><br>
+<li> <strong>\"1\", \"2\",&nbsp;&hellip;</strong><br>
      define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\", &hellip;
      The DXF-files must be found either in the current directory or in the directory where
      the Shape instance is stored that references the DXF file.

--- a/Modelica/Mechanics/MultiBody/Types.mo
+++ b/Modelica/Mechanics/MultiBody/Types.mo
@@ -154,7 +154,7 @@ Additionally, external shapes can be specified as (not all options might be supp
 
 <ul>
 <li> <strong>\"1\", \"2\",&nbsp;&hellip;</strong><br>
-     define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\", &hellip;
+     define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\",&nbsp;&hellip;
      The DXF-files must be found either in the current directory or in the directory where
      the Shape instance is stored that references the DXF file.
      This (very limited) option should not be used for new models. Example:<br>

--- a/Modelica/Mechanics/MultiBody/Types.mo
+++ b/Modelica/Mechanics/MultiBody/Types.mo
@@ -62,8 +62,8 @@ For an example see parameter \"n\" in model
 <p>
 Type <strong>Color</strong> is an Integer vector with 3 elements,
 {r, g, b}, and specifies the color of a shape.
-{r,g,b} are the \"red\", \"green\" and \"blue\" color parts.
-Note, r g, b are given in the range 0 .. 255.
+{r, g, b} are the \"red\", \"green\" and \"blue\" color parts.
+Note, r, g and b are given in the range 0&nbsp;&hellip;&nbsp;255.
 </p>
 </html>"));
   type RealColor =
@@ -92,7 +92,7 @@ Note, r g, b are given in the range 0 .. 255.
 Type <strong>RealColor</strong> is a Real vector with 3 elements,
 {r, g, b}, and specifies the color of a shape.
 {r,g,b} are the \"red\", \"green\" and \"blue\" color parts.
-Note, r g, b are given in the range 0 .. 255.
+Note, r, g and b are given in the range 0&nbsp;&hellip;&nbsp;255.
 </p>
 </html>"));
   type SpecularCoefficient = Modelica.Icons.TypeReal(min=0)
@@ -153,8 +153,8 @@ Additionally, external shapes can be specified as (not all options might be supp
 </p>
 
 <ul>
-<li> <strong>\"1\", \"2\", ...</strong><br>
-     define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\", ...
+<li> <strong>\"1\", \"2\", &hellip;</strong><br>
+     define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\", &hellip;
      The DXF-files must be found either in the current directory or in the directory where
      the Shape instance is stored that references the DXF file.
      This (very limited) option should not be used for new models. Example:<br>

--- a/Modelica/Mechanics/MultiBody/Visualizers.mo
+++ b/Modelica/Mechanics/MultiBody/Visualizers.mo
@@ -82,7 +82,7 @@ Additionally, <strong>external shapes</strong> can be specified as (not all opti
 </p>
 
 <ul>
-<li> <strong>\"1\", \"2\", &hellip;</strong><br>
+<li> <strong>\"1\", \"2\",&nbsp;&hellip;</strong><br>
      define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\", &hellip;
      The DXF-files must be found either in the current directory or in the directory where
      the Shape instance is stored that references the DXF file.
@@ -321,7 +321,7 @@ Additionally, <strong>external shapes</strong> can be specified as (not all opti
 </p>
 
 <ul>
-<li> <strong>\"1\", \"2\", &hellip;</strong><br>
+<li> <strong>\"1\", \"2\",&nbsp;&hellip;</strong><br>
      define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\", &hellip;
      The DXF-files must be found either in the current directory or in the directory where
      the Shape instance is stored that references the DXF file.
@@ -2121,7 +2121,7 @@ Additionally, <strong>external shapes</strong> can be specified as (not all opti
 </p>
 
 <ul>
-<li> <strong>\"1\", \"2\", &hellip;</strong><br>
+<li> <strong>\"1\", \"2\",&nbsp;&hellip;</strong><br>
      define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\", &hellip;
      The DXF-files must be found either in the current directory or in the directory where
      the Shape instance is stored that references the DXF file.

--- a/Modelica/Mechanics/MultiBody/Visualizers.mo
+++ b/Modelica/Mechanics/MultiBody/Visualizers.mo
@@ -322,7 +322,7 @@ Additionally, <strong>external shapes</strong> can be specified as (not all opti
 
 <ul>
 <li> <strong>\"1\", \"2\",&nbsp;&hellip;</strong><br>
-     define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\", &hellip;
+     define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\",&nbsp;&hellip;
      The DXF-files must be found either in the current directory or in the directory where
      the Shape instance is stored that references the DXF file.
      This (very limited) option should not be used for new models. Example:<br>

--- a/Modelica/Mechanics/MultiBody/Visualizers.mo
+++ b/Modelica/Mechanics/MultiBody/Visualizers.mo
@@ -2122,7 +2122,7 @@ Additionally, <strong>external shapes</strong> can be specified as (not all opti
 
 <ul>
 <li> <strong>\"1\", \"2\",&nbsp;&hellip;</strong><br>
-     define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\", &hellip;
+     define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\",&nbsp;&hellip;
      The DXF-files must be found either in the current directory or in the directory where
      the Shape instance is stored that references the DXF file.
      This (very limited) option should not be used for new models. Example:<br>

--- a/Modelica/Mechanics/MultiBody/Visualizers.mo
+++ b/Modelica/Mechanics/MultiBody/Visualizers.mo
@@ -82,8 +82,8 @@ Additionally, <strong>external shapes</strong> can be specified as (not all opti
 </p>
 
 <ul>
-<li> <strong>\"1\", \"2\", ...</strong><br>
-     define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\", ...
+<li> <strong>\"1\", \"2\", &hellip;</strong><br>
+     define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\", &hellip;
      The DXF-files must be found either in the current directory or in the directory where
      the Shape instance is stored that references the DXF file.
      This (very limited) option should not be used for new models. Example:<br>
@@ -156,7 +156,7 @@ width = height = 2*radiusOfGearWheel.</td>
 Parameter <strong>color</strong> is a vector with 3 elements,
 {r,&nbsp;g,&nbsp;b}, and specifies the color of the shape.
 {r,&nbsp;g,&nbsp;b} are the \"red\", \"green\" and \"blue\" color parts.
-Note, r, g, b are given as Integer[3] in the ranges 0&nbsp;..&nbsp;255,
+Note, r, g and b are given as Integer[3] in the ranges 0&nbsp;&hellip;&nbsp;255,
 respectively. The predefined type
 <a href=\"modelica://Modelica.Mechanics.MultiBody.Types.Color\">MultiBody.Types.Color</a> contains a menu
 definition of the colors used in the MultiBody library together with a color editor.
@@ -321,8 +321,8 @@ Additionally, <strong>external shapes</strong> can be specified as (not all opti
 </p>
 
 <ul>
-<li> <strong>\"1\", \"2\", ...</strong><br>
-     define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\", ...
+<li> <strong>\"1\", \"2\", &hellip;</strong><br>
+     define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\", &hellip;
      The DXF-files must be found either in the current directory or in the directory where
      the Shape instance is stored that references the DXF file.
      This (very limited) option should not be used for new models. Example:<br>
@@ -396,7 +396,7 @@ width = height = 2*radiusOfGearWheel.</td>
 Parameter <strong>color</strong> is a vector with 3 elements,
 {r,&nbsp;g,&nbsp;b}, and specifies the color of the shape.
 {r,&nbsp;g,&nbsp;b} are the \"red\", \"green\" and \"blue\" color parts.
-Note, r, g, b are given as Integer[3] in the ranges 0&nbsp;..&nbsp;255,
+Note, r, g, b are given as Integer[3] in the ranges 0&nbsp;&hellip;&nbsp;255,
 respectively. The predefined type
 <a href=\"modelica://Modelica.Mechanics.MultiBody.Types.Color\">MultiBody.Types.Color</a> contains a menu
 definition of the colors used in the MultiBody library together with a color editor.
@@ -1793,7 +1793,7 @@ The color is selected from the colorMap by interpolation so that
 This package contains functions to operate on colors.
 Note, a color is represented as a Real array with 3 elements where
 the elements are the red, green, blue values of the RGB color model.
-Every element must be in the range 0..255.
+Every element must be in the range 0&nbsp;&hellip;&nbsp;255.
 The type of a color is Real and not Integer in order that a color
 can be used with less problems in a model, since in a model an Integer
 type could only be used in a when-clause. Typical declaration of a color value:
@@ -1904,8 +1904,8 @@ model where an <strong>Arrow</strong> instance is used, e.g., in the form
 <p>
 Variable <strong>color</strong> is an Integer vector with 3 elements,
 {r, g, b}, and specifies the color of the shape.
-{r,g,b} are the \"red\", \"green\" and \"blue\" color parts.
-Note, r g, b are given in the range 0 .. 255.
+{r, g, b} are the \"red\", \"green\" and \"blue\" color parts.
+Note, r, g and b are given in the range 0&nbsp;&hellip;&nbsp;255.
 The predefined type <strong>MultiBody.Types.Color</strong> contains
 a menu definition of the colors used in the MultiBody
 library (will be replaced by a color editor).
@@ -2047,8 +2047,8 @@ model where an <strong>Arrow</strong> instance is used, e.g., in the form
 <p>
 Variable <strong>color</strong> is an Integer vector with 3 elements,
 {r, g, b}, and specifies the color of the shape.
-{r,g,b} are the \"red\", \"green\" and \"blue\" color parts.
-Note, r g, b are given in the range 0 .. 255.
+{r, g, b} are the \"red\", \"green\" and \"blue\" color parts.
+Note, r, g and b are given in the range 0&nbsp;&hellip;&nbsp;255.
 The predefined type <strong>MultiBody.Types.Color</strong> contains
 a menu definition of the colors used in the MultiBody
 library (will be replaced by a color editor).
@@ -2121,8 +2121,8 @@ Additionally, <strong>external shapes</strong> can be specified as (not all opti
 </p>
 
 <ul>
-<li> <strong>\"1\", \"2\", ...</strong><br>
-     define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\", ...
+<li> <strong>\"1\", \"2\", &hellip;</strong><br>
+     define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\", &hellip;
      The DXF-files must be found either in the current directory or in the directory where
      the Shape instance is stored that references the DXF file.
      This (very limited) option should not be used for new models. Example:<br>
@@ -2196,7 +2196,7 @@ width = height = 2*radiusOfGearWheel.</td>
 Parameter <strong>color</strong> is a vector with 3 elements,
 {r,&nbsp;g,&nbsp;b}, and specifies the color of the shape.
 {r,&nbsp;g,&nbsp;b} are the \"red\", \"green\" and \"blue\" color parts.
-Note, r, g, b are given as Integer[3] in the ranges 0&nbsp;..&nbsp;255,
+Note, r, g, b are given as Integer[3] in the ranges 0&nbsp;&hellip;&nbsp;255,
 respectively. The predefined type
 <a href=\"modelica://Modelica.Mechanics.MultiBody.Types.Color\">MultiBody.Types.Color</a> contains a menu
 definition of the colors used in the MultiBody library together with a color editor.
@@ -2907,7 +2907,7 @@ the predefined type <strong>MultiBody.Types.Color</strong>.
 This is a vector with 3 elements,
 {r, g, b}, and specifies the color of the shape.
 {r,g,b} are the \"red\", \"green\" and \"blue\" color parts.
-Note, r g, b are given as Integer[3] in the ranges 0 .. 255,
+Note, r g, b are given as Integer[3] in the ranges 0&nbsp;&hellip;&nbsp;255,
 respectively.
 </p>
 </html>"), Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},

--- a/Modelica/Mechanics/MultiBody/Visualizers.mo
+++ b/Modelica/Mechanics/MultiBody/Visualizers.mo
@@ -83,7 +83,7 @@ Additionally, <strong>external shapes</strong> can be specified as (not all opti
 
 <ul>
 <li> <strong>\"1\", \"2\",&nbsp;&hellip;</strong><br>
-     define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\", &hellip;
+     define external shapes specified in DXF format in files \"1.dxf\", \"2.dxf\",&nbsp;&hellip;
      The DXF-files must be found either in the current directory or in the directory where
      the Shape instance is stored that references the DXF file.
      This (very limited) option should not be used for new models. Example:<br>

--- a/Modelica/Mechanics/MultiBody/package.mo
+++ b/Modelica/Mechanics/MultiBody/package.mo
@@ -385,7 +385,7 @@ the Frame connector.
 <pre>
   <strong>connector</strong> Frame
      ...
-     <strong>flow</strong> SI.Force f[3] <strong>annotation</strong>(unassignedMessage=\"..\");
+     <strong>flow</strong> SI.Force f[3] <strong>annotation</strong>(unassignedMessage=\"...\");
   <strong>end</strong> Frame;
 </pre>
 <p>
@@ -747,11 +747,11 @@ This is shown in the next figure, where this option is selected for spring3.fram
 <p>
 Note, if this flag is not set to <strong>true</strong>, a translation error will occur.
 Due to the usage of overdetermined connectors in the MultiBody library, the error
-message will be something like: .
+message will be something like:
 </p>
 
 <blockquote><p>
-\"The overdetermined connectors &lt;...&gt; are connected but do not have any root defined\"
+\"The overdetermined connectors &lt;&hellip;&gt; are connected but do not have any root defined\"
 </p></blockquote>
 
 <p>

--- a/Modelica/Mechanics/Rotational.mo
+++ b/Modelica/Mechanics/Rotational.mo
@@ -422,7 +422,7 @@ as possible.
 
       annotation (Documentation(info="<html>
 <p>
-Only a few components of the Rotational library use the der(..) operator
+Only a few components of the Rotational library use the der(&hellip;) operator
 and are therefore candidates to have states. Most important, component <a href=\"modelica://Modelica.Mechanics.Rotational.Components.Inertia\">Inertia</a>
 defines the absolute rotation angle and the absolute angular velocity of this
 component as candidate for states. In the \"Advanced\" menu the built-in StateSelect
@@ -3682,8 +3682,8 @@ distributions:
    Typical values of coefficients of friction:
 </p>
 <pre>
-      dry operation   :  <strong>mu</strong> = 0.2 .. 0.4
-      operating in oil:  <strong>mu</strong> = 0.05 .. 0.1
+      dry operation   :  <strong>mu</strong> = 0.2 ... 0.4
+      operating in oil:  <strong>mu</strong> = 0.05 ... 0.1
 </pre>
 <p>
    When plates are pressed together, where  <strong>ri</strong>  is the inner radius,
@@ -3839,8 +3839,8 @@ distributions:
    Typical values of coefficients of friction:
 </p>
 <pre>
-      dry operation   :  <strong>mu</strong> = 0.2 .. 0.4
-      operating in oil:  <strong>mu</strong> = 0.05 .. 0.1
+      dry operation   :  <strong>mu</strong> = 0.2 ... 0.4
+      operating in oil:  <strong>mu</strong> = 0.05 ... 0.1
 </pre>
 <p>
    When plates are pressed together, where  <strong>ri</strong>  is the inner radius,
@@ -4044,8 +4044,8 @@ Typical values of coefficients of friction:
 </p>
 
 <blockquote><pre>
-dry operation   :  <strong>mu</strong> = 0.2 .. 0.4
-operating in oil:  <strong>mu</strong> = 0.05 .. 0.1
+dry operation   :  <strong>mu</strong> = 0.2 ... 0.4
+operating in oil:  <strong>mu</strong> = 0.05 ... 0.1
 </pre></blockquote>
 
 <p>
@@ -4412,18 +4412,18 @@ meaning:
       <td>|tau_bf2|</td>
     </tr>
     <tr>
-      <td align=\"center\">...</td>
-      <td align=\"center\">...</td>
-      <td align=\"center\">...</td>
-      <td align=\"center\">...</td>
-      <td align=\"center\">...</td>
+      <td align=\"center\">&hellip;</td>
+      <td align=\"center\">&hellip;</td>
+      <td align=\"center\">&hellip;</td>
+      <td align=\"center\">&hellip;</td>
+      <td align=\"center\">&hellip;</td>
     </tr>
     <tr>
-      <td align=\"center\">...</td>
-      <td align=\"center\">...</td>
-      <td align=\"center\">...</td>
-      <td align=\"center\">...</td>
-      <td align=\"center\">...</td>
+      <td align=\"center\">&hellip;</td>
+      <td align=\"center\">&hellip;</td>
+      <td align=\"center\">&hellip;</td>
+      <td align=\"center\">&hellip;</td>
+      <td align=\"center\">&hellip;</td>
     </tr>
   </tbody>
 </table>

--- a/Modelica/Mechanics/Rotational.mo
+++ b/Modelica/Mechanics/Rotational.mo
@@ -3679,7 +3679,7 @@ distributions:
         frictional_torque = <strong>cgeo</strong> * <strong>mu</strong>(w) * <strong>fn</strong>
 </pre>
 <p>
-   Typical values of coefficients of friction <strong>mue</strong>:
+   Typical values of coefficients of friction <strong>mu</strong>:
 </p>
 <ul>
   <li>0.2&nbsp;&hellip;&nbsp;0.4 for dry operation,</li>
@@ -3836,7 +3836,7 @@ distributions:
         frictional_torque = <strong>cgeo</strong> * <strong>mu</strong>(w_rel) * <strong>fn</strong>
 </pre>
 <p>
-   Typical values of coefficients of friction <strong>mue</strong>:
+   Typical values of coefficients of friction <strong>mu</strong>:
 </p>
 <ul>
   <li>0.2&nbsp;&hellip;&nbsp;0.4 for dry operation,</li>
@@ -4040,7 +4040,7 @@ frictional_torque = <strong>cgeo</strong> * <strong>mu</strong>(w_rel) * <strong
 </pre></blockquote>
 
 <p>
-Typical values of coefficients of friction <strong>mue</strong>:
+Typical values of coefficients of friction <strong>mu</strong>:
 </p>
 <ul>
   <li>0.2&nbsp;&hellip;&nbsp;0.4 for dry operation,</li>

--- a/Modelica/Mechanics/Rotational.mo
+++ b/Modelica/Mechanics/Rotational.mo
@@ -3679,12 +3679,12 @@ distributions:
         frictional_torque = <strong>cgeo</strong> * <strong>mu</strong>(w) * <strong>fn</strong>
 </pre>
 <p>
-   Typical values of coefficients of friction:
+   Typical values of coefficients of friction <strong>mue</strong>:
 </p>
-<pre>
-      dry operation   :  <strong>mu</strong> = 0.2 ... 0.4
-      operating in oil:  <strong>mu</strong> = 0.05 ... 0.1
-</pre>
+<ul>
+  <li>0.2&nbsp;&hellip;&nbsp;0.4 for dry operation,</li>
+  <li>0.05&nbsp;&hellip;&nbsp;0.1 when operating in oil.</li>
+</ul>
 <p>
    When plates are pressed together, where  <strong>ri</strong>  is the inner radius,
    <strong>ro</strong> is the outer radius and <strong>N</strong> is the number of friction interfaces,
@@ -3836,12 +3836,12 @@ distributions:
         frictional_torque = <strong>cgeo</strong> * <strong>mu</strong>(w_rel) * <strong>fn</strong>
 </pre>
 <p>
-   Typical values of coefficients of friction:
+   Typical values of coefficients of friction <strong>mue</strong>:
 </p>
-<pre>
-      dry operation   :  <strong>mu</strong> = 0.2 ... 0.4
-      operating in oil:  <strong>mu</strong> = 0.05 ... 0.1
-</pre>
+<ul>
+  <li>0.2&nbsp;&hellip;&nbsp;0.4 for dry operation,</li>
+  <li>0.05&nbsp;&hellip;&nbsp;0.1 when operating in oil.</li>
+</ul>
 <p>
    When plates are pressed together, where  <strong>ri</strong>  is the inner radius,
    <strong>ro</strong> is the outer radius and <strong>N</strong> is the number of friction interfaces,
@@ -4040,13 +4040,12 @@ frictional_torque = <strong>cgeo</strong> * <strong>mu</strong>(w_rel) * <strong
 </pre></blockquote>
 
 <p>
-Typical values of coefficients of friction:
+Typical values of coefficients of friction <strong>mue</strong>:
 </p>
-
-<blockquote><pre>
-dry operation   :  <strong>mu</strong> = 0.2 ... 0.4
-operating in oil:  <strong>mu</strong> = 0.05 ... 0.1
-</pre></blockquote>
+<ul>
+  <li>0.2&nbsp;&hellip;&nbsp;0.4 for dry operation,</li>
+  <li>0.05&nbsp;&hellip;&nbsp;0.1 when operating in oil.</li>
+</ul>
 
 <p>
 The geometry constant is calculated - under the

--- a/Modelica/Mechanics/Translational.mo
+++ b/Modelica/Mechanics/Translational.mo
@@ -1861,9 +1861,10 @@ force law in a target system between two masses.
         end for;
         annotation (Documentation(info="<html>
 <p>
-Returns a table with the friction characteristic table[nTable,2] = [0,&nbsp;f1; &hellip;; v_max,&nbsp;fn], where the first
-column is the velocity&nbsp;v in the range 0&nbsp;&hellip;&nbsp;v_max and the second column is the friction force
-according to the Stribeck curve:
+Returns a table with the friction characteristic
+table[nTable,&nbsp;2]&nbsp;=&nbsp;[0,&nbsp;f1;&nbsp;&hellip;;&nbsp;v_max,&nbsp;fn],
+where the first column is the velocity&nbsp;v in the range 0&nbsp;&hellip;&nbsp;v_max
+and the second column is the friction force according to the Stribeck curve:
 </p>
 
 <blockquote><pre>

--- a/Modelica/Mechanics/Translational.mo
+++ b/Modelica/Mechanics/Translational.mo
@@ -3144,7 +3144,7 @@ distributions:
         frictional_force = <strong>cgeo</strong> * <strong>mu</strong>(v) * <strong>fn</strong>
 </pre>
 <p>
-   Typical values of coefficients of friction <strong>mue</strong>:
+   Typical values of coefficients of friction <strong>mu</strong>:
 </p>
 <ul>
   <li>0.2&nbsp;&hellip;&nbsp;0.4 for dry operation,</li>

--- a/Modelica/Mechanics/Translational.mo
+++ b/Modelica/Mechanics/Translational.mo
@@ -326,7 +326,7 @@ diagram and is therefore less convenient to use.
 
       annotation (Documentation(info="<html>
 <p>
-Only a few components of the Translational library use the der(..) operator
+Only a few components of the Translational library use the der(&hellip;) operator
 and are therefore candidates to have states. Most important, component <a href=\"modelica://Modelica.Mechanics.Translational.Components.Mass\">Mass</a>
 defines the absolute position and the absolute velocity of this
 component as candidate for states. In the \"Advanced\" menu the built-in StateSelect
@@ -1228,12 +1228,12 @@ to see the difference.
 <li> The same model is also available by modeling the system with a Mass and
      a SupportFriction model. The SupportFriction model defines the friction characteristic
      with a table. The table is constructed with function
-     Examples.Utilities.GenerateStribeckFrictionTable(..) to generate the
+     Examples.Utilities.GenerateStribeckFrictionTable(&hellip;) to generate the
      same friction characteristic as with stop1.
      The simulation results of stop1 and of model mass are therefore identical.</li>
 <li> Model stop2 gives an example for a hard stop. However there
      can arise some problems with the used modeling approach (use of
-     <strong>reinit</strong>(..), convergence problems). In this case use the ElastoGap
+     <strong>reinit</strong>(&hellip;), convergence problems). In this case use the ElastoGap
      to model a stop (see example Preload).</li>
 </ol>
 </html>"),
@@ -1861,14 +1861,14 @@ force law in a target system between two masses.
         end for;
         annotation (Documentation(info="<html>
 <p>
-Returns a table with the friction characteristic table[nTable,2] = [0, f1; ....; v_max, fn], where the first
-column is the velocity v in the range 0..v_max and the second column is the friction force
+Returns a table with the friction characteristic table[nTable,2] = [0,&nbsp;f1; &hellip;; v_max,&nbsp;fn], where the first
+column is the velocity&nbsp;v in the range 0&nbsp;&hellip;&nbsp;v_max and the second column is the friction force
 according to the Stribeck curve:
 </p>
-<pre>
-  F_Coulomb + F_prop*v + F_Stribeck*exp(-fexp*v);
-</pre>
 
+<blockquote><pre>
+f = F_Coulomb + F_prop*v + F_Stribeck*exp(-fexp*v);
+</pre></blockquote>
 </html>"));
       end GenerateStribeckFrictionTable;
 
@@ -3146,8 +3146,8 @@ distributions:
    Typical values of coefficients of friction:
 </p>
 <pre>
-      dry operation   :  <strong>mu</strong> = 0.2 .. 0.4
-      operating in oil:  <strong>mu</strong> = 0.05 .. 0.1
+      dry operation   :  <strong>mu</strong> = 0.2 ... 0.4
+      operating in oil:  <strong>mu</strong> = 0.05 ... 0.1
 </pre>
 <p>
     The positive part of the friction characteristic <strong>mu</strong>(v),

--- a/Modelica/Mechanics/Translational.mo
+++ b/Modelica/Mechanics/Translational.mo
@@ -1065,10 +1065,10 @@ omega_res&nbsp;=&nbsp;sqrt(c&nbsp;/&nbsp;m)
 with:
 </p>
 
-<blockquote><pre>
-c ... spring stiffness
-m ... mass
-</pre></blockquote>
+<blockquote>
+  c &hellip; spring stiffness and<br>
+  m &hellip; mass.
+</blockquote>
 
 <p>
 To make sure that the system is initially at rest the initial
@@ -3143,12 +3143,12 @@ distributions:
         frictional_force = <strong>cgeo</strong> * <strong>mu</strong>(v) * <strong>fn</strong>
 </pre>
 <p>
-   Typical values of coefficients of friction:
+   Typical values of coefficients of friction <strong>mue</strong>:
 </p>
-<pre>
-      dry operation   :  <strong>mu</strong> = 0.2 ... 0.4
-      operating in oil:  <strong>mu</strong> = 0.05 ... 0.1
-</pre>
+<ul>
+  <li>0.2&nbsp;&hellip;&nbsp;0.4 for dry operation,</li>
+  <li>0.05&nbsp;&hellip;&nbsp;0.1 when operating in oil.</li>
+</ul>
 <p>
     The positive part of the friction characteristic <strong>mu</strong>(v),
     v >= 0, is defined via table mu_pos (first column = v,


### PR DESCRIPTION
Use ellipses (a row of three points) in documentation of MultiBody, Rotational and Translational.

refs #2749