### PR TITLE
Avoid Boolean comparison with Real in DynamicSelect

### DIFF
--- a/Modelica/Blocks/Interaction.mo
+++ b/Modelica/Blocks/Interaction.mo
@@ -164,7 +164,7 @@ The usage is demonstrated, e.g., in example
             extent={{-188.0,-80.0},{62.0,-60.0}},
             textString="%active"),
           Ellipse(lineColor={64,64,64},
-            fillColor=DynamicSelect({192,192,192}, if showActive > 0.5 then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({192,192,192}, if showActive then {0,255,0} else {235,235,235}),
             pattern=LinePattern.None,
             fillPattern=FillPattern.Sphere,
             extent={{-100.0,-40.0},{-20.0,40.0}})}), Documentation(info="<html>

--- a/Modelica/Blocks/Interfaces.mo
+++ b/Modelica/Blocks/Interfaces.mo
@@ -987,16 +987,12 @@ where the signal sizes of the input and output vector are identical.
     annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
               {100,100}}), graphics={Ellipse(
             extent={{-71,7},{-85,-7}},
-            lineColor=DynamicSelect({235,235,235}, if u > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillColor=DynamicSelect({235,235,235}, if u > 0.5 then {0,255,0}
-                 else {235,235,235}),
+            lineColor=DynamicSelect({235,235,235}, if u then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({235,235,235}, if u then {0,255,0} else {235,235,235}),
             fillPattern=FillPattern.Solid), Ellipse(
             extent={{71,7},{85,-7}},
-            lineColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
+            lineColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
             fillPattern=FillPattern.Solid)}), Documentation(info="<html>
 <p>
 Block has one continuous Boolean input and one continuous Boolean output signal
@@ -1022,24 +1018,18 @@ with a 3D icon (e.g., used in Blocks.Logical library).
           extent={{-100,-100},{100,100}}), graphics={
           Ellipse(
             extent={{-71,7},{-85,-7}},
-            lineColor=DynamicSelect({235,235,235}, if u1 > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillColor=DynamicSelect({235,235,235}, if u1 > 0.5 then {0,255,0}
-                 else {235,235,235}),
+            lineColor=DynamicSelect({235,235,235}, if u1 then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({235,235,235}, if u1 then {0,255,0} else {235,235,235}),
             fillPattern=FillPattern.Solid),
           Ellipse(
             extent={{-71,-74},{-85,-88}},
-            lineColor=DynamicSelect({235,235,235}, if u2 > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillColor=DynamicSelect({235,235,235}, if u2 > 0.5 then {0,255,0}
-                 else {235,235,235}),
+            lineColor=DynamicSelect({235,235,235}, if u2 then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({235,235,235}, if u2 then {0,255,0} else {235,235,235}),
             fillPattern=FillPattern.Solid),
           Ellipse(
             extent={{71,7},{85,-7}},
-            lineColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
+            lineColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
             fillPattern=FillPattern.Solid)}), Documentation(info="<html>
 <p>
 Block has two continuous Boolean input and one continuous Boolean output signal
@@ -1067,31 +1057,23 @@ with a 3D icon (e.g., used in Blocks.Logical library).
           extent={{-100,-100},{100,100}}), graphics={
           Ellipse(
             extent={{-71,74},{-85,88}},
-            lineColor=DynamicSelect({235,235,235}, if u1 > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillColor=DynamicSelect({235,235,235}, if u1 > 0.5 then {0,255,0}
-                 else {235,235,235}),
+            lineColor=DynamicSelect({235,235,235}, if u1 then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({235,235,235}, if u1 then {0,255,0} else {235,235,235}),
             fillPattern=FillPattern.Solid),
           Ellipse(
             extent={{-71,7},{-85,-7}},
-            lineColor=DynamicSelect({235,235,235}, if u2 > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillColor=DynamicSelect({235,235,235}, if u2 > 0.5 then {0,255,0}
-                 else {235,235,235}),
+            lineColor=DynamicSelect({235,235,235}, if u2 then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({235,235,235}, if u2 then {0,255,0} else {235,235,235}),
             fillPattern=FillPattern.Solid),
           Ellipse(
             extent={{-71,-74},{-85,-88}},
-            lineColor=DynamicSelect({235,235,235}, if u3 > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillColor=DynamicSelect({235,235,235}, if u3 > 0.5 then {0,255,0}
-                 else {235,235,235}),
+            lineColor=DynamicSelect({235,235,235}, if u3 then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({235,235,235}, if u3 then {0,255,0} else {235,235,235}),
             fillPattern=FillPattern.Solid),
           Ellipse(
             extent={{71,7},{85,-7}},
-            lineColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
+            lineColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
             fillPattern=FillPattern.Solid)}), Documentation(info="<html><p>
 Block has three continuous Boolean input and one continuous Boolean output signal
 with a 3D icon (e.g., used in Blocks.Logical library).
@@ -1109,10 +1091,8 @@ with a 3D icon (e.g., used in Blocks.Logical library).
     annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
               {100,100}}), graphics={Ellipse(
             extent={{-71,7},{-85,-7}},
-            lineColor=DynamicSelect({235,235,235}, if u > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillColor=DynamicSelect({235,235,235}, if u > 0.5 then {0,255,0}
-                 else {235,235,235}),
+            lineColor=DynamicSelect({235,235,235}, if u then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({235,235,235}, if u then {0,255,0} else {235,235,235}),
             fillPattern=FillPattern.Solid)}), Documentation(info="<html>
 <p>
 Block has one continuous Boolean input signal
@@ -1131,10 +1111,8 @@ with a 3D icon (e.g., used in Blocks.Logical library).
     annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
               {100,100}}), graphics={Ellipse(
             extent={{71,7},{85,-7}},
-            lineColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
+            lineColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
             fillPattern=FillPattern.Solid)}), Documentation(info="<html>
 <p>
 Block has one continuous Boolean output signal
@@ -1168,10 +1146,8 @@ with a 3D icon (e.g., used in Blocks.Logical library).
             fillPattern=FillPattern.Solid),
           Ellipse(
             extent={{71,7},{85,-7}},
-            lineColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
+            lineColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
             fillPattern=FillPattern.Solid)}),
       Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{
               100,100}}), graphics={Polygon(
@@ -1221,14 +1197,12 @@ and a 3D icon (e.g., used in Blocks.Logical library).
             textString="%threshold"),
           Ellipse(
             extent={{71,7},{85,-7}},
-            lineColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillPattern=FillPattern.Solid),      Text(
+            lineColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
+            fillPattern=FillPattern.Solid), Text(
             extent={{-150,150},{150,110}},
             textString="%name",
-            lineColor={0,0,255})}),           Documentation(info="<html>
+            lineColor={0,0,255})}), Documentation(info="<html>
 <p>
 Block has one continuous Real input and one continuous Boolean output signal
 as well as a 3D icon (e.g., used in Blocks.Logical library).
@@ -1256,10 +1230,8 @@ as well as a 3D icon (e.g., used in Blocks.Logical library).
             borderPattern=BorderPattern.Raised),
           Ellipse(
             extent={{73,7},{87,-7}},
-            lineColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
+            lineColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
             fillPattern=FillPattern.Solid),
           Ellipse(extent={{32,10},{52,-10}}, lineColor={0,0,127}),
           Line(points={{-100,-80},{42,-80},{42,0}}, color={0,0,127}),
