### PR TITLE
Fix component name from variableResistor to variableConductor to match class name

### DIFF
--- a/Modelica/Electrical/QuasiStationary/MultiPhase.mo
+++ b/Modelica/Electrical/QuasiStationary/MultiPhase.mo
@@ -1668,20 +1668,20 @@ A linear temperature dependency of the resistances is also taken into account.
             extent={{-20,-20},{20,20}},
             rotation=270,
             origin={0,120})));
-      QuasiStationary.SinglePhase.Basic.VariableConductor variableResistor[m](
+      QuasiStationary.SinglePhase.Basic.VariableConductor variableConductor[m](
         final T_ref=T_ref,
         final alpha_ref=alpha_ref,
         each final useHeatPort=useHeatPort,
         final T=T) annotation (Placement(transformation(extent={{-10,-10},{10,
                 10}})));
     equation
-      connect(variableResistor.pin_p, plugToPins_p.pin_p) annotation (Line(
+      connect(variableConductor.pin_p, plugToPins_p.pin_p) annotation (Line(
             points={{-10,0},{-24.5,0},{-24.5,0},{-39,0},{-39,0},{-68,0}}, color={85,170,255}));
-      connect(variableResistor.pin_n, plugToPins_n.pin_n) annotation (Line(
+      connect(variableConductor.pin_n, plugToPins_n.pin_n) annotation (Line(
             points={{10,0},{39,0},{39,0},{68,0}}, color={85,170,255}));
-      connect(variableResistor.heatPort, heatPort) annotation (Line(points={{0,
+      connect(variableConductor.heatPort, heatPort) annotation (Line(points={{0,
               -10},{0,-32.5},{0,-32.5},{0,-55},{0,-55},{0,-100}}, color={191,0,0}));
-      connect(G_ref, variableResistor.G_ref) annotation (Line(points={{0,120},{0,120},{0,12},{0,12}}, color={0,0,127}));
+      connect(G_ref, variableConductor.G_ref) annotation (Line(points={{0,120},{0,120},{0,12},{0,12}}, color={0,0,127}));
       annotation (defaultComponentName="conductor",
         Icon(graphics={Line(points={{60,0},{90,0}}, color={85,170,255}),
               Line(points={{-90,0},{-60,0}}, color={85,170,255}),

--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -45,6 +45,9 @@ convertElement({"Modelica.Mechanics.Rotational.Components.Brake",
 convertElement({"Modelica.Mechanics.Rotational.Sources.SignTorque"},
                 "tau_constant", "tau_nominal");
 
+convertElement("Modelica.Electrical.QuasiStationary.MultiPhase.Basic.VariableConductor",
+                "variableResistor", "variableConductor");
+
 convertModifiers({"Modelica.Blocks.Nonlinear.Limiter",
                   "Modelica.Blocks.Nonlinear.VariableLimiter",
                   "Modelica.Blocks.Continuous.LimPID"},

--- a/ModelicaTestConversion4.mo
+++ b/ModelicaTestConversion4.mo
@@ -143,6 +143,24 @@ Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrar
 </html>"));
       end Issue758;
     end Digital;
+
+    package QuasiStationary
+      extends Modelica.Icons.ExamplesPackage;
+      model Issue2693 "Conversion test for #2693"
+        Modelica.Electrical.QuasiStationary.MultiPhase.Basic.VariableConductor variableConductor(variableResistor "Variable Conductor");
+        Modelica.Blocks.Sources.RealExpression realExpression[3](each y=time + 1);
+        Modelica.Electrical.QuasiStationary.MultiPhase.Sources.VoltageSource voltageSource;
+      equation
+        connect(realExpression.y, variableConductor.G_ref);
+        connect(variableConductor.plug_n, voltageSource.plug_p);
+        connect(voltageSource.plug_n, variableConductor.plug_p);
+      annotation(experiment(StopTime=1), Documentation(info="<html>
+<p>
+Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/2693\">#2693</a>.
+</p>
+</html>"));
+      end Issue2693;
+    end QuasiStationary;
   end Electrical;
 
   package Fluid


### PR DESCRIPTION
Fix #2693.