### PR TITLE
Declare external functions as pure/impure

### DIFF
--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -1690,9 +1690,6 @@ parameter Real table[:, <strong>2</strong>]=[0, 0; 1, 1; 2, 4];
     discrete Real nextTimeEventScaled(start=0, fixed=true)
       "Next scaled time event instant";
     Real timeScaled "Scaled time";
-    function readTableData =
-      Modelica.Blocks.Tables.Internal.readTimeTableData "Read table data from text or MATLAB MAT-file";
-                             // No longer used, but kept for backward compatibility
   equation
     if tableOnFile then
       assert(tableName <> "NoName",

--- a/Modelica/Blocks/Tables.mo
+++ b/Modelica/Blocks/Tables.mo
@@ -49,9 +49,6 @@ package Tables
           smoothness,
           extrapolation,
           if tableOnFile then verboseRead else false) "External table object";
-    function readTableData =
-      Modelica.Blocks.Tables.Internal.readTable1DData "Read table data from text or MATLAB MAT-file";
-                             // No longer used, but kept for backward compatibility
   equation
     if tableOnFile then
       assert(tableName <> "NoName",
@@ -299,9 +296,6 @@ MATLAB is a registered trademark of The MathWorks, Inc.
           smoothness,
           extrapolation,
           if tableOnFile then verboseRead else false) "External table object";
-    function readTableData =
-      Modelica.Blocks.Tables.Internal.readTable1DData "Read table data from text or MATLAB MAT-file";
-                             // No longer used, but kept for backward compatibility
   equation
     if tableOnFile then
       assert(tableName <> "NoName",
@@ -507,9 +501,6 @@ MATLAB is a registered trademark of The MathWorks, Inc.
   block CombiTable2Ds "Table look-up in two dimensions (matrix/file)"
     extends Modelica.Blocks.Interfaces.SI2SO;
     extends Internal.CombiTable2DBase;
-    function readTableData =
-      Modelica.Blocks.Tables.Internal.readTable2DData "Read table data from text or MATLAB MAT-file";
-                             // No longer used, but kept for backward compatibility
   equation
     if verboseExtrapolation and (
       extrapolation == Modelica.Blocks.Types.Extrapolation.LastTwoPoints or
@@ -904,7 +895,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         "Minimum abscissa value defined in table";
       final parameter Real u_max[2]=getTable2DAbscissaUmax(tableID)
         "Maximum abscissa value defined in table";
-    protected
+      protected
         parameter Modelica.Blocks.Types.ExternalCombiTable2D tableID=
           Modelica.Blocks.Types.ExternalCombiTable2D(
             if tableOnFile then tableName else "NoName",
@@ -913,7 +904,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
             smoothness,
             extrapolation,
             if tableOnFile then verboseRead else false) "External table object";
-    equation
+      equation
         if tableOnFile then
           assert(tableName <> "NoName",
             "tableOnFile = true and no table name given");
@@ -954,18 +945,6 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{
               100,100}})));
     end CombiTable2DBase;
-
-    impure function readTimeTableData "Read table data from text or MATLAB MAT-file"
-      extends Modelica.Icons.Function;
-      input Modelica.Blocks.Types.ExternalCombiTimeTable tableID "External table object";
-      input Boolean forceRead = false
-        "= true: Force reading of table data; = false: Only read, if not yet read.";
-      output Real readSuccess "Table read success";
-      input Boolean verboseRead = true
-        "= true: Print info message; = false: No info message";
-      external"C" readSuccess = ModelicaStandardTables_CombiTimeTable_read(tableID, forceRead, verboseRead)
-        annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
-    end readTimeTableData;
 
     pure function getTimeTableValue
       "Interpolate 1-dim. table where first column is time"
@@ -1077,18 +1056,6 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getTimeTableTmax;
 
-    impure function readTable1DData "Read table data from text or MATLAB MAT-file"
-      extends Modelica.Icons.Function;
-      input Modelica.Blocks.Types.ExternalCombiTable1D tableID "External table object";
-      input Boolean forceRead = false
-        "= true: Force reading of table data; = false: Only read, if not yet read.";
-      input Boolean verboseRead = true
-        "= true: Print info message; = false: No info message";
-      output Real readSuccess "Table read success";
-      external"C" readSuccess = ModelicaStandardTables_CombiTable1D_read(tableID, forceRead, verboseRead)
-        annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
-    end readTable1DData;
-
     pure function getNextTimeEvent
       "Return next time event value of 1-dim. table where first column is time"
       extends Modelica.Icons.Function;
@@ -1188,18 +1155,6 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       external"C" uMax = ModelicaStandardTables_CombiTable1D_maximumAbscissa(tableID)
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getTable1DAbscissaUmax;
-
-    impure function readTable2DData "Read table data from text or MATLAB MAT-file"
-      extends Modelica.Icons.Function;
-      input Modelica.Blocks.Types.ExternalCombiTable2D tableID "External table object";
-      input Boolean forceRead = false
-        "= true: Force reading of table data; = false: Only read, if not yet read.";
-      input Boolean verboseRead = true
-        "= true: Print info message; = false: No info message";
-      output Real readSuccess "Table read success";
-      external"C" readSuccess = ModelicaStandardTables_CombiTable2D_read(tableID, forceRead, verboseRead)
-        annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
-    end readTable2DData;
 
     pure function getTable2DValue "Interpolate 2-dim. table defined by matrix"
       extends Modelica.Icons.Function;

--- a/Modelica/Blocks/Tables.mo
+++ b/Modelica/Blocks/Tables.mo
@@ -967,7 +967,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end readTimeTableData;
 
-    function getTimeTableValue
+    pure function getTimeTableValue
       "Interpolate 1-dim. table where first column is time"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTimeTable tableID "External table object";
@@ -983,7 +983,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
           noDerivative=pre_nextTimeEvent) = getDerTimeTableValue);
     end getTimeTableValue;
 
-    function getTimeTableValueNoDer
+    pure function getTimeTableValueNoDer
       "Interpolate 1-dim. table where first column is time (but do not provide a derivative function)"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTimeTable tableID "External table object";
@@ -996,7 +996,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getTimeTableValueNoDer;
 
-    function getTimeTableValueNoDer2
+    pure function getTimeTableValueNoDer2
       "Interpolate 1-dim. table where first column is time (but do not provide a second derivative function)"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTimeTable tableID "External table object";
@@ -1030,7 +1030,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
           noDerivative=pre_nextTimeEvent) = getDer2TimeTableValue);
     end getDerTimeTableValue;
 
-    function getDerTimeTableValueNoDer
+    pure function getDerTimeTableValueNoDer
       "Derivative of interpolated 1-dim. table where first column is time (but do not provide a derivative function)"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTimeTable tableID "External table object";
@@ -1068,7 +1068,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getTimeTableTmin;
 
-    function getTimeTableTmax
+    pure function getTimeTableTmax
       "Return maximum abscissa value of 1-dim. table where first column is time"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTimeTable tableID "External table object";
@@ -1089,7 +1089,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end readTable1DData;
 
-    function getNextTimeEvent
+    pure function getNextTimeEvent
       "Return next time event value of 1-dim. table where first column is time"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTimeTable tableID "External table object";
@@ -1099,7 +1099,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getNextTimeEvent;
 
-    function getTable1DValue "Interpolate 1-dim. table defined by matrix"
+    pure function getTable1DValue "Interpolate 1-dim. table defined by matrix"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable1D tableID "External table object";
       input Integer icol "Column number";
@@ -1110,7 +1110,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       annotation (derivative = getDerTable1DValue);
     end getTable1DValue;
 
-    function getTable1DValueNoDer
+    pure function getTable1DValueNoDer
       "Interpolate 1-dim. table defined by matrix (but do not provide a derivative function)"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable1D tableID "External table object";
@@ -1121,6 +1121,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getTable1DValueNoDer;
 
+    pure function getDerTable1DValue
     function getTable1DValueNoDer2
       "Interpolate 1-dim. table defined by matrix (but do not provide a second derivative function)"
       extends Modelica.Icons.Function;
@@ -1146,7 +1147,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       annotation (derivative(order=2) = getDer2Table1DValue);
     end getDerTable1DValue;
 
-    function getDerTable1DValueNoDer
+    pure function getDerTable1DValueNoDer
       "Derivative of interpolated 1-dim. table defined by matrix (but do not provide a second derivative function)"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable1D tableID "External table object";
@@ -1180,7 +1181,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getTable1DAbscissaUmin;
 
-    function getTable1DAbscissaUmax
+    pure function getTable1DAbscissaUmax
       "Return maximum abscissa value of 1-dim. table defined by matrix"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable1D tableID "External table object";
@@ -1201,7 +1202,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end readTable2DData;
 
-    function getTable2DValue "Interpolate 2-dim. table defined by matrix"
+    pure function getTable2DValue "Interpolate 2-dim. table defined by matrix"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable2D tableID "External table object";
       input Real u1 "Value of first independent variable";
@@ -1212,7 +1213,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       annotation (derivative = getDerTable2DValue);
     end getTable2DValue;
 
-    function getTable2DValueNoDer
+    pure function getTable2DValueNoDer
       "Interpolate 2-dim. table defined by matrix (but do not provide a derivative function)"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable2D tableID "External table object";
@@ -1223,7 +1224,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getTable2DValueNoDer;
 
-    function getTable2DValueNoDer2
+    pure function getTable2DValueNoDer2
       "Interpolate 2-dim. table defined by matrix (but do not provide a second derivative function)"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable2D tableID "External table object";
@@ -1249,7 +1250,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       annotation (derivative(order=2) = getDer2Table2DValue);
     end getDerTable2DValue;
 
-    function getDerTable2DValueNoDer
+    pure function getDerTable2DValueNoDer
       "Derivative of interpolated 2-dim. table defined by matrix (but do not provide a second derivative function)"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable2D tableID "External table object";
