### PR TITLE
Add connectorSizing to StateGraph.PartialStep

### DIFF
--- a/Modelica/Fluid/Examples/AST_BatchPlant.mo
+++ b/Modelica/Fluid/Examples/AST_BatchPlant.mo
@@ -998,36 +998,36 @@ Full steady state initialization is not supported, because the corresponding ini
       parameter Real startTime=1;
       parameter Real T5_batch_level=0.211;
 
-      Modelica.StateGraph.InitialStep InitialStep1
+      Modelica.StateGraph.InitialStep InitialStep1(nIn=1, nOut=1)
         annotation (Placement(transformation(extent={{-180,90},{-160,110}})));
       Modelica.StateGraph.Transition Transition1(enableTimer=true, waitTime=
             startTime) annotation (Placement(transformation(extent={{-150,90},{
                 -130,110}})));
-      Modelica.StateGraph.Step Step1
+      Modelica.StateGraph.Step Step1(nIn=1, nOut=1)
         annotation (Placement(transformation(extent={{-120,90},{-100,110}})));
       Modelica.StateGraph.Transition Transition2(condition=LIS_301 >= 0.13)
         annotation (Placement(transformation(extent={{-90,90},{-70,110}})));
-      Modelica.StateGraph.Step Step2 annotation (Placement(transformation(
+      Modelica.StateGraph.Step Step2(nIn=1, nOut=1) annotation (Placement(transformation(
               extent={{-60,90},{-40,110}})));
       Modelica.StateGraph.Transition Transition3(
         condition=true,
         enableTimer=true,
         waitTime=500)
         annotation (Placement(transformation(extent={{-30,90},{-10,110}})));
-      Modelica.StateGraph.Step Step3 annotation (Placement(transformation(
+      Modelica.StateGraph.Step Step3(nIn=1, nOut=1) annotation (Placement(transformation(
               extent={{0,90},{20,110}})));
       Modelica.StateGraph.Transition Transition4(condition=LIS_301 <= 0.01)
         annotation (Placement(transformation(extent={{30,90},{50,110}})));
-      Modelica.StateGraph.Step Step4 annotation (Placement(transformation(
+      Modelica.StateGraph.Step Step4(nIn=1, nOut=1) annotation (Placement(transformation(
               extent={{60,90},{80,110}})));
       Modelica.StateGraph.Transition Transition5(condition=T5_idle)
         annotation (Placement(transformation(extent={{90,90},{110,110}})));
-      Modelica.StateGraph.Step Step5 annotation (Placement(transformation(
+      Modelica.StateGraph.Step Step5(nIn=1, nOut=1) annotation (Placement(transformation(
               extent={{120,90},{140,110}})));
       Modelica.StateGraph.Transition Transition6(condition=LIS_501 >=
             T5_batch_level) annotation (Placement(transformation(extent={{150,
                 90},{170,110}})));
-      Modelica.StateGraph.Step Step6 annotation (Placement(transformation(
+      Modelica.StateGraph.Step Step6(nIn=1, nOut=1) annotation (Placement(transformation(
               extent={{-120,30},{-100,50}})));
       Modelica.StateGraph.Transition Transition7(
         condition=true,
@@ -1036,21 +1036,21 @@ Full steady state initialization is not supported, because the corresponding ini
         annotation (Placement(transformation(extent={{-90,30},{-70,50}})));
       Modelica.StateGraph.Parallel Parallel1 annotation (Placement(
             transformation(extent={{-176,-100},{194,0}})));
-      Modelica.StateGraph.Step Step7 annotation (Placement(transformation(
+      Modelica.StateGraph.Step Step7(nIn=1, nOut=1) annotation (Placement(transformation(
               extent={{-122,-80},{-102,-60}})));
-      Modelica.StateGraph.Step Step8 annotation (Placement(transformation(
+      Modelica.StateGraph.Step Step8(nIn=1, nOut=1) annotation (Placement(transformation(
               extent={{-62,-80},{-42,-60}})));
-      Modelica.StateGraph.Step Step9 annotation (Placement(transformation(
+      Modelica.StateGraph.Step Step9(nIn=1, nOut=1) annotation (Placement(transformation(
               extent={{-2,-80},{18,-60}})));
-      Modelica.StateGraph.Step Step10 annotation (Placement(transformation(
+      Modelica.StateGraph.Step Step10(nIn=1, nOut=1) annotation (Placement(transformation(
               extent={{58,-80},{78,-60}})));
-      Modelica.StateGraph.Step Step11 annotation (Placement(transformation(
+      Modelica.StateGraph.Step Step11(nIn=1, nOut=1) annotation (Placement(transformation(
               extent={{118,-80},{138,-60}})));
-      Modelica.StateGraph.Step Step12 annotation (Placement(transformation(
+      Modelica.StateGraph.Step Step12(nIn=1, nOut=1) annotation (Placement(transformation(
               extent={{-62,-40},{-42,-20}})));
-      Modelica.StateGraph.Step Step13 annotation (Placement(transformation(
+      Modelica.StateGraph.Step Step13(nIn=1, nOut=1) annotation (Placement(transformation(
               extent={{-2,-40},{18,-20}})));
-      Modelica.StateGraph.Step Step14 annotation (Placement(transformation(
+      Modelica.StateGraph.Step Step14(nIn=1, nOut=1) annotation (Placement(transformation(
               extent={{58,-40},{78,-20}})));
       Modelica.StateGraph.Transition Transition8(condition=T7_idle)
         annotation (Placement(transformation(extent={{-92,-80},{-72,-60}})));

--- a/Modelica/Fluid/Examples/ControlledTankSystem.mo
+++ b/Modelica/Fluid/Examples/ControlledTankSystem.mo
@@ -213,9 +213,8 @@ This example is based on
       parameter SI.Height minLevel "Lowest level of tank 1 and 2";
       parameter SI.Time waitTime "Wait time, between operations";
 
-      Modelica.StateGraph.InitialStep s1(nIn=2)
-                     annotation (Placement(transformation(extent={{-72,30},{-52,
-                50}})));
+      Modelica.StateGraph.InitialStep s1(nIn=2, nOut=1)
+                     annotation (Placement(transformation(extent={{-72,30},{-52,50}})));
       Modelica.Fluid.Examples.ControlledTankSystem.Utilities.NormalOperation
         normal(
         maxLevel=maxLevel,
@@ -232,7 +231,7 @@ This example is based on
             origin={-23,-1},
             extent={{-10,-10},{10,10}},
             rotation=270)));
-      Modelica.StateGraph.Step s2(nOut=2)
+      Modelica.StateGraph.Step s2(nIn=1, nOut=2)
               annotation (Placement(transformation(extent={{-50,-60},{-30,-40}})));
       Modelica.StateGraph.Transition T4(condition=start)
         annotation (Placement(transformation(
@@ -242,7 +241,7 @@ This example is based on
       Modelica.StateGraph.Transition T5(condition=shut)
                                     annotation (Placement(transformation(extent=
                {{-6,-60},{14,-40}})));
-      Modelica.StateGraph.Step emptyTanks
+      Modelica.StateGraph.Step emptyTanks(nIn=1, nOut=1)
                       annotation (Placement(transformation(extent={{20,-60},{40,
                 -40}})));
       Modelica.StateGraph.Transition T6(condition=level1 < minLevel and level2
@@ -283,18 +282,14 @@ This example is based on
         annotation (Placement(transformation(extent={{-94,74},{-74,94}})));
     equation
 
-      connect(s1.outPort[1], T1.inPort)
-                                     annotation (Line(points={{-51.5,40},{-44,
-              40}}));
+      connect(s1.outPort[1], T1.inPort) annotation (Line(points={{-51.5,40},{-44,40}}));
       connect(T1.outPort, normal.inPort) annotation (Line(points={{-38.5,
               40},{-21.3333,40}}));
       connect(normal.outPort, T2.inPort) annotation (Line(points={{20.6667,
               40},{33,40}}));
-      connect(T5.outPort, emptyTanks.inPort[1])
-                                             annotation (Line(points={{5.5,-50},
+      connect(T5.outPort, emptyTanks.inPort[1]) annotation (Line(points={{5.5,-50},
               {19,-50}}));
-      connect(emptyTanks.outPort[1], T6.inPort)
-                                             annotation (Line(points={{40.5,-50},
+      connect(emptyTanks.outPort[1], T6.inPort) annotation (Line(points={{40.5,-50},
               {51,-50}}));
       connect(setValve1.y, valve1)
         annotation (Line(points={{83,82.5},{90,82.5},{90,60},{105,60}}, color={
@@ -306,8 +301,7 @@ This example is based on
               95,-60},{105,-60}}, color={255,0,255}));
       connect(normal.suspend[1], T3.inPort) annotation (Line(points={{-10,
               19.3333},{-10,12},{-23,12},{-23,3}}));
-      connect(T3.outPort, s2.inPort[1])
-                                     annotation (Line(points={{-23,-2.5},{-23,
+      connect(T3.outPort, s2.inPort[1]) annotation (Line(points={{-23,-2.5},{-23,
               -20},{-60,-20},{-60,-50},{-51,-50}}));
       connect(level1, normal.level1) annotation (Line(points={{-60,-110},{
               -60,-80},{-80,-80},{-80,20},{-30,20},{-30,24},{-22.6667,24}}, color={0,0,255}));
@@ -363,24 +357,24 @@ This example is based on
 
       Modelica.Blocks.Interfaces.RealInput level1
         annotation (Placement(transformation(extent={{-190,-140},{-150,-100}})));
-      Modelica.StateGraph.Step fillTank1
+      Modelica.StateGraph.Step fillTank1(nIn=1, nOut=1)
                      annotation (Placement(transformation(extent={{-140,-10},{
                 -120,10}})));
       Modelica.StateGraph.Transition T1(condition=level1 > maxLevel)
         annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
-      Modelica.StateGraph.Step fillTank2
+      Modelica.StateGraph.Step fillTank2(nIn=1, nOut=1)
                      annotation (Placement(transformation(extent={{-10,-10},{10,
                 10}})));
       Modelica.StateGraph.Transition T3(condition=level1 < minLevel)
         annotation (Placement(transformation(extent={{20,-10},{40,10}})));
-      Modelica.StateGraph.Step emptyTank2
+      Modelica.StateGraph.Step emptyTank2(nIn=1, nOut=1)
                       annotation (Placement(transformation(extent={{120,-10},{
                 140,10}})));
-      Modelica.StateGraph.Step wait1
+      Modelica.StateGraph.Step wait1(nIn=1, nOut=1)
                  annotation (Placement(transformation(extent={{-80,-10},{-60,10}})));
       Modelica.StateGraph.Transition T2(enableTimer=true, waitTime=waitTime)
         annotation (Placement(transformation(extent={{-50,-10},{-30,10}})));
-      Modelica.StateGraph.Step wait2
+      Modelica.StateGraph.Step wait2(nIn=1, nOut=1)
                  annotation (Placement(transformation(extent={{54,-10},{74,10}})));
       Modelica.StateGraph.Transition T4(enableTimer=true, waitTime=waitTime)
         annotation (Placement(transformation(extent={{82,-10},{102,10}})));

--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -360,6 +360,13 @@ convertModifiers("Modelica.StateGraph.Temporary.NumericValue",
 convertModifiers("Modelica.StateGraph.Temporary.NumericValue",
                   {"hideConnector"}, {"use_numberPort=not %hideConnector%"});
 
+convertModifiers({"Modelica.StateGraph.PartialStep",
+                  "Modelica.StateGraph.InitialStep",
+                  "Modelica.StateGraph.InitialStepWithSignal",
+                  "Modelica.StateGraph.Step",
+                  "Modelica.StateGraph.StepWithSignal"},
+                  fill("",0), {"nIn=1", "nOut=1"});
+
 convertElement("Modelica.Mechanics.MultiBody.Joints.RollingWheel",
                {"wheelRadius"},
                {"radius"});

--- a/Modelica/StateGraph.mo
+++ b/Modelica/StateGraph.mo
@@ -507,14 +507,6 @@ library:
      The \"Parallel\" component is both used as \"composite step\" (so only one branch),
      as well as \"parallel step\" (so several execution branches).<br>&nbsp;</li>
 
-<li> <strong>Conveniently connecting components</strong><br>
-     Connecting components of a state machine in Modelica means to provide
-     new vector dimensions and to provide a vector index to connect to.
-     In StateGraph2, the new \"connectorSizing\" annotation is used and
-     therefore all this is now performed automatically (from a users point
-     of view, these actions are hidden; this is not the case in
-     StateGraph1 and makes the usage of the StateGraph1 library clumsy).<br>&nbsp;</li>
-
 <li> <strong>Safer state machines</strong><br>
      It is no longer possible to construct a wrong state machine in the sense that properties
      of the graph are violated (e.g., two initial steps, or branching wrongly out of a parallel
@@ -802,11 +794,11 @@ package Examples
 
   model FirstExample "A first simple StateGraph example"
     extends Modelica.Icons.Example;
-    InitialStep initialStep annotation (Placement(transformation(extent={{-48,0},
+    InitialStep initialStep(nIn=1, nOut=1) annotation (Placement(transformation(extent={{-48,0},
                 {-28,20}})));
     Transition transition1(enableTimer=true, waitTime=1)
       annotation (Placement(transformation(extent={{-20,0},{0,20}})));
-    Step step annotation (Placement(transformation(extent={{10,0},{30,20}})));
+    Step step(nIn=1, nOut=1) annotation (Placement(transformation(extent={{10,0},{30,20}})));
     Transition transition2(enableTimer=true, waitTime=1)
       annotation (Placement(transformation(extent={{40,0},{60,20}})));
       inner StateGraphRoot stateGraphRoot
@@ -827,11 +819,10 @@ package Examples
   model FirstExample_Variant2
       "A variant of the first simple StateGraph example"
     extends Modelica.Icons.Example;
-    InitialStep initialStep annotation (Placement(transformation(extent={{-70,0},
-                {-50,20}})));
+    InitialStep initialStep(nIn=1, nOut=1) annotation (Placement(transformation(extent={{-70,0},{-50,20}})));
     Transition transition1(enableTimer=true, waitTime=1)
       annotation (Placement(transformation(extent={{-42,0},{-22,20}})));
-    StepWithSignal step
+    StepWithSignal step(nIn=1, nOut=1)
               annotation (Placement(transformation(extent={{-14,0},{6,20}})));
     TransitionWithSignal transition2
       annotation (Placement(transformation(extent={{52,0},{72,20}})));
@@ -864,11 +855,10 @@ package Examples
   model FirstExample_Variant3
       "A variant of the first simple StateGraph example"
     extends Modelica.Icons.Example;
-    InitialStep initialStep annotation (Placement(transformation(extent={{-70,0},
-                {-50,20}})));
+    InitialStep initialStep(nIn=1, nOut=1) annotation (Placement(transformation(extent={{-70,0},{-50,20}})));
     Transition transition1(enableTimer=true, waitTime=1)
       annotation (Placement(transformation(extent={{-42,0},{-22,20}})));
-    StepWithSignal step
+    StepWithSignal step(nIn=1, nOut=1)
               annotation (Placement(transformation(extent={{-14,0},{6,20}})));
     TransitionWithSignal transition2
       annotation (Placement(transformation(extent={{56,0},{76,20}})));
@@ -905,19 +895,19 @@ package Examples
 
     extends Modelica.Icons.Example;
 
-    InitialStep step0 annotation (
+    InitialStep step0(nIn=1, nOut=1) annotation (
           Placement(transformation(extent={{-140,-100},{-120,-80}})));
     Transition transition1(enableTimer=true, waitTime=1)
       annotation (Placement(
             transformation(extent={{-100,-100},{-80,-80}})));
-    Step step1 annotation (
+    Step step1(nIn=1, nOut=1) annotation (
           Placement(transformation(extent={{-10,-40},{10,-20}})));
     Transition transition2(enableTimer=true, waitTime=1)
       annotation (Placement(
             transformation(extent={{90,-100},{110,-80}})));
-    Step step6 annotation (Placement(
+    Step step6(nIn=1, nOut=1) annotation (Placement(
             transformation(extent={{120,-100},{140,-80}})));
-    Step step2 annotation (
+    Step step2(nIn=1, nOut=1) annotation (
           Placement(transformation(extent={{-98,40},{-78,60}})));
     Transition transition3(enableTimer=true, waitTime=1)
       annotation (Placement(
@@ -925,9 +915,9 @@ package Examples
     Transition transition4(enableTimer=true, waitTime=1)
       annotation (Placement(
             transformation(extent={{-42,40},{-22,60}})));
-    Step step3 annotation (Placement(
+    Step step3(nIn=1, nOut=1) annotation (Placement(
             transformation(extent={{-8,80},{12,100}})));
-    Step step4 annotation (Placement(
+    Step step4(nIn=1, nOut=1) annotation (Placement(
             transformation(extent={{-8,40},{12,60}})));
     Transition transition5(enableTimer=true, waitTime=1)
       annotation (Placement(
@@ -935,7 +925,7 @@ package Examples
     Transition transition6(enableTimer=true, waitTime=1)
       annotation (Placement(
             transformation(extent={{26,40},{46,60}})));
-    Step step5 annotation (Placement(
+    Step step5(nIn=1, nOut=1) annotation (Placement(
             transformation(extent={{80,40},{100,60}})));
     Modelica.Blocks.Sources.RealExpression setReal(y=time)
       annotation (Placement(transformation(extent={{21,-160},{41,-140}})));
@@ -945,7 +935,7 @@ package Examples
       annotation (Placement(transformation(extent={{-77,-160},{-19,-140}})));
     Transition transition4a(enableTimer=true, waitTime=1)
       annotation (Placement(transformation(extent={{-42,0},{-22,20}})));
-    Step step4a annotation (Placement(
+    Step step4a(nIn=1, nOut=1) annotation (Placement(
             transformation(extent={{-8,0},{12,20}})));
     Transition transition6a(enableTimer=true, waitTime=2)
       annotation (Placement(
@@ -1039,17 +1029,17 @@ has a higher priority to fire as alternative.split[2]).
     Utilities.CompositeStep compositeStep
                                      annotation (Placement(transformation(
               extent={{-10,5},{20,35}})));
-    InitialStep step0 annotation (
+    InitialStep step0(nIn=1, nOut=1) annotation (
           Placement(transformation(extent={{-89,-10},{-69,10}})));
     Transition transition1(enableTimer=true, waitTime=1)
       annotation (Placement(
             transformation(extent={{-59,-10},{-39,10}})));
-    Step step1 annotation (Placement(
+    Step step1(nIn=1, nOut=1) annotation (Placement(
             transformation(extent={{-4,-30},{16,-10}})));
     Transition transition2(enableTimer=true, waitTime=1)
       annotation (Placement(
             transformation(extent={{45,-10},{65,10}})));
-    Step step6 annotation (Placement(
+    Step step6(nIn=1, nOut=1) annotation (Placement(
             transformation(extent={{71,-10},{91,10}})));
     TransitionWithSignal transition7 annotation (Placement(transformation(
               extent={{10,-70},{-10,-50}})));
@@ -1098,11 +1088,9 @@ is that the alternative paths are included in a \"CompositeStep\".
 
     extends Modelica.Icons.Example;
 
-    Utilities.CompositeStep1 compositeStep
-                                annotation (Placement(transformation(extent={{
+    Utilities.CompositeStep1 compositeStep annotation (Placement(transformation(extent={{
                 -20,25},{10,55}})));
-    InitialStep initialStep
-                      annotation (
+    InitialStep initialStep(nIn=1, nOut=1) annotation (
           Placement(transformation(extent={{-80,30},{-60,50}})));
     Transition transition1(enableTimer=true, waitTime=1)
       annotation (Placement(
@@ -1113,7 +1101,7 @@ is that the alternative paths are included in a \"CompositeStep\".
     Transition transition3(enableTimer=true, waitTime=2)
       annotation (Placement(
             transformation(extent={{-55,-30},{-35,-10}})));
-    Step step1 annotation (Placement(transformation(extent={{-24,-30},{-4,-10}})));
+    Step step1(nIn=1, nOut=1) annotation (Placement(transformation(extent={{-24,-30},{-4,-10}})));
     Transition transition4(enableTimer=true, waitTime=1)
       annotation (Placement(
             transformation(extent={{10,-30},{30,-10}})));
@@ -1272,7 +1260,7 @@ buttons:
       parameter Real limit=0.98 "Limit level of tank 1";
       parameter Modelica.SIunits.Time waitTime=3 "Wait time";
 
-      InitialStep s1(nIn=2)
+      InitialStep s1(nIn=2, nOut=1)
         annotation (Placement(transformation(extent={{-72,30},{-52,50}})));
       MakeProduct makeProduct(limit=limit, waitTime=waitTime)
         annotation (Placement(transformation(extent={{-20,25},{10,55}})));
@@ -1285,7 +1273,7 @@ buttons:
               origin={-23,-1},
               extent={{-10,-10},{10,10}},
               rotation=270)));
-      Step s2(nOut=2)
+      Step s2(nIn=1, nOut=2)
               annotation (Placement(transformation(extent={{-50,-60},{-30,-40}})));
       Transition T4(condition=start)
         annotation (Placement(transformation(
@@ -1294,8 +1282,7 @@ buttons:
               rotation=90)));
       Transition T5(condition=shut) annotation (Placement(transformation(extent=
                  {{-6,-60},{14,-40}})));
-      Step emptyTanks annotation (Placement(transformation(extent={{22,-60},{42,
-                  -40}})));
+      Step emptyTanks(nIn=1, nOut=1) annotation (Placement(transformation(extent={{22,-60},{42,-40}})));
       Transition T6(condition=level1+level2<0.001)
         annotation (Placement(transformation(extent={{45,-60},{65,-40}})));
       Modelica.Blocks.Interfaces.BooleanInput start
@@ -1408,17 +1395,17 @@ buttons:
 
       Modelica.Blocks.Interfaces.RealInput level1
         annotation (Placement(transformation(extent={{-190,-140},{-150,-100}})));
-      Step fillTank1 annotation (Placement(transformation(extent={{-140,-10},{-120,10}})));
+      Step fillTank1(nIn=1, nOut=1) annotation (Placement(transformation(extent={{-140,-10},{-120,10}})));
       Transition T1(condition=level1 > limit)
         annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
-      Step fillTank2 annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+      Step fillTank2(nIn=1, nOut=1) annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
       Transition T3(condition=level1 < 0.001)
         annotation (Placement(transformation(extent={{20,-10},{40,10}})));
-      Step emptyTank2 annotation (Placement(transformation(extent={{120,-10},{140,10}})));
-      Step wait1 annotation (Placement(transformation(extent={{-80,-10},{-60,10}})));
+      Step emptyTank2(nIn=1, nOut=1) annotation (Placement(transformation(extent={{120,-10},{140,10}})));
+      Step wait1(nIn=1, nOut=1) annotation (Placement(transformation(extent={{-80,-10},{-60,10}})));
       Transition T2(enableTimer=true, waitTime=waitTime)
         annotation (Placement(transformation(extent={{-50,-10},{-30,10}})));
-      Step wait2 annotation (Placement(transformation(extent={{54,-10},{74,10}})));
+      Step wait2(nIn=1, nOut=1) annotation (Placement(transformation(extent={{54,-10},{74,10}})));
       Transition T4(enableTimer=true, waitTime=waitTime)
         annotation (Placement(transformation(extent={{82,-10},{102,10}})));
     equation
@@ -1624,9 +1611,9 @@ buttons:
       Transition transition4(enableTimer=true, waitTime=1)
         annotation (Placement(
               transformation(extent={{-64,-10},{-44,10}})));
-      Step step3 annotation (
+      Step step3(nIn=1, nOut=1) annotation (
             Placement(transformation(extent={{-10,50},{10,70}})));
-      Step step4 annotation (
+      Step step4(nIn=1, nOut=1) annotation (
             Placement(transformation(extent={{-10,-10},{10,10}})));
       Transition transition5(enableTimer=true, waitTime=2)
         annotation (Placement(
@@ -1637,15 +1624,13 @@ buttons:
       Transition transition4a(enableTimer=true, waitTime=1)
         annotation (Placement(
               transformation(extent={{-64,-70},{-44,-50}})));
-      Step step4a annotation (
+      Step step4a(nIn=1, nOut=1) annotation (
             Placement(transformation(extent={{-10,-70},{10,-50}})));
       Transition transition6a(enableTimer=true, waitTime=2)
         annotation (Placement(
               transformation(extent={{36,-70},{56,-50}})));
-      Step initStep annotation (Placement(transformation(extent={{-140,-10},{
-                  -120,10}})));
-      Step exitStep annotation (Placement(transformation(extent={{120,-10},{140,
-                  10}})));
+      Step initStep(nIn=1, nOut=1) annotation (Placement(transformation(extent={{-140,-10},{-120,10}})));
+      Step exitStep(nIn=1, nOut=1) annotation (Placement(transformation(extent={{120,-10},{140,10}})));
       Alternative Alternative1(nBranches=3) annotation (Placement(
               transformation(extent={{-98,-90},{98,90}})));
     equation
@@ -1692,10 +1677,8 @@ buttons:
         condition=time >= 8)
         annotation (Placement(
               transformation(extent={{-60,20},{-40,40}})));
-      Step initStep annotation (Placement(transformation(extent={{-140,-10},{
-                  -120,10}})));
-      Step exitStep annotation (Placement(transformation(extent={{110,-10},{130,
-                  10}})));
+      Step initStep(nIn=1, nOut=1) annotation (Placement(transformation(extent={{-140,-10},{-120,10}})));
+      Step exitStep(nIn=1, nOut=1) annotation (Placement(transformation(extent={{110,-10},{130,10}})));
       CompositeStep2 compositeStep11(waitTime=3)
                                            annotation (Placement(transformation(
                 extent={{-20,15},{10,45}})));
@@ -1750,8 +1733,8 @@ buttons:
       extends PartialCompositeStep;
       Transition transition(enableTimer=true, waitTime=waitTime)
         annotation (Placement(transformation(extent={{-30,-10},{-10,10}})));
-      Step initStep annotation (Placement(transformation(extent={{-140,-10},{-120,10}})));
-      Step exitStep annotation (Placement(transformation(extent={{110,-10},{130,10}})));
+      Step initStep(nIn=1, nOut=1) annotation (Placement(transformation(extent={{-140,-10},{-120,10}})));
+      Step exitStep(nIn=1, nOut=1) annotation (Placement(transformation(extent={{110,-10},{130,10}})));
       parameter Modelica.SIunits.Time waitTime=2 "Waiting time in this composite step";
     equation
       connect(exitStep.outPort[1], outPort)
@@ -1889,8 +1872,7 @@ package Interfaces "Connectors and partial models"
         "= true, if suspend transition of CompositeStep fires";
     input Boolean resume "= true, if resume transition of CompositeStep fires";
     Real activeStepsDummy
-        "Dummy variable in order that connector fulfills restriction of connector"
-                                                                                annotation(HideResult=true);
+        "Dummy variable in order that connector fulfills restriction of connector" annotation(HideResult=true);
     flow Real activeSteps "Number of active steps in the CompositeStep";
   end CompositeStepStatePort_in;
 
@@ -1901,16 +1883,15 @@ package Interfaces "Connectors and partial models"
         "= true, if suspend transition of CompositeStep fires";
     output Boolean resume "= true, if resume transition of CompositeStep fires";
     Real activeStepsDummy
-        "Dummy variable in order that connector fulfills restriction of connector"
-                                                                                 annotation(HideResult=true);
+        "Dummy variable in order that connector fulfills restriction of connector" annotation(HideResult=true);
     flow Real activeSteps "Number of active steps in the CompositeStep";
   end CompositeStepStatePort_out;
 
   partial block PartialStep
       "Partial step with one input and one output transition port"
 
-    parameter Integer nIn(min=0) = 1 "Number of input connections";
-    parameter Integer nOut(min=0) = 1 "Number of output connections";
+    parameter Integer nIn(min=0) = 0 "Number of input connections" annotation(Dialog(connectorSizing=true), HideResult=true);
+    parameter Integer nOut(min=0) = 0 "Number of output connections" annotation(Dialog(connectorSizing=true), HideResult=true);
 
     /* localActive is introduced since component 'Step' has Boolean variable 'active'
      and component 'StepWithSignal' has connector instance 'active' defined

--- a/ModelicaTestConversion4.mo
+++ b/ModelicaTestConversion4.mo
@@ -269,6 +269,44 @@ Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrar
 </p>
 </html>"));
     end Issue2880;
+
+    model Issue3086 "Conversion test for #3086"
+      extends Modelica.Icons.Example;
+      Modelica.StateGraph.InitialStep initialStep annotation (Placement(transformation(extent={{-48,0},{-28,20}})));
+      Modelica.StateGraph.Transition transition1(enableTimer=true, waitTime=1) annotation (Placement(transformation(extent={{-20,0},{0,20}})));
+      Modelica.StateGraph.Step step annotation (Placement(transformation(extent={{10,0},{30,20}})));
+      Modelica.StateGraph.Transition transition2(enableTimer=true, waitTime=1) annotation (Placement(transformation(extent={{40,0},{60,20}})));
+      inner Modelica.StateGraph.StateGraphRoot stateGraphRoot annotation (Placement(transformation(extent={{-80,60},{-60,80}})));
+    equation
+      connect(initialStep.outPort[1], transition1.inPort) annotation (Line(points={{-27.5,10},{-14,10}}));
+      connect(transition1.outPort, step.inPort[1]) annotation (Line(points={{-8.5,10},{9,10}}));
+      connect(step.outPort[1], transition2.inPort) annotation (Line(points={{30.5,10},{46,10}}));
+      connect(transition2.outPort, initialStep.inPort[1]) annotation (Line(points={{51.5,10},{70,10},{70,32},{-62,32},{-62,10},{-49,10}}));
+      annotation(experiment(StopTime=5), Documentation(info="<html>
+<p>
+Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/3086\">#3086</a>.
+</p>
+</html>"));
+    end Issue3086;
+
+    model Issue3086_WithSignal "Conversion test for #3086"
+      extends Modelica.Icons.Example;
+      Modelica.StateGraph.InitialStepWithSignal initialStep annotation (Placement(transformation(extent={{-48,0},{-28,20}})));
+      Modelica.StateGraph.Transition transition1(enableTimer=true, waitTime=1) annotation (Placement(transformation(extent={{-20,0},{0,20}})));
+      Modelica.StateGraph.StepWithSignal step annotation (Placement(transformation(extent={{10,0},{30,20}})));
+      Modelica.StateGraph.Transition transition2(enableTimer=true, waitTime=1) annotation (Placement(transformation(extent={{40,0},{60,20}})));
+      inner Modelica.StateGraph.StateGraphRoot stateGraphRoot annotation (Placement(transformation(extent={{-80,60},{-60,80}})));
+    equation
+      connect(initialStep.outPort[1], transition1.inPort) annotation (Line(points={{-27.5,10},{-14,10}}));
+      connect(transition1.outPort, step.inPort[1]) annotation (Line(points={{-8.5,10},{9,10}}));
+      connect(step.outPort[1], transition2.inPort) annotation (Line(points={{30.5,10},{46,10}}));
+      connect(transition2.outPort, initialStep.inPort[1]) annotation (Line(points={{51.5,10},{70,10},{70,32},{-62,32},{-62,10},{-49,10}}));
+      annotation(experiment(StopTime=5), Documentation(info="<html>
+<p>
+Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/3086\">#3086</a>.
+</p>
+</html>"));
+    end Issue3086_WithSignal;
   end StateGraph;
 
   package Electrical


### PR DESCRIPTION
Update StateGraph with the connectorSizing feature (of StateGraph2) to improve the modeling comfort in a Modelica editor.

A conversion is required since the default values for nIn and nOut needed to be adapted.