### PR TITLE
Fix initialization of ModelicaTest.MultiBody.Joints.UniversalSpherical

### DIFF
--- a/ModelicaTest/MultiBody.mo
+++ b/ModelicaTest/MultiBody.mo
@@ -6369,6 +6369,7 @@ and plot gasForce.press over gasForce.s_rel.
         r={0.5,0,0},
         width=0.1,
         height=0.1,
+        r_0(start = {1, 0, 0}),
         angles_fixed=true,
         w_0_fixed=true,
         w_0_start={0,0,0})


### PR DESCRIPTION
Setting initialization guess value for `bodyBox.r_0`.

This addresses the remaining issue in #2705.