### PR TITLE
Add symlink in order to keep the new structure backwards compatible

### DIFF
--- a/om
+++ b/om
@@ -1,0 +1,1 @@
+Modelica 3.2.3/Resources/helpOM/


### PR DESCRIPTION
This way old (<3.2.3) deeplinks will still work.