@@ -1299,10 +1271,8 @@ has a 3D icon (e.g., used in Blocks.Logical library).
             borderPattern=BorderPattern.Raised),
           Ellipse(
             extent={{60,10},{80,-10}},
-            lineColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
+            lineColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
             fillPattern=FillPattern.Solid)}));
   end PartialBooleanSISO_small;
 
@@ -1331,10 +1301,8 @@ has a 3D icon (e.g., used in Blocks.Logical library).
             borderPattern=BorderPattern.Raised),
           Ellipse(
             extent={{60,10},{80,-10}},
-            lineColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
-            fillColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0}
-                 else {235,235,235}),
+            lineColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
+            fillColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
             fillPattern=FillPattern.Solid)}));
   end PartialBooleanMISO;
 

--- a/Modelica/Blocks/MathBoolean.mo
+++ b/Modelica/Blocks/MathBoolean.mo
@@ -63,10 +63,8 @@ equation
               textString="%expr"),
             Ellipse(
               extent={{275,8},{289,-6}},
-              lineColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0} else
-                        {235,235,235}),
-              fillColor=DynamicSelect({235,235,235}, if y > 0.5 then {0,255,0} else
-                        {235,235,235}),
+              lineColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
+              fillColor=DynamicSelect({235,235,235}, if y then {0,255,0} else {235,235,235}),
               fillPattern=FillPattern.Solid)}),
     Documentation(info="<html>
 <p>

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -100,10 +100,8 @@ variable <strong>y</strong> is both a variable and a connector.
             lineColor={0,0,255}),
           Polygon(
             points={{100,10},{120,0},{100,-10},{100,10}},
-            lineColor=DynamicSelect({255,0,255}, if y > 0.5 then {0,255,0}
-                 else {255,0,255}),
-            fillColor=DynamicSelect({255,255,255}, if y > 0.5 then {0,255,0}
-                 else {255,255,255}),
+            lineColor=DynamicSelect({255,0,255}, if y then {0,255,0} else {255,0,255}),
+            fillColor=DynamicSelect({255,255,255}, if y then {0,255,0} else {255,255,255}),
             fillPattern=FillPattern.Solid)}), Documentation(info="<html>
 <p>
 The (time varying) Boolean output signal of this block can be defined in its
@@ -2935,10 +2933,8 @@ The precise semantics is:
           initialScale=0.06), graphics={Rectangle(
             extent={{-100,-100},{100,100}},
             borderPattern=BorderPattern.Raised,
-            fillColor=DynamicSelect({192,192,192}, if on > 0.5 then {0,255,0}
-                 else {192,192,192}),
-            fillPattern=DynamicSelect(FillPattern.Solid, if on > 0.5 then
-                FillPattern.Solid else FillPattern.Solid),
+            fillColor=DynamicSelect({192,192,192}, if on then {0,255,0} else {192,192,192}),
+            fillPattern=FillPattern.Solid,
             lineColor={128,128,128}), Text(
             extent={{-300,110},{300,175}},
             lineColor={0,0,255},

--- a/Modelica/Fluid/Examples/ControlledTankSystem.mo
+++ b/Modelica/Fluid/Examples/ControlledTankSystem.mo
@@ -439,20 +439,16 @@ This example is based on
          on := true;
       end when;
       annotation (Icon(
-          coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
-                100}}),
+          coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}}),
           graphics={Rectangle(
               extent={{-100,-100},{100,100}},
-              fillColor=DynamicSelect({192,192,192}, if on > 0.5 then {0,255,0} else
-                        {192,192,192}),
-              fillPattern=DynamicSelect(FillPattern.Solid, if on > 0.5 then
-                  FillPattern.Solid else FillPattern.Solid),
+              fillColor=DynamicSelect({192,192,192}, if on then {0,255,0} else {192,192,192}),
+              fillPattern=FillPattern.Solid,
               lineColor={128,128,128},
               lineThickness=0.5), Text(
               extent={{-80,-40},{80,40}},
               textString="%name")},
