### PR TITLE
Remove unused initialization parameters from limiter blocks and DeadZone

### DIFF
--- a/Modelica/Blocks/Continuous.mo
+++ b/Modelica/Blocks/Continuous.mo
@@ -937,9 +937,6 @@ to compute u by an algebraic equation.
       annotation (Evaluate=true, Dialog(group="Initialization"));
     parameter Boolean strict=false "= true, if strict limits with noEvent(..)"
       annotation (Evaluate=true, choices(checkBox=true), Dialog(tab="Advanced"));
-    parameter Boolean limitsAtInit=true
-      "Has no longer an effect and is only kept for backwards compatibility (the implementation uses now the homotopy operator)"
-      annotation (Dialog(tab="Dummy"),Evaluate=true, choices(checkBox=true));
     constant Modelica.SIunits.Time unitTime=1 annotation (HideResult=true);
     Modelica.Blocks.Interfaces.RealInput u_ff if withFeedForward
       "Optional connector of feed-forward input signal"
@@ -986,7 +983,6 @@ to compute u by an algebraic equation.
       uMax=yMax,
       uMin=yMin,
       strict=strict,
-      limitsAtInit=limitsAtInit,
       homotopyType=homotopyType)
       annotation (Placement(transformation(extent={{70,-10},{90,10}})));
   protected

--- a/Modelica/Blocks/Continuous.mo
+++ b/Modelica/Blocks/Continuous.mo
@@ -223,13 +223,13 @@ This is discussed in the description of package
 </p>
 
 <p>
-If parameter <strong>limitAtInit</strong> = <strong>false</strong>, the limits of the
+If parameter <strong>limitsAtInit</strong> = <strong>false</strong>, the limits of the
 integrator are removed from the initialization problem which
 leads to a much simpler equation system. After initialization has been
 performed, it is checked via an assert whether the output is in the
 defined limits. For backward compatibility reasons
-<strong>limitAtInit</strong> = <strong>true</strong>. In most cases it is best
-to use <strong>limitAtInit</strong> = <strong>false</strong>.
+<strong>limitsAtInit</strong> = <strong>true</strong>. In most cases it is best
+to use <strong>limitsAtInit</strong> = <strong>false</strong>.
 </p>
 <p>
 If the <em>reset</em> port is enabled, then the output <strong>y</strong> is reset to <em>set</em>
@@ -1257,10 +1257,6 @@ limiter active throughout the homotopy transformation. Use this if it is unknown
 is saturated or not at initialization and if the limitations on the output must be enforced throughout
 the entire homotopy transformation.</li>
 </ul>
-
-<p>
-The parameter <strong>limitAtInit</strong> is obsolete since MSL 3.2.2 and only kept for backwards compatibility.
-</p>
 </html>"));
   end LimPID;
 

--- a/Modelica/Blocks/Nonlinear.mo
+++ b/Modelica/Blocks/Nonlinear.mo
@@ -11,9 +11,6 @@ package Nonlinear
           annotation (Evaluate=true, choices(checkBox=true), Dialog(tab="Advanced"));
         parameter Types.LimiterHomotopy homotopyType = Modelica.Blocks.Types.LimiterHomotopy.Linear "Simplified model for homotopy-based initialization"
           annotation (Evaluate=true, Dialog(group="Initialization"));
-        parameter Boolean limitsAtInit=true
-          "Has no longer an effect and is only kept for backwards compatibility (the implementation uses now the homotopy operator)"
-          annotation (Dialog(tab="Dummy"),Evaluate=true, choices(checkBox=true));
         extends Interfaces.SISO;
   protected
         Real simplifiedExpr "Simplified expression for homotopy-based initialization";
@@ -131,9 +128,6 @@ a lot by removing one strong nonlinearity from the initialization problem.
       annotation (Evaluate=true, Dialog(group="Initialization"));
     parameter Real ySimplified = 0 "Fixed value of output in simplified model"
       annotation (Dialog(tab="Advanced", enable=homotopyType == Modelica.Blocks.Types.VariableLimiterHomotopy.Fixed));
-    parameter Boolean limitsAtInit=true
-      "Has no longer an effect and is only kept for backwards compatibility (the implementation uses now the homotopy operator)"
-      annotation (Dialog(tab="Dummy"),Evaluate=true, choices(checkBox=true));
     Interfaces.RealInput limit1
       "Connector of Real input signal used as maximum of input u"
       annotation (Placement(transformation(extent={{-140,60},{-100,100}})));
@@ -327,10 +321,6 @@ with derivative time constant <code>Td</code>. Smaller time constant <code>Td</c
       block DeadZone "Provide a region of zero output"
         parameter Real uMax(start=1) "Upper limits of dead zones";
         parameter Real uMin=-uMax "Lower limits of dead zones";
-        parameter Boolean deadZoneAtInit = true
-          "Has no longer an effect and is only kept for backwards compatibility (the implementation uses now the homotopy operator)"
-          annotation (Dialog(tab="Dummy"),Evaluate=true, choices(checkBox=true));
-
         extends Interfaces.SISO;
 
       equation

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -123,12 +123,6 @@ This is a simple drive train controlled by a PID controller:
 </ul>
 
 <p>
