### PR TITLE
Rename table blocks CombiTable1D to CombiTable1Dv and CombiTable2D to CombiTable2Ds

### DIFF
--- a/Modelica/Blocks/Tables.mo
+++ b/Modelica/Blocks/Tables.mo
@@ -2,297 +2,6 @@ within Modelica.Blocks;
 package Tables
   "Library of blocks to interpolate in one and two-dimensional tables"
   extends Modelica.Icons.Package;
-  block CombiTable1D
-    "Table look-up in one dimension (matrix/file) with n inputs and n outputs"
-    extends Modelica.Blocks.Interfaces.MIMOs(final n=size(columns, 1));
-    parameter Boolean tableOnFile=false
-      "= true, if table is defined on file or in function usertab"
-      annotation (Dialog(group="Table data definition"));
-    parameter Real table[:, :] = fill(0.0, 0, 2)
-      "Table matrix (grid = first column; e.g., table=[0, 0; 1, 1; 2, 4])"
-      annotation (Dialog(group="Table data definition",enable=not tableOnFile));
-    parameter String tableName="NoName"
-      "Table name on file or in function usertab (see docu)"
-      annotation (Dialog(group="Table data definition",enable=tableOnFile));
-    parameter String fileName="NoName" "File where matrix is stored"
-      annotation (Dialog(
-        group="Table data definition",
-        enable=tableOnFile,
-        loadSelector(filter="Text files (*.txt);;MATLAB MAT-files (*.mat)",
-            caption="Open file in which table is present")));
-    parameter Boolean verboseRead=true
-      "= true, if info message that file is loading is to be printed"
-      annotation (Dialog(group="Table data definition",enable=tableOnFile));
-    parameter Integer columns[:]=2:size(table, 2)
-      "Columns of table to be interpolated"
-      annotation (Dialog(group="Table data interpretation"));
-    parameter Modelica.Blocks.Types.Smoothness smoothness=Modelica.Blocks.Types.Smoothness.LinearSegments
-      "Smoothness of table interpolation"
-      annotation (Dialog(group="Table data interpretation"));
-    parameter Modelica.Blocks.Types.Extrapolation extrapolation=Modelica.Blocks.Types.Extrapolation.LastTwoPoints
-      "Extrapolation of data outside the definition range"
-      annotation (Dialog(group="Table data interpretation"));
-    parameter Boolean verboseExtrapolation=false
-      "= true, if warning messages are to be printed if table input is outside the definition range"
-      annotation (Dialog(group="Table data interpretation", enable=extrapolation == Modelica.Blocks.Types.Extrapolation.LastTwoPoints or extrapolation == Modelica.Blocks.Types.Extrapolation.HoldLastPoint));
-    final parameter Real u_min=Internal.getTable1DAbscissaUmin(tableID)
-      "Minimum abscissa value defined in table";
-    final parameter Real u_max=Internal.getTable1DAbscissaUmax(tableID)
-      "Maximum abscissa value defined in table";
-  protected
-    parameter Modelica.Blocks.Types.ExternalCombiTable1D tableID=
-        Modelica.Blocks.Types.ExternalCombiTable1D(
-          if tableOnFile then tableName else "NoName",
-          if tableOnFile and fileName <> "NoName" and not Modelica.Utilities.Strings.isEmpty(fileName) then fileName else "NoName",
-          table,
-          columns,
-          smoothness,
-          extrapolation,
-          if tableOnFile then verboseRead else false) "External table object";
-    function readTableData = // No longer used, but kept for backward compatibility
-      Modelica.Blocks.Tables.Internal.readTable1DData "Read table data from text or MATLAB MAT-file";
-  equation
-    if tableOnFile then
-      assert(tableName <> "NoName",
-        "tableOnFile = true and no table name given");
-    else
-      assert(size(table, 1) > 0 and size(table, 2) > 0,
-        "tableOnFile = false and parameter table is an empty matrix");
-    end if;
-
-    if verboseExtrapolation and (
-      extrapolation == Modelica.Blocks.Types.Extrapolation.LastTwoPoints or
-      extrapolation == Modelica.Blocks.Types.Extrapolation.HoldLastPoint) then
-      for i in 1:n loop
-        assert(noEvent(u[i] >= u_min), "
-Extrapolation warning: The value u[" + String(i) +"] (=" + String(u[i]) + ") must be greater or equal
-than the minimum abscissa value u_min (=" + String(u_min) + ") defined in the table.
-", level=AssertionLevel.warning);
-        assert(noEvent(u[i] <= u_max), "
-Extrapolation warning: The value u[" + String(i) +"] (=" + String(u[i]) + ") must be less or equal
-than the maximum abscissa value u_max (=" + String(u_max) + ") defined in the table.
-", level=AssertionLevel.warning);
-      end for;
-    end if;
-
-    if smoothness == Modelica.Blocks.Types.Smoothness.ConstantSegments then
-      for i in 1:n loop
-        y[i] = Internal.getTable1DValueNoDer(tableID, i, u[i]);
-      end for;
-    else
-      for i in 1:n loop
-        y[i] = Internal.getTable1DValue(tableID, i, u[i]);
-      end for;
-    end if;
-    annotation (
-      Documentation(info="<html>
-<p>
-<strong>Univariate constant</strong>, <strong>linear</strong> or <strong>cubic Hermite
-spline interpolation</strong> in <strong>one</strong> dimension of a
-<strong>table</strong>.
-Via parameter <strong>columns</strong> it can be defined how many columns of the
-table are interpolated. If, e.g., columns={2,4}, it is assumed that 2 input
-and 2 output signals are present and that the first output interpolates
-the first input via column 2 and the second output interpolates the
-second input via column 4 of the table matrix.
-</p>
-<p>
-The grid points and function values are stored in a matrix \"table[i,j]\",
-where the first column \"table[:,1]\" contains the grid points and the
-other columns contain the data to be interpolated. Example:
-</p>
-<pre>
-   table = [0,  0;
-            1,  1;
-            2,  4;
-            4, 16]
-   If, e.g., the input u = 1.0, the output y =  1.0,
-       e.g., the input u = 1.5, the output y =  2.5,
-       e.g., the input u = 2.0, the output y =  4.0,
-       e.g., the input u =-1.0, the output y = -1.0 (i.e., extrapolation).
-</pre>
-<ul>
-<li>The interpolation interval is found by a binary search where the interval used in the
-    last call is used as start interval.</li>
-<li>Via parameter <strong>smoothness</strong> it is defined how the data is interpolated:
-<pre>
-  smoothness = 1: Linear interpolation
-             = 2: Akima interpolation: Smooth interpolation by cubic Hermite
-                  splines such that der(y) is continuous, also if extrapolated.
-             = 3: Constant segments
-             = 4: Fritsch-Butland interpolation: Smooth interpolation by cubic
-                  Hermite splines such that y preserves the monotonicity and
-                  der(y) is continuous, also if extrapolated.
-             = 5: Steffen interpolation: Smooth interpolation by cubic Hermite
-                  splines such that y preserves the monotonicity and der(y)
-                  is continuous, also if extrapolated.
-</pre></li>
-<li>Values <strong>outside</strong> of the table range, are computed by
-    extrapolation according to the setting of parameter <strong>extrapolation</strong>:
-<pre>
-  extrapolation = 1: Hold the first or last value of the table,
-                     if outside of the table scope.
-                = 2: Extrapolate by using the derivative at the first/last table
-                     points if outside of the table scope.
-                     (If smoothness is LinearSegments or ConstantSegments
-                     this means to extrapolate linearly through the first/last
-                     two table points.).
-                = 3: Periodically repeat the table data (periodical function).
-                = 4: No extrapolation, i.e. extrapolation triggers an error
-</pre></li>
-<li>If the table has only <strong>one row</strong>, the table value is returned,
-    independent of the value of the input signal.</li>
-<li>The grid values (first column) have to be strictly increasing.</li>
-</ul>
-<p>
-The table matrix can be defined in the following ways:
-</p>
-<ol>
-<li>Explicitly supplied as <strong>parameter matrix</strong> \"table\",
-    and the other parameters have the following values:
-<pre>
-   tableName is \"NoName\" or has only blanks,
-   fileName  is \"NoName\" or has only blanks.
-</pre></li>
-<li><strong>Read</strong> from a <strong>file</strong> \"fileName\" where the matrix is stored as
-    \"tableName\". Both text and MATLAB MAT-file format is possible.
-    (The text format is described below).
-    The MAT-file format comes in four different versions: v4, v6, v7 and v7.3.
-    The library supports at least v4, v6 and v7 whereas v7.3 is optional.
-    It is most convenient to generate the MAT-file from FreeMat or MATLAB&reg;
-    by command
-<pre>
-   save tables.mat tab1 tab2 tab3
-</pre>
-    or Scilab by command
-<pre>
-   savematfile tables.mat tab1 tab2 tab3
-</pre>
-    when the three tables tab1, tab2, tab3 should be used from the model.<br>
-    Note, a fileName can be defined as URI by using the helper function
-    <a href=\"modelica://Modelica.Utilities.Files.loadResource\">loadResource</a>.</li>
-<li>Statically stored in function \"usertab\" in file \"usertab.c\".
-    The matrix is identified by \"tableName\". Parameter
-    fileName = \"NoName\" or has only blanks. Row-wise storage is always to be
-    preferred as otherwise the table is reallocated and transposed.
-    See the <a href=\"modelica://Modelica.Blocks.Tables\">Tables</a> package
-    documentation for more details.</li>
-</ol>
-<p>
-When the constant \"NO_FILE_SYSTEM\" is defined, all file I/O related parts of the
-source code are removed by the C-preprocessor, such that no access to files takes place.
-</p>
-<p>
-If tables are read from a text file, the file needs to have the
-following structure (\"-----\" is not part of the file content):
-</p>
-<pre>
------------------------------------------------------
-#1
-double tab1(5,2)   # comment line
-  0   0
-  1   1
-  2   4
-  3   9
-  4  16
-double tab2(5,2)   # another comment line
-  0   0
-  2   2
-  4   8
-  6  18
-  8  32
------------------------------------------------------
-</pre>
-<p>
-Note, that the first two characters in the file need to be
-\"#1\" (a line comment defining the version number of the file format).
-Afterwards, the corresponding matrix has to be declared
-with type (= \"double\" or \"float\"), name and actual dimensions.
-Finally, in successive rows of the file, the elements of the matrix
-have to be given. The elements have to be provided as a sequence of
-numbers in row-wise order (therefore a matrix row can span several
-lines in the file and need not start at the beginning of a line).
-Numbers have to be given according to C syntax (such as 2.3, -2, +2.e4).
-Number separators are spaces, tab (\\t), comma (,), or semicolon (;).
-Several matrices may be defined one after another. Line comments start
-with the hash symbol (#) and can appear everywhere.
-Text files should either be ASCII or UTF-8 encoded, where UTF-8 encoded strings are only allowed in line comments and an optional UTF-8 BOM at the start of the text file is ignored.
-Other characters, like trailing non comments, are not allowed in the file.
-</p>
-<p>
-MATLAB is a registered trademark of The MathWorks, Inc.
-</p>
-</html>"),
-      Icon(
-      coordinateSystem(preserveAspectRatio=true,
-        extent={{-100.0,-100.0},{100.0,100.0}}),
-        graphics={
-      Line(points={{-60.0,40.0},{-60.0,-40.0},{60.0,-40.0},{60.0,40.0},{30.0,40.0},{30.0,-40.0},{-30.0,-40.0},{-30.0,40.0},{-60.0,40.0},{-60.0,20.0},{60.0,20.0},{60.0,0.0},{-60.0,0.0},{-60.0,-20.0},{60.0,-20.0},{60.0,-40.0},{-60.0,-40.0},{-60.0,40.0},{60.0,40.0},{60.0,-40.0}}),
-      Line(points={{0.0,40.0},{0.0,-40.0}}),
-      Rectangle(fillColor={255,215,136},
-        fillPattern=FillPattern.Solid,
-        extent={{-60.0,20.0},{-30.0,40.0}}),
-      Rectangle(fillColor={255,215,136},
-        fillPattern=FillPattern.Solid,
-        extent={{-60.0,0.0},{-30.0,20.0}}),
-      Rectangle(fillColor={255,215,136},
-        fillPattern=FillPattern.Solid,
-        extent={{-60.0,-20.0},{-30.0,0.0}}),
-      Rectangle(fillColor={255,215,136},
-        fillPattern=FillPattern.Solid,
-        extent={{-60.0,-40.0},{-30.0,-20.0}})}),
-      Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{
-              100,100}}), graphics={
-          Rectangle(
-            extent={{-60,60},{60,-60}},
-            fillColor={235,235,235},
-            fillPattern=FillPattern.Solid,
-            lineColor={0,0,255}),
-          Line(points={{-100,0},{-58,0}}, color={0,0,255}),
-          Line(points={{60,0},{100,0}}, color={0,0,255}),
-          Text(
-            extent={{-100,100},{100,64}},
-            textString="Univariate constant, linear or cubic Hermite spline table interpolation",
-            lineColor={0,0,255}),
-          Line(points={{-54,40},{-54,-40},{54,-40},{54,40},{28,40},{28,-40},{-28,
-                -40},{-28,40},{-54,40},{-54,20},{54,20},{54,0},{-54,0},{-54,-20},
-                {54,-20},{54,-40},{-54,-40},{-54,40},{54,40},{54,-40}}, color={
-                0,0,0}),
-          Line(points={{0,40},{0,-40}}),
-          Rectangle(
-            extent={{-54,40},{-28,20}},
-            fillColor={255,255,0},
-            fillPattern=FillPattern.Solid),
-          Rectangle(
-            extent={{-54,20},{-28,0}},
-            fillColor={255,255,0},
-            fillPattern=FillPattern.Solid),
-          Rectangle(
-            extent={{-54,0},{-28,-20}},
-            fillColor={255,255,0},
-            fillPattern=FillPattern.Solid),
-          Rectangle(
-            extent={{-54,-20},{-28,-40}},
-            fillColor={255,255,0},
-            fillPattern=FillPattern.Solid),
-          Text(
-            extent={{-50,54},{-32,42}},
-            textString="u[1]/[2]",
-            lineColor={0,0,255}),
-          Text(
-            extent={{-24,54},{0,42}},
-            textString="y[1]",
-            lineColor={0,0,255}),
-          Text(
-            extent={{-2,-40},{30,-54}},
-            textString="columns",
-            lineColor={0,0,255}),
-          Text(
-            extent={{2,54},{26,42}},
-            textString="y[2]",
-            lineColor={0,0,255})}));
-  end CombiTable1D;
-
   block CombiTable1Ds
     "Table look-up in one dimension (matrix/file) with one input and n outputs"
     extends Modelica.Blocks.Interfaces.SIMO(final nout=size(columns, 1));
@@ -582,7 +291,298 @@ MATLAB is a registered trademark of The MathWorks, Inc.
             lineColor={0,0,255})}));
   end CombiTable1Ds;
 
