### PR TITLE
Add missing 'each' in ModelicaTest

### DIFF
--- a/ModelicaTest/Electrical/MultiSensorTest.mo
+++ b/ModelicaTest/Electrical/MultiSensorTest.mo
@@ -43,7 +43,7 @@ model MultiSensorTest
   Modelica.Electrical.MultiPhase.Basic.Resistor resistorM(m=m, R=fill(R, m)) annotation (Placement(transformation(extent={{40,10},
             {60,30}})));
   Modelica.Electrical.MultiPhase.Basic.Inductor inductorM(m=m, L=fill(L, m),
-    i(start=zeros(m), fixed=true))                                           annotation (Placement(transformation(extent={{70,10},
+    i(start=zeros(m), each fixed=true))                                           annotation (Placement(transformation(extent={{70,10},
             {90,30}})));
   Modelica.Electrical.MultiPhase.Sensors.MultiSensor multiSensorM(m=m)
     annotation (Placement(transformation(extent={{10,10},{30,30}})));

--- a/ModelicaTest/Media.mo
+++ b/ModelicaTest/Media.mo
@@ -681,7 +681,7 @@ package Media "Test models for Modelica.Media"
         p(start=1.0e5,fixed=true));
       Medium.BaseProperties medium2(
         T(start=300.0,fixed=true),
-        X(start={0.2,0.8},fixed=true),
+        X(start={0.2,0.8},each fixed=true),
         p(start=2.0e5,fixed=true));
       Medium.SpecificHeatCapacity cp=Medium.specificHeatCapacityCp(medium.state);
       Medium.SpecificHeatCapacity cv=Medium.specificHeatCapacityCv(medium.state);
@@ -722,7 +722,7 @@ is given to compare the approximation.
         p(start=1.0e5,fixed=true));
       Medium.BaseProperties medium2(
         T(start=300.0,fixed=true),
-        X(start={0.2,0.1,0.3,0.4},fixed=true),
+        X(start={0.2,0.1,0.3,0.4},each fixed=true),
         p(start=2.0e5,fixed=true));
       Medium.SpecificHeatCapacity cp=Medium.specificHeatCapacityCp(state);
       Medium.SpecificHeatCapacity cv=Medium.specificHeatCapacityCv(state);

--- a/ModelicaTest/MultiBody.mo
+++ b/ModelicaTest/MultiBody.mo
@@ -6959,8 +6959,8 @@ often possible to use the FreeMotion joint such that the singularity
         r={0.4,0,0},
         r_CM={0.2,0,0},
         width=0.05,
-        r_0(start={0.2,-0.5,0.1}, fixed=true),
-        v_0(fixed=true),
+        r_0(start={0.2,-0.5,0.1}, each fixed=true),
+        v_0(each fixed=true),
         angles_fixed=true,
         w_0_fixed=true,
         enforceStates=true,
@@ -6981,8 +6981,8 @@ often possible to use the FreeMotion joint such that the singularity
         I_22=0.1,
         I_33=0.1,
         enforceStates=true,
-        r_0(start={0.2,-0.5,0.1}, fixed=true),
-        v_0(fixed=true),
+        r_0(start={0.2,-0.5,0.1}, each fixed=true),
+        v_0(each fixed=true),
         m=1,
         r_CM={0,-0.3,0},
         angles_fixed=true,
@@ -7003,8 +7003,8 @@ often possible to use the FreeMotion joint such that the singularity
         r={0,-0.3,0},
         width=0.05,
         enforceStates=true,
-        r_0(start={0.2,-0.5,0.1}, fixed=true),
-        v_0(fixed=true),
+        r_0(start={0.2,-0.5,0.1}, each fixed=true),
+        v_0(each fixed=true),
         angles_fixed=true,
         w_0_fixed=true) annotation (Placement(transformation(
             extent={{-10,-10},{10,10}},
@@ -7031,8 +7031,8 @@ often possible to use the FreeMotion joint such that the singularity
       Modelica.Mechanics.MultiBody.Parts.BodyCylinder bodyCylinder(
         r={0,-0.3,0},
         diameter=0.05,
-        r_0(start={0.2,-0.5,0.1}, fixed=true),
-        v_0(fixed=true),
+        r_0(start={0.2,-0.5,0.1}, each fixed=true),
+        v_0(each fixed=true),
         enforceStates=true,
         angles_fixed=true,
         w_0_fixed=true) annotation (Placement(transformation(
@@ -7043,8 +7043,8 @@ often possible to use the FreeMotion joint such that the singularity
         m=1,
         sphereDiameter=0.1,
         stateSelect=StateSelect.always,
-        r_0(start={0.2,-0.5,0.1}, fixed=true),
-        v_0(fixed=true)) annotation (Placement(transformation(
+        r_0(start={0.2,-0.5,0.1}, each fixed=true),
+        v_0(each fixed=true)) annotation (Placement(transformation(
             extent={{-10,-10},{10,10}},
             rotation=-90,
             origin={30,-30})));
@@ -8450,9 +8450,9 @@ often possible to use the FreeMotion joint such that the singularity
           g=0) annotation(Placement(transformation(extent={{-140,40},{-120,60}})));
         Modelica.Mechanics.MultiBody.Joints.FreeMotion freeMotion1(
           animation=false,
-          r_rel_a(fixed=true),
-          v_rel_a(fixed=true),
-          a_rel_a(fixed=false),
+          r_rel_a(each fixed=true),
+          v_rel_a(each fixed=true),
+          a_rel_a(each fixed=false),
           angles_fixed=true,
           w_rel_a_fixed=true,
           useQuaternions=false) annotation(Placement(transformation(extent={{-119,92},
@@ -8506,7 +8506,7 @@ often possible to use the FreeMotion joint such that the singularity
           color={0,128,0},
           r_0(
             start={0,0,0},
-            fixed=false)) annotation(Placement(transformation(extent={{96,112},{116,132}})));
+            each fixed=false)) annotation(Placement(transformation(extent={{96,112},{116,132}})));
         Modelica.Mechanics.MultiBody.Parts.BodyCylinder cyl2(
           r={0.4,0,0},
           diameter=0.2) annotation(Placement(transformation(extent={{160,112},{180,
@@ -8521,9 +8521,9 @@ often possible to use the FreeMotion joint such that the singularity
           r={0.4,0,0}) annotation(Placement(transformation(extent={{36,92},{56,112}})));
         Modelica.Mechanics.MultiBody.Joints.FreeMotion freeMotion2(
           animation=false,
-          r_rel_a(fixed=true),
-          v_rel_a(fixed=true),
-          a_rel_a(fixed=false),
+          r_rel_a(each fixed=true),
+          v_rel_a(each fixed=true),
+          a_rel_a(each fixed=false),
           angles_fixed=true,
           w_rel_a_fixed=true,
           useQuaternions=false) annotation(Placement(transformation(extent={{-119,-58},
@@ -8598,7 +8598,7 @@ often possible to use the FreeMotion joint such that the singularity
           color={0,128,0},
           r_0(
             start={0,0,0},
-            fixed=false)) annotation(Placement(transformation(extent={{100,-80},{120,
+            each fixed=false)) annotation(Placement(transformation(extent={{100,-80},{120,
                   -60}})));
         Modelica.Mechanics.MultiBody.Parts.BodyCylinder cyl4(
           r={0.4,0,0},


### PR DESCRIPTION
- Adds missing `each` qualifiers to array modifiers in ModelicaTest.