### PR TITLE
Change unit of apparent power from "VA" to "V.A" in maint/3.2.3

### DIFF
--- a/Modelica/SIunits.mo
+++ b/Modelica/SIunits.mo
@@ -1265,7 +1265,7 @@ argument):</p>
   type Susceptance = Conductance;
   type InstantaneousPower = Real (final quantity="Power", final unit="W");
   type ActivePower = Real (final quantity="Power", final unit="W");
-  type ApparentPower = Real (final quantity="Power", final unit="VA");
+  type ApparentPower = Real (final quantity="Power", final unit="V.A");
   type ReactivePower = Real (final quantity="Power", final unit="var");
   type PowerFactor = Real (final quantity="PowerFactor", final unit="1");
   type LinearTemperatureCoefficientResistance = Real (


### PR DESCRIPTION
Back-porting #2982 to maint/3.2.3 (since labeled as bug).