### PR TITLE
ModelicaReference: add AutoCompletion subpackage

### DIFF
--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -871,9 +871,12 @@ Evaluate is for example used for axis of rotation parameters in the Modelica.Mec
 </html>"));
   end Evaluate;
 
-  class experiment "experiment"
+  record experiment "experiment"
     extends ModelicaReference.Icons.Information;
-
+      Real StartTime(unit = "s") "Default start time of simulation";
+      Real StopTime(unit = "s") "Default stop time of simulation";
+      Real Interval(unit = "s", min = 0) "Resolution for the result grid";
+      Real Tolerance(unit = "1", min = 0) "Default relative integration tolerance";
     annotation (Documentation(info="<html>
 <p>
 Define default experiment parameters


### PR DESCRIPTION
To start with, add an experiment annotation as an example, so one can debug this feature and extend it separately.

This PR is related to OpenModelica/OMEdit#219 and is based on already existing text in this repo, as well as a Modelica Standard. Unfortunately, this will probably be partial copy-paste of `ModelicaReference.Annotations` instead of plain its usage, since descriptions there are more standard-related and human-readable than machine-readable formal record-like form.

Another idea, is to gather there documentation on the keywords, too, to not hardcode it in the IDE code.