### PR TITLE
Move Polynomials from Media to Math

### DIFF
--- a/Modelica/Math/Polynomials.mo
+++ b/Modelica/Math/Polynomials.mo
@@ -1,0 +1,261 @@
+within Modelica.Math;
+    package Polynomials
+      "Library of functions operating on polynomials (including polynomial fitting)"
+      extends Modelica.Icons.FunctionsPackage;
+
+      function evaluate "Evaluate polynomial at a given abscissa value"
+        extends Modelica.Icons.Function;
+        input Real p[:]
+          "Polynomial coefficients (p[1] is coefficient of highest power)";
+        input Real u "Abscissa value";
+        output Real y "Value of polynomial at u";
+      algorithm
+        y := p[1];
+        for j in 2:size(p, 1) loop
+          y := p[j] + u*y;
+        end for;
+        annotation(derivative(zeroDerivative=p)=evaluate_der);
+      end evaluate;
+
+      function evaluateWithRange
+        "Evaluate polynomial at a given abscissa value with linear extrapolation outside of the defined range"
+        extends Modelica.Icons.Function;
+        input Real p[:]
+          "Polynomial coefficients (p[1] is coefficient of highest power)";
+        input Real uMin "Polynomial valid in the range uMin .. uMax";
+        input Real uMax "Polynomial valid in the range uMin .. uMax";
+        input Real u "Abscissa value";
+        output Real y
+          "Value of polynomial at u. Outside of uMin,uMax, linear extrapolation is used";
+      algorithm
+        if u < uMin then
+          y := evaluate(p, uMin) - evaluate_der(
+                  p,
+                  uMin,
+                  uMin - u);
+        elseif u > uMax then
+          y := evaluate(p, uMax) + evaluate_der(
+                  p,
+                  uMax,
+                  u - uMax);
+        else
+          y := evaluate(p, u);
+        end if;
+        annotation (derivative(
+            zeroDerivative=p,
+            zeroDerivative=uMin,
+            zeroDerivative=uMax) = evaluateWithRange_der);
+      end evaluateWithRange;
+
+      function derivative "Derivative of polynomial"
+        extends Modelica.Icons.Function;
+        input Real p1[:]
+          "Polynomial coefficients (p1[1] is coefficient of highest power)";
+        output Real p2[size(p1, 1) - 1] "Derivative of polynomial p1";
+      protected
+        Integer n=size(p1, 1);
+      algorithm
+        for j in 1:n-1 loop
+          p2[j] := p1[j]*(n - j);
+        end for;
+      end derivative;
+
+      function derivativeValue
+        "Value of derivative of polynomial at abscissa value u"
+        extends Modelica.Icons.Function;
+        input Real p[:]
+          "Polynomial coefficients (p[1] is coefficient of highest power)";
+        input Real u "Abscissa value";
+        output Real y "Value of derivative of polynomial at u";
+      protected
+        Integer n=size(p, 1);
+      algorithm
+        y := p[1]*(n - 1);
+        for j in 2:size(p, 1)-1 loop
+          y := p[j]*(n - j) + u*y;
+        end for;
+        annotation(derivative(zeroDerivative=p)=derivativeValue_der);
+      end derivativeValue;
+
+      function secondDerivativeValue
+        "Value of 2nd derivative of polynomial at abscissa value u"
+        extends Modelica.Icons.Function;
+        input Real p[:]
+          "Polynomial coefficients (p[1] is coefficient of highest power)";
+        input Real u "Abscissa value";
+        output Real y "Value of 2nd derivative of polynomial at u";
+      protected
+        Integer n=size(p, 1);
+      algorithm
+        y := p[1]*(n - 1)*(n - 2);
+        for j in 2:size(p, 1)-2 loop
+          y := p[j]*(n - j)*(n - j - 1) + u*y;
+        end for;
+      end secondDerivativeValue;
+
+      function integral "Indefinite integral of polynomial p(u)"
+        extends Modelica.Icons.Function;
+        input Real p1[:]
+          "Polynomial coefficients (p1[1] is coefficient of highest power)";
+        output Real p2[size(p1, 1) + 1]
+          "Polynomial coefficients of indefinite integral of polynomial p1 (polynomial p2 + C is the indefinite integral of p1, where C is an arbitrary constant)";
+      protected
+        Integer n=size(p1, 1) + 1 "Degree of output polynomial";
+      algorithm
+        for j in 1:n-1 loop
+          p2[j] := p1[j]/(n-j);
+        end for;
+        p2[n] := 0.0;
+      end integral;
+
+      function integralValue "Integral of polynomial p(u) from u_low to u_high"
+        extends Modelica.Icons.Function;
+        input Real p[:] "Polynomial coefficients";
+        input Real u_high "High integrand value";
+        input Real u_low=0 "Low integrand value, default 0";
+        output Real integral=0.0
+          "Integral of polynomial p from u_low to u_high";
+      protected
+        Integer n=size(p, 1) "Degree of integrated polynomial";
+        Real y_low=0 "Value at lower integrand";
+      algorithm
+        for j in 1:n loop
+          integral := u_high*(p[j]/(n - j + 1) + integral);
+          y_low := u_low*(p[j]/(n - j + 1) + y_low);
+        end for;
+        integral := integral - y_low;
+        annotation(derivative(zeroDerivative=p)=integralValue_der);
+      end integralValue;
+
+      function fitting
+        "Computes the coefficients of a polynomial that fits a set of data points in a least-squares sense"
+        extends Modelica.Icons.Function;
+        input Real u[:] "Abscissa data values";
+        input Real y[size(u, 1)] "Ordinate data values";
+        input Integer n(min=1)
+          "Order of desired polynomial that fits the data points (u,y)";
+        output Real p[n + 1]
+          "Polynomial coefficients of polynomial that fits the date points";
+      protected
+        Real V[size(u, 1), n + 1] "Vandermonde matrix";
+      algorithm
+        // Construct Vandermonde matrix
+        V[:, n + 1] := ones(size(u, 1));
+        for j in n:-1:1 loop
+          V[:, j] := {u[i] * V[i, j + 1] for i in 1:size(u,1)};
+        end for;
+
+        // Solve least squares problem
+        p :=Modelica.Math.Matrices.leastSquares(V, y);
+        annotation (Documentation(info="<html>
+<p>
+Polynomials.fitting(u,y,n) computes the coefficients of a polynomial
+p(u) of degree \"n\" that fits the data \"p(u[i]) - y[i]\"
+in a least squares sense. The polynomial is
+returned as a vector p[n+1] that has the following definition:
+</p>
+<pre>
+  p(u) = p[1]*u^n + p[2]*u^(n-1) + ... + p[n]*u + p[n+1];
+</pre>
+</html>"));
+      end fitting;
+
+      function evaluate_der
+        "Evaluate derivative of polynomial at a given abscissa value"
+        extends Modelica.Icons.Function;
+        input Real p[:]
+          "Polynomial coefficients (p[1] is coefficient of highest power)";
+        input Real u "Abscissa value";
+        input Real du "Delta of abscissa value";
+        output Real dy "Value of derivative of polynomial at u";
+      protected
+        Integer n=size(p, 1);
+      algorithm
+        dy := p[1]*(n - 1);
+        for j in 2:size(p, 1)-1 loop
+          dy := p[j]*(n - j) + u*dy;
+        end for;
+        dy := dy*du;
+      end evaluate_der;
+
+      function evaluateWithRange_der
+        "Evaluate derivative of polynomial at a given abscissa value with extrapolation outside of the defined range"
+        extends Modelica.Icons.Function;
+        input Real p[:]
+          "Polynomial coefficients (p[1] is coefficient of highest power)";
+        input Real uMin "Polynomial valid in the range uMin .. uMax";
+        input Real uMax "Polynomial valid in the range uMin .. uMax";
+        input Real u "Abscissa value";
+        input Real du "Delta of abscissa value";
+        output Real dy "Value of derivative of polynomial at u";
+      algorithm
+        if u < uMin then
+          dy := evaluate_der(
+                  p,
+                  uMin,
+                  du);
+        elseif u > uMax then
+          dy := evaluate_der(
+                  p,
+                  uMax,
+                  du);
+        else
+          dy := evaluate_der(
+                  p,
+                  u,
+                  du);
+        end if;
+      end evaluateWithRange_der;
+
+      function integralValue_der
+        "Time derivative of integral of polynomial p(u) from u_low to u_high, assuming only u_high as time-dependent (Leibniz rule)"
+        extends Modelica.Icons.Function;
+        input Real p[:] "Polynomial coefficients";
+        input Real u_high "High integrand value";
+        input Real u_low=0 "Low integrand value, default 0";
+        input Real du_high "High integrand value";
+        input Real du_low=0 "Low integrand value, default 0";
+        output Real dintegral=0.0
+          "Integral of polynomial p from u_low to u_high";
+      algorithm
+        dintegral := evaluate(p,u_high)*du_high;
+      end integralValue_der;
+
+      function derivativeValue_der
+        "Time derivative of derivative of polynomial"
+        extends Modelica.Icons.Function;
+        input Real p[:]
+          "Polynomial coefficients (p[1] is coefficient of highest power)";
+        input Real u "Abscissa value";
+        input Real du "Delta of abscissa value";
+        output Real dy
+          "Time-derivative of derivative of polynomial w.r.t. input variable at u";
+      protected
+        Integer n=size(p, 1);
+      algorithm
+        dy := secondDerivativeValue(p,u)*du;
+      end derivativeValue_der;
+      annotation (Documentation(info="<html>
+<p>
+This package contains functions to operate on polynomials,
+in particular to determine the derivative and the integral
+of a polynomial and to use a polynomial to fit a given set
+of data points.
+</p>
+
+<p>
+Copyright &copy; 2004-2019, Modelica Association and contributors
+</p>
+</html>",     revisions="<html>
+<ul>
+<li><em>Oct. 22, 2004</em> by Martin Otter (DLR):<br>
+       Renamed functions to not have abbreviations.<br>
+       Based fitting on LAPACK<br>
+       New function to return the polynomial of an indefinite integral</li>
+<li><em>Sept. 3, 2004</em> by Jonas Eborn (Scynamics):<br>
+       polyderval, polyintval added</li>
+<li><em>March 1, 2004</em> by Martin Otter (DLR):<br>
+       first version implemented</li>
+</ul>
+</html>"));
+    end Polynomials;

--- a/Modelica/Math/package.order
+++ b/Modelica/Math/package.order
@@ -2,6 +2,7 @@ Vectors
 BooleanVectors
 Matrices
 Nonlinear
+Polynomials
 Random
 Distributions
 Special

--- a/Modelica/Media/Air/DryAirNasa.mo
+++ b/Modelica/Media/Air/DryAirNasa.mo
@@ -11,9 +11,9 @@ package DryAirNasa "Air: Detailed dry air model as ideal gas (200..6000 K)"
     extends Modelica.Icons.Function;
     input ThermodynamicState state "Thermodynamic state record";
     output DynamicViscosity eta "Dynamic viscosity";
-    import Modelica.Media.Incompressible.TableBased.Polynomials_Temp;
+    import Modelica.Math.Polynomials;
   algorithm
-    eta := 1e-6*Polynomials_Temp.evaluateWithRange(
+    eta := 1e-6*Polynomials.evaluateWithRange(
         {9.7391102886305869E-15,-3.1353724870333906E-11,4.3004876595642225E-08,
         -3.8228016291758240E-05,5.0427874367180762E-02,1.7239260139242528E+01},
         Cv.to_degC(123.15),
@@ -31,10 +31,10 @@ package DryAirNasa "Air: Detailed dry air model as ideal gas (200..6000 K)"
     input ThermodynamicState state "Thermodynamic state record";
     input Integer method=1 "Dummy for compatibility reasons";
     output ThermalConductivity lambda "Thermal conductivity";
-    import Modelica.Media.Incompressible.TableBased.Polynomials_Temp;
+    import Modelica.Math.Polynomials;
     import Cv = Modelica.SIunits.Conversions;
   algorithm
-    lambda := 1e-3*Polynomials_Temp.evaluateWithRange(
+    lambda := 1e-3*Polynomials.evaluateWithRange(
         {6.5691470817717812E-15,-3.4025961923050509E-11,5.3279284846303157E-08,
         -4.5340839289219472E-05,7.6129675309037664E-02,2.4169481088097051E+01},
         Cv.to_degC(123.15),

--- a/Modelica/Media/Air/MoistAir.mo
+++ b/Modelica/Media/Air/MoistAir.mo
@@ -1164,9 +1164,9 @@ The specific heat capacity at constant density <strong>cv</strong> is computed f
 redeclare function extends dynamicViscosity
     "Return dynamic viscosity as a function of the thermodynamic state record, valid from 123.15 K to 1273.15 K"
 
-  import Modelica.Media.Incompressible.TableBased.Polynomials_Temp;
+  import Modelica.Math.Polynomials;
 algorithm
-  eta := 1e-6*Polynomials_Temp.evaluateWithRange(
+  eta := 1e-6*Polynomials.evaluateWithRange(
       {9.7391102886305869E-15,-3.1353724870333906E-11,4.3004876595642225E-08,
       -3.8228016291758240E-05,5.0427874367180762E-02,1.7239260139242528E+01},
       Cv.to_degC(123.15),
@@ -1180,10 +1180,10 @@ end dynamicViscosity;
 
 redeclare function extends thermalConductivity
     "Return thermal conductivity as a function of the thermodynamic state record, valid from 123.15 K to 1273.15 K"
-  import Modelica.Media.Incompressible.TableBased.Polynomials_Temp;
+  import Modelica.Math.Polynomials;
   import Cv = Modelica.SIunits.Conversions;
 algorithm
-  lambda := 1e-3*Polynomials_Temp.evaluateWithRange(
+  lambda := 1e-3*Polynomials.evaluateWithRange(
       {6.5691470817717812E-15,-3.4025961923050509E-11,5.3279284846303157E-08,
       -4.5340839289219472E-05,7.6129675309037664E-02,2.4169481088097051E+01},
       Cv.to_degC(123.15),

--- a/Modelica/Media/Air/ReferenceAir.mo
+++ b/Modelica/Media/Air/ReferenceAir.mo
@@ -891,7 +891,7 @@ Modelica.Media.UsersGuide.MediumUsage.TwoPhase</a>.
 
         algorithm
           Omega := exp(
-            Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate(
+            Modelica.Math.Polynomials.evaluate(
             {b[5],b[4],b[3],b[2],b[1]}, log(T/103.3)));
           eta_0 := 0.0266958*sqrt(1000*ReferenceAir.Air_Utilities.Basic.Constants.MM
             *T)/(0.36^2*Omega);
@@ -948,7 +948,7 @@ Modelica.Media.UsersGuide.MediumUsage.TwoPhase</a>.
           //calculating f at the given state
           f := Basic.Helmholtz(d, T);
           Omega := exp(
-            Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate(
+            Modelica.Math.Polynomials.evaluate(
             {b[5],b[4],b[3],b[2],b[1]}, log(T/103.3)));
           //Ideal-gas part of dynamic viscosity
           eta_0 := 0.0266958*sqrt(1000*ReferenceAir.Air_Utilities.Basic.Constants.MM

--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -15,6 +15,8 @@ convertClass("Modelica.Electrical.Digital.Converters.LogicToXO1Z",
               "Modelica.Electrical.Digital.Converters.LogicToX01Z");
 convertClass("Modelica.SIunits.FluxiodQuantum",
               "Modelica.SIunits.FluxoidQuantum");
+convertClass("Modelica.Media.Incompressible.TableBased.Polynomials_Temp",
+              "Modelica.Math.Polynomials");
 
 // Change renamed elements of classes
 // mue -> mu

--- a/ModelicaTest/Math.mo
+++ b/ModelicaTest/Math.mo
@@ -111,10 +111,9 @@ extends Modelica.Icons.ExamplesPackage;
   end BooleanFunctions;
 
   function Polynomials
-    "Test functions of Modelica.Media.Incompressible.TableBased.Polynomials_Temp"
+    "Test functions of Modelica.Math.Polynomials"
     extends Modelica.Icons.Function;
     import Modelica.Utilities.Streams;
-    import Poly = Modelica.Media.Incompressible.TableBased.Polynomials_Temp;
     input String logFile = "ModelicaTestLog.txt"
       "Filename where the log is stored";
     output Boolean ok;
@@ -129,31 +128,31 @@ extends Modelica.Icons.ExamplesPackage;
     Real u[7] = {0,1,2,3,4,5,6};
     Real y[7];
   algorithm
-    Streams.print("... Test of Modelica.Media.Incompressible.TableBased.Polynomials_Temp");
-    Streams.print("... Test of Modelica.Media.Incompressible.TableBased.Polynomials_Temp", logFile);
+    Streams.print("... Test of Modelica.Math.Polynomials");
+    Streams.print("... Test of Modelica.Math.Polynomials", logFile);
 
-    r := Poly.evaluate(p1,-3);
+    r := Modelica.Math.Polynomials.evaluate(p1,-3);
     assert(r == 38, "Polynomials.evaluate failed");
 
-    p2 := Poly.integral(p1);
+    p2 := Modelica.Math.Polynomials.integral(p1);
     assert( p2[1] == -0.5 and p2[2] == -1 and p2[3] == -2 and
             p2[4] == -1 and p2[5] == 0, "Polynomials.integral failed");
 
-    p3 := Poly.derivative(p2);
+    p3 := Modelica.Math.Polynomials.derivative(p2);
     assert( p3[1] == p1[1] and p3[2] == p1[2] and p3[3] == p1[3] and p3[4] == p1[4],
            "Polynomials.derivative failed");
 
-    r1 := Poly.derivativeValue(p2,-3);
-    r2 := Poly.evaluate(p3, -3);
+    r1 := Modelica.Math.Polynomials.derivativeValue(p2,-3);
+    r2 := Modelica.Math.Polynomials.evaluate(p3, -3);
     assert(r1 == r2, "Polynomials.derivativeValue failed");
 
-    r := Poly.integralValue(p1,2,1);
+    r := Modelica.Math.Polynomials.integralValue(p1,2,1);
     assert(r == -21.5, "Polynomials.integralValue failed");
 
     for i in 1:size(u,1) loop
-       y[i] := Poly.evaluate(p1,u[i]) + 0.01*i;
+       y[i] := Modelica.Math.Polynomials.evaluate(p1,u[i]) + 0.01*i;
     end for;
-    p4 := Poly.fitting(u,y,3);
+    p4 := Modelica.Math.Polynomials.fitting(u,y,3);
     assert( abs(p4[1] - p1[1]) <= 1.e-8 and
             abs(p4[2] - p1[2]) <= 1.e-8 and
             abs(p4[3] - p1[3]) <= 0.1 and

--- a/ModelicaTestConversion4.mo
+++ b/ModelicaTestConversion4.mo
@@ -219,6 +219,28 @@ Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrar
     end Translational;
   end Mechanics;
 
+  package Math
+    extends Modelica.Icons.ExamplesPackage;
+    model Issue978 "Conversion test for #978"
+      extends Modelica.Icons.Example;
+      import Polynomials = Modelica.Media.Incompressible.TableBased.Polynomials_Temp;
+      parameter Real p1[:] = {-2, -3, -4, -1};
+      Real p2[size(p1, 1) + 1] = Polynomials.integral(p1);
+      Real p3[size(p1, 1)] = Polynomials.derivative(p2);
+      Real r;
+    algorithm
+      r := Polynomials.evaluate(p1, -3);
+      r := Polynomials.derivativeValue(p2, r);
+      r := Polynomials.evaluate(p3, r);
+      r := Polynomials.integralValue(p1, 2, 1);
+    annotation(experiment(StopTime=1), Documentation(info="<html>
+<p>
+Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/978\">#978</a>.
+</p>
+</html>"));
+    end Issue978;
+  end Math;
+
   package SIunits
     extends Modelica.Icons.ExamplesPackage;
     model Issue385 "Conversion test for #385"


### PR DESCRIPTION
When Polynomials were added to Modelica.Media.Incompressible.TableBased they were considered temporary. This is a cleanup to move the existing Polynomials package to Modelica.Math (as proposed by #978).

In #978, there has been some intent to introduce the Modelica_LinearSystems2.Math.Polynomial package instead, but given the current limited resources and requirements, it is enough to do this cleanup.

Close #978.