### PR TITLE
maint/3.2.3: Fix uninitialized memory and realpath behaviour in ModelicaInternal_fullPathName

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaInternal.c
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.c
@@ -30,6 +30,10 @@
 */
 
 /* Release Notes:
+      Jun. 24, 2019: by Thomas Beutlich
+                     Fixed uninitialized memory and realpath behaviour in
+                     ModelicaInternal_fullPathName (ticket #3003)
+
       Jun. 28, 2018: by Hans Olsson, Dassault Systemes
                      Proper error message when out of string memory
                      in ModelicaInternal_readLine (ticket #2676)
@@ -588,9 +592,18 @@ _Ret_z_ const char* ModelicaInternal_fullPathName(_In_z_ const char* name) {
             name, strerror(errno));
         return "";
     }
-    fullName = ModelicaAllocateString(strlen(tempName));
+    fullName = ModelicaAllocateString(strlen(tempName) + 1);
     strcpy(fullName, tempName);
     ModelicaConvertToUnixDirectorySeparator(fullName);
+#if (_BSD_SOURCE || _XOPEN_SOURCE >= 500 || _XOPEN_SOURCE && _XOPEN_SOURCE_EXTENDED || _POSIX_VERSION >= 200112L)
+    {
+        /* In case of realpath: Retain trailing slash to match _fullpath behaviour */
+        size_t len = strlen(name);
+        if (len > 0 && '/' == name[len - 1]) {
+            strcat(fullName, "/");
+        }
+    }
+#endif
 #elif defined(_POSIX_)
     char* fullName;
     char localbuf[BUFFER_LENGTH];
@@ -605,6 +618,9 @@ _Ret_z_ const char* ModelicaInternal_fullPathName(_In_z_ const char* name) {
         /* Any name beginning with "/" is regarded as already being a full path. */
         strcpy(fullName, cwd);
         strcat(fullName, "/");
+    }
+    else {
+        fullName[0] = '\0';
     }
     strcat(fullName, name);
 #else


### PR DESCRIPTION
Back-port of #3004 for maint/3.2.3 branch to fix #3003.