### PR TITLE
Fixes #2839 by correcting misspelled model name.

### DIFF
--- a/ModelicaTest/Electrical/MultiSensorTest.mo
+++ b/ModelicaTest/Electrical/MultiSensorTest.mo
@@ -1,5 +1,5 @@
 within ModelicaTest.Electrical;
-model MulitSensorTest
+model MultiSensorTest
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
   parameter Integer m = 3 "Number of phases";
@@ -172,4 +172,4 @@ equation
   connect(multiSensorA.power, meanpowerA.u) annotation (Line(points={{9,74},{0,74},
           {0,88},{-30,88},{-30,80},{-38,80}}, color={0,0,127}));
   annotation (experiment(StopTime=0.1));
-end MulitSensorTest;
+end MultiSensorTest;

--- a/ModelicaTest/Electrical/package.order
+++ b/ModelicaTest/Electrical/package.order
@@ -2,4 +2,4 @@ Machines
 PowerConverters
 QuasiStatic
 SingularTransfomer
-MulitSensorTest
+MultiSensorTest


### PR DESCRIPTION
Since in ModelicaTest no conversion script is needed.