### PR TITLE
maint/3.2.3: Fix uninitialized memory in ModelicaInternal_readLine, ModelicaStrings_scanIdentifier and ModelicaStrings_scanString

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaInternal.c
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.c
@@ -1000,6 +1000,7 @@ END_OF_FILE:
     CloseCachedFile(fileName);
     *endOfFile = 1;
     line = ModelicaAllocateString(0);
+    line[0] = '\0';
     return line;
 
 Modelica_ERROR3:

--- a/Modelica/Resources/C-Sources/ModelicaStrings.c
+++ b/Modelica/Resources/C-Sources/ModelicaStrings.c
@@ -264,7 +264,11 @@ void ModelicaStrings_scanIdentifier(_In_z_ const char* string,
 
     /* Token missing or not identifier. */
     *nextIndex  = startIndex;
-    *identifier = ModelicaAllocateString(0);
+    {
+        char* s = ModelicaAllocateString(0);
+        s[0] = '\0';
+        *identifier = s;
+    }
     return;
 }
 
@@ -491,7 +495,11 @@ void ModelicaStrings_scanString(_In_z_ const char* string, int startIndex,
     }
 
 Modelica_ERROR:
-    *result = ModelicaAllocateString(0);
+    {
+        char* s = ModelicaAllocateString(0);
+        s[0] = '\0';
+        *result = s;
+    }
     *nextIndex = startIndex;
     return;
 }


### PR DESCRIPTION
Back-port #3092 for maint/3.2.3.