### PR TITLE
Add magnetic domain to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Modelica Standard Library
 
-Free library from the Modelica Association to model mechanical (1D/3D), electrical (analog, digital, machines), thermal, fluid, control systems and hierarchical state machines. Also numerical functions and functions for strings, files and streams are included.
+Free library from the Modelica Association to model mechanical (1D/3D), electrical (analog, digital, machines), magnetic, thermal, fluid, control systems and hierarchical state machines. Also numerical functions and functions for strings, files and streams are included.
 
 ## Library description
 


### PR DESCRIPTION
I suppose the correct spelling in this PR is *magnetic* not *magnetical*. 

The magnetic domain should actually also be added to the library description:

![image](https://user-images.githubusercontent.com/4184218/47620936-b8aaaf00-daf0-11e8-858c-8d5a260c1bf7.png)