@@ -1286,7 +1287,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getTable2DAbscissaUmin;
 
-    function getTable2DAbscissaUmax
+    pure function getTable2DAbscissaUmax
       "Return maximum abscissa value of 2-dim. table defined by matrix"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable2D tableID "External table object";

--- a/Modelica/Blocks/Tables.mo
+++ b/Modelica/Blocks/Tables.mo
@@ -1262,23 +1262,21 @@ that can be used as a template for own developments. While &quot;usertab.c&quot;
 &quot;usertab.h&quot; needs to adapted for the own needs.</p>
 <p>In order to work it is necessary that the compiler pulls in the &quot;usertab.c&quot; file. Different Modelica tools might provide different mechanisms to do so.
 Please consult the respective documentation/support for your Modelica tool.</p>
-<p>A possible (though a bit &quot;hackish&quot;) Modelica standard conformant approach is to pull in the required files by utilizing a &quot;dummy&quot;-function that uses the Modelica external function
-interface to pull in the required &quot;usertab.c&quot;. An example how this can be done is given below.</p>
+<p>A possible (though slightly makeshift) approach is to pull in the required files by utilizing a &quot;dummy&quot;-function that uses the Modelica external function
+interface to include the required &quot;usertab.c&quot;. An example how this can be done is given below.</p>
 <blockquote><pre>
-model Test25_usertab \"Test utilizing the usertab.c interface\"
+model ExampleCTable \"Example utilizing the usertab.c interface\"
   extends Modelica.Icons.Example;