-                              interaction={OnMouseDownSetBoolean(
-                              on, true)}));
+          interaction={OnMouseDownSetBoolean(on, true)}));
     end RadioButton;
   end Utilities;
 end ControlledTankSystem;

--- a/Modelica/Fluid/Valves.mo
+++ b/Modelica/Fluid/Valves.mo
@@ -391,8 +391,7 @@ a simple model of a variable pressure loss is needed.</p>
             fillPattern=FillPattern.Solid),
           Polygon(
             points={{-100,50},{100,-50},{100,50},{0,0},{-100,-50},{-100,50}},
-            fillColor=DynamicSelect({255,255,255}, if open > 0.5 then {0,255,0} else
-                      {255,255,255}),
+            fillColor=DynamicSelect({255,255,255}, if open then {0,255,0} else {255,255,255}),
             fillPattern=FillPattern.Solid)}),
     Documentation(info="<html>
 <p>

--- a/Modelica/StateGraph.mo
+++ b/Modelica/StateGraph.mo
@@ -2126,8 +2126,7 @@ equation
             lineColor={0,0,255}),
           Rectangle(
             extent={{-100,100},{100,-100}},
-            fillColor=DynamicSelect({255,255,255}, if active > 0.5 then {0,255,
-                0} else {255,255,255}),
+            fillColor=DynamicSelect({255,255,255}, if active then {0,255,0} else {255,255,255}),
             fillPattern=FillPattern.Solid),
           Rectangle(extent={{-80,80},{80,-80}})}),
     Diagram(coordinateSystem(
@@ -2159,8 +2158,7 @@ equation
             lineColor={0,0,255}),
           Rectangle(
             extent={{-100,100},{100,-100}},
-            fillColor=DynamicSelect({255,255,255}, if active > 0.5 then {0,255,
-                0} else {255,255,255}),
+            fillColor=DynamicSelect({255,255,255}, if active then {0,255,0} else {255,255,255}),
             fillPattern=FillPattern.Solid),
           Text(
             extent={{-92,-50},{94,-68}},
@@ -2187,8 +2185,7 @@ equation
             textString="%name",
             lineColor={0,0,255}), Rectangle(
             extent={{-100,100},{100,-100}},
-            fillColor=DynamicSelect({255,255,255}, if active > 0.5 then {0,255,
-                0} else {255,255,255}),
+            fillColor=DynamicSelect({255,255,255}, if active then {0,255,0} else {255,255,255}),
             fillPattern=FillPattern.Solid)}),
     Diagram(coordinateSystem(
           preserveAspectRatio=true,
@@ -2219,8 +2216,7 @@ equation
             lineColor={0,0,255}),
           Rectangle(
             extent={{-100,100},{100,-100}},
-            fillColor=DynamicSelect({255,255,255}, if active > 0.5 then {0,255,
-                0} else {255,255,255}),
+            fillColor=DynamicSelect({255,255,255}, if active then {0,255,0} else {255,255,255}),
             fillPattern=FillPattern.Solid),
           Text(
             extent={{-92,-74},{94,-92}},
@@ -2242,8 +2238,7 @@ block Transition
           extent={{-100,-100},{100,100}}), graphics={
           Rectangle(
             extent={{-10,100},{10,-100}},
-            fillColor=DynamicSelect({0,0,0}, if enableFire > 0.5 then {0,255,0} else
-                      {0,0,0}),
+            fillColor=DynamicSelect({0,0,0}, if enableFire then {0,255,0} else {0,0,0}),
             fillPattern=FillPattern.Solid),
           Line(points={{-30,0},{-10,0}}),
           Text(
@@ -2252,13 +2247,11 @@ block Transition
             lineColor={0,0,255}),
           Text(
             extent={{20,20},{200,45}},
-            lineColor=DynamicSelect({0,0,0}, if enableTimer < 0.5 then {255,255,
-                255} else {0,0,0}),
+            lineColor=DynamicSelect({0,0,0}, if enableTimer then {255,255,255} else {0,0,0}),
             textString="%waitTime"),
           Text(
             extent={{-200,-120},{200,-145}},
-            lineColor=DynamicSelect({0,0,0}, if condition > 0.5 then {0,255,0} else
-                      {0,0,0}),
+            lineColor=DynamicSelect({0,0,0}, if condition then {0,255,0} else {0,0,0}),
             textString="%condition")}),
     Diagram(coordinateSystem(
           preserveAspectRatio=true,
@@ -2286,13 +2279,11 @@ block TransitionWithSignal
           extent={{-100,-100},{100,100}}), graphics={
           Text(
             extent={{20,20},{200,45}},
-            lineColor=DynamicSelect({0,0,0}, if enableTimer < 0.5 then {255,255,
-                255} else {0,0,0}),
+            lineColor=DynamicSelect({0,0,0}, if enableTimer then {255,255,255} else {0,0,0}),
             textString="%waitTime"),
           Rectangle(
             extent={{-10,100},{10,-100}},
-            fillColor=DynamicSelect({0,0,0}, if enableFire > 0.5 then {0,255,0} else
-                      {0,0,0}),
+            fillColor=DynamicSelect({0,0,0}, if enableFire then {0,255,0} else {0,0,0}),
             fillPattern=FillPattern.Solid),
           Line(points={{-30,0},{-10,0}}),
           Text(
@@ -2301,10 +2292,8 @@ block TransitionWithSignal
             lineColor={0,0,255}),
           Ellipse(
             extent={{7,-81},{-7,-95}},
-            lineColor=DynamicSelect({0,0,0}, if condition > 0.5 then {0,255,0} else
-                      {0,0,0}),
-            fillColor=DynamicSelect({0,0,0}, if condition > 0.5 then {0,255,0} else
-                      {0,0,0}),
+            lineColor=DynamicSelect({0,0,0}, if condition then {0,255,0} else {0,0,0}),
+            fillColor=DynamicSelect({0,0,0}, if condition then {0,255,0} else {0,0,0}),
             fillPattern=FillPattern.Solid)}),
     Diagram(coordinateSystem(
           preserveAspectRatio=true,
@@ -2721,8 +2710,7 @@ inside the CompositeStep to the outPort connector.");
             lineColor={0,0,255}),
           Rectangle(
             extent={{-150,150},{150,-150}},
-            fillColor=DynamicSelect({255,255,255}, if active > 0.5 then {0,255,
-                0} else {255,255,255}),
+            fillColor=DynamicSelect({255,255,255}, if active then {0,255,0} else {255,255,255}),
             fillPattern=FillPattern.Solid),
           Text(
             extent={{4,-115},{145,-130}},
@@ -2952,8 +2940,7 @@ value, still requires to go in to the text layer.
       Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
                 -100},{100,100}}), graphics={Ellipse(
               extent={{-100,-100},{100,100}},
-              fillColor=DynamicSelect({235,235,235}, if u > 0.5 then {0,255,0} else
-                        {235,235,235}),
+              fillColor=DynamicSelect({235,235,235}, if u then {0,255,0} else {235,235,235}),
               pattern=LinePattern.None,
               fillPattern=FillPattern.Sphere), Text(
               extent={{-150,150},{150,110}},


### PR DESCRIPTION
Comparisons of type Boolean with Real is illegal, but so far it was not detected if applied in DynamicSelect.