### PR TITLE
Remove legacy initialization of Modelica.Blocks.Continuous.{PID, LimPID}

### DIFF
--- a/Modelica/Blocks/Continuous.mo
+++ b/Modelica/Blocks/Continuous.mo
@@ -16,7 +16,7 @@ package Continuous "Library of continuous control blocks with internal states"
     /* InitialState is the default, because it was the default in Modelica 2.2
      and therefore this setting is backward compatible
   */
-    parameter Modelica.Blocks.Types.Init initType=Modelica.Blocks.Types.Init.InitialState
+    parameter Init initType=Init.InitialState
       "Type of initialization (1: no init, 2: steady state, 3,4: initial output)" annotation(Evaluate=true,
         Dialog(group="Initialization"));
     parameter Real y_start=0 "Initial or guess value of output (= state)"
@@ -146,7 +146,7 @@ port has a rising edge.
       annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
     parameter Boolean use_set = false "= true, if set port enabled and used as reinitialization value when reset"
       annotation(Dialog(enable=use_reset), Evaluate=true, HideResult=true, choices(checkBox=true));
-    parameter Modelica.Blocks.Types.Init initType=Modelica.Blocks.Types.Init.InitialState
+    parameter Init initType=Init.InitialState
       "Type of initialization (1: no init, 2: steady state, 3/4: initial output)"
       annotation(Evaluate=true, Dialog(group="Initialization"));
     parameter Boolean limitsAtInit = true
@@ -297,7 +297,7 @@ port has a rising edge.
     parameter Real k(unit="1")=1 "Gains";
     parameter SIunits.Time T(min=Modelica.Constants.small) = 0.01
       "Time constants (T>0 required; T=0 is ideal derivative block)";
-    parameter Modelica.Blocks.Types.Init initType=Modelica.Blocks.Types.Init.NoInit
+    parameter Init initType=Init.NoInit
       "Type of initialization (1: no init, 2: steady state, 3: initial state, 4: initial output)"
                                                                                       annotation(Evaluate=true,
         Dialog(group="Initialization"));
@@ -394,7 +394,7 @@ If k=0, the block reduces to y=0.
     import Modelica.Blocks.Types.Init;
     parameter Real k(unit="1")=1 "Gain";
     parameter SIunits.Time T(start=1) "Time Constant";
-    parameter Modelica.Blocks.Types.Init initType=Modelica.Blocks.Types.Init.NoInit
+    parameter Init initType=Init.NoInit
       "Type of initialization (1: no init, 2: steady state, 3/4: initial output)" annotation(Evaluate=true,
         Dialog(group="Initialization"));
     parameter Real y_start=0 "Initial or guess value of output (= state)"
@@ -482,7 +482,7 @@ Example:
     parameter Real k(unit="1")=1 "Gain";
     parameter Real w(start=1) "Angular frequency";
     parameter Real D(start=1) "Damping";
-    parameter Modelica.Blocks.Types.Init initType=Modelica.Blocks.Types.Init.NoInit
+    parameter Init initType=Init.NoInit
       "Type of initialization (1: no init, 2: steady state, 3/4: initial output)" annotation(Evaluate=true,
         Dialog(group="Initialization"));
     parameter Real y_start=0 "Initial or guess value of output (= state)"
@@ -602,7 +602,7 @@ Example:
     parameter Real k(unit="1")=1 "Gain";
     parameter SIunits.Time T(start=1,min=Modelica.Constants.small)
       "Time Constant (T>0 required)";
-    parameter Modelica.Blocks.Types.Init initType=Modelica.Blocks.Types.Init.NoInit
+    parameter Init initType=Init.NoInit
       "Type of initialization (1: no init, 2: steady state, 3: initial state, 4: initial output)"
                                                                               annotation(Evaluate=true,
         Dialog(group="Initialization"));
@@ -707,7 +707,6 @@ This is discussed in the description of package
   end PI;
 
   block PID "PID-controller in additive description form"
-    import Modelica.Blocks.Types.InitPID;
     import Modelica.Blocks.Types.Init;
     extends Interfaces.SISO;
 
@@ -718,7 +717,7 @@ This is discussed in the description of package
       "Time Constant of Derivative block";
     parameter Real Nd(min=Modelica.Constants.small) = 10
       "The higher Nd, the more ideal the derivative block";