-public
-  Modelica.Blocks.Sources.RealExpression realExpression(y=getUsertab(t_new.y))
-    annotation (Placement(transformation(extent={{-40,-34},{-10,-14}})));
-  Modelica.Blocks.Tables.CombiTable1Dv t_new(tableOnFile=true, tableName=\"TestTable_1D_a\")
+  parameter Real dummy(fixed=false) \"Dummy parameter\";
+  Modelica.Blocks.Tables.CombiTable1Dv table(tableOnFile=true, tableName=\"TestTable_1D_a\")
     annotation (Placement(transformation(extent={{-40,0},{-20,20}})));
   Modelica.Blocks.Sources.ContinuousClock clock
     annotation (Placement(transformation(extent={{-80,0},{-60,20}})));
 protected
-  encapsulated function getUsertab
+  encapsulated impure function getUsertab \"External dummy function to include \\\"usertab.c\\\"\"
     input Real dummy_u[:];
     output Real dummy_y;
-    external \"C\" dummy_y=  mydummyfunc(dummy_u);
+    external \"C\" dummy_y = mydummyfunc(dummy_u);
     annotation(IncludeDirectory=\"modelica://Modelica/Resources/Data/Tables\",
            Include = \"#include \"usertab.c\"
 double mydummyfunc(double* dummy_in) {
@@ -1286,11 +1284,12 @@ double mydummyfunc(double* dummy_in) {
 }
 \");
   end getUsertab;
+initial equation
+  dummy = getUsertab(table.y);
 equation
-  connect(clock.y,t_new. u[1]) annotation (Line(
-      points={{-59,10},{-42,10}}, color={0,0,127}));
-  annotation (experiment(StartTime=0, StopTime=5), uses(Modelica(version=\"3.2.2\")));
-end Test25_usertab;
+  connect(clock.y, table.u[1]) annotation (Line(points={{-59,10},{-42,10}}, color={0,0,127}));
+  annotation (experiment(StartTime=0, StopTime=5), uses(Modelica(version=\"4.0.0\")));
+end ExampleCTable;
 </pre></blockquote>
 </html>"), Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
             {100,100}}), graphics={

--- a/Modelica/Blocks/Tables.mo
+++ b/Modelica/Blocks/Tables.mo
@@ -955,7 +955,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
               100,100}})));
     end CombiTable2DBase;
 
-    function readTimeTableData "Read table data from text or MATLAB MAT-file"
+    impure function readTimeTableData "Read table data from text or MATLAB MAT-file"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTimeTable tableID "External table object";
       input Boolean forceRead = false
@@ -965,7 +965,6 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         "= true: Print info message; = false: No info message";
       external"C" readSuccess = ModelicaStandardTables_CombiTimeTable_read(tableID, forceRead, verboseRead)
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
-      annotation(__ModelicaAssociation_Impure=true);
     end readTimeTableData;
 
     function getTimeTableValue
@@ -1078,7 +1077,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getTimeTableTmax;
 
-    function readTable1DData "Read table data from text or MATLAB MAT-file"
+    impure function readTable1DData "Read table data from text or MATLAB MAT-file"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable1D tableID "External table object";
       input Boolean forceRead = false
@@ -1088,7 +1087,6 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       output Real readSuccess "Table read success";
       external"C" readSuccess = ModelicaStandardTables_CombiTable1D_read(tableID, forceRead, verboseRead)
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
-      annotation(__ModelicaAssociation_Impure=true);
     end readTable1DData;
 
     function getNextTimeEvent
@@ -1191,7 +1189,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getTable1DAbscissaUmax;
 
-    function readTable2DData "Read table data from text or MATLAB MAT-file"
+    impure function readTable2DData "Read table data from text or MATLAB MAT-file"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable2D tableID "External table object";
       input Boolean forceRead = false
@@ -1201,7 +1199,6 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       output Real readSuccess "Table read success";
       external"C" readSuccess = ModelicaStandardTables_CombiTable2D_read(tableID, forceRead, verboseRead)
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
-      annotation(__ModelicaAssociation_Impure=true);
     end readTable2DData;
 
     function getTable2DValue "Interpolate 2-dim. table defined by matrix"

--- a/Modelica/Blocks/Tables.mo
+++ b/Modelica/Blocks/Tables.mo
@@ -1012,7 +1012,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
           noDerivative=pre_nextTimeEvent) = getDerTimeTableValueNoDer);
     end getTimeTableValueNoDer2;
 
-    function getDerTimeTableValue
+    pure function getDerTimeTableValue
       "Derivative of interpolated 1-dim. table where first column is time"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTimeTable tableID "External table object";
@@ -1044,7 +1044,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getDerTimeTableValueNoDer;
 
-    function getDer2TimeTableValue
+    pure function getDer2TimeTableValue
       "Second derivative of interpolated 1-dim. table where first column is time"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTimeTable tableID "External table object";
@@ -1059,7 +1059,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getDer2TimeTableValue;
 
-    function getTimeTableTmin
+    pure function getTimeTableTmin
       "Return minimum abscissa value of 1-dim. table where first column is time"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTimeTable tableID "External table object";
@@ -1121,8 +1121,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getTable1DValueNoDer;
 
-    pure function getDerTable1DValue
-    function getTable1DValueNoDer2
+    pure function getTable1DValueNoDer2
       "Interpolate 1-dim. table defined by matrix (but do not provide a second derivative function)"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable1D tableID "External table object";
@@ -1134,7 +1133,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       annotation (derivative = getDerTable1DValueNoDer);
     end getTable1DValueNoDer2;
 
-    function getDerTable1DValue
+    pure function getDerTable1DValue
       "Derivative of interpolated 1-dim. table defined by matrix"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable1D tableID "External table object";
@@ -1159,7 +1158,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getDerTable1DValueNoDer;
 
-    function getDer2Table1DValue
+    pure function getDer2Table1DValue
       "Second derivative of interpolated 1-dim. table defined by matrix"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable1D tableID "External table object";
@@ -1172,7 +1171,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getDer2Table1DValue;
 
-    function getTable1DAbscissaUmin
+    pure function getTable1DAbscissaUmin
       "Return minimum abscissa value of 1-dim. table defined by matrix"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable1D tableID "External table object";
@@ -1236,7 +1235,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       annotation (derivative = getDerTable2DValueNoDer);
     end getTable2DValueNoDer2;
 
-    function getDerTable2DValue
+    pure function getDerTable2DValue
       "Derivative of interpolated 2-dim. table defined by matrix"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable2D tableID "External table object";
@@ -1263,7 +1262,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getDerTable2DValueNoDer;
 
-    function getDer2Table2DValue
+    pure function getDer2Table2DValue
       "Second derivative of interpolated 2-dim. table defined by matrix"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable2D tableID "External table object";
@@ -1278,7 +1277,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
     end getDer2Table2DValue;
 
-    function getTable2DAbscissaUmin
+    pure function getTable2DAbscissaUmin
       "Return minimum abscissa value of 2-dim. table defined by matrix"
       extends Modelica.Icons.Function;
       input Modelica.Blocks.Types.ExternalCombiTable2D tableID "External table object";

--- a/Modelica/Math/FastFourierTransform.mo
+++ b/Modelica/Math/FastFourierTransform.mo
@@ -632,7 +632,7 @@ See detailed example model:
   package Internal
     "Internal library that should not be used directly by a user"
     extends Modelica.Icons.InternalPackage;
-    function rawRealFFT "Compute raw Fast Fourier Transform for real signal vector"
+    pure function rawRealFFT "Compute raw Fast Fourier Transform for real signal vector"
       extends Modelica.Icons.Function;
       input Real  u[:]
         "Signal for which FFT shall be computed (size(nu,1) MUST be EVEN and should be an integer multiple of 2,3,5, that is size(nu,1) = 2^a*3^b*5^c, with a,b,c Integer >= 0)";

--- a/Modelica/Math/Random.mo
+++ b/Modelica/Math/Random.mo
@@ -212,7 +212,7 @@ and the returned state is the one from the last iteration.
 </html>"));
       end initialState;
 
-      impure function random
+      pure function random
         "Returns a uniform random number with the xorshift64* algorithm"
         extends Modelica.Icons.Function;
         input Integer stateIn[nState]
@@ -385,7 +385,7 @@ random number generator is used to fill the internal state vector with 64 bit ra
 </html>"));
       end initialState;
 
-      impure function random
+      pure function random
         "Returns a uniform random number with the xorshift128+ algorithm"
         extends Modelica.Icons.Function;
         input Integer stateIn[nState]
@@ -562,7 +562,7 @@ random number generator is used to fill the internal state vector with 64 bit ra
 </html>"));
       end initialState;
 
-      impure function random
+      pure function random
         "Returns a uniform random number with the xorshift1024* algorithm"
         extends Modelica.Icons.Function;
         input Integer stateIn[nState]

--- a/Modelica/Math/Random.mo
+++ b/Modelica/Math/Random.mo
@@ -212,7 +212,7 @@ and the returned state is the one from the last iteration.
 </html>"));
       end initialState;
 
-      function random
+      impure function random
         "Returns a uniform random number with the xorshift64* algorithm"
         extends Modelica.Icons.Function;
         input Integer stateIn[nState]
@@ -385,7 +385,7 @@ random number generator is used to fill the internal state vector with 64 bit ra
 </html>"));
       end initialState;
 
-      function random
+      impure function random
         "Returns a uniform random number with the xorshift128+ algorithm"
         extends Modelica.Icons.Function;
         input Integer stateIn[nState]
@@ -562,7 +562,7 @@ random number generator is used to fill the internal state vector with 64 bit ra
 </html>"));
       end initialState;
 
-      function random
+      impure function random
         "Returns a uniform random number with the xorshift1024* algorithm"
         extends Modelica.Icons.Function;
         input Integer stateIn[nState]
@@ -930,15 +930,13 @@ If the same localSeed, globalSeed, nState is given, the same state vector is ret
 </html>"));
     end initialStateWithXorshift64star;
 
-    function automaticGlobalSeed
+    impure function automaticGlobalSeed
       "Creates an automatic integer seed (typically from the current time and process id; this is an impure function)"
       extends Modelica.Icons.Function;
       output Integer seed "Automatically generated seed";
 
       external "C" seed = ModelicaRandom_automaticGlobalSeed(0.0) annotation (Library="ModelicaExternalC");
-
-     annotation (__ModelicaAssociation_Impure=true,
-        Documentation(info="<html>
+     annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 seed = Utilities.<strong>automaticGlobalSeed</strong>();
@@ -1069,7 +1067,7 @@ path is provided.
       Integer rngState[33]
         "The internal state vector of the impure random number generator";
 
-      function setInternalState
+      impure function setInternalState
         "Stores the given state vector in an external static variable"
         extends Modelica.Icons.Function;
         input Integer[33] rngState "The initial state";
@@ -1085,8 +1083,7 @@ path is provided.
 
       // Copy the internal state into the internal C static memory
       setInternalState(rngState, id);
-      annotation (
-      Documentation(info="<html>
+      annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 id = <strong>initializeImpureRandom</strong>(seed;
@@ -1148,7 +1145,7 @@ random number generator to fill the internal state vector with 64 bit random num
 </html>"));
     end initializeImpureRandom;
 
-    function impureRandom
+    impure function impureRandom
       "Impure random number generator (with hidden state vector)"
       extends Modelica.Icons.Function;
       input Integer id
@@ -1157,9 +1154,7 @@ random number generator to fill the internal state vector with 64 bit random num
         "A random number with a uniform distribution on the interval (0,1]";
       external "C" y = ModelicaRandom_impureRandom_xorshift1024star(id)
         annotation (Library="ModelicaExternalC");
-      annotation(__ModelicaAssociation_Impure=true,
-        Documentation(info=
-                   "<html>
+      annotation(Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 r = <strong>impureRandom</strong>(id);
@@ -1222,7 +1217,7 @@ is returned, so the function is impure.
 </html>"));
     end impureRandom;
 
-    function impureRandomInteger
+    impure function impureRandomInteger
       "Impure random number generator for integer values (with hidden state vector)"
       extends Modelica.Icons.Function;
       input Integer id
@@ -1236,10 +1231,7 @@ is returned, so the function is impure.
     algorithm
       r  := impureRandom(id=id);
       y  := min(imax, integer(r*(imax-imin+1))+imin);
-
-      annotation (__ModelicaAssociation_Impure=true,
-        Documentation(info=
-                    "<html>
+      annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 r = <strong>impureRandomInteger</strong>(id, imin=1, imax=Modelica.Constants.Integer_inf);

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -1385,7 +1385,7 @@ has a unique solution.
 </html>"));
   end equalityLeastSquares;
 
-  function LU "LU decomposition of square or rectangular matrix"
+  pure function LU "LU decomposition of square or rectangular matrix"
     extends Modelica.Icons.Function;
     input Real A[:, :] "Square or rectangular matrix";
     output Real LU[size(A, 1), size(A, 2)]=A
@@ -4851,7 +4851,7 @@ A_fud  = [-1, 2, -3;
     "Interface to LAPACK library (should usually not directly be used but only indirectly via Modelica.Math.Matrices)"
     extends Modelica.Icons.FunctionsPackage;
 
-    function dgeev
+    pure function dgeev
       "Compute eigenvalues and (right) eigenvectors for real nonsymmetric matrix A"
 
       extends Modelica.Icons.Function;
@@ -4986,7 +4986,7 @@ Lapack documentation
 "));
     end dgeev;
 
-    function dgeev_eigenValues
+    pure function dgeev_eigenValues
       "Compute eigenvalues for real nonsymmetric matrix A"
 
       extends Modelica.Icons.Function;
@@ -5125,7 +5125,7 @@ Lapack documentation
 "));
     end dgeev_eigenValues;
 
-    function dgelsy
+    pure function dgelsy
       "Compute the minimum-norm solution to a real linear least squares problem with rank deficient A"
 
       extends Modelica.Icons.Function;
@@ -5275,7 +5275,7 @@ Lapack documentation
 "));
     end dgelsy;
 
-    function dgelsy_vec
+    pure function dgelsy_vec
       "Compute the minimum-norm solution to a real linear least squares problem with rank deficient A"
 
       extends Modelica.Icons.Function;
@@ -5425,7 +5425,7 @@ Lapack documentation
 "));
     end dgelsy_vec;
 
-    function dgels_vec
+    pure function dgels_vec
       "Solve overdetermined or underdetermined real linear equations A*x=b with a b vector"
 
       extends Modelica.Icons.Function;
@@ -5561,7 +5561,7 @@ Lapack documentation
 "));
     end dgels_vec;
 
-    function dgesv
+    pure function dgesv
       "Solve real system of linear equations A*X=B with a B matrix"
       extends Modelica.Icons.Function;
       input Real A[:, size(A, 1)];
@@ -5639,7 +5639,7 @@ Lapack documentation
 "));
     end dgesv;
 
-    function dgesv_vec
+    pure function dgesv_vec
       "Solve real system of linear equations A*x=b with a b vector"
       extends Modelica.Icons.Function;
       input Real A[:, size(A, 1)];
@@ -5669,7 +5669,7 @@ For details of the arguments, see documentation of dgesv.
 "));
     end dgesv_vec;
 
-    function dgglse_vec
+    pure function dgglse_vec
       "Solve a linear equality constrained least squares problem"
       extends Modelica.Icons.Function;
       input Real A[:, :] "Minimize |A*x - c|^2";
@@ -5800,7 +5800,7 @@ For details of the arguments, see documentation of dgesv.
 "));
     end dgglse_vec;
 
-    function dgtsv
+    pure function dgtsv
       "Solve real system of linear equations A*X=B with B matrix and tridiagonal A"
 
       extends Modelica.Icons.Function;
@@ -5887,7 +5887,7 @@ For details of the arguments, see documentation of dgesv.
 "));
     end dgtsv;
 
-    function dgtsv_vec
+    pure function dgtsv_vec
       "Solve real system of linear equations A*x=b with b vector and tridiagonal A"
 
       extends Modelica.Icons.Function;
@@ -5920,7 +5920,7 @@ For details of the arguments, see documentation of dgtsv.
 "));
     end dgtsv_vec;
 
-    function dgbsv
+    pure function dgbsv
       "Solve real system of linear equations A*X=B with a B matrix"
       extends Modelica.Icons.Function;
       input Integer n "Number of equations";
@@ -6032,7 +6032,7 @@ For details of the arguments, see documentation of dgtsv.
 "));
     end dgbsv;
 
-    function dgbsv_vec
+    pure function dgbsv_vec
       "Solve real system of linear equations A*x=b with a b vector"
       extends Modelica.Icons.Function;
       input Integer n "Number of equations";
@@ -6065,7 +6065,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dgbsv_vec;
 
-    function dgesvd "Determine singular value decomposition"
+    pure function dgesvd "Determine singular value decomposition"
       extends Modelica.Icons.Function;
       input Real A[:, :];
       output Real sigma[min(size(A, 1), size(A, 2))];
@@ -6213,7 +6213,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dgesvd;
 
-    function dgesvd_sigma "Determine singular values"
+    pure function dgesvd_sigma "Determine singular values"
       extends Modelica.Icons.Function;
       input Real A[:, :];
       output Real sigma[min(size(A, 1), size(A, 2))];
@@ -6361,7 +6361,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dgesvd_sigma;
 
-    function dgetrf
+    pure function dgetrf
       "Compute LU factorization of square or rectangular matrix A (A = P*L*U)"
 
       extends Modelica.Icons.Function;
@@ -6427,7 +6427,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dgetrf;
 
-    function dgetrs
+    pure function dgetrs
       "Solve a system of linear equations with the LU decomposition from dgetrf"
 
       extends Modelica.Icons.Function;
@@ -6503,7 +6503,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dgetrs;
 
-    function dgetrs_vec
+    pure function dgetrs_vec
       "Solve a system of linear equations with the LU decomposition from dgetrf"
 
       extends Modelica.Icons.Function;
@@ -6580,7 +6580,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dgetrs_vec;
 
-    function dgetri
+    pure function dgetri
       "Compute the inverse of a matrix using the LU factorization from dgetrf"
 
       extends Modelica.Icons.Function;
@@ -6654,7 +6654,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dgetri;
 
-    function dgeqp3 "Compute QR factorization with column pivoting of square or rectangular matrix A"
+    pure function dgeqp3 "Compute QR factorization with column pivoting of square or rectangular matrix A"
 
       extends Modelica.Icons.Function;
       input Real A[:, :] "Square or rectangular matrix";
@@ -6756,7 +6756,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dgeqp3;
 
-    function dorgqr
+    pure function dorgqr
       "Generate a Real orthogonal matrix Q which is defined as the product of elementary reflectors as returned from dgeqrf"
 
       extends Modelica.Icons.Function;
@@ -6843,7 +6843,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dorgqr;
 
-    function dgees
+    pure function dgees
       "Compute real Schur form T of real nonsymmetric matrix A, and, optionally, the matrix of Schur vectors Z as well as the eigenvalues"
       extends Modelica.Icons.Function;
 
@@ -6999,7 +6999,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dgees;
 
-    function dtrsen "Reorder the real Schur factorization of a real matrix"
+    pure function dtrsen "Reorder the real Schur factorization of a real matrix"
       extends Modelica.Icons.Function;
 
       input String job="N" "Specifies the usage of a condition number";
@@ -7257,7 +7257,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dtrsen;
 
-    function dgesvx
+    pure function dgesvx
       "Solve real system of linear equations op(A)*X=B, op(A) is A or A' according to the Boolean input transposed"
       extends Modelica.Icons.Function;
       input Real A[:, size(A, 1)] "Real square matrix A";
@@ -7536,7 +7536,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dgesvx;
 
-    function dtrsyl
+    pure function dtrsyl
       "Solve the real Sylvester matrix equation op(A)*X + X*op(B) = scale*C or op(A)*X - X*op(B) = scale*C"
       extends Modelica.Icons.Function;
 
@@ -7652,7 +7652,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dtrsyl;
 
-    function dhseqr
+    pure function dhseqr
       "Compute eigenvalues of a matrix H using lapack routine DHSEQR for Hessenberg form matrix"
       extends Modelica.Icons.Function;
 
@@ -7844,7 +7844,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dhseqr;
 
-    function dlange "Norm of a matrix"
+    pure function dlange "Norm of a matrix"
       extends Modelica.Icons.Function;
 
       input Real A[:, :] "Real matrix A";
@@ -7917,7 +7917,7 @@ For details of the arguments, see documentation of dgbsv.
 
     end dlange;
 
-    function dgecon
+    pure function dgecon
       "Estimate the reciprocal of the condition number of a general real matrix A"
       extends Modelica.Icons.Function;
 
@@ -7993,7 +7993,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dgecon;
 
-    function dgehrd
+    pure function dgehrd
       "Reduce a real general matrix A to upper Hessenberg form H by an orthogonal similarity transformation:  Q' * A * Q = H"
       extends Modelica.Icons.Function;
 
@@ -8112,7 +8112,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dgehrd;
 
-    function dgeqrf "Compute a QR factorization without pivoting"
+    pure function dgeqrf "Compute a QR factorization without pivoting"
       extends Modelica.Icons.Function;
 
       input Real A[:, :] "Square or rectangular matrix";
@@ -8203,7 +8203,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dgeqrf;
 
-    function dgeevx
+    pure function dgeevx
       "Compute the eigenvalues and the (real) left and right eigenvectors of matrix A, using lapack routine dgeevx"
       extends Modelica.Icons.Function;
 
@@ -8435,7 +8435,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dgeevx;
 
-    function dgesdd "Determine singular value decomposition"
+    pure function dgesdd "Determine singular value decomposition"
       extends Modelica.Icons.Function;
       input Real A[:, :];
       output Real sigma[min(size(A, 1), size(A, 2))];
@@ -8600,7 +8600,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dgesdd;
 
-    function dggev
+    pure function dggev
       "Compute generalized eigenvalues, as well as the left and right eigenvectors for a (A,B) system"
       extends Modelica.Icons.Function;
 
@@ -8769,7 +8769,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dggev;
 
-    function dggevx
+    pure function dggevx
       "Compute generalized eigenvalues for a (A,B) system, using lapack routine dggevx"
       extends Modelica.Icons.Function;
 
@@ -9073,7 +9073,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dggevx;
 
-    function dhgeqz "Compute generalized eigenvalues for a (A,B) system"
+    pure function dhgeqz "Compute generalized eigenvalues for a (A,B) system"
       extends Modelica.Icons.Function;
 
       input Real A[:, size(A, 1)];
@@ -9312,7 +9312,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dhgeqz;
 
-    function dormhr
+    pure function dormhr
       "Overwrite the general real M-by-N matrix C with Q * C or C * Q or Q' * C or C * Q', where Q is an orthogonal matrix as returned by dgehrd"
       extends Modelica.Icons.Function;
 
@@ -9440,7 +9440,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dormhr;
 
-    function dormqr
+    pure function dormqr
       "Overwrite the general real M-by-N matrix C with Q * C or C * Q or Q' * C or C * Q', where Q is an orthogonal matrix of a QR factorization as returned by dgeqrf"
       extends Modelica.Icons.Function;
 
@@ -9562,7 +9562,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dormqr;
 
-    function dtrevc
+    pure function dtrevc
       "Compute the right and/or left eigenvectors of a real upper quasi-triangular matrix T"
       extends Modelica.Icons.Function;
 
@@ -9730,7 +9730,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dtrevc;
 
-    function dpotrf
+    pure function dpotrf
       "Compute the Cholesky factorization of a real symmetric positive definite matrix A"
       extends Modelica.Icons.Function;
 
@@ -9797,7 +9797,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dpotrf;
 
-    function dtrsm
+    pure function dtrsm
       "Solve one of the matrix equations op( A )*X = alpha*B, or X*op( A ) = alpha*B, where A is triangular matrix. BLAS routine"
       extends Modelica.Icons.Function;
 
@@ -9947,7 +9947,7 @@ For details of the arguments, see documentation of dgbsv.
 "));
     end dtrsm;
 
-    function dorghr
+    pure function dorghr
       "Generate a real orthogonal matrix Q which is defined as the product of IHI-ILO elementary reflectors of order N, as returned by DGEHRD"
       extends Modelica.Icons.Function;
 

--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -293,6 +293,12 @@ convertClass("Modelica.Electrical.Machines.Utilities.VoltageController",
               "Modelica.Electrical.Machines.Utilities.DQCurrentController");
 convertClass("Modelica.Media.Common.OneNonLinearEquation",
               "ObsoleteModelica4.Media.Common.OneNonLinearEquation");
+convertClass("Modelica.Blocks.Tables.Internal.readTimeTableData",
+              "ObsoleteModelica4.Blocks.Tables.Internal.readTimeTableData");
+convertClass("Modelica.Blocks.Tables.Internal.readTable1DData",
+              "ObsoleteModelica4.Blocks.Tables.Internal.readTable1DData");
+convertClass("Modelica.Blocks.Tables.Internal.readTable2DData",
+              "ObsoleteModelica4.Blocks.Tables.Internal.readTable2DData");
 
 // The Modelica_Synchronous library was integrated into the MSL as Modelica.Clocked
 convertElement({"Modelica_Synchronous.RealSignals.TimeBasedSources.Sin"},

--- a/Modelica/Utilities/Files.mo
+++ b/Modelica/Utilities/Files.mo
@@ -2,7 +2,7 @@ within Modelica.Utilities;
 package Files "Functions to work with files and directories"
   extends Modelica.Icons.FunctionsPackage;
 
-function list "List content of file or directory"
+impure function list "List content of file or directory"
   extends Modelica.Icons.Function;
   input String name
       "If name is a directory, list directory content. If it is a file, list the file content";
@@ -10,7 +10,7 @@ function list "List content of file or directory"
   protected
   Types.FileType fileType;
 
-  function listFile "List content of file"
+  impure function listFile "List content of file"
      extends Modelica.Icons.Function;
      input String name;
     protected
@@ -21,7 +21,7 @@ function list "List content of file or directory"
      end for;
   end listFile;
 
-  function sortDirectory
+  impure function sortDirectory
       "Sort directory in directories and files with alphabetic order"
      extends Modelica.Icons.Function;
      input String directory
@@ -66,7 +66,7 @@ function list "List content of file or directory"
      end if;
   end sortDirectory;
 
-  function listDirectory "List content of directory"
+  impure function listDirectory "List content of directory"
      extends Modelica.Icons.Function;
      input String directoryName;
      input Integer nEntries;
@@ -101,13 +101,11 @@ function list "List content of file or directory"
      end if;
   end listDirectory;
 algorithm
-  fileType := Modelica.Utilities.Internal.FileSystem.stat(
-                            name);
+  fileType := Modelica.Utilities.Internal.FileSystem.stat(name);
   if fileType == Types.FileType.RegularFile then
      listFile(name);
   elseif fileType == Types.FileType.Directory then
-     listDirectory(name, Modelica.Utilities.Internal.FileSystem.getNumberOfFiles(
-                                                   name));
+     listDirectory(name, Modelica.Utilities.Internal.FileSystem.getNumberOfFiles(name));
   elseif fileType == Types.FileType.SpecialFile then
      Streams.error("Cannot list file \"" + name + "\"\n" +
                    "since it is not a regular file (pipe, device, ...)");
@@ -115,9 +113,7 @@ algorithm
      Streams.error("Cannot list file or directory \"" + name + "\"\n" +
                    "since it does not exist");
   end if;
-
-  annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 Files.<strong>list</strong>(name);
@@ -134,7 +130,7 @@ in the \"name\" directory are printed in sorted order.
 </html>"));
 end list;
 
-function copy "Generate a copy of a file or of a directory"
+impure function copy "Generate a copy of a file or of a directory"
   extends Modelica.Icons.Function;
   input String oldName "Name of file or directory to be copied";
   input String newName "Name of copy of the file or of the directory";
@@ -142,7 +138,7 @@ function copy "Generate a copy of a file or of a directory"
       "= true, if an existing file may be replaced by the required copy";
 //..............................................................
   protected
-  function copyDirectory "Copy a directory"
+  impure function copyDirectory "Copy a directory"
      extends Modelica.Icons.Function;
      input String oldName
         "Old directory name without trailing '/'; existence is guaranteed";
@@ -153,10 +149,9 @@ function copy "Generate a copy of a file or of a directory"
      copyDirectoryContents(Modelica.Utilities.Internal.FileSystem.readDirectory(
                                        oldName, Modelica.Utilities.Internal.FileSystem.getNumberOfFiles(
                                                 oldName)), oldName, newName, replace);
-     annotation(__ModelicaAssociation_Impure=true);
   end copyDirectory;
 
-  function copyDirectoryContents
+  impure function copyDirectoryContents
     extends Modelica.Icons.Function;
     input String oldNames[:];
     input String oldName;
@@ -171,7 +166,6 @@ function copy "Generate a copy of a file or of a directory"
         newName_i := newName + "/" + oldNames[i];
         Files.copy(oldName_i, newName_i, replace);
      end for;
-     annotation (__ModelicaAssociation_Impure=true);
   end copyDirectoryContents;
 //..............................................................
 
@@ -216,9 +210,7 @@ algorithm
      Modelica.Utilities.Internal.FileSystem.copyFile(
                        oldName2, newName2);
   end if;
-
-  annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 Files.<strong>copy</strong>(oldName, newName);
@@ -253,7 +245,7 @@ copy(\"test1.txt\", \"test2.txt\")
 </html>"));
 end copy;
 
-function move "Move a file or a directory to another place"
+impure function move "Move a file or a directory to another place"
   extends Modelica.Icons.Function;
   input String oldName "Name of file or directory to be moved";
   input String newName "New name of the moved file or directory";
@@ -271,9 +263,7 @@ algorithm
      Files.copy(oldName, newName, replace);
      Files.remove(oldName);
   end if;
-
-  annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 Files.<strong>move</strong>(oldName, newName);
@@ -309,12 +299,12 @@ move(\"test1.txt\", \"test2.txt\")
 </html>"));
 end move;
 
-function remove "Remove file or directory (ignore call, if it does not exist)"
+impure function remove "Remove file or directory (ignore call, if it does not exist)"
   extends Modelica.Icons.Function;
   input String name "Name of file or directory to be removed";
 //..............................................................
   protected
-  function removeDirectory "Remove a directory, even if it is not empty"
+  impure function removeDirectory "Remove a directory, even if it is not empty"
      extends Modelica.Icons.Function;
      input String name;
     protected
@@ -327,10 +317,9 @@ function remove "Remove file or directory (ignore call, if it does not exist)"
                                         name2, Modelica.Utilities.Internal.FileSystem.getNumberOfFiles(
                                                 name2)), name2);
      Modelica.Utilities.Internal.FileSystem.rmdir(name2);
-     annotation(__ModelicaAssociation_Impure=true);
   end removeDirectory;
 
-  function removeDirectoryContents
+  impure function removeDirectoryContents
       extends Modelica.Icons.Function;
       input String fileNames[:];
       input String name2;
@@ -338,7 +327,6 @@ function remove "Remove file or directory (ignore call, if it does not exist)"
       for i in 1:size(fileNames,1) loop
          Files.remove(name2 + "/" + fileNames[i]);
       end for;
-      annotation(__ModelicaAssociation_Impure=true);
   end removeDirectoryContents;
 //..............................................................
   String fullName;
@@ -351,9 +339,7 @@ algorithm
      fullName :=Files.fullPathName(name);
      removeDirectory(fullName);
   end if;
-
-  annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 Files.<strong>remove</strong>(name);
@@ -371,7 +357,7 @@ This function is silent, i.e., it does not print a message.
 </html>"));
 end remove;
 
-function removeFile "Remove file (ignore call, if it does not exist)"
+impure function removeFile "Remove file (ignore call, if it does not exist)"
   extends Modelica.Icons.Function;
   input String fileName "Name of file that should be removed";
   protected
@@ -389,9 +375,7 @@ algorithm
      Streams.error("File \"" + fileName + "\" should be removed.\n" +
                    "This is not possible, because it is a special file (pipe, device, etc.)");
   end if;
-
-  annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 Files.<strong>removeFile</strong>(fileName);
@@ -409,14 +393,14 @@ This function is silent, i.e., it does not print a message.
 </html>"));
 end removeFile;
 
-function createDirectory
+impure function createDirectory
     "Create directory (if directory already exists, ignore call)"
   extends Modelica.Icons.Function;
   input String directoryName
       "Name of directory to be created (if present, ignore call)";
 //..............................................................
   protected
-  function existDirectory
+  impure function existDirectory
       "Inquire whether directory exists; if present and not a directory, trigger an error"
      extends Modelica.Icons.Function;
      input String directoryName;
@@ -434,7 +418,6 @@ function createDirectory
      else
         exists :=false;
      end if;
-     annotation(__ModelicaAssociation_Impure=true);
   end existDirectory;
 
   function assertCorrectIndex
@@ -505,9 +488,7 @@ algorithm
            end if;
         end while;
   end if;
-
-  annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 Files.<strong>createDirectory</strong>(directoryName);
@@ -530,16 +511,14 @@ file), an assert is triggered.
 </html>"));
 end createDirectory;
 
-function exist "Inquire whether file or directory exists"
+impure function exist "Inquire whether file or directory exists"
   extends Modelica.Icons.Function;
   input String name "Name of file or directory";
   output Boolean result "= true, if file or directory exists";
 algorithm
   result := Modelica.Utilities.Internal.FileSystem.stat(
                           name) > Types.FileType.NoFile;
-
-  annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 result = Files.<strong>exist</strong>(name);
@@ -552,7 +531,7 @@ If this is not the case, the function returns false.
 </html>"));
 end exist;
 
-function assertNew "Trigger an assert, if a file or directory exists"
+impure function assertNew "Trigger an assert, if a file or directory exists"
   extends Modelica.Icons.Function;
   input String name "Name of file or directory";
   input String message="This is not allowed."
@@ -568,9 +547,7 @@ algorithm
   elseif fileType == Types.FileType.SpecialFile then
      Streams.error("A special file (pipe, device, etc.) \"" + name + "\" already exists.\n" + message);
   end if;
-
-  annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 Files.<strong>assertNew</strong>(name);
@@ -588,14 +565,12 @@ File \"&lt;name&gt;\" already exists.
 </html>"));
 end assertNew;
 
-function fullPathName "Get full path name of file or directory name"
+impure function fullPathName "Get full path name of file or directory name"
   extends Modelica.Icons.Function;
   input String name "Absolute or relative file or directory name";
   output String fullName "Full path of 'name'";
 external "C" fullName = ModelicaInternal_fullPathName(name) annotation(Library="ModelicaExternalC");
-
-  annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 fullName = Files.<strong>fullPathName</strong>(name);
@@ -607,7 +582,7 @@ Returns the full path name of a file or directory \"name\".
 </html>"));
 end fullPathName;
 
-function splitPathName
+impure function splitPathName
     "Split path name in directory, file name kernel, file name extension"
   extends Modelica.Icons.Function;
   input String pathName "Absolute or relative file or directory name";
@@ -659,8 +634,7 @@ algorithm
        name :=pathName;
      end if;
    end if;
-  annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 (directory, name, extension) = Files.<strong>splitPathName</strong>(pathName);
@@ -680,14 +654,12 @@ Function <strong>splitPathName</strong>(..) splits a path name into its parts.
 </html>"));
 end splitPathName;
 
-function temporaryFileName
+impure function temporaryFileName
     "Return arbitrary name of a file that does not exist and is in a directory where access rights allow to write to this file (useful for temporary output of files)"
   extends Modelica.Icons.Function;
   output String fileName "Full path name of temporary file";
   external "C" fileName=ModelicaInternal_temporaryFileName() annotation(Library="ModelicaExternalC");
-
-  annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 fileName = Files.<strong>temporaryFileName</strong>();

--- a/Modelica/Utilities/Files.mo
+++ b/Modelica/Utilities/Files.mo
@@ -582,7 +582,7 @@ Returns the full path name of a file or directory \"name\".
 </html>"));
 end fullPathName;
 
-impure function splitPathName
+function splitPathName
     "Split path name in directory, file name kernel, file name extension"
   extends Modelica.Icons.Function;
   input String pathName "Absolute or relative file or directory name";

--- a/Modelica/Utilities/Internal.mo
+++ b/Modelica/Utilities/Internal.mo
@@ -142,53 +142,47 @@ package FileSystem
     "Internal package with external functions as interface to the file system"
  extends Modelica.Icons.InternalPackage;
 
-  function mkdir "Make directory (POSIX: 'mkdir')"
+  impure function mkdir "Make directory (POSIX: 'mkdir')"
     extends Modelica.Icons.Function;
     input String directoryName "Make a new directory";
   external "C" ModelicaInternal_mkdir(directoryName) annotation(Library="ModelicaExternalC");
-  annotation(__ModelicaAssociation_Impure=true);
   end mkdir;
 
-  function rmdir "Remove empty directory (POSIX function 'rmdir')"
+  impure function rmdir "Remove empty directory (POSIX function 'rmdir')"
     extends Modelica.Icons.Function;
     input String directoryName "Empty directory to be removed";
   external "C" ModelicaInternal_rmdir(directoryName) annotation(Library="ModelicaExternalC");
-  annotation(__ModelicaAssociation_Impure=true);
   end rmdir;
 
-  function stat "Inquire file information (POSIX function 'stat')"
+  impure function stat "Inquire file information (POSIX function 'stat')"
     extends Modelica.Icons.Function;
     input String name "Name of file, directory, pipe etc.";
     output Types.FileType fileType "Type of file";
   external "C" fileType=  ModelicaInternal_stat(name) annotation(Library="ModelicaExternalC");
-  annotation(__ModelicaAssociation_Impure=true);
   end stat;
 
-  function rename "Rename existing file or directory (C function 'rename')"
+  impure function rename "Rename existing file or directory (C function 'rename')"
     extends Modelica.Icons.Function;
     input String oldName "Current name";
     input String newName "New name";
   external "C" ModelicaInternal_rename(oldName, newName) annotation(Library="ModelicaExternalC");
-  annotation(__ModelicaAssociation_Impure=true);
   end rename;
 
-  function removeFile "Remove existing file (C function 'remove')"
+  impure function removeFile "Remove existing file (C function 'remove')"
     extends Modelica.Icons.Function;
     input String fileName "File to be removed";
   external "C" ModelicaInternal_removeFile(fileName) annotation(Library="ModelicaExternalC");
-  annotation(__ModelicaAssociation_Impure=true);
   end removeFile;
 
-  function copyFile
+  impure function copyFile
       "Copy existing file (C functions 'fopen', 'fread', 'fwrite', 'fclose')"
     extends Modelica.Icons.Function;
     input String fromName "Name of file to be copied";
     input String toName "Name of copy of file";
   external "C" ModelicaInternal_copyFile(fromName, toName) annotation(Library="ModelicaExternalC");
-  annotation(__ModelicaAssociation_Impure=true);
   end copyFile;
 
-  function readDirectory
+  impure function readDirectory
       "Read names of a directory (POSIX functions opendir, readdir, closedir)"
     extends Modelica.Icons.Function;
     input String directory
@@ -198,17 +192,15 @@ package FileSystem
     output String names[nNames]
         "All file and directory names in any order from the desired directory";
     external "C" ModelicaInternal_readDirectory(directory,nNames,names) annotation(Library="ModelicaExternalC");
-  annotation(__ModelicaAssociation_Impure=true);
   end readDirectory;
 
-function getNumberOfFiles
+impure function getNumberOfFiles
       "Get number of files and directories in a directory (POSIX functions opendir, readdir, closedir)"
   extends Modelica.Icons.Function;
   input String directory "Directory name";
   output Integer result
         "Number of files and directories present in 'directory'";
   external "C" result = ModelicaInternal_getNumberOfFiles(directory) annotation(Library="ModelicaExternalC");
-  annotation(__ModelicaAssociation_Impure=true);
 end getNumberOfFiles;
 
   annotation (

--- a/Modelica/Utilities/Streams.mo
+++ b/Modelica/Utilities/Streams.mo
@@ -117,7 +117,7 @@ separated by LF or CR-LF.
 </html>"));
   end countLines;
 
-  impure function error "Print error message and cancel all actions - in case of an unrecoverable error"
+  pure function error "Print error message and cancel all actions - in case of an unrecoverable error"
     extends Modelica.Icons.Function;
     input String string "String to be printed to error message window";
     external "C" ModelicaError(string) annotation(Library="ModelicaExternalC");

--- a/Modelica/Utilities/Streams.mo
+++ b/Modelica/Utilities/Streams.mo
@@ -42,7 +42,7 @@ Streams.print(\"x = \" + String(y), \"mytestfile.txt\");
 </html>"));
   end print;
 
-  function readFile
+  impure function readFile
     "Read content of a file and return it in a vector of strings"
     extends Modelica.Icons.Function;
     input String fileName "Name of the file that shall be read"
@@ -117,7 +117,7 @@ separated by LF or CR-LF.
 </html>"));
   end countLines;
 
-  function error "Print error message and cancel all actions - in case of an unrecoverable error"
+  impure function error "Print error message and cancel all actions - in case of an unrecoverable error"
     extends Modelica.Icons.Function;
     input String string "String to be printed to error message window";
     external "C" ModelicaError(string) annotation(Library="ModelicaExternalC");
@@ -166,7 +166,7 @@ file is already closed or does not exist.
 </html>"));
   end close;
 
-  function readMatrixSize "Read dimensions of a Real matrix from a MATLAB MAT file"
+  impure function readMatrixSize "Read dimensions of a Real matrix from a MATLAB MAT file"
     extends Modelica.Icons.Function;
     input String fileName "File where external data is stored" annotation(Dialog(loadSelector(filter="MATLAB MAT files (*.mat)", caption="Open MATLAB MAT file")));
     input String matrixName "Name / identifier of the 2D Real array on the file";
@@ -200,7 +200,7 @@ See <a href=\"modelica://Modelica.Utilities.Examples.ReadRealMatrixFromFile\">Ex
 </html>"));
   end readMatrixSize;
 
-  function readRealMatrix "Read Real matrix from MATLAB MAT file"
+  impure function readRealMatrix "Read Real matrix from MATLAB MAT file"
     extends Modelica.Icons.Function;
     input String fileName "File where external data is stored" annotation(Dialog(loadSelector(filter="MATLAB MAT files (*.mat)", caption="Open MATLAB MAT file")));
     input String matrixName "Name / identifier of the 2D Real array on the file";

--- a/Modelica/Utilities/Streams.mo
+++ b/Modelica/Utilities/Streams.mo
@@ -2,7 +2,7 @@ within Modelica.Utilities;
 package Streams "Read from files and write to files"
   extends Modelica.Icons.FunctionsPackage;
 
-  function print "Print string to terminal or file"
+  impure function print "Print string to terminal or file"
     extends Modelica.Icons.Function;
     input String string="" "String to be printed";
     input String fileName=""
@@ -10,9 +10,7 @@ package Streams "Read from files and write to files"
                  annotation(Dialog(saveSelector(filter="Text files (*.txt)",
                         caption="Text file to store the output of print(..)")));
   external "C" ModelicaInternal_print(string, fileName) annotation(Library="ModelicaExternalC");
-
-    annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+    annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 Streams.<strong>print</strong>(string);
@@ -67,7 +65,7 @@ Note, a fileName can be defined as URI by using the helper function
 </html>"));
   end readFile;
 
-  function readLine "Read a line of text from a file and return it in a string"
+  impure function readLine "Read a line of text from a file and return it in a string"
     extends Modelica.Icons.Function;
     input String fileName "Name of the file that shall be read"
                         annotation(Dialog(loadSelector(filter="Text files (*.txt)",
@@ -77,8 +75,7 @@ Note, a fileName can be defined as URI by using the helper function
     output Boolean endOfFile
       "If true, end-of-file was reached when trying to read line";
    external "C" string=  ModelicaInternal_readLine(fileName,lineNumber,endOfFile) annotation(Library="ModelicaExternalC");
-    annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+    annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 (string, endOfFile) = Streams.<strong>readLine</strong>(fileName, lineNumber)
@@ -98,7 +95,7 @@ and endOfFile=true. Otherwise endOfFile=false.
 </html>"));
   end readLine;
 
-  function countLines "Return the number of lines in a file"
+  impure function countLines "Return the number of lines in a file"
     extends Modelica.Icons.Function;
     input String fileName "Name of the file that shall be read"
                        annotation(Dialog(loadSelector(filter="Text files (*.txt)",
@@ -106,8 +103,7 @@ and endOfFile=true. Otherwise endOfFile=false.
 
     output Integer numberOfLines "Number of lines in file";
   external "C" numberOfLines=  ModelicaInternal_countLines(fileName) annotation(Library="ModelicaExternalC");
-    annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+    annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 numberOfLines = Streams.<strong>countLines</strong>(fileName)
@@ -151,14 +147,13 @@ Streams.error(\"x (= \" + String(x) + \")\\nhas to be in the range 0 .. 1\");
 </html>"));
   end error;
 
-  function close "Close file"
+  impure function close "Close file"
     extends Modelica.Icons.Function;
     input String fileName "Name of the file that shall be closed"
                  annotation(Dialog(loadSelector(filter="Text files (*.txt)",
                         caption="Close text file")));
     external "C" ModelicaStreams_closeFile(fileName) annotation(Library="ModelicaExternalC");
-    annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+    annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 Streams.<strong>close</strong>(fileName)
@@ -246,7 +241,7 @@ See <a href=\"modelica://Modelica.Utilities.Examples.ReadRealMatrixFromFile\">Ex
 </html>"));
   end readRealMatrix;
 
-  function writeRealMatrix "Write Real matrix to a MATLAB MAT file"
+  impure function writeRealMatrix "Write Real matrix to a MATLAB MAT file"
     extends Modelica.Icons.Function;
     input String fileName "File where external data is to be stored" annotation(Dialog(saveSelector(filter="MATLAB MAT files (*.mat)", caption="Save MATLAB MAT file")));
     input String matrixName "Name / identifier of the 2D Real array on the file";
@@ -259,9 +254,7 @@ See <a href=\"modelica://Modelica.Utilities.Examples.ReadRealMatrixFromFile\">Ex
     output Boolean success "true if successful";
     external "C" success = ModelicaIO_writeRealMatrix(fileName, matrixName, matrix, size(matrix, 1), size(matrix, 2), append, format)
     annotation(Library={"ModelicaIO", "ModelicaMatIO", "zlib"});
-
-    annotation(__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+    annotation(Documentation(info="<html>
 
 <h4>Syntax</h4>
 <blockquote><pre>

--- a/Modelica/Utilities/Strings.mo
+++ b/Modelica/Utilities/Strings.mo
@@ -2,11 +2,11 @@ within Modelica.Utilities;
 package Strings "Operations on strings"
   extends Modelica.Icons.FunctionsPackage;
 
-  function length "Return length of string"
+  pure function length "Return length of string"
     extends Modelica.Icons.Function;
     input String string;
     output Integer result "Number of characters of string";
-  external "C" result=  ModelicaStrings_length(string) annotation(Library="ModelicaExternalC");
+  external "C" result = ModelicaStrings_length(string) annotation(Library="ModelicaExternalC");
     annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -19,8 +19,7 @@ Returns the number of characters of \"string\".
 </html>"));
   end length;
 
-  function substring "Return a substring defined by start and end index"
-
+  pure function substring "Return a substring defined by start and end index"
     extends Modelica.Icons.Function;
     input String string "String from which a substring is inquired";
     input Integer startIndex(min=1)
@@ -28,8 +27,7 @@ Returns the number of characters of \"string\".
     input Integer endIndex(min=1) "Character position of substring end";
     output String result
       "String containing substring string[startIndex:endIndex]";
-  external "C" result =
-                      ModelicaStrings_substring(string,startIndex,endIndex) annotation(Library="ModelicaExternalC");
+  external "C" result = ModelicaStrings_substring(string,startIndex,endIndex) annotation(Library="ModelicaExternalC");
     annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -81,13 +79,13 @@ defined by the optional argument \"string\".
 </html>"));
   end repeat;
 
-  function compare "Compare two strings lexicographically"
+  pure function compare "Compare two strings lexicographically"
     extends Modelica.Icons.Function;
     input String string1;
     input String string2;
     input Boolean caseSensitive=true "= false, if case of letters is ignored";
     output Modelica.Utilities.Types.Compare result "Result of comparison";
-  external "C" result=  ModelicaStrings_compare(string1, string2, caseSensitive) annotation(Library="ModelicaExternalC");
+  external "C" result = ModelicaStrings_compare(string1, string2, caseSensitive) annotation(Library="ModelicaExternalC");
     annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -451,7 +449,7 @@ s2 = Strings.sort(s1);
 </html>"));
   end sort;
 
-  function hashString "Create a hash value of a string"
+  pure function hashString "Create a hash value of a string"
     extends Modelica.Icons.Function;
     input String string "The string to create a hash from";
     output Integer hash "The hash value of string";
@@ -1023,7 +1021,7 @@ part of the string is printed.
   package Advanced "Advanced scanning functions"
     extends Modelica.Icons.FunctionsPackage;
 
-    function scanReal "Scan a signed real number"
+    pure function scanReal "Scan a signed real number"
       extends Modelica.Icons.Function;
       input String string;
       input Integer startIndex(min=1)=1 "Index where scanning starts";
@@ -1070,7 +1068,7 @@ shall not start with '+' or '-'. The default of \"unsigned\" is <strong>false</s
 </html>"));
     end scanReal;
 
-    function scanInteger "Scan signed integer number"
+    pure function scanInteger "Scan signed integer number"
       extends Modelica.Icons.Function;
       input String string;
       input Integer startIndex(min=1)=1;
@@ -1116,7 +1114,7 @@ shall not start with '+' or '-'. The default of \"unsigned\" is <strong>false</s
 </html>"));
     end scanInteger;
 
-    function scanString "Scan string"
+    pure function scanString "Scan string"
       extends Modelica.Icons.Function;
       input String string;
       input Integer startIndex(min=1)=1 "Index where scanning starts";
@@ -1150,7 +1148,7 @@ the second output argument is an empty string.
 </html>"));
     end scanString;
 
-    function scanIdentifier "Scan simple identifiers"
+    pure function scanIdentifier "Scan simple identifiers"
       extends Modelica.Icons.Function;
       input String string;
       input Integer startIndex(min=1)=1 "Index where scanning starts";
@@ -1186,7 +1184,7 @@ the second output argument is an empty string.
 </html>"));
     end scanIdentifier;
 
-    function skipWhiteSpace "Scan white space"
+    pure function skipWhiteSpace "Scan white space"
       extends Modelica.Icons.Function;
       input String string;
       input Integer startIndex(min=1)=1;

--- a/Modelica/Utilities/System.mo
+++ b/Modelica/Utilities/System.mo
@@ -131,7 +131,7 @@ All returned values are of type Integer and have the following meaning:
   impure function getPid "Retrieve the current process id"
     extends Modelica.Icons.Function;
     output Integer pid "Process ID";
-    external "C" pid=  ModelicaInternal_getpid() annotation(Library="ModelicaExternalC");
+    external "C" pid = ModelicaInternal_getpid() annotation(Library="ModelicaExternalC");
     annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>

--- a/Modelica/Utilities/System.mo
+++ b/Modelica/Utilities/System.mo
@@ -2,29 +2,27 @@ within Modelica.Utilities;
 package System "Interaction with environment"
   extends Modelica.Icons.FunctionsPackage;
 
-function getWorkDirectory "Get full path name of work directory"
+impure function getWorkDirectory "Get full path name of work directory"
   extends Modelica.Icons.Function;
   output String directory "Full path name of work directory";
 // POSIX function "getcwd"
   external "C" directory = ModelicaInternal_getcwd(0) annotation(Library="ModelicaExternalC");
-    annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+    annotation (Documentation(info="<html>
 
 </html>"));
 end getWorkDirectory;
 
-function setWorkDirectory "Set work directory"
+impure function setWorkDirectory "Set work directory"
   extends Modelica.Icons.Function;
   input String directory "New work directory";
 // POSIX function "chdir"
 external "C" ModelicaInternal_chdir(directory) annotation(Library="ModelicaExternalC");
-    annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+    annotation (Documentation(info="<html>
 
 </html>"));
 end setWorkDirectory;
 
-function getEnvironmentVariable "Get content of environment variable"
+impure function getEnvironmentVariable "Get content of environment variable"
   extends Modelica.Icons.Function;
   input String name "Name of environment variable";
   input Boolean convertToSlash =  false
@@ -34,26 +32,24 @@ function getEnvironmentVariable "Get content of environment variable"
   output Boolean exist
       "= true, if environment variable exists; = false, if it does not exist";
   external "C" ModelicaInternal_getenv(name, convertToSlash, content, exist) annotation(Library="ModelicaExternalC");
-    annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+    annotation (Documentation(info="<html>
 
 </html>"));
 end getEnvironmentVariable;
 
-function setEnvironmentVariable "Set content of local environment variable"
+impure function setEnvironmentVariable "Set content of local environment variable"
   extends Modelica.Icons.Function;
   input String name "Name of environment variable";
   input String content "Value of the environment variable";
   input Boolean convertFromSlash =  false
       "True, if '/' in environment variable shall be changed to native directory separators";
 external "C" ModelicaInternal_setenv(name, content, convertFromSlash) annotation(Library="ModelicaExternalC");
-    annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+    annotation (Documentation(info="<html>
 
 </html>"));
 end setEnvironmentVariable;
 
-  function getTime "Retrieve the local time (in the local time zone)"
+  impure function getTime "Retrieve the local time (in the local time zone)"
     extends Modelica.Icons.Function;
     output Integer ms "Millisecond";
     output Integer sec "Second";
@@ -64,8 +60,7 @@ end setEnvironmentVariable;
     output Integer year "Year";
     external "C" ModelicaInternal_getTime(ms,sec,min,hour,day,mon,year)
       annotation(Library="ModelicaExternalC");
-    annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+    annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 (ms, sec, min, hour, day, mon, year) = System.<strong>getTime</strong>();
@@ -133,12 +128,11 @@ All returned values are of type Integer and have the following meaning:
 </html>"));
   end getTime;
 
-  function getPid "Retrieve the current process id"
+  impure function getPid "Retrieve the current process id"
     extends Modelica.Icons.Function;
     output Integer pid "Process ID";
     external "C" pid=  ModelicaInternal_getpid() annotation(Library="ModelicaExternalC");
-    annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+    annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 pid = System.<strong>getPid</strong>();
@@ -177,21 +171,19 @@ getPid()   // = 3044
 </html>"));
   end getPid;
 
-function command "Execute command in default shell"
+impure function command "Execute command in default shell"
   extends Modelica.Icons.Function;
   input String string "String to be passed to shell";
   output Integer result "Return value from command (depends on environment)";
   external "C" result = system(string) annotation(Include="#include <stdlib.h>", Library="ModelicaExternalC");
-    annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+    annotation (Documentation(info="<html>
 
 </html>"));
 end command;
 
-function exit "Terminate execution of Modelica environment"
+impure function exit "Terminate execution of Modelica environment"
   extends ModelicaServices.System.exit;
-    annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+    annotation (Documentation(info="<html>
 
 </html>"));
 end exit;

--- a/ModelicaServices/package.mo
+++ b/ModelicaServices/package.mo
@@ -176,10 +176,10 @@ but indirectly via the alias definition in
 
   package System "System dependent functions"
     extends Modelica.Icons.Package;
-    function exit "Terminate execution of Modelica environment"
+    impure function exit "Terminate execution of Modelica environment"
       extends Modelica.Utilities.Internal.PartialModelicaServices.System.exitBase;
       external "C" exit(status) annotation(Include="#include <stdlib.h>", Library="ModelicaExternalC");
-      annotation(__ModelicaAssociation_Impure=true, Documentation(info="<html>
+      annotation(Documentation(info="<html>
 <p>
 Tool-specific implementation of <a href=\"modelica://Modelica.Utilities.System.exit\">Modelica.Utilities.System.exit</a>.
 </p>

--- a/ModelicaTest/Math.mo
+++ b/ModelicaTest/Math.mo
@@ -1195,7 +1195,7 @@ extends Modelica.Icons.ExamplesPackage;
 </html>"));
     end truncatedDistributions;
 
-    function automaticGlobalSeed "Test automatic global seed"
+    impure function automaticGlobalSeed "Test automatic global seed"
       extends Modelica.Icons.Function;
       output Integer seed "Automatically generated seed";
       external "C" seed = ModelicaRandom_automaticGlobalSeed()

--- a/ModelicaTest/Tables/CombiTable1Ds.mo
+++ b/ModelicaTest/Tables/CombiTable1Ds.mo
@@ -225,8 +225,9 @@ package CombiTable1Ds "Test models for Modelica.Blocks.Tables.CombiTable1Ds"
         tableOnFile=true,
         tableName="TestTable_1D_b",
         columns={2,3}));
+    parameter Real dummy(fixed=false) "Dummy parameter";
   protected
-    encapsulated function getUsertab
+    encapsulated impure function getUsertab
       import Modelica;
       extends Modelica.Icons.Function;
       input Real dummy_u[:];
@@ -239,9 +240,8 @@ double mydummyfunc(double* dummy_in) {
 }
 ");
     end getUsertab;
-  public
-    Modelica.Blocks.Sources.RealExpression realExpression(y=getUsertab(t_new.y))
-      annotation (Placement(transformation(extent={{-20,-42},{10,-22}})));
+  initial equation
+    dummy = getUsertab(t_new.y);
     annotation (experiment(StartTime=0, StopTime=4));
   end Test25_usertab;
 

--- a/ModelicaTest/Tables/CombiTable1Dv.mo
+++ b/ModelicaTest/Tables/CombiTable1Dv.mo
@@ -225,8 +225,9 @@ package CombiTable1Dv "Test models for Modelica.Blocks.Tables.CombiTable1Dv"
   model Test25_usertab "Test utilizing the usertab.c interface"
     extends Modelica.Icons.Example;
     extends TestDer(t_new(tableOnFile=true, tableName="TestTable_1D_a"));
+    parameter Real dummy(fixed=false) "Dummy parameter";
   protected
-    encapsulated function getUsertab
+    encapsulated impure function getUsertab
       import Modelica;
       extends Modelica.Icons.Function;
       input Real dummy_u[:];
@@ -239,9 +240,8 @@ double mydummyfunc(double* dummy_in) {
 }
 ");
     end getUsertab;
-  public
-    Modelica.Blocks.Sources.RealExpression realExpression(y=getUsertab(t_new.y))
-      annotation (Placement(transformation(extent={{-20,-42},{10,-22}})));
+  initial equation
+    dummy = getUsertab(t_new.y);
     annotation (experiment(StartTime=0, StopTime=4));
   end Test25_usertab;
 

--- a/ModelicaTest/Tables/CombiTable2Ds.mo
+++ b/ModelicaTest/Tables/CombiTable2Ds.mo
@@ -488,12 +488,13 @@ package CombiTable2Ds "Test models for Modelica.Blocks.Tables.CombiTable2Ds"
   model Test18_usertab "Test utilizing the usertab.c interface"
     extends Modelica.Icons.Example;
     extends TestDer(t_new(tableOnFile=true, tableName="TestTable_2D"));
+    parameter Real dummy(fixed=false) "Dummy parameter";
     Modelica.Blocks.Sources.Ramp ramp(height=2, duration=1)
       annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
     Modelica.Blocks.Sources.Ramp ramp1(duration=1, height=6)
       annotation (Placement(transformation(extent={{-80,-20},{-60,0}})));
   protected
-    encapsulated function getUsertab
+    encapsulated impure function getUsertab
       import Modelica;
       extends Modelica.Icons.Function;
       input Real dummy_u;
@@ -506,9 +507,8 @@ double mydummyfunc(double dummy_in) {
 }
 ");
     end getUsertab;
-  public
-    Modelica.Blocks.Sources.RealExpression realExpression(y=getUsertab(t_new.y))
-      annotation (Placement(transformation(extent={{-20,-40},{10,-20}})));
+  initial equation
+    dummy = getUsertab(t_new.y);
   equation
     connect(ramp1.y, t_new.u2) annotation (Line(
         points={{-59,-10},{-50,-10},{-50,4},{-42,4}}, color={0,0,127}));

--- a/ModelicaTest/Tables/CombiTable2Dv.mo
+++ b/ModelicaTest/Tables/CombiTable2Dv.mo
@@ -313,12 +313,13 @@ package CombiTable2Dv "Test models for Modelica.Blocks.Tables.CombiTable2Dv"
   model Test18_usertab "Test utilizing the usertab.c interface"
     extends Modelica.Icons.Example;
     extends TestDer(t_new(tableOnFile=true, tableName="TestTable_2D"));
+    parameter Real dummy(fixed=false) "Dummy parameter";
     Modelica.Blocks.Sources.Ramp ramp(height=2, duration=1)
       annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
     Modelica.Blocks.Sources.Ramp ramp1(duration=1, height=6)
       annotation (Placement(transformation(extent={{-80,-20},{-60,0}})));
   protected
-    encapsulated function getUsertab
+    encapsulated impure function getUsertab
       import Modelica;
       extends Modelica.Icons.Function;
       input Real dummy_u;
@@ -331,9 +332,8 @@ double mydummyfunc(double dummy_in) {
 }
 ");
     end getUsertab;
-  public
-    Modelica.Blocks.Sources.RealExpression realExpression(y=getUsertab(t_new.y[1]))
-      annotation (Placement(transformation(extent={{-20,-40},{10,-20}})));
+  initial equation
+    dummy = getUsertab(t_new.y);
   equation
     connect(ramp1.y, t_new.u2[1]) annotation (Line(
         points={{-59,-10},{-50,-10},{-50,4},{-42,4}}, color={0,0,127}));

--- a/ModelicaTest/Tables/CombiTimeTable.mo
+++ b/ModelicaTest/Tables/CombiTimeTable.mo
@@ -742,8 +742,9 @@ package CombiTimeTable "Test models for Modelica.Blocks.Sources.CombiTimeTable"
   model Test66_usertab "Test utilizing the usertab.c interface"
     extends Modelica.Icons.Example;
     extends TestDer(t_new(tableOnFile=true, tableName="TestTable_1D_Time"));
+    parameter Real dummy(fixed=false) "Dummy parameter";
   protected
-    encapsulated function getUsertab
+    encapsulated impure function getUsertab
       import Modelica;
       extends Modelica.Icons.Function;
       input Real dummy_u[:];
@@ -756,9 +757,8 @@ double mydummyfunc(double* dummy_in) {
 }
 ");
     end getUsertab;
-  public
-    Modelica.Blocks.Sources.RealExpression realExpression(y=getUsertab(t_new.y))
-      annotation (Placement(transformation(extent={{-20,-40},{10,-20}})));
+  initial equation
+    dummy = getUsertab(t_new.y);
     annotation (experiment(StartTime=0, StopTime=4));
   end Test66_usertab;
 

--- a/ObsoleteModelica4.mo
+++ b/ObsoleteModelica4.mo
@@ -200,6 +200,54 @@ for signal buses, see example
         end ReceiveInteger;
       end Adaptors;
     end Interfaces;
+
+    package Tables "Library of blocks to interpolate in one and two-dimensional tables"
+      extends Modelica.Icons.Package;
+      package Internal "Internal external object definitions for table functions that should not be directly utilized by the user"
+        extends Modelica.Icons.InternalPackage;
+        function readTimeTableData "Read table data from text or MATLAB MAT-file"
+          extends Modelica.Icons.Function;
+          extends Modelica.Icons.ObsoleteModel;
+          input Modelica.Blocks.Types.ExternalCombiTimeTable tableID "External table object";
+          input Boolean forceRead = false
+            "= true: Force reading of table data; = false: Only read, if not yet read.";
+          output Real readSuccess "Table read success";
+          input Boolean verboseRead = true
+            "= true: Print info message; = false: No info message";
+          external"C" readSuccess = ModelicaStandardTables_CombiTimeTable_read(tableID, forceRead, verboseRead)
+            annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+          annotation(__ModelicaAssociation_Impure=true);
+        end readTimeTableData;
+
+        function readTable1DData "Read table data from text or MATLAB MAT-file"
+          extends Modelica.Icons.Function;
+          extends Modelica.Icons.ObsoleteModel;
+          input Modelica.Blocks.Types.ExternalCombiTable1D tableID "External table object";
+          input Boolean forceRead = false
+            "= true: Force reading of table data; = false: Only read, if not yet read.";
+          input Boolean verboseRead = true
+            "= true: Print info message; = false: No info message";
+          output Real readSuccess "Table read success";
+          external"C" readSuccess = ModelicaStandardTables_CombiTable1D_read(tableID, forceRead, verboseRead)
+            annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+          annotation(__ModelicaAssociation_Impure=true);
+        end readTable1DData;
+
+        function readTable2DData "Read table data from text or MATLAB MAT-file"
+          extends Modelica.Icons.Function;
+          extends Modelica.Icons.ObsoleteModel;
+          input Modelica.Blocks.Types.ExternalCombiTable2D tableID "External table object";
+          input Boolean forceRead = false
+            "= true: Force reading of table data; = false: Only read, if not yet read.";
+          input Boolean verboseRead = true
+            "= true: Print info message; = false: No info message";
+          output Real readSuccess "Table read success";
+          external"C" readSuccess = ModelicaStandardTables_CombiTable2D_read(tableID, forceRead, verboseRead)
+            annotation (Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+          annotation(__ModelicaAssociation_Impure=true);
+        end readTable2DData;
+      end Internal;
+    end Tables;
   end Blocks;
 
   package Electrical "Library of electrical models (analog, digital, machines, polyphase)"


### PR DESCRIPTION
Fix #1478.

@HansOlsson @MartinOtter Please review thoroughly.

For me, one open issue is the "dummy" table hack as for instance documented in https://github.com/modelica/ModelicaStandardLibrary/blob/ec70d1f10887371f11f14cb1abb696b60ee8cd6f/Modelica/Blocks/Tables.mo#L1320-L1330. This is a pure external function, but must not removed during optimization due to the intended side-effect to include the usertab header file. Is the recommendation to mark it as impure then?