### PR TITLE
Add final to modifiers in examples HeatingNPN_NORGate and HeatingPNP_NORGate

### DIFF
--- a/Modelica/Electrical/Analog/Examples/HeatingNPN_OrGate.mo
+++ b/Modelica/Electrical/Analog/Examples/HeatingNPN_OrGate.mo
@@ -65,17 +65,17 @@ model HeatingNPN_OrGate "Heating NPN Or Gate"
   annotation (Placement(transformation(extent={{-10,16},{10,36}})));
   Modelica.Electrical.Analog.Basic.Ground Gnd4
   annotation (Placement(transformation(extent={{30,-52},{50,-32}})));
-  Modelica.Electrical.Analog.Basic.Capacitor C1(C=CapVal)
+  Modelica.Electrical.Analog.Basic.Capacitor C1(final C=CapVal)
   annotation (Placement(transformation(
         origin={-70,38},
         extent={{-10,-10},{10,10}},
         rotation=270)));
-  Modelica.Electrical.Analog.Basic.Capacitor C2(C=CapVal)
+  Modelica.Electrical.Analog.Basic.Capacitor C2(final C=CapVal)
   annotation (Placement(transformation(
         origin={60,42},
         extent={{-10,-10},{10,10}},
         rotation=270)));
-  Modelica.Electrical.Analog.Basic.Capacitor C3(C=CapVal)
+  Modelica.Electrical.Analog.Basic.Capacitor C3(final C=CapVal)
   annotation (Placement(transformation(
         origin={-16,-40},
         extent={{-10,-10},{10,10}},
@@ -91,11 +91,11 @@ model HeatingNPN_OrGate "Heating NPN Or Gate"
     Br=1,
     Is=1e-14,
     Vak=0,
-    Tauf=tauVal,
-    Taur=tauVal,
-    Ccs=CapVal,
-    Cje=CapVal,
-    Cjc=CapVal,
+    final Tauf=tauVal,
+    final Taur=tauVal,
+    final Ccs=CapVal,
+    final Cje=CapVal,
+    final Cjc=CapVal,
     Phie=1,
     Me=0.5,
     Phic=1,
@@ -111,11 +111,11 @@ model HeatingNPN_OrGate "Heating NPN Or Gate"
     Br=1,
     Is=1e-14,
     Vak=0,
-    Tauf=tauVal,
-    Taur=tauVal,
-    Ccs=CapVal,
-    Cje=CapVal,
-    Cjc=CapVal,
+    final Tauf=tauVal,
+    final Taur=tauVal,
+    final Ccs=CapVal,
+    final Cje=CapVal,
+    final Cjc=CapVal,
     Phie=1,
     Me=0.5,
     Phic=1,

--- a/Modelica/Electrical/Analog/Examples/HeatingPNP_NORGate.mo
+++ b/Modelica/Electrical/Analog/Examples/HeatingPNP_NORGate.mo
@@ -61,17 +61,17 @@ model HeatingPNP_NORGate "Heating PNP NOR Gate"
   annotation (Placement(transformation(extent={{-10,16},{10,36}})));
   Modelica.Electrical.Analog.Basic.Ground Gnd4
   annotation (Placement(transformation(extent={{30,-52},{50,-32}})));
-  Modelica.Electrical.Analog.Basic.Capacitor C1(C=CapVal)
+  Modelica.Electrical.Analog.Basic.Capacitor C1(final C=CapVal)
   annotation (Placement(transformation(
         origin={-70,38},
         extent={{-10,-10},{10,10}},
         rotation=270)));
-  Modelica.Electrical.Analog.Basic.Capacitor C2(C=CapVal)
+  Modelica.Electrical.Analog.Basic.Capacitor C2(final C=CapVal)
   annotation (Placement(transformation(
         origin={60,42},
         extent={{-10,-10},{10,10}},
         rotation=270)));
-  Modelica.Electrical.Analog.Basic.Capacitor C3(C=CapVal)
+  Modelica.Electrical.Analog.Basic.Capacitor C3(final C=CapVal)
   annotation (Placement(transformation(
         origin={-16,-40},
         extent={{-10,-10},{10,10}},
@@ -87,11 +87,11 @@ model HeatingPNP_NORGate "Heating PNP NOR Gate"
     Br=1,
     Is=1e-14,
     Vak=0,
-    Tauf=tauVal,
-    Taur=tauVal,
-    Ccs=CapVal,
-    Cje=CapVal,
-    Cjc=CapVal,
+    final Tauf=tauVal,
+    final Taur=tauVal,
+    final Ccs=CapVal,
+    final Cje=CapVal,
+    final Cjc=CapVal,
     Phie=1,
     Me=0.5,
     Phic=1,
@@ -107,11 +107,11 @@ model HeatingPNP_NORGate "Heating PNP NOR Gate"
     Br=1,
     Is=1e-14,
     Vak=0,
-    Tauf=tauVal,
-    Taur=tauVal,
-    Ccs=CapVal,
-    Cje=CapVal,
-    Cjc=CapVal,
+    final Tauf=tauVal,
+    final Taur=tauVal,
+    final Ccs=CapVal,
+    final Cje=CapVal,
+    final Cjc=CapVal,
     Phie=1,
     Me=0.5,
     Phic=1,


### PR DESCRIPTION
These two examples define `tauVal = 0` and `capVal = 0` with `annotation(Evaluate = true)`. Then, these parameters are passed to capacitor and transistor parameter values. However, if they are not passed as `final`, a tool does not necessarily evaluate the actual capacitor and transistor parameter values, possibly ending up in a singular model. This actually happens to OpenModelica, see [report](https://libraries.openmodelica.org/branches/newInst/Modelica_trunk/files/Modelica_trunk_Modelica.Electrical.Analog.Examples.HeatingNPN_OrGate.sim)

Adding `final` to the capacitor and transistor parameter modifiers ensures that those values are immutably assigned to parameters evaluated to zero, so they can also be evaluated to zero, thus avoiding the singularity thanks to some further symbolic processing.