### PR TITLE
Fix for cross-compilation of OSX binaries

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaStandardTablesUsertab.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTablesUsertab.c
@@ -48,7 +48,7 @@
 #include "ModelicaUtilities.h"
 
 #if defined(DUMMY_FUNCTION_USERTAB)
-#if (defined(__clang__) || defined(__GNUC__)) && !(defined(__apple_build_version__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__))
+#if (defined(__clang__) || defined(__GNUC__)) && !(defined(__apple_build_version__) || defined(__APPLE__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__))
 int usertab(char* tableName, int nipo, int dim[], int* colWise,
             double** table) __attribute__ ((weak, alias ("dummy_usertab")));
 #define USERTAB_NAME dummy_usertab


### PR DESCRIPTION
__apple_build_version__ is not defined in the OSX cross-compilation
toolchain.

Split from #2933 