### PR TITLE
Fix spelling and enhance battery example of #2957

### DIFF
--- a/Modelica/Electrical/Analog/Batteries.mo
+++ b/Modelica/Electrical/Analog/Batteries.mo
@@ -3,7 +3,7 @@ package Batteries "Simple battery models"
   extends Modelica.Icons.Package;
   model BatteryOCV_SOCtable
     "Battery with inner resistance and open-circuit voltage dependent on state of charge"
-    extends Partials.BaseBatteryOCV_SOCtable;
+    extends BaseClasses.BaseBatteryOCV_SOCtable;
     parameter Modelica.SIunits.Current Isc "Short-circuit current at SOC = SOCmax";
     parameter Modelica.SIunits.Resistance Ri=OCVmax/Isc "Inner resistance";
     extends Modelica.Electrical.Analog.Interfaces.PartialConditionalHeatPort;
@@ -29,7 +29,7 @@ whose losses are dissipated to the optional <code>heatPort</code>.
 </html>"));
   end BatteryOCV_SOCtable;
 
-  package Partials "Partials for battery models"
+  package BaseClasses "Base classes for battery models"
     extends Modelica.Icons.BasesPackage;
 
     partial model BaseBatteryOCV_SOCtable
@@ -140,9 +140,9 @@ Note: SOC &gt; SOCmax and SOC &lt; SOCmin triggers an error.
 </html>"));
     end BaseBatteryOCV_SOCtable;
     annotation (Documentation(info="<html>
-<p>Partial models for batteries</p>
+<p>Base classes for batteries</p>
 </html>"));
-  end Partials;
+  end BaseClasses;
   annotation (Icon(graphics={
         Ellipse(extent={{-10,50},{10,-50}},  lineColor={95,95,95},
           fillColor={215,215,215},

--- a/Modelica/Electrical/Analog/Batteries.mo
+++ b/Modelica/Electrical/Analog/Batteries.mo
@@ -4,7 +4,7 @@ package Batteries "Simple battery models"
   model BatteryOCV_SOCtable
     "Battery with inner resistance and open-circuit voltage dependent on state of charge"
     extends Partials.BaseBatteryOCV_SOCtable;
-    parameter Modelica.SIunits.Current Isc "Short-cicuit current at SOC = SOCmax";
+    parameter Modelica.SIunits.Current Isc "Short-circuit current at SOC = SOCmax";
     parameter Modelica.SIunits.Resistance Ri=OCVmax/Isc "Inner resistance";
     extends Modelica.Electrical.Analog.Interfaces.PartialConditionalHeatPort;
     Modelica.Electrical.Analog.Basic.Resistor resistor(final R=Ri,
@@ -24,7 +24,7 @@ package Batteries "Simple battery models"
       Documentation(info="<html>
 <p>
 The battery is modeled by open-circuit voltage (OCV) dependent on state of charge (SOC) and an inner resistance, 
-whoses losses are dissipated to the optional <code>heatPort</code>. 
+whose losses are dissipated to the optional <code>heatPort</code>. 
 </p>
 </html>"));
   end BatteryOCV_SOCtable;

--- a/Modelica/Electrical/Analog/Batteries.mo
+++ b/Modelica/Electrical/Analog/Batteries.mo
@@ -99,31 +99,28 @@ whose losses are dissipated to the optional <code>heatPort</code>.
         Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,
                 100}}), graphics={
             Text(
-              extent={{-150,-90},{150,-50}},
+              extent={{-150,-110},{150,-70}},
               lineColor={0,0,0},
               textString="OCV=%OCVnom"),
-            Ellipse(extent={{-90,20},{-82,-20}}, lineColor={0,0,255},
-              fillColor={170,170,255},
-              fillPattern=FillPattern.Sphere),
-            Rectangle(extent={{-86,20},{-60,-20}},lineColor={0,0,255},
-              fillColor={170,170,255},
-              fillPattern=FillPattern.HorizontalCylinder),
-            Ellipse(extent={{-64,20},{-56,-20}}, lineColor={0,0,255},
-              fillColor={170,170,255},
-              fillPattern=FillPattern.Sphere),
-            Ellipse(extent={{-70,50},{-50,-50}}, lineColor={0,0,255},
-              fillColor={170,170,255},
-              fillPattern=FillPattern.Sphere),
-            Rectangle(extent={{-60,50},{80,-50}}, lineColor={0,0,255},
-              fillColor={170,170,255},
-              fillPattern=FillPattern.HorizontalCylinder),
-            Ellipse(extent={{70,50},{90,-50}}, lineColor={0,0,255},
-              fillColor={170,170,255},
-              fillPattern=FillPattern.Sphere),
             Text(
               extent={{-150,70},{150,110}},
               lineColor={0,0,255},
-              textString="%name")}),
+              textString="%name"),
+            Rectangle(
+              extent={{-90,50},{90,-50}},
+              lineColor={0,0,255},
+              radius=10),
+            Rectangle(
+              extent=DynamicSelect({{70,-30},{-70,30}},{{70,-30},{70-140*SOC,30}}),
+              lineColor={0,0,255},
+              fillColor={0,0,255},
+              fillPattern=FillPattern.Solid),
+            Polygon(
+              points={{-90,30},{-100,30},{-110,10},{-110,-10},{-100,-30},{-90,-30},{
+                  -90,30}},
+              lineColor={0,0,255},
+              fillColor={0,0,255},
+              fillPattern=FillPattern.Solid)}),
         Documentation(info="<html>
 <p>
 The battery is modeled by open-circuit voltage (OCV) dependent on state of charge (SOC).

--- a/Modelica/Electrical/Analog/Examples/BatteryDischargeCharge.mo
+++ b/Modelica/Electrical/Analog/Examples/BatteryDischargeCharge.mo
@@ -35,7 +35,7 @@ model BatteryDischargeCharge "Discharge and charge idealized battery"
     annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
   Modelica.Electrical.Analog.Sensors.PowerSensor powerSensor
     annotation (Placement(transformation(extent={{-10,30},{10,50}})));
-  Modelica.Blocks.Continuous.Integrator energy
+  Modelica.Blocks.Continuous.Integrator energy(u(unit="W"), y(unit="J"))
     annotation (Placement(transformation(extent={{30,10},{50,30}})));
 equation
   connect(battery.n, ground.p)
@@ -56,13 +56,13 @@ equation
     annotation (Line(points={{-10,40},{-10,50},{0,50}}, color={0,0,255}));
   connect(powerSensor.power, energy.u)
     annotation (Line(points={{-10,29},{-10,20},{28,20}}, color={0,0,127}));
-  annotation (                                     experiment(
+  annotation (experiment(
       StopTime=1440,
       Interval=0.1,
       Tolerance=1e-06),
     Documentation(info="<html>
-<p>An idealized battery with a nominal charge of 10 Ah is 99&percnt; charged at the beginning.</p>
-<p>It is first discharged with 6 current pulses of 98 A for 1 minute, and breaks between the pulses of 1 minute, reaching SOC = 0.01.<(p>
+<p>An idealized battery with a nominal charge of 10 Ah is 99 % charged at the beginning.</p>
+<p>It is first discharged with 6 current pulses of 98 A for 1 minute, and breaks between the pulses of 1 minute, reaching SOC = 0.01.</p>
 <p>Subsequently, it is charged with 6 current pulses of 98 A for 1 minute, and breaks between the pulses of 1 minute, reaching SOC = 0.99 again.</p>
 <p>Simulate and plot terminal voltage <code>battery.v</code> versus state of charge <code>battery.SOC</code>.<p>
 <p>Note: Dependency of OCV on SOC can be chosen either linear (<code>useLinearSOCDependency=true</code>) or table based.</p>


### PR DESCRIPTION
I merged #2959 too early, while some small fixes are required.

Would be also very nice if the SOC is visualized in the icon of BatteryOCV_SOCtable using DynamicSelect.