### PR TITLE
Remove Complex record icon

### DIFF
--- a/Complex.mo
+++ b/Complex.mo
@@ -255,15 +255,6 @@ Copyright &copy; 2010-2018, DLR, A.&nbsp;Haumer and <a href=\"modelica://Modelic
 
 <p>
 <em>This Modelica package is <u>free</u> software and the use is completely at <u>your own risk</u>; it can be redistributed and/or modified under the terms of the 3-Clause BSD license. For license conditions (including the disclaimer of warranty) visit <a href=\"https://modelica.org/licenses/modelica-3-clause-bsd\">https://modelica.org/licenses/modelica-3-clause-bsd</a>.</em>
-</p></html>"),
-    Icon(graphics={Rectangle(
-          lineColor={160,160,164},
-          fillColor={160,160,164},
-          fillPattern=FillPattern.Solid,
-          extent={{-100,-100},{100,100}},
-          radius=25.0), Text(
-          lineColor={255,255,255},
-          extent={{-90,-50},{90,50}},
-          textString="C")}));
+</p></html>"));
 
 end Complex;


### PR DESCRIPTION
Remove the icon graphics from the operator record Complex, and thus also from the ComplexInput/ComplexOutput (which inherited the graphics via the short-class connector definition).

close #2765