### PR TITLE
Fix allTrue to return true on empty input vector

### DIFF
--- a/Modelica/Blocks/MathBoolean.mo
+++ b/Modelica/Blocks/MathBoolean.mo
@@ -121,7 +121,7 @@ The usage is demonstrated, e.g., in example
 
 <p>
 If no connection to the input connector \"u\" is present,
-the output is set to <strong>false</strong>: y=false.
+the output is set to <strong>true</strong>: y=true.
 </p>
 </html>"));
   end And;

--- a/Modelica/Math/BooleanVectors.mo
+++ b/Modelica/Math/BooleanVectors.mo
@@ -7,7 +7,7 @@ function allTrue
   input Boolean b[:] "Boolean vector";
   output Boolean result "= true, if all elements of b are true";
 algorithm
-  result := size(b,1) > 0;
+  result := true;
   for i in 1:size(b,1) loop
      result := result and b[i];
   end for;
@@ -21,7 +21,7 @@ algorithm
 <p>
 Returns <strong>true</strong> if all elements of the Boolean input vector b are <strong>true</strong>.
 Otherwise the function returns <strong>false</strong>. If b is an empty vector,
-i.e., size(b,1)=0, the function returns <strong>false</strong>.
+i.e., size(b,1)=0, the function returns <strong>true</strong>.
 </p>
 
 <h4>Example</h4>

--- a/ModelicaTest/Math.mo
+++ b/ModelicaTest/Math.mo
@@ -60,10 +60,12 @@ extends Modelica.Icons.ExamplesPackage;
     Streams.print("... Test of Modelica.Math.<Boolean functions>");
     Streams.print("... Test of Modelica.Math.<Boolean functions>", logFile);
 
+    assert(BooleanVectors.allTrue(fill(false, 0)) == true, "allTrue is wrong for empty vector");
     assert(BooleanVectors.allTrue(b1) == true, "allTrue is wrong at (1)");
     assert(BooleanVectors.allTrue(b2) == false, "allTrue is wrong at (2)");
     assert(BooleanVectors.allTrue(b3) == false, "allTrue is wrong at (3)");
 
+    assert(BooleanVectors.anyTrue(fill(true, 0)) == false, "anyTrue is wrong for empty vector");
     assert(BooleanVectors.anyTrue(b1) == true, "anyTrue is wrong at (1)");
     assert(BooleanVectors.anyTrue(b2) == false, "anyTrue is wrong at (2)");
     assert(BooleanVectors.anyTrue(b3) == true, "anyTrue is wrong at (3)");


### PR DESCRIPTION
Make Modelica.Math.BooleanVectors.allTrue equivalent to obsolete (and to be removed) function Modelica.StateGraph.Temporary.allTrue.

Closes #682, #2860.