### PR TITLE
Fix for Euler's constant

### DIFF
--- a/Modelica/Constants.mo
+++ b/Modelica/Constants.mo
@@ -12,7 +12,7 @@ package Constants
   final constant Real pi=2*Modelica.Math.asin(1.0); // 3.14159265358979;
   final constant Real D2R=pi/180 "Degree to Radian";
   final constant Real R2D=180/pi "Radian to Degree";
-  final constant Real gamma=0.57721566490153286060
+  final constant Real gamma=0.57721566490153286061
     "see http://en.wikipedia.org/wiki/Euler_constant";
 
   // Machine dependent constants


### PR DESCRIPTION
The last recorded digit for Euler's constant was not correctly rounded. Fixed.