### PR TITLE
Avoid inclusion of C source file win32_dirent.c

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaInternal.c
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.c
@@ -212,7 +212,7 @@ void ModelicaInternal_setenv(_In_z_ const char* name,
 
   #if defined(__MINGW32__) || defined(__CYGWIN__) /* MinGW and Cygwin have dirent.h */
     #include <dirent.h>
-  #else /* include the opendir/readdir/closedir implementation for _WIN32 */
+  #else /* include the opendir/readdir/closedir interface for _WIN32 */
     #include "win32_dirent.h"
   #endif
 

--- a/Modelica/Resources/C-Sources/ModelicaInternal.c
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.c
@@ -213,7 +213,7 @@ void ModelicaInternal_setenv(_In_z_ const char* name,
   #if defined(__MINGW32__) || defined(__CYGWIN__) /* MinGW and Cygwin have dirent.h */
     #include <dirent.h>
   #else /* include the opendir/readdir/closedir implementation for _WIN32 */
-    #include "win32_dirent.c"
+    #include "win32_dirent.h"
   #endif
 
 #elif defined(_POSIX_) || defined(__GNUC__)

--- a/Modelica/Resources/C-Sources/win32_dirent.c
+++ b/Modelica/Resources/C-Sources/win32_dirent.c
@@ -21,6 +21,8 @@
  *     current directory can be changed after "opendir".
  */
 
+#if defined(_WIN32) && !defined(NO_FILE_SYSTEM) && !defined(__WATCOMC__) && !defined(__BORLANDC__) && !defined(__MINGW32__) && !defined(__CYGWIN__)
+
 #include <stdlib.h>
 #include <errno.h>
 #include <string.h>
@@ -317,3 +319,5 @@ seekdir (DIR * dirp, long lPos)
             ;
     }
 }
+
+#endif


### PR DESCRIPTION
Avoid inclusion of C source file win32_dirent.c.

The readme already mentions win32_dirent.c as stand-alone C module:

https://github.com/modelica/ModelicaStandardLibrary/blob/cf4ceff0dcde83ea9b50e60dabea3be2b3a652cd/Modelica/Resources/C-Sources/readme.txt#L4-L9