### PR TITLE
Add new source block BooleanConstantVariability and introduce BooleanParameter as an alternative name for BooleanConstant

### DIFF
--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -2889,8 +2889,8 @@ MATLAB is a registered trademark of The MathWorks, Inc.
             textString="y[2]")}));
   end CombiTimeTable;
 
-  block BooleanConstant "Generate constant signal of type Boolean"
-    parameter Boolean k=true "Constant output value"
+  block BooleanParameter "Generate parameter signal of type Boolean"
+    parameter Boolean k=true "Parameter output value"
     annotation(Dialog(groupImage="modelica://Modelica/Resources/Images/Blocks/Sources/BooleanConstant.png"));
     extends Interfaces.partialBooleanSource;
 
@@ -2929,7 +2929,26 @@ The Boolean output y is a constant signal:
      alt=\"BooleanConstant.png\">
 </p>
 </html>"));
-  end BooleanConstant;
+  end BooleanParameter;
+
+  block BooleanConstant = BooleanParameter "Legacy name for a source with parameter variability Boolean output.";
+
+  block BooleanConstantVariability "Generate constant signal of type Boolean"
+    constant Boolean k = true "Constant output value" annotation(Dialog(group="Constants"));
+    extends Interfaces.partialBooleanSource;
+  equation
+    y = k;
+    annotation(Icon(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}, initialScale = 0.1, grid = {10, 10}), graphics = {Line(visible = true, origin = {-4.523, 0}, points = {{-75.477, 0}, {75.477, 0}}, color = {64, 64, 64}), Text(visible = true, textColor = {64, 64, 64}, extent = {{-150, -140}, {150, -110}}, textString = "%k"), Text(visible = true, origin = {-0, 25}, extent = {{-100, -15}, {100, 15}}, textString = "constant")}), Diagram(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}, initialScale = 0.1, grid = {10, 10}), graphics = {Line(visible = true, points = {{-70, 0}, {80, 0}}, color = {0, 36, 164}, thickness = 0.5), Text(visible = true, textColor = {64, 64, 64}, extent = {{-69, 0}, {-49, 20}}, textString = "k"), Text(visible = true, textColor = {64, 64, 64}, extent = {{-96, -4}, {-76, 6}}, textString = "true"), Text(visible = true, textColor = {64, 64, 64}, extent = {{-98, -68}, {-72, -58}}, textString = "false")}), Documentation(info = "<html>
+<p>
+The Boolean output y has constant variability:
+</p>
+
+<p>
+<img src=\"modelica://Modelica/Resources/Images/Blocks/Sources/BooleanConstant.png\"
+     alt=\"BooleanConstant.png\">
+</p>
+</html>"));
+  end BooleanConstantVariability;
 
   block BooleanStep "Generate step signal of type Boolean"
     parameter Modelica.SIunits.Time startTime=0 "Time instant of step start"


### PR DESCRIPTION
Sometimes, a Boolean signal may have structural impact on the model equations if it can be evaluated during translation.  The `Modelica.Blocks.Sources.BooleanConstant` source cannot be used to this end in general, as it may be totally fine for a tool to not evaluate the parameter.  Hence, a new source block is needed to express that the Boolean signal should really be considered a constant by the tools.

It is a pity that the old block was named `BooleanConstant`, but I guess this can be made right later using a conversion:
1. Any use of `BooleanConstant` is changed to use `BooleanParameter`.
1. Remove `BooleanConstant`.
1. Rename `BooleanConstantVariability` → `BooleanConstant`.