-  block CombiTable2D "Table look-up in two dimensions (matrix/file)"
+  block CombiTable1Dv
+    "Table look-up in one dimension (matrix/file) with n inputs and n outputs"
+    extends Modelica.Blocks.Interfaces.MIMOs(final n=size(columns, 1));
+    parameter Boolean tableOnFile=false
+      "= true, if table is defined on file or in function usertab"
+      annotation (Dialog(group="Table data definition"));
+    parameter Real table[:, :] = fill(0.0, 0, 2)
+      "Table matrix (grid = first column; e.g., table=[0, 0; 1, 1; 2, 4])"
+      annotation (Dialog(group="Table data definition",enable=not tableOnFile));
+    parameter String tableName="NoName"
+      "Table name on file or in function usertab (see docu)"
+      annotation (Dialog(group="Table data definition",enable=tableOnFile));
+    parameter String fileName="NoName" "File where matrix is stored"
+      annotation (Dialog(
+        group="Table data definition",
+        enable=tableOnFile,
+        loadSelector(filter="Text files (*.txt);;MATLAB MAT-files (*.mat)",
+            caption="Open file in which table is present")));
+    parameter Boolean verboseRead=true
+      "= true, if info message that file is loading is to be printed"
+      annotation (Dialog(group="Table data definition",enable=tableOnFile));
+    parameter Integer columns[:]=2:size(table, 2)
+      "Columns of table to be interpolated"
+      annotation (Dialog(group="Table data interpretation"));
+    parameter Modelica.Blocks.Types.Smoothness smoothness=Modelica.Blocks.Types.Smoothness.LinearSegments
+      "Smoothness of table interpolation"
+      annotation (Dialog(group="Table data interpretation"));
+    parameter Modelica.Blocks.Types.Extrapolation extrapolation=Modelica.Blocks.Types.Extrapolation.LastTwoPoints
+      "Extrapolation of data outside the definition range"
+      annotation (Dialog(group="Table data interpretation"));
+    parameter Boolean verboseExtrapolation=false
+      "= true, if warning messages are to be printed if table input is outside the definition range"
+      annotation (Dialog(group="Table data interpretation", enable=extrapolation == Modelica.Blocks.Types.Extrapolation.LastTwoPoints or extrapolation == Modelica.Blocks.Types.Extrapolation.HoldLastPoint));
+    final parameter Real u_min=Internal.getTable1DAbscissaUmin(tableID)
+      "Minimum abscissa value defined in table";
+    final parameter Real u_max=Internal.getTable1DAbscissaUmax(tableID)
+      "Maximum abscissa value defined in table";
+  protected
+    parameter Modelica.Blocks.Types.ExternalCombiTable1D tableID=
+        Modelica.Blocks.Types.ExternalCombiTable1D(
+          if tableOnFile then tableName else "NoName",
+          if tableOnFile and fileName <> "NoName" and not Modelica.Utilities.Strings.isEmpty(fileName) then fileName else "NoName",
+          table,
+          columns,
+          smoothness,
+          extrapolation,
+          if tableOnFile then verboseRead else false) "External table object";
+    function readTableData = // No longer used, but kept for backward compatibility
+      Modelica.Blocks.Tables.Internal.readTable1DData "Read table data from text or MATLAB MAT-file";
+  equation
+    if tableOnFile then
+      assert(tableName <> "NoName",
+        "tableOnFile = true and no table name given");
+    else
+      assert(size(table, 1) > 0 and size(table, 2) > 0,
+        "tableOnFile = false and parameter table is an empty matrix");
+    end if;
+
+    if verboseExtrapolation and (
+      extrapolation == Modelica.Blocks.Types.Extrapolation.LastTwoPoints or
+      extrapolation == Modelica.Blocks.Types.Extrapolation.HoldLastPoint) then
+      for i in 1:n loop
+        assert(noEvent(u[i] >= u_min), "
+Extrapolation warning: The value u[" + String(i) +"] (=" + String(u[i]) + ") must be greater or equal
+than the minimum abscissa value u_min (=" + String(u_min) + ") defined in the table.
+", level=AssertionLevel.warning);
+        assert(noEvent(u[i] <= u_max), "
+Extrapolation warning: The value u[" + String(i) +"] (=" + String(u[i]) + ") must be less or equal
+than the maximum abscissa value u_max (=" + String(u_max) + ") defined in the table.
+", level=AssertionLevel.warning);
+      end for;
+    end if;
+
+    if smoothness == Modelica.Blocks.Types.Smoothness.ConstantSegments then
+      for i in 1:n loop
+        y[i] = Internal.getTable1DValueNoDer(tableID, i, u[i]);
+      end for;
+    else
+      for i in 1:n loop
+        y[i] = Internal.getTable1DValue(tableID, i, u[i]);
+      end for;
+    end if;
+    annotation (
+      Documentation(info="<html>
+<p>
+<strong>Univariate constant</strong>, <strong>linear</strong> or <strong>cubic Hermite
+spline interpolation</strong> in <strong>one</strong> dimension of a
+<strong>table</strong>.
+Via parameter <strong>columns</strong> it can be defined how many columns of the
+table are interpolated. If, e.g., columns={2,4}, it is assumed that 2 input
+and 2 output signals are present and that the first output interpolates
+the first input via column 2 and the second output interpolates the
+second input via column 4 of the table matrix.
+</p>
+<p>
+The grid points and function values are stored in a matrix \"table[i,j]\",
+where the first column \"table[:,1]\" contains the grid points and the
+other columns contain the data to be interpolated. Example:
+</p>
+<pre>
+   table = [0,  0;
+            1,  1;
+            2,  4;
+            4, 16]
+   If, e.g., the input u = 1.0, the output y =  1.0,
+       e.g., the input u = 1.5, the output y =  2.5,
+       e.g., the input u = 2.0, the output y =  4.0,
+       e.g., the input u =-1.0, the output y = -1.0 (i.e., extrapolation).
+</pre>
+<ul>
+<li>The interpolation interval is found by a binary search where the interval used in the
+    last call is used as start interval.</li>
+<li>Via parameter <strong>smoothness</strong> it is defined how the data is interpolated:
+<pre>
+  smoothness = 1: Linear interpolation
+             = 2: Akima interpolation: Smooth interpolation by cubic Hermite
+                  splines such that der(y) is continuous, also if extrapolated.
+             = 3: Constant segments
+             = 4: Fritsch-Butland interpolation: Smooth interpolation by cubic
+                  Hermite splines such that y preserves the monotonicity and
+                  der(y) is continuous, also if extrapolated.
+             = 5: Steffen interpolation: Smooth interpolation by cubic Hermite
+                  splines such that y preserves the monotonicity and der(y)
+                  is continuous, also if extrapolated.
+</pre></li>
+<li>Values <strong>outside</strong> of the table range, are computed by
+    extrapolation according to the setting of parameter <strong>extrapolation</strong>:
+<pre>
+  extrapolation = 1: Hold the first or last value of the table,
+                     if outside of the table scope.
+                = 2: Extrapolate by using the derivative at the first/last table
+                     points if outside of the table scope.
+                     (If smoothness is LinearSegments or ConstantSegments
+                     this means to extrapolate linearly through the first/last
+                     two table points.).
+                = 3: Periodically repeat the table data (periodical function).
+                = 4: No extrapolation, i.e. extrapolation triggers an error
+</pre></li>
+<li>If the table has only <strong>one row</strong>, the table value is returned,
+    independent of the value of the input signal.</li>
+<li>The grid values (first column) have to be strictly increasing.</li>
+</ul>
+<p>
+The table matrix can be defined in the following ways:
+</p>
+<ol>
+<li>Explicitly supplied as <strong>parameter matrix</strong> \"table\",
+    and the other parameters have the following values:
+<pre>
+   tableName is \"NoName\" or has only blanks,
+   fileName  is \"NoName\" or has only blanks.
+</pre></li>
+<li><strong>Read</strong> from a <strong>file</strong> \"fileName\" where the matrix is stored as
+    \"tableName\". Both text and MATLAB MAT-file format is possible.
+    (The text format is described below).
+    The MAT-file format comes in four different versions: v4, v6, v7 and v7.3.
+    The library supports at least v4, v6 and v7 whereas v7.3 is optional.
+    It is most convenient to generate the MAT-file from FreeMat or MATLAB&reg;
+    by command
+<pre>
+   save tables.mat tab1 tab2 tab3
+</pre>
+    or Scilab by command
+<pre>
+   savematfile tables.mat tab1 tab2 tab3
+</pre>
+    when the three tables tab1, tab2, tab3 should be used from the model.<br>
+    Note, a fileName can be defined as URI by using the helper function
+    <a href=\"modelica://Modelica.Utilities.Files.loadResource\">loadResource</a>.</li>
+<li>Statically stored in function \"usertab\" in file \"usertab.c\".
+    The matrix is identified by \"tableName\". Parameter
+    fileName = \"NoName\" or has only blanks. Row-wise storage is always to be
+    preferred as otherwise the table is reallocated and transposed.
+    See the <a href=\"modelica://Modelica.Blocks.Tables\">Tables</a> package
+    documentation for more details.</li>
+</ol>
+<p>
+When the constant \"NO_FILE_SYSTEM\" is defined, all file I/O related parts of the
+source code are removed by the C-preprocessor, such that no access to files takes place.
+</p>
+<p>
+If tables are read from a text file, the file needs to have the
+following structure (\"-----\" is not part of the file content):
+</p>
+<pre>
+-----------------------------------------------------
+#1
+double tab1(5,2)   # comment line
+  0   0
+  1   1
+  2   4
+  3   9
+  4  16
+double tab2(5,2)   # another comment line
+  0   0
+  2   2
+  4   8
+  6  18
+  8  32
+-----------------------------------------------------
+</pre>
+<p>
+Note, that the first two characters in the file need to be
+\"#1\" (a line comment defining the version number of the file format).
+Afterwards, the corresponding matrix has to be declared
+with type (= \"double\" or \"float\"), name and actual dimensions.
+Finally, in successive rows of the file, the elements of the matrix
+have to be given. The elements have to be provided as a sequence of
+numbers in row-wise order (therefore a matrix row can span several
+lines in the file and need not start at the beginning of a line).
+Numbers have to be given according to C syntax (such as 2.3, -2, +2.e4).
+Number separators are spaces, tab (\\t), comma (,), or semicolon (;).
+Several matrices may be defined one after another. Line comments start
+with the hash symbol (#) and can appear everywhere.
+Text files should either be ASCII or UTF-8 encoded, where UTF-8 encoded strings are only allowed in line comments and an optional UTF-8 BOM at the start of the text file is ignored.
+Other characters, like trailing non comments, are not allowed in the file.
+</p>
+<p>
+MATLAB is a registered trademark of The MathWorks, Inc.
+</p>
+</html>"),
+      Icon(
+      coordinateSystem(preserveAspectRatio=true,
+        extent={{-100.0,-100.0},{100.0,100.0}}),
+        graphics={
+      Line(points={{-60.0,40.0},{-60.0,-40.0},{60.0,-40.0},{60.0,40.0},{30.0,40.0},{30.0,-40.0},{-30.0,-40.0},{-30.0,40.0},{-60.0,40.0},{-60.0,20.0},{60.0,20.0},{60.0,0.0},{-60.0,0.0},{-60.0,-20.0},{60.0,-20.0},{60.0,-40.0},{-60.0,-40.0},{-60.0,40.0},{60.0,40.0},{60.0,-40.0}}),
+      Line(points={{0.0,40.0},{0.0,-40.0}}),
+      Rectangle(fillColor={255,215,136},
+        fillPattern=FillPattern.Solid,
+        extent={{-60.0,20.0},{-30.0,40.0}}),
+      Rectangle(fillColor={255,215,136},
+        fillPattern=FillPattern.Solid,
+        extent={{-60.0,0.0},{-30.0,20.0}}),
+      Rectangle(fillColor={255,215,136},
+        fillPattern=FillPattern.Solid,
+        extent={{-60.0,-20.0},{-30.0,0.0}}),
+      Rectangle(fillColor={255,215,136},
+        fillPattern=FillPattern.Solid,
+        extent={{-60.0,-40.0},{-30.0,-20.0}})}),
+      Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{
+              100,100}}), graphics={
+          Rectangle(
+            extent={{-60,60},{60,-60}},
+            fillColor={235,235,235},
+            fillPattern=FillPattern.Solid,
+            lineColor={0,0,255}),
+          Line(points={{-100,0},{-58,0}}, color={0,0,255}),
+          Line(points={{60,0},{100,0}}, color={0,0,255}),
+          Text(
+            extent={{-100,100},{100,64}},
+            textString="Univariate constant, linear or cubic Hermite spline table interpolation",
+            lineColor={0,0,255}),
+          Line(points={{-54,40},{-54,-40},{54,-40},{54,40},{28,40},{28,-40},{-28,
+                -40},{-28,40},{-54,40},{-54,20},{54,20},{54,0},{-54,0},{-54,-20},
+                {54,-20},{54,-40},{-54,-40},{-54,40},{54,40},{54,-40}}, color={
+                0,0,0}),
+          Line(points={{0,40},{0,-40}}),
+          Rectangle(
+            extent={{-54,40},{-28,20}},
+            fillColor={255,255,0},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-54,20},{-28,0}},
+            fillColor={255,255,0},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-54,0},{-28,-20}},
+            fillColor={255,255,0},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-54,-20},{-28,-40}},
+            fillColor={255,255,0},
+            fillPattern=FillPattern.Solid),
+          Text(
+            extent={{-50,54},{-32,42}},
+            textString="u[1]/[2]",
+            lineColor={0,0,255}),
+          Text(
+            extent={{-24,54},{0,42}},
+            textString="y[1]",
+            lineColor={0,0,255}),
+          Text(
+            extent={{-2,-40},{30,-54}},
+            textString="columns",
+            lineColor={0,0,255}),
+          Text(
+            extent={{2,54},{26,42}},
+            textString="y[2]",
+            lineColor={0,0,255})}));
+  end CombiTable1Dv;
+
+  block CombiTable2Ds "Table look-up in two dimensions (matrix/file)"
     extends Modelica.Blocks.Interfaces.SI2SO;
     extends Internal.CombiTable2DBase;
     function readTableData = // No longer used, but kept for backward compatibility