-    parameter Modelica.Blocks.Types.InitPID initType= Modelica.Blocks.Types.InitPID.DoNotUse_InitialIntegratorState
+    parameter Init initType= Init.InitialState
       "Type of initialization (1: no init, 2: steady state, 3: initial state, 4: initial output)"
                                        annotation(Evaluate=true,
         Dialog(group="Initialization"));
@@ -729,25 +728,24 @@ This is discussed in the description of package
       "Initial or guess value for state of derivative block"
       annotation (Dialog(group="Initialization"));
     parameter Real y_start=0 "Initial value of output"
-      annotation(Dialog(enable=initType == InitPID.InitialOutput, group=
+      annotation(Dialog(enable=initType == Init.InitialOutput, group=
             "Initialization"));
     constant SI.Time unitTime=1 annotation(HideResult=true);
 
     Blocks.Math.Gain P(k=1) "Proportional part of PID controller"
       annotation (Placement(transformation(extent={{-60,60},{-20,100}})));
     Blocks.Continuous.Integrator I(k=unitTime/Ti, y_start=xi_start,
-      initType=if initType==InitPID.SteadyState then
+      initType=if initType==Init.SteadyState then
                   Init.SteadyState else
-               if initType==InitPID.InitialState or
-                  initType==InitPID.DoNotUse_InitialIntegratorState then
+               if initType==Init.InitialState then
                   Init.InitialState else Init.NoInit)
       "Integral part of PID controller"
       annotation (Placement(transformation(extent={{-60,-20},{-20,20}})));
     Blocks.Continuous.Derivative D(k=Td/unitTime, T=max([Td/Nd, 100*Modelica.
           Constants.eps]), x_start=xd_start,
-      initType=if initType==InitPID.SteadyState or
-                  initType==InitPID.InitialOutput then Init.SteadyState else
-               if initType==InitPID.InitialState then Init.InitialState else
+      initType=if initType==Init.SteadyState or
+                  initType==Init.InitialOutput then Init.SteadyState else
+               if initType==Init.InitialState then Init.InitialState else
                   Init.NoInit) "Derivative part of PID controller"
       annotation (Placement(transformation(extent={{-60,-100},{-20,-60}})));
     Blocks.Math.Gain Gain(k=k) "Gain of PID controller"
@@ -755,7 +753,7 @@ This is discussed in the description of package
     Blocks.Math.Add3 Add annotation (Placement(transformation(extent={{20,-10},
               {40,10}})));
   initial equation
-    if initType==InitPID.InitialOutput then
+    if initType==Init.InitialOutput then
        y = y_start;
     end if;
 
@@ -808,15 +806,7 @@ block LimPID.
 The PID block can be initialized in different
 ways controlled by parameter <strong>initType</strong>. The possible
 values of initType are defined in
-<a href=\"modelica://Modelica.Blocks.Types.InitPID\">Modelica.Blocks.Types.InitPID</a>.
-This type is identical to
-<a href=\"modelica://Modelica.Blocks.Types.Init\">Types.Init</a>,
-with the only exception that the additional option
-<strong>DoNotUse_InitialIntegratorState</strong> is added for
-backward compatibility reasons (= integrator is initialized with
-InitialState whereas differential part is initialized with
-NoInit which was the initialization in version 2.2 of the Modelica
-standard library).
+<a href=\"modelica://Modelica.Blocks.Types.Init\">Modelica.Blocks.Types.Init</a>.
 </p>
 
 <p>
@@ -845,16 +835,12 @@ blocks inside the PID controller are initialized according to the following tabl
           and initial equation: y = y_start</td>
       <td>NoInit</td>
       <td>SteadyState</td></tr>
-
-  <tr><td><strong>DoNotUse_InitialIntegratorState</strong></td>
-      <td>InitialState</td>
-      <td>NoInit</td></tr>
 </table>
 
 <p>
 In many cases, the most useful initial condition is
 <strong>SteadyState</strong> because initial transients are then no longer
-present. If initType = InitPID.SteadyState, then in some
+present. If initType = Init.SteadyState, then in some
 cases difficulties might occur. The reason is the
 equation of the integrator:
 </p>
@@ -880,7 +866,6 @@ to compute u by an algebraic equation.
 
   block LimPID
     "P, PI, PD, and PID controller with limited output, anti-windup compensation, setpoint weighting and optional feed-forward"
-    import Modelica.Blocks.Types.InitPID;
     import Modelica.Blocks.Types.Init;
     import Modelica.Blocks.Types.SimpleController;
     extends Modelica.Blocks.Interfaces.SVcontrol;
@@ -916,7 +901,7 @@ to compute u by an algebraic equation.
       annotation(Evaluate=true, choices(checkBox=true));
     parameter Real kFF=1 "Gain of feed-forward input"
       annotation(Dialog(enable=withFeedForward));
-    parameter .Modelica.Blocks.Types.InitPID initType= .Modelica.Blocks.Types.InitPID.DoNotUse_InitialIntegratorState
+    parameter Init initType = Init.NoInit
       "Type of initialization (1: no init, 2: steady state, 3: initial state, 4: initial output)"
       annotation(Evaluate=true, Dialog(group="Initialization"));
     parameter Real xi_start=0
@@ -930,7 +915,7 @@ to compute u by an algebraic equation.
                            enable=controllerType==.Modelica.Blocks.Types.SimpleController.PD or
                                   controllerType==.Modelica.Blocks.Types.SimpleController.PID));
     parameter Real y_start=0 "Initial value of output"
