### PR TITLE
Remove unused parameter show_NPSHa from Modelica.Fluid.Machines.PartialPump

### DIFF
--- a/Modelica/Fluid/Machines.mo
+++ b/Modelica/Fluid/Machines.mo
@@ -408,9 +408,6 @@ Then the model can be replaced with a Pump with rotational shaft or with a Presc
         Modelica.Fluid.Machines.BaseClasses.PumpMonitoring.PumpMonitoringBase
         "Optional pump monitoring"
         annotation(Dialog(tab="Advanced", group="Diagnostics"), choicesAllMatching=true);
-    final parameter Boolean show_NPSHa = false
-        "obsolete -- remove modifier and specify Monitoring for NPSH instead"
-      annotation(Dialog(tab="Advanced", group="Obsolete"));
     Monitoring monitoring(
             redeclare final package Medium = Medium,
             final state_in = Medium.setState_phX(port_a.p, inStream(port_a.h_outflow), inStream(port_a.Xi_outflow)),

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -2385,6 +2385,9 @@ The following <font color=\"blue\"><strong>existing components</strong></font> h
     <td>The superfluous constant <code>phi_offset</code> has been removed.</td></tr>
 <tr><td>Parts.Body</td>
     <td>The superfluous parameter <code>z_a_start</code> has been removed.</td></tr>
+<tr><td colspan=\"2\"><strong>Modelica.Fluid.Machines</strong></td></tr>
+<tr><td>PartialPump</td>
+    <td>The superfluous parameter <code>show_NPSHa</code> has been removed.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Thermal.HeatTransfer</strong></td></tr>
 <tr><td>Fahrenheit.FromKelvin<br>Rankine.FromKelvin<br>Rankine.ToKelvin</td>
     <td>The superfluous parameter <code>n</code> has been removed.</td></tr>


### PR DESCRIPTION
This PR removes the unused parameter show_NPSHa from Modelica.Fluid.Machines.PartialPump as already was intended for MSL v3.2.1+build.3, but was reverted by #1306 to not break the backwards-compatibility.

However, removing public components is not covered by the conversion rules (section [18.8.2.1](https://specification.modelica.org/v3.4/Ch18.html#conversion-rules) of the Modelica Specification 3.4).

My test model (that I wanted to add to ModelicaTestConversion4.mo) fails any conversion I could think of, since the removed component is referenced in a (declaration) equation.

```mo
    model Issue3038 "Conversion test for #3038"
      extends Modelica.Icons.Example;
      Boolean hideNPSHa = not pumps.show_NPSHa; // reference to obsolete/removed public component
      replaceable package Medium = Modelica.Media.Water.StandardWaterOnePhase constrainedby Modelica.Media.Interfaces.PartialMedium;
      inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial) annotation(Placement(transformation(extent={{-20,0},{0,20}})));
      Modelica.Fluid.Sources.FixedBoundary source(
        redeclare package Medium=Medium,
        nPorts=1,
        p=system.p_ambient,
        use_T=true,
        T=Modelica.SIunits.Conversions.from_degC(20)) annotation(Placement(transformation(extent={{-80,-40},{-60,-20}})));
      Modelica.Fluid.Pipes.StaticPipe pipe(
        redeclare package Medium=Medium,
        allowFlowReversal=true,
        length=100,
        diameter=0.3,
        height_ab=50) annotation (Placement(transformation(origin={10,-30},extent={{-10,-10},{10,10}})));
      Modelica.Fluid.Machines.PrescribedPump pumps(
        redeclare package Medium=Medium,
        redeclare function flowCharacteristic=Modelica.Fluid.Machines.BaseClasses.PumpCharacteristics.quadraticFlow(
          V_flow_nominal={0,0.25,0.5},
          head_nominal={100,60,0}),
        energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial,
        massDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial,
        T_start=system.T_start,
        p_b_start=600000,
        nParallel=1,
        N_nominal=1200,
        checkValve=true,
        V=0.05,
        use_N_in=true) annotation(Placement(transformation(extent={{-40,-40},{-20,-20}})));
      Modelica.Fluid.Sensors.Pressure pressure(
        redeclare package Medium = Medium) annotation(Placement(transformation(extent={{40,-20},{60,0}})));
      Modelica.Blocks.Sources.RealExpression realExpression(y=time) annotation(Placement(transformation(extent={{-80,0},{-60,20}})));
    equation
      connect(pipe.port_a,pumps.port_b) annotation(Line(points={{0,-30},{-20,-30}},color={0,127,255}));
      connect(source.ports[1],pumps.port_a) annotation(Line(points={{-60,-30},{-40,-30}},color={0,127,255}));
      connect(realExpression.y, pumps.N_in) annotation(Line(points={{-59,10},{-30,10},{-30,-20}}, color={0,0,127}));
      connect(pipe.port_b, pressure.port) annotation(Line(points={{20,-30},{50,-30},{50,-20}}, color={0,127,255}));
      annotation(uses(Modelica(version=3.2.3)), experiment(StopTime=1), Documentation(info="<html>
<p>
Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/3038\">#3038</a>.
</p>
</html>"));
    end Issue3038;
```

(Note, that #2887 is a similar issue, where the test case ModelicaTestConversion4.Thermal.HeatTransfer.Issue1202 **only** considers the removal of the modifier, but if we add equations for the removed public parameters, say `Integer y[3] = {toKelvin.n, fromKelvin1.n, fromKelvin2.n};` we see, that the converted model becomes invalid in MSL v4.0.0.)

@HansOlsson Since I believe this is not a specification hole, the only possibility I see for MSL v4.0.0 is to well document all backward-compatibility breaking changes not covered by conversion. We usually did this in the Release Notes on prominent site.