-The PI controller settings included \"limitAtInit=false\", in order that
-the controller output limits of 12 Nm are removed from the initialization
-problem.
-</p>
-
-<p>
 The PI controller is initialized in steady state (initType=SteadyState)
 and the drive shall also be initialized in steady state.
 However, it is not possible to initialize \"inertia1\" in SteadyState, because

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -22,7 +22,6 @@ package Examples
       yMax=12,
       Ni=0.1,
       initType=Modelica.Blocks.Types.InitPID.SteadyState,
-      limitsAtInit=false,
       controllerType=Modelica.Blocks.Types.SimpleController.PI,
       Td=0.1) annotation (Placement(transformation(extent={{-56,-20},{-36,0}})));
     Modelica.Mechanics.Rotational.Components.Inertia inertia1(

--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -25,3 +25,10 @@ convertElement({"Modelica.Mechanics.Rotational.Components.Brake",
                 "Modelica.Mechanics.Rotational.Components.OneWayClutch",
                 "Modelica.Mechanics.Translational.Components.Brake"},
                 "mue0", "mu0");
+
+convertModifiers({"Modelica.Blocks.Nonlinear.Limiter",
+                  "Modelica.Blocks.Nonlinear.VariableLimiter",
+                  "Modelica.Blocks.Continuous.LimPID"},
+                  {"limitsAtInit"}, fill("", 0), true);
+convertModifiers({"Modelica.Blocks.Nonlinear.DeadZone"},
+                  {"deadZoneAtInit"}, fill("", 0), true);

--- a/ModelicaTest/Blocks.mo
+++ b/ModelicaTest/Blocks.mo
@@ -285,11 +285,11 @@ package Blocks "Test models for Modelica.Blocks"
 
   model Limiters
     extends Modelica.Icons.Example;
-    Modelica.Blocks.Nonlinear.Limiter limiter(limitsAtInit=false, uMax=1)
+    Modelica.Blocks.Nonlinear.Limiter limiter(uMax=1)
       annotation (Placement(transformation(extent={{0,0},{20,20}})));
-    Modelica.Blocks.Nonlinear.VariableLimiter variableLimiter(limitsAtInit=
-          false) annotation (Placement(transformation(extent={{0,-40},{20,-20}})));
-    Modelica.Blocks.Nonlinear.DeadZone deadZone(deadZoneAtInit=false, uMax=1)
+    Modelica.Blocks.Nonlinear.VariableLimiter variableLimiter
+      annotation (Placement(transformation(extent={{0,-40},{20,-20}})));
+    Modelica.Blocks.Nonlinear.DeadZone deadZone(uMax=1)
       annotation (Placement(transformation(extent={{0,-80},{20,-60}})));
     Modelica.Blocks.Sources.Sine sine(amplitude=2, freqHz=1) annotation (
         Placement(transformation(extent={{-80,20},{-60,40}})));

--- a/ModelicaTestConversion4.mo
+++ b/ModelicaTestConversion4.mo
@@ -1,5 +1,41 @@
 package ModelicaTestConversion4
   extends Modelica.Icons.ExamplesPackage;
+  package Blocks
+    extends Modelica.Icons.ExamplesPackage;
+    model Issue2891 "Conversion test for #2891"
+      extends Modelica.Icons.Example;
+      Modelica.Blocks.Continuous.LimPID PID(
+        controllerType=Modelica.Blocks.Types.SimpleController.P,
+        yMax=0.5,
+        initType=Modelica.Blocks.Types.InitPID.DoNotUse_InitialIntegratorState,
+        limitsAtInit=true);
+      Modelica.Blocks.Sources.Clock clock;
+      Modelica.Blocks.Nonlinear.Limiter limiter(
+        uMax=0.5,
+        limitsAtInit=true);
+      Modelica.Blocks.Nonlinear.VariableLimiter variableLimiter(
+        limitsAtInit=false);
+      Modelica.Blocks.Nonlinear.DeadZone deadZone(
+        uMax=0.5,
+        deadZoneAtInit=false);
+      Modelica.Blocks.Sources.Constant const1(k=0.5);
+      Modelica.Blocks.Sources.Constant const2(k=-0.5);
+    equation
+      connect(clock.y, PID.u_s);
+      connect(clock.y, PID.u_m);
+      connect(clock.y, limiter.u);
+      connect(clock.y, variableLimiter.u);
+      connect(clock.y, deadZone.u);
+      connect(const1.y, variableLimiter.limit1);
+      connect(const2.y, variableLimiter.limit2);
+      annotation(experiment(StopTime=1), Documentation(info="<html>
+<p>
+Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/2891\">#2891</a>.
+</p>
+</html>"));
+    end Issue2891;
+  end Blocks;
+
   package Constants
     extends Modelica.Icons.ExamplesPackage;
     model Issue194 "Conversion test for #194"


### PR DESCRIPTION
These parameters got obsoleted by #1012 for MSL 3.2.2 and #2561 for MSL 3.2.3, respectively.