-      annotation(Dialog(enable=initType == .Modelica.Blocks.Types.InitPID.InitialOutput, group=
+      annotation(Dialog(enable=initType == Init.InitialOutput, group=
             "Initialization"));
     parameter Modelica.Blocks.Types.LimiterHomotopy homotopyType = Modelica.Blocks.Types.LimiterHomotopy.Linear
       "Simplified model for homotopy-based initialization"
@@ -954,16 +939,16 @@ to compute u by an algebraic equation.
     Modelica.Blocks.Continuous.Integrator I(
       k=unitTime/Ti,
       y_start=xi_start,
-      initType=if initType == InitPID.SteadyState then Init.SteadyState else if
-          initType == InitPID.InitialState or initType == InitPID.DoNotUse_InitialIntegratorState
+      initType=if initType == Init.SteadyState then Init.SteadyState else if
+          initType == Init.InitialState
            then Init.InitialState else Init.NoInit) if with_I
       annotation (Placement(transformation(extent={{-50,-60},{-30,-40}})));
     Modelica.Blocks.Continuous.Derivative D(
       k=Td/unitTime,
       T=max([Td/Nd,1.e-14]),
       x_start=xd_start,
-      initType=if initType == InitPID.SteadyState or initType == InitPID.InitialOutput
-           then Init.SteadyState else if initType == InitPID.InitialState then
+      initType=if initType == Init.SteadyState or initType == Init.InitialOutput
+           then Init.SteadyState else if initType == Init.InitialState then
           Init.InitialState else Init.NoInit) if with_D
       annotation (Placement(transformation(extent={{-50,-10},{-30,10}})));
     Modelica.Blocks.Math.Gain gainPID(k=k)
@@ -1000,11 +985,11 @@ to compute u by an algebraic equation.
     Modelica.Blocks.Math.Add addFF(k1=1, k2=kFF)
       annotation (Placement(transformation(extent={{48,-6},{60,6}})));
   initial equation
-    if initType==InitPID.InitialOutput then
+    if initType==Init.InitialOutput then
       gainPID.y = y_start;
     end if;
   equation
-    if initType == InitPID.InitialOutput and (y_start < yMin or y_start > yMax) then
+    if initType == Init.InitialOutput and (y_start < yMin or y_start > yMax) then
         Modelica.Utilities.Streams.error("LimPID: Start value y_start (=" + String(y_start) +
            ") is outside of the limits of yMin (=" + String(yMin) +") and yMax (=" + String(yMax) + ")");
     end if;
@@ -1173,15 +1158,7 @@ together) and using the following strategy:
 This block can be initialized in different
 ways controlled by parameter <strong>initType</strong>. The possible
 values of initType are defined in
-<a href=\"modelica://Modelica.Blocks.Types.InitPID\">Modelica.Blocks.Types.InitPID</a>.
-This type is identical to
-<a href=\"modelica://Modelica.Blocks.Types.Init\">Types.Init</a>,
-with the only exception that the additional option
-<strong>DoNotUse_InitialIntegratorState</strong> is added for
-backward compatibility reasons (= integrator is initialized with
-InitialState whereas differential part is initialized with
-NoInit which was the initialization in version 2.2 of the Modelica
-standard library).
+<a href=\"modelica://Modelica.Blocks.Types.Init\">Modelica.Blocks.Types.Init</a>.
 </p>
 
 <p>
@@ -1210,16 +1187,12 @@ blocks inside the PID controller are initialized according to the following tabl
           and initial equation: y = y_start</td>
       <td>NoInit</td>
       <td>SteadyState</td></tr>
-
-  <tr><td><strong>DoNotUse_InitialIntegratorState</strong></td>
-      <td>InitialState</td>
-      <td>NoInit</td></tr>
 </table>
 
 <p>
 In many cases, the most useful initial condition is
 <strong>SteadyState</strong> because initial transients are then no longer
-present. If initType = InitPID.SteadyState, then in some
+present. If initType = Init.SteadyState, then in some
 cases difficulties might occur. The reason is the
 equation of the integrator:
 </p>

--- a/Modelica/Blocks/Types.mo
+++ b/Modelica/Blocks/Types.mo
@@ -53,44 +53,6 @@ package Types
   </dl>
 </html>"));
 
-    type InitPID = enumeration(
-      NoInit
-        "No initialization (start values are used as guess values with fixed=false)",
-      SteadyState
-        "Steady state initialization (derivatives of states are zero)",
-      InitialState "Initialization with initial states",
-      InitialOutput
-        "Initialization with initial outputs (and steady state of the states if possible)",
-      DoNotUse_InitialIntegratorState
-        "Do not use, only for backward compatibility (initialize only integrator state)")
-    "Enumeration defining initialization of PID and LimPID blocks" annotation (
-      Evaluate=true, Documentation(info="<html>
-<p>
-This initialization type is identical to <a href=\"modelica://Modelica.Blocks.Types.Init\">Types.Init</a> and has just one
-additional option <strong><code>DoNotUse_InitialIntegratorState</code></strong>. This option
-is introduced in order that the default initialization for the
-<code>Continuous.PID</code> and <code>Continuous.LimPID</code> blocks are backward
-compatible. In Modelica 2.2, the integrators have been initialized
-with their given states where as the D-part has not been initialized.
-The option <strong><code>DoNotUse_InitialIntegratorState</code></strong> leads to this
-initialization definition.
-</p>
-
- <p>The following initialization alternatives are available:</p>
-  <dl>
-    <dt><code><strong>NoInit</strong></code></dt>
-      <dd>No initialization (start values are used as guess values with <code>fixed=false</code>)</dd>
-    <dt><code><strong>SteadyState</strong></code></dt>
-      <dd>Steady state initialization (derivatives of states are zero)</dd>
-    <dt><code><strong>InitialState</strong></code></dt>
-      <dd>Initialization with initial states</dd>
-    <dt><code><strong>InitialOutput</strong></code></dt>
-      <dd>Initialization with initial outputs (and steady state of the states if possible)</dd>
-    <dt><code><strong>DoNotUse_InitialIntegratorState</strong></code></dt>
-      <dd>Do not use, only for backward compatibility (initialize only integrator state)</dd>
-  </dl>
-</html>"));
-
    type SimpleController = enumeration(
       P "P controller",
       PI "PI controller",

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -21,7 +21,7 @@ package Examples
       Ti=0.1,
       yMax=12,
       Ni=0.1,
-      initType=Modelica.Blocks.Types.InitPID.SteadyState,
+      initType=Modelica.Blocks.Types.Init.SteadyState,
       controllerType=Modelica.Blocks.Types.SimpleController.PI,
       Td=0.1) annotation (Placement(transformation(extent={{-56,-20},{-36,0}})));
     Modelica.Mechanics.Rotational.Components.Inertia inertia1(

--- a/Modelica/Electrical/Machines.mo
+++ b/Modelica/Electrical/Machines.mo
@@ -3611,7 +3611,7 @@ rotor angle is very slowly increased. This allows to see several characteristics
           Ti=Ti,
           yMax=2.5*Ve0,
           yMin=0,
-          initType=Modelica.Blocks.Types.InitPID.InitialState,
+          initType=Modelica.Blocks.Types.Init.InitialState,
           Td=0.001)
           annotation (Placement(transformation(extent={{-70,-20},{-50,-40}})));
         Modelica.Electrical.Analog.Sources.SignalVoltage excitationVoltage
@@ -3845,7 +3845,7 @@ Voltage is controlled, the set point depends on speed. After start-up the genera
           Ti=Ti,
           yMax=2.5*Ve0,
           yMin=0,
-          initType=Modelica.Blocks.Types.InitPID.InitialState,
+          initType=Modelica.Blocks.Types.Init.InitialState,
           Td=0.001)
           annotation (Placement(transformation(extent={{-70,-20},{-50,-40}})));
         Modelica.Electrical.Analog.Sources.SignalVoltage excitationVoltage
@@ -4163,7 +4163,7 @@ Default machine parameters of model <em>DC_PermanentMagnet</em> are used.
           initType=Modelica.Blocks.Types.Init.InitialOutput,
           y_start=0)
           annotation (Placement(transformation(extent={{-20,50},{0,70}})));
-        Blocks.Continuous.LimPID PID(withFeedForward=true, initType=Modelica.Blocks.Types.InitPID.InitialOutput,
+        Blocks.Continuous.LimPID PID(withFeedForward=true, initType=Modelica.Blocks.Types.Init.InitialOutput,
           controllerType=Modelica.Blocks.Types.SimpleController.PI,
           k=k,
           Ti=Ti,

--- a/Modelica/Magnetic/FundamentalWave.mo
+++ b/Modelica/Magnetic/FundamentalWave.mo
@@ -5030,7 +5030,7 @@ Simulate for 30 seconds and plot (versus <code>rotorAngleM.rotorDisplacementAngl
           Ti=Ti,
           yMax=2.5*Ve0,
           yMin=0,
-          initType=Modelica.Blocks.Types.InitPID.InitialState,
+          initType=Modelica.Blocks.Types.Init.InitialState,
           Td=0.001)
           annotation (Placement(transformation(extent={{-70,-20},{-50,-40}})));
         Modelica.Electrical.Analog.Sources.SignalVoltage excitationVoltage
@@ -5241,7 +5241,7 @@ Voltage is controlled, the set point depends on speed. After start-up the genera
           Ti=Ti,
           yMax=2.5*Ve0,
           yMin=0,
-          initType=Modelica.Blocks.Types.InitPID.InitialState,
+          initType=Modelica.Blocks.Types.Init.InitialState,
           Td=0.001)
           annotation (Placement(transformation(extent={{-70,-20},{-50,-40}})));
         Modelica.Electrical.Analog.Sources.SignalVoltage excitationVoltage

--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -83,6 +83,12 @@ convertClass("Modelica.Blocks.Interfaces.Adaptors.ReceiveBoolean",
               "ObsoleteModelica4.Blocks.Interfaces.Adaptors.ReceiveBoolean");
 convertClass("Modelica.Blocks.Interfaces.Adaptors.ReceiveInteger",
               "ObsoleteModelica4.Blocks.Interfaces.Adaptors.ReceiveInteger");
+convertClass("Modelica.Blocks.Types.Init.DoNotUse_InitialIntegratorState",
+              "Modelica.Blocks.Types.Init.NoInit");
+convertClass("Modelica.Blocks.Types.InitPID.DoNotUse_InitialIntegratorState",
+              "Modelica.Blocks.Types.Init.NoInit");
+convertClass("Modelica.Blocks.Types.InitPID",
+              "Modelica.Blocks.Types.Init");
 
 // Change renamed elements of classes
 // mue -> mu

--- a/ModelicaTest/Blocks.mo
+++ b/ModelicaTest/Blocks.mo
@@ -22,13 +22,13 @@ package Blocks "Test models for Modelica.Blocks"
     Modelica.Blocks.Continuous.PID pID(
       Ti=0.5,
       Td=0.1,
-      initType=Modelica.Blocks.Types.InitPID.InitialState) annotation (
+      initType=Modelica.Blocks.Types.Init.InitialState) annotation (
         Placement(transformation(extent={{-60,-140},{-40,-120}})));
     Modelica.Blocks.Continuous.LimPID limPID(
       Ti=0.5,
       Td=0.1,
       yMax=1,
-      initType=Modelica.Blocks.Types.InitPID.InitialState) annotation (
+      initType=Modelica.Blocks.Types.Init.InitialState) annotation (
         Placement(transformation(extent={{40,100},{60,120}})));
     Modelica.Blocks.Continuous.TransferFunction transferFunction(
       a={1,1},
@@ -128,8 +128,8 @@ package Blocks "Test models for Modelica.Blocks"
       firstOrder(initType=Modelica.Blocks.Types.Init.InitialState),
       secondOrder(initType=Modelica.Blocks.Types.Init.InitialState),
       pI(initType=Modelica.Blocks.Types.Init.InitialState),
-      pID(initType=Modelica.Blocks.Types.InitPID.InitialState),
-      limPID(initType=Modelica.Blocks.Types.InitPID.InitialState),
+      pID(initType=Modelica.Blocks.Types.Init.InitialState),
+      limPID(initType=Modelica.Blocks.Types.Init.InitialState),
       transferFunction(
         initType=Modelica.Blocks.Types.Init.InitialState,
         a={1,1},
@@ -154,9 +154,9 @@ package Blocks "Test models for Modelica.Blocks"
       firstOrder(initType=Modelica.Blocks.Types.Init.InitialOutput, y_start=2),
       secondOrder(initType=Modelica.Blocks.Types.Init.InitialOutput, y_start=2),
       pI(initType=Modelica.Blocks.Types.Init.InitialOutput, y_start=2),
-      pID(initType=Modelica.Blocks.Types.InitPID.InitialOutput, y_start=2),
+      pID(initType=Modelica.Blocks.Types.Init.InitialOutput, y_start=2),
       limPID(
-        initType=Modelica.Blocks.Types.InitPID.InitialOutput,
+        initType=Modelica.Blocks.Types.Init.InitialOutput,
         yMax=3,
         y_start=2),
       transferFunction(
@@ -370,12 +370,12 @@ package Blocks "Test models for Modelica.Blocks"
       k=5.0,
       outMax=0.9)
       annotation (Placement(transformation(extent={{40,-30},{60,-10}})));
-    Modelica.Blocks.Continuous.LimPID PID1(yMax=0.4, initType=Modelica.Blocks.Types.InitPID.InitialOutput)
+    Modelica.Blocks.Continuous.LimPID PID1(yMax=0.4, initType=Modelica.Blocks.Types.Init.InitialOutput)
       annotation (Placement(transformation(extent={{38,-60},{58,-40}})));
     Modelica.Blocks.Continuous.LimPID PID2(
       yMax=0.4,
       strict=true,
-      initType=Modelica.Blocks.Types.InitPID.InitialOutput)
+      initType=Modelica.Blocks.Types.Init.InitialOutput)
       annotation (Placement(transformation(extent={{40,-100},{60,-80}})));
   equation
     connect(sine1.y, limiter1.u) annotation (Line(
@@ -811,13 +811,13 @@ if homotopy is active, the solution accepted by the assert statement (x = 100) i
     Modelica.Blocks.Continuous.PID PID(
       Ti=2,
       Td=3,
-      initType=Modelica.Blocks.Types.InitPID.InitialState)
+      initType=Modelica.Blocks.Types.Init.InitialState)
       annotation (Placement(transformation(extent={{60,30},{80,50}})));
     Modelica.Blocks.Continuous.LimPID PID1(
       Ti=2,
       Td=3,
       yMax=4,
-      initType=Modelica.Blocks.Types.InitPID.InitialState)
+      initType=Modelica.Blocks.Types.Init.InitialState)
       annotation (Placement(transformation(extent={{60,0},{80,20}})));
     Modelica.Electrical.Analog.Sources.SineVoltage sineVoltage(V=10, freqHz=2)
       annotation (Placement(transformation(
@@ -1947,7 +1947,7 @@ This shows the improvements in the numerics when balance=true is set.
       Ti=1,
       yMax=1,
       yMin=0,
-      initType=Modelica.Blocks.Types.InitPID.SteadyState,
+      initType=Modelica.Blocks.Types.Init.SteadyState,
       controllerType=Modelica.Blocks.Types.SimpleController.PI)
       annotation (Placement(transformation(extent={{-40,80},{-20,100}})));
     Modelica.Blocks.Sources.Step step1(
@@ -1961,7 +1961,7 @@ This shows the improvements in the numerics when balance=true is set.
       Ti=1,
       yMax=1,
       yMin=0,
-      initType=Modelica.Blocks.Types.InitPID.SteadyState,
+      initType=Modelica.Blocks.Types.Init.SteadyState,
       controllerType=Modelica.Blocks.Types.SimpleController.PI,
       homotopyType=Modelica.Blocks.Types.LimiterHomotopy.UpperLimit)
       annotation (Placement(transformation(extent={{-40,20},{-20,40}})));
@@ -1976,7 +1976,7 @@ This shows the improvements in the numerics when balance=true is set.
       Ti=1,
       yMax=1,
       yMin=0,
-      initType=Modelica.Blocks.Types.InitPID.SteadyState,
+      initType=Modelica.Blocks.Types.Init.SteadyState,
       controllerType=Modelica.Blocks.Types.SimpleController.PI,
       homotopyType=Modelica.Blocks.Types.LimiterHomotopy.LowerLimit)
       annotation (Placement(transformation(extent={{-40,-40},{-20,-20}})));
@@ -1991,7 +1991,7 @@ This shows the improvements in the numerics when balance=true is set.
       Ti=1,
       yMax=1,
       yMin=0,
-      initType=Modelica.Blocks.Types.InitPID.SteadyState,
+      initType=Modelica.Blocks.Types.Init.SteadyState,
       controllerType=Modelica.Blocks.Types.SimpleController.PI,
       homotopyType=Modelica.Blocks.Types.LimiterHomotopy.NoHomotopy)
       annotation (Placement(transformation(extent={{-40,-100},{-20,-80}})));

--- a/ModelicaTestConversion4.mo
+++ b/ModelicaTestConversion4.mo
@@ -102,6 +102,33 @@ Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrar
 </html>"));
     end Issue2891;
 
+    model Issue2892 "Conversion test for #2892"
+      extends Modelica.Icons.Example;
+      import Modelica.Blocks.Types.InitPID;
+      Modelica.Blocks.Continuous.LimPID pid1(initType=InitPID(3), yMax=1);
+      Modelica.Blocks.Continuous.LimPID pid2(initType=InitPID.DoNotUse_InitialIntegratorState, yMax=1);
+      Modelica.Blocks.Continuous.LimPID pid3(initType=InitPID.SteadyState, yMax=1);
+      Modelica.Blocks.Continuous.PID pid4(initType=Modelica.Blocks.Types.InitPID(3), Td=0.5, Ti=0.5);
+      Modelica.Blocks.Continuous.PID pid5(initType=Modelica.Blocks.Types.InitPID.DoNotUse_InitialIntegratorState, Td=0.5, Ti=0.5);
+      Modelica.Blocks.Continuous.PID pid6(initType=Modelica.Blocks.Types.InitPID.NoInit, Td=0.5, Ti=0.5);
+      Modelica.Blocks.Sources.Clock clock;
+    equation
+      connect(clock.y, pid1.u_s);
+      connect(clock.y, pid1.u_m);
+      connect(clock.y, pid2.u_s);
+      connect(clock.y, pid2.u_m);
+      connect(clock.y, pid3.u_s);
+      connect(clock.y, pid3.u_m);
+      connect(clock.y, pid4.u);
+      connect(clock.y, pid5.u);
+      connect(clock.y, pid6.u);
+      annotation(experiment(StopTime=1), Documentation(info="<html>
+<p>
+Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/2892\">#2892</a>.
+</p>
+</html>"));
+    end Issue2892;
+
     model Issue2945 "Conversion test for #2945"
       extends Modelica.Icons.Example;
       Modelica.Blocks.Sources.Clock clock(


### PR DESCRIPTION
@HansOlsson This is what I tried to remove the now invalid modifier `Init.DoNotUse_InitialIntegratorState`. But no matter what I did, it did not work out, since enumeration simplification did not run when converting `ModelicaTestConversion4.Blocks.Issue2892`.

```
convertModifiers({"Modelica.Blocks.Continuous.LimPID",
                  "Modelica.Blocks.Continuous.PID"},
                  {"initType"}, {"initType=if Integer(%initType%) < 5 then %initType% else Modelica.Blocks.Types.Init.NoInit"}, true);
```

Do you have any hint how to do it?

Closes #2892.