@@ -757,7 +757,7 @@ and the first row \"table2D_1[1,2:]\" contains the u[2] grid points.
 MATLAB is a registered trademark of The MathWorks, Inc.
 </p>
 </html>"));
-  end CombiTable2D;
+  end CombiTable2Ds;
 
   block CombiTable2Dv "Table look-up in two dimensions (matrix/file) with vector inputs and vector output of size n"
     extends Modelica.Blocks.Interfaces.MI2MO;
@@ -941,7 +941,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
 
   package Internal "Internal external object definitions for table functions that should not be directly utilized by the user"
     extends Modelica.Icons.InternalPackage;
-    partial block CombiTable2DBase "Base class for variants of CombiTable2D"
+    partial block CombiTable2DBase "Base class for variants of table look-up in two dimensions"
       parameter Boolean tableOnFile=false
         "= true, if table is defined on file or in function usertab"
         annotation (Dialog(group="Table data definition"));
@@ -1312,7 +1312,7 @@ model Test25_usertab \"Test utilizing the usertab.c interface\"
 public
   Modelica.Blocks.Sources.RealExpression realExpression(y=getUsertab(t_new.y))
     annotation (Placement(transformation(extent={{-40,-34},{-10,-14}})));
-  Modelica.Blocks.Tables.CombiTable1D t_new(tableOnFile=true, tableName=\"TestTable_1D_a\")
+  Modelica.Blocks.Tables.CombiTable1Dv t_new(tableOnFile=true, tableName=\"TestTable_1D_a\")
     annotation (Placement(transformation(extent={{-40,0},{-20,20}})));
   Modelica.Blocks.Sources.Clock clock
     annotation (Placement(transformation(extent={{-80,0},{-60,20}})));

--- a/Modelica/Magnetic/FluxTubes.mo
+++ b/Modelica/Magnetic/FluxTubes.mo
@@ -5496,11 +5496,11 @@ An overview of all available hysteresis and permanent magnet elements of the pac
         constant SI.MagneticFluxDensity unitT=1;
         parameter SI.MagneticFluxDensity eps = unitT*mat.tabris[size(mat.tabris,1),2]/1000;
 
-        Modelica.Blocks.Tables.CombiTable1D tabris(
+        Modelica.Blocks.Tables.CombiTable1Dv tabris(
           table=mat.tabris,
           smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative);
 
-        Modelica.Blocks.Tables.CombiTable1D tabfal(
+        Modelica.Blocks.Tables.CombiTable1Dv tabfal(
           table=mat.tabfal,
           smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative);
 

--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -7,6 +7,10 @@ convertClass("Modelica.Fluid.Dissipation.Utilities.Functions.General.CubicInterp
               "Modelica.Fluid.Dissipation.Utilities.Functions.General.CubicInterpolation_lambda");
 convertClass("Modelica.Mechanics.MultiBody.Sensors.Internal.ZeroForceAndTorque",
               "Modelica.Mechanics.MultiBody.Forces.Internal.ZeroForceAndTorque");
+convertClass("Modelica.Blocks.Tables.CombiTable1D",
+              "Modelica.Blocks.Tables.CombiTable1Dv");
+convertClass("Modelica.Blocks.Tables.CombiTable2D",
+              "Modelica.Blocks.Tables.CombiTable2Ds");
 convertClass("Modelica.Electrical.Analog.Basic.EMF",
               "Modelica.Electrical.Analog.Basic.RotationalEMF");
 convertClass("Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimted",

--- a/ModelicaTest/Tables/CombiTable1Dv.mo
+++ b/ModelicaTest/Tables/CombiTable1Dv.mo
@@ -1,10 +1,10 @@
 within ModelicaTest.Tables;
-package CombiTable1D "Test models for Modelica.Blocks.Tables.CombiTable1D"
+package CombiTable1Dv "Test models for Modelica.Blocks.Tables.CombiTable1Dv"
   import Modelica.Utilities.Files.loadResource;
   extends Modelica.Icons.ExamplesPackage;
 
   partial model Test0
-    Modelica.Blocks.Tables.CombiTable1D t_new
+    Modelica.Blocks.Tables.CombiTable1Dv t_new
       annotation (Placement(transformation(extent={{-40,0},{-20,20}})));
     Modelica.Blocks.Continuous.Der d_t_new
       annotation (Placement(transformation(extent={{0,0},{20,20}})));
@@ -326,4 +326,4 @@ double mydummyfunc(double* dummy_in) {
         fileName=loadResource("modelica://ModelicaTest/Resources/Data/Tables/test_utf8.txt")));
     annotation (experiment(StartTime=0, StopTime=100));
   end Test33;
-end CombiTable1D;
+end CombiTable1Dv;

--- a/ModelicaTest/Tables/CombiTable2Ds.mo
+++ b/ModelicaTest/Tables/CombiTable2Ds.mo
@@ -1,10 +1,10 @@
 within ModelicaTest.Tables;
-package CombiTable2D "Test models for Modelica.Blocks.Tables.CombiTable2D"
+package CombiTable2Ds "Test models for Modelica.Blocks.Tables.CombiTable2Ds"
   import Modelica.Utilities.Files.loadResource;
   extends Modelica.Icons.ExamplesPackage;
 
   partial model Test0
-    Modelica.Blocks.Tables.CombiTable2D t_new
+    Modelica.Blocks.Tables.CombiTable2Ds t_new
       annotation (Placement(transformation(extent={{-40,0},{-20,20}})));
     Modelica.Blocks.Continuous.Der d_t_new
       annotation (Placement(transformation(extent={{0,0},{20,20}})));
@@ -16,7 +16,7 @@ package CombiTable2D "Test models for Modelica.Blocks.Tables.CombiTable2D"
   end Test0;
 
   partial model Test0_noDer
-    Modelica.Blocks.Tables.CombiTable2D t_new
+    Modelica.Blocks.Tables.CombiTable2Ds t_new
       annotation (Placement(transformation(extent={{-40,0},{-20,20}})));
   end Test0_noDer;
 
@@ -518,20 +518,20 @@ double mydummyfunc(double dummy_in) {
 
   model Test19 "Constant 2D (Ticket #1307)"
     extends Modelica.Icons.Example;
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D1D(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D1D(
       table=[1,1;2,4;3,9;4,16],
       smoothness=Modelica.Blocks.Types.Smoothness.ConstantSegments) annotation(Placement(transformation(extent={{-95,60},{-75,80}})));
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D1DT(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D1DT(
       table=transpose([1,1;2,4;3,9;4,16]),
       smoothness=Modelica.Blocks.Types.Smoothness.ConstantSegments) annotation(Placement(transformation(extent={{-95,30},{-75,50}})));
     Modelica.Blocks.Sources.Clock clock1 annotation(Placement(transformation(extent={{-130,65},{-110,85}})));
     Modelica.Blocks.Tables.CombiTable1Ds combiTable1D(
       table=[2,4;3,9;4,16],
       smoothness=Modelica.Blocks.Types.Smoothness.ConstantSegments) annotation(Placement(transformation(extent={{-95,0},{-75,20}})));
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D(
       table=[1,0,6;2,4,4;3,9,9;4,16,16],
       smoothness=Modelica.Blocks.Types.Smoothness.ConstantSegments) annotation(Placement(transformation(extent={{-95,-30},{-75,-10}})));
-    Modelica.Blocks.Tables.CombiTable2D combiTable2DT(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2DT(
       table=transpose([1,0,6;2,4,4;3,9,9;4,16,16]),
       smoothness=Modelica.Blocks.Types.Smoothness.ConstantSegments) annotation(Placement(transformation(extent={{-95,-60},{-75,-40}})));
     equation
@@ -576,16 +576,16 @@ double mydummyfunc(double dummy_in) {
 
   model Test20 "Bilinear (Ticket #1307)"
     extends Modelica.Icons.Example;
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D1D(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D1D(
       table=[1,1;2,4;3,9;4,16]) annotation(Placement(transformation(extent={{-95,60},{-75,80}})));
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D1DT(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D1DT(
       table=transpose([1,1;2,4;3,9;4,16])) annotation(Placement(transformation(extent={{-95,30},{-75,50}})));
     Modelica.Blocks.Sources.Clock clock1 annotation(Placement(transformation(extent={{-130,65},{-110,85}})));
     Modelica.Blocks.Tables.CombiTable1Ds combiTable1D(
       table=[2,4;3,9;4,16]) annotation(Placement(transformation(extent={{-95,0},{-75,20}})));
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D(
       table=[1,0,6;2,4,4;3,9,9;4,16,16]) annotation(Placement(transformation(extent={{-95,-30},{-75,-10}})));
-    Modelica.Blocks.Tables.CombiTable2D combiTable2DT(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2DT(
       table=transpose([1,0,6;2,4,4;3,9,9;4,16,16])) annotation(Placement(transformation(extent={{-95,-60},{-75,-40}})));
     Modelica.Blocks.Continuous.Der der1 annotation(Placement(transformation(extent={{-60,60},{-40,80}})));
     Modelica.Blocks.Continuous.Der der2 annotation(Placement(transformation(extent={{-60,30},{-40,50}})));
@@ -654,20 +654,20 @@ double mydummyfunc(double dummy_in) {
 
   model Test21 "Akima2D (Ticket #1307)"
     extends Modelica.Icons.Example;
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D1D(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D1D(
       table=[1,1;2,4;3,9;4,16],
       smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative) annotation(Placement(transformation(extent={{-95,60},{-75,80}})));
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D1DT(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D1DT(
       table=transpose([1,1;2,4;3,9;4,16]),
       smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative) annotation(Placement(transformation(extent={{-95,30},{-75,50}})));
     Modelica.Blocks.Sources.Clock clock1 annotation(Placement(transformation(extent={{-130,65},{-110,85}})));
     Modelica.Blocks.Tables.CombiTable1Ds combiTable1D(
       table=[2,4;3,9;4,16],
       smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative) annotation(Placement(transformation(extent={{-95,0},{-75,20}})));
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D(
       table=[1,0,6;2,4,4;3,9,9;4,16,16],
       smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative) annotation(Placement(transformation(extent={{-95,-30},{-75,-10}})));
-    Modelica.Blocks.Tables.CombiTable2D combiTable2DT(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2DT(
       table=transpose([1,0,6;2,4,4;3,9,9;4,16,16]),
       smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative) annotation(Placement(transformation(extent={{-95,-60},{-75,-40}})));
     Modelica.Blocks.Continuous.Der der1 annotation(Placement(transformation(extent={{-60,60},{-40,80}})));
@@ -740,12 +740,12 @@ double mydummyfunc(double dummy_in) {
     parameter Real tableR[4,4] = [0,75,83,88;18,778,773,769;28,970,-950,938;33,860,1030,1039] "Table matrix for right extrapolation";
     parameter Real tableL[4,4] = [0,75,80,88;18,1039,1030,860;23,938,-950,970;33,769,773,778] "Table matrix for left extrapolation";
     // Right extrapolate u1
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D_1R(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D_1R(
       table=tableR,
       smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative) annotation(Placement(transformation(extent={{-70,55},{-50,75}})));
     Modelica.Blocks.Continuous.Der der_1R annotation(Placement(transformation(extent={{-30,55},{-10,75}})));
     // Right extrapolate u2
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D_2R(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D_2R(
       table=transpose(tableR),
       smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative) annotation(Placement(transformation(extent={{-70,20},{-50,40}})));
     Modelica.Blocks.Continuous.Der der_2R annotation(Placement(transformation(extent={{-30,20},{-10,40}})));
@@ -756,12 +756,12 @@ double mydummyfunc(double dummy_in) {
       offset=33) annotation(Placement(transformation(extent={{-130,60},{-110,80}})));
     Modelica.Blocks.Sources.Constant const_R(k=81) annotation(Placement(transformation(extent={{-130,25},{-110,45}})));
     // Left extrapolate u1
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D_1L(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D_1L(
       table=tableL,
       smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative) annotation(Placement(transformation(extent={{-70,-15},{-50,5}})));
     Modelica.Blocks.Continuous.Der der_1L annotation(Placement(transformation(extent={{-30,-15},{-10,5}})));
     // Left extrapolate u2
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D_2L(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D_2L(
       table=transpose(tableL),
       smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative) annotation(Placement(transformation(extent={{-70,-50},{-50,-30}})));
     Modelica.Blocks.Continuous.Der der_2L annotation(Placement(transformation(extent={{-30,-50},{-10,-30}})));
@@ -851,11 +851,11 @@ double mydummyfunc(double dummy_in) {
     extends Modelica.Icons.Example;
     parameter Real tableR[4,4] = [0,75,83,88;18,778,773,769;28,970,-950,938;33,860,1030,1039] "Table matrix for right extrapolation";
     parameter Real tableL[4,4] = [0,75,80,88;18,1039,1030,860;23,938,-950,970;33,769,773,778] "Table matrix for left extrapolation";
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D_1R(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D_1R(
       table=tableR,
       smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative) annotation(Placement(transformation(extent={{-70,55},{-50,75}})));
     Modelica.Blocks.Continuous.Der der_1R annotation(Placement(transformation(extent={{-30,55},{-10,75}})));
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D_2R(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D_2R(
       table=transpose(tableR),
       smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative) annotation(Placement(transformation(extent={{-70,20},{-50,40}})));
     Modelica.Blocks.Continuous.Der der_2R annotation(Placement(transformation(extent={{-30,20},{-10,40}})));
@@ -869,11 +869,11 @@ double mydummyfunc(double dummy_in) {
       freqHz=1/3,
       offset=81,
       startTime=1) annotation(Placement(transformation(extent={{-130,25},{-110,45}})));
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D_1L(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D_1L(
       table=tableL,
       smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative) annotation(Placement(transformation(extent={{-70,-15},{-50,5}})));
     Modelica.Blocks.Continuous.Der der_1L annotation(Placement(transformation(extent={{-30,-15},{-10,5}})));
-    Modelica.Blocks.Tables.CombiTable2D combiTable2D_2L(
+    Modelica.Blocks.Tables.CombiTable2Ds combiTable2D_2L(
       table=transpose(tableL),
       smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative) annotation(Placement(transformation(extent={{-70,-50},{-50,-30}})));
     Modelica.Blocks.Continuous.Der der_2L annotation(Placement(transformation(extent={{-30,-50},{-10,-30}})));
@@ -1075,4 +1075,4 @@ double mydummyfunc(double dummy_in) {
         points={{-59,-10},{-50,-10},{-50,4},{-42,4}}, color={0,0,127}));
     annotation (experiment(StartTime=0, StopTime=60));
   end Test31;
-end CombiTable2D;
+end CombiTable2Ds;

--- a/ModelicaTest/Tables/package.order
+++ b/ModelicaTest/Tables/package.order
@@ -1,5 +1,5 @@
-CombiTable1D
 CombiTable1Ds
-CombiTable2D
+CombiTable1Dv
+CombiTable2Ds
 CombiTable2Dv
 CombiTimeTable

--- a/ModelicaTestConversion4.mo
+++ b/ModelicaTestConversion4.mo
@@ -2,6 +2,17 @@ package ModelicaTestConversion4
   extends Modelica.Icons.ExamplesPackage;
   package Blocks
     extends Modelica.Icons.ExamplesPackage;
+    model Issue2441 "Conversion test for #2441"
+      extends Modelica.Icons.Example;
+      Modelica.Blocks.Tables.CombiTable1D table1(table=[0,0;0,1]);
+      Modelica.Blocks.Tables.CombiTable2D table2(table=[0,0;0,1]);
+      annotation(experiment(StopTime=1), Documentation(info="<html>
+<p>
+Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/2441\">#2441</a>.
+</p>
+</html>"));
+    end Issue2441;
+
     model Issue2891 "Conversion test for #2891"
       extends Modelica.Icons.Example;
       Modelica.Blocks.Continuous.LimPID PID(


### PR DESCRIPTION
Please note that I also changed the order of the blocks, which explains the non-intuitive diff.

![grafik](https://user-images.githubusercontent.com/14896695/55673134-fa136780-58a3-11e9-96f3-90913cff57a6.png)

Close #2441.