### PR TITLE
Fix compilation of ModelicaStandardTables.c if both TABLE_SHARE and NO_FILE_SYSTEM are defined

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -485,7 +485,7 @@ static size_t key_strlen(_In_z_ const char *s);
   /* Special strlen for key consisting of concatenated names of file and table */
 #endif
 
-#if defined(TABLE_SHARE)
+#if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
 #define READ_RESULT TableShare*
 #else
 #define READ_RESULT double*
@@ -569,7 +569,7 @@ void* ModelicaStandardTables_CombiTimeTable_init2(_In_z_ const char* fileName,
                                                   int timeEvents,
                                                   int verbose) {
     CombiTimeTable* tableID;
-#if defined(TABLE_SHARE)
+#if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
     TableShare* file = NULL;
     char* keyFile = NULL;
 #endif
@@ -580,7 +580,7 @@ void* ModelicaStandardTables_CombiTimeTable_init2(_In_z_ const char* fileName,
 
     /* Read table from file before any other heap allocation */
     if (TABLESOURCE_FILE == source) {
-#if defined(TABLE_SHARE)
+#if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
         file = readTable(fileName, tableName, &nRowFile, &nColFile, verbose, 0);
         if (NULL != file) {
             keyFile = file->key;
@@ -599,7 +599,7 @@ void* ModelicaStandardTables_CombiTimeTable_init2(_In_z_ const char* fileName,
 
     tableID = (CombiTimeTable*)calloc(1, sizeof(CombiTimeTable));
     if (NULL == tableID) {
-#if defined(TABLE_SHARE)
+#if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
         if (NULL != file) {
             MUTEX_LOCK();
             if (--file->refCount == 0) {
@@ -631,7 +631,7 @@ void* ModelicaStandardTables_CombiTimeTable_init2(_In_z_ const char* fileName,
 
     switch (tableID->source) {
         case TABLESOURCE_FILE:
-#if defined(TABLE_SHARE)
+#if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
             tableID->key = keyFile;
 #else
             {
@@ -1732,7 +1732,7 @@ void* ModelicaStandardTables_CombiTable1D_init2(_In_z_ const char* fileName,
                                                 int extrapolation,
                                                 int verbose) {
     CombiTable1D* tableID;
-#if defined(TABLE_SHARE)
+#if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
     TableShare* file = NULL;
     char* keyFile = NULL;
 #endif
@@ -1743,7 +1743,7 @@ void* ModelicaStandardTables_CombiTable1D_init2(_In_z_ const char* fileName,
 
     /* Read table from file before any other heap allocation */
     if (TABLESOURCE_FILE == source) {
-#if defined(TABLE_SHARE)
+#if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
         file = readTable(fileName, tableName, &nRowFile, &nColFile, verbose, 0);
         if (NULL != file) {
             keyFile = file->key;
@@ -1762,7 +1762,7 @@ void* ModelicaStandardTables_CombiTable1D_init2(_In_z_ const char* fileName,
 
     tableID = (CombiTable1D*)calloc(1, sizeof(CombiTable1D));
     if (NULL == tableID) {
-#if defined(TABLE_SHARE)
+#if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
         if (NULL != file) {
             MUTEX_LOCK();
             if (--file->refCount == 0) {
@@ -1789,7 +1789,7 @@ void* ModelicaStandardTables_CombiTable1D_init2(_In_z_ const char* fileName,
 
     switch (tableID->source) {
         case TABLESOURCE_FILE:
-#if defined(TABLE_SHARE)
+#if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
             tableID->key = keyFile;
 #else
             {
@@ -2362,7 +2362,7 @@ void* ModelicaStandardTables_CombiTable2D_init2(_In_z_ const char* fileName,
                                                 int extrapolation,
                                                 int verbose) {
     CombiTable2D* tableID;
-#if defined(TABLE_SHARE)
+#if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
     TableShare* file = NULL;
     char* keyFile = NULL;
 #endif
@@ -2373,7 +2373,7 @@ void* ModelicaStandardTables_CombiTable2D_init2(_In_z_ const char* fileName,
 
     /* Read table from file before any other heap allocation */
     if (TABLESOURCE_FILE == source) {
-#if defined(TABLE_SHARE)
+#if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
         file = readTable(fileName, tableName, &nRowFile, &nColFile, verbose, 0);
         if (NULL != file) {
             keyFile = file->key;
@@ -2392,7 +2392,7 @@ void* ModelicaStandardTables_CombiTable2D_init2(_In_z_ const char* fileName,
 
     tableID = (CombiTable2D*)calloc(1, sizeof(CombiTable2D));
     if (NULL == tableID) {
-#if defined(TABLE_SHARE)
+#if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
         if (NULL != file) {
             MUTEX_LOCK();
             if (--file->refCount == 0) {
@@ -2418,7 +2418,7 @@ void* ModelicaStandardTables_CombiTable2D_init2(_In_z_ const char* fileName,
 
     switch (tableID->source) {
         case TABLESOURCE_FILE:
-#if defined(TABLE_SHARE)
+#if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
             tableID->key = keyFile;
 #else
             {


### PR DESCRIPTION
TABLE_SHARE only is relevant if NO_FILE_SYSTEM is not defined.