### PR TITLE
Improve the numerical conditioning of AST_BatchPlant example case

### DIFF
--- a/Modelica/Fluid/Examples/AST_BatchPlant.mo
+++ b/Modelica/Fluid/Examples/AST_BatchPlant.mo
@@ -95,6 +95,7 @@ package AST_BatchPlant
     Modelica.Fluid.Valves.ValveDiscrete V3(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
+      opening_min = 1e-5,
       dp_nominal = 100)
       annotation (Placement(transformation(extent={{-150,210},{-130,230}})));
     Fittings.TeeJunctionIdeal volume2(
@@ -106,6 +107,7 @@ package AST_BatchPlant
     Modelica.Fluid.Valves.ValveDiscrete V6(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
+      opening_min = 1e-5,
       dp_nominal = 100)
       annotation (Placement(transformation(extent={{130,210},{110,230}})));
     Fittings.TeeJunctionIdeal volume8(
@@ -124,24 +126,24 @@ package AST_BatchPlant
           rotation=180)));
     Modelica.Fluid.Valves.ValveDiscrete V1(
       redeclare package Medium = BatchMedium,
-      m_flow_nominal = 1,
-      dp_nominal = 100)
+      m_flow_nominal = 0.1,
+      dp_nominal = 1000)
       annotation (Placement(transformation(
           origin={-180,110},
           extent={{-10,10},{10,-10}},
           rotation=90)));
     Modelica.Fluid.Valves.ValveDiscrete V22(
       redeclare package Medium = BatchMedium,
-      m_flow_nominal = 1,
-      dp_nominal = 100)
+      m_flow_nominal = 0.1,
+      dp_nominal = 1000)
       annotation (Placement(transformation(
           origin={-180,-170},
           extent={{-10,10},{10,-10}},
           rotation=90)));
     Modelica.Fluid.Valves.ValveDiscrete V5(
       redeclare package Medium = BatchMedium,
-      m_flow_nominal = 1,
-      dp_nominal = 100)
+      m_flow_nominal = 0.1,
+      dp_nominal = 1000)
       annotation (Placement(transformation(
           origin={160,110},
           extent={{10,-10},{-10,10}},
@@ -156,8 +158,8 @@ package AST_BatchPlant
           rotation=180)));
     Modelica.Fluid.Valves.ValveDiscrete V25(
       redeclare package Medium = BatchMedium,
-      m_flow_nominal = 1,
-      dp_nominal = 100)
+      m_flow_nominal = 0.1,
+      dp_nominal = 1000)
       annotation (Placement(transformation(
           origin={160,-170},
           extent={{10,-10},{-10,10}},
@@ -251,7 +253,7 @@ package AST_BatchPlant
       stiffCharacteristicForEmptyPort=false)
                          annotation (Placement(transformation(extent={{-110,180},
               {-70,220}})));
-    inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial)
+    inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial, dp_small=1000)
                           annotation (Placement(transformation(extent={{180,250},
               {200,270}})));
     Modelica.Blocks.Logical.TriggeredTrapezoid P1_on(               rising=0,
@@ -554,7 +556,7 @@ package AST_BatchPlant
         points={{-8,0},{-8,-80},{-21,-80},{-21,-160}}, color={0,127,255}));
     connect(B3.ports[2], pipeB1B1.port_a) annotation (Line(
         points={{-8,99},{-8,20},{-8,20}}, color={0,127,255}));
-    annotation (experiment(StopTime=3600),
+    annotation (experiment(StopTime=3600,Interval=1),
       __Dymola_Commands(file=
             "modelica://Modelica/Resources/Scripts/Dymola/Fluid/AST_BatchPlant_StandardWater/plot level.mos"
           "plot level"),


### PR DESCRIPTION
The AST_BatchPlant example case in Modelica.Fluid is very numerically ill-conditioned, which makes it critical for the MSL, that must run with all Modelica tools producing the same results. This PR addresses two specific issues, trying to improve the situation.

The first is that the two groups of valves V1-V2-V3 and V4-V5-V6 are closed during some time intervals (including initialization). This means that the ideal (zero-volume) tee junctions volume2 and volume8 find themselves enclosed by closed valves only, and thus have an undetermined pressure. Hence, the Jacobian of the corresponding nonlinear system is singular. Although some tools may somehow manage this situation, producing an arbitrary value of the pressure, I don't think this is a good idea for a MSL example, that should run and produce the same results in all tools. 

The second is that the two pipes pipePump1B1 and pumpPipe2B2 show extremely fast changes of pressure when the valves enclosing them are opened, producing fantastically high values of the pressure derivative for extremely short periods, and sometimes causing solver failure because of excessive stiffness of the system of equations. By the way, this is not realistic, as the real plant most likely uses rubber pipes, whose elasticity dominates the very low compressibility of water by several orders of magnitude. Unfortunately, the pipe model does not (yet) have a provision to include this effect, that would make the model a lot more realistic and numerically well-behaved.

I addressed the first issue by adding a small leakage coefficient (1e-5) to valves V3 and V6, so that the pressure of the two ideal junctions is well-defined and equal to the atmosferic ones when the valves are closed. Note that there is actually no leak through these valves during the simulation, because when V3 and V6 are closed, so are the other ones, completely blocking any flow.

I addressed the second issue by increasing the pressure losses of the valves surrounding the pipes when they are opened, still keeping them low compared to the static head that the pumps need to counteract. This is supposed to make the system less stiff. I also increased changed the value of dp_nom for the regularization of the pressure losses inside the pipes, for the same reason. Finally, I reduced the reporting interval to 1 s, which is also beneficial to help the solver deal with the state events that cause such abrupt pressure changes.

The important results of the simulations (the flows and the levels) are virtually unchanged.

I successfully tested the updated model with both Dymola and OpenModelica.