### PR TITLE
Evaluate parameters with intended structural impact in Mechanics

### DIFF
--- a/Modelica/Mechanics/MultiBody/Joints.mo
+++ b/Modelica/Mechanics/MultiBody/Joints.mo
@@ -1812,7 +1812,7 @@ frame_b of the joint.
 
     parameter Types.RotationSequence sequence_start={1,2,3}
       "Sequence of angle rotations"
-      annotation(Evaluate=true,Dialog(enable=use_angle, tab="Angle initialization", group="Angles to rotate frame_a to frame_b along sequence_start"));
+      annotation(Evaluate=true, Dialog(enable=use_angle, tab="Angle initialization", group="Angles to rotate frame_a to frame_b along sequence_start"));
 
     Modelica.Blocks.Interfaces.RealOutput angle_1(final quantity="Angle", final unit="rad", start=0, stateSelect=angle_1_stateSelect) if use_angle
       "First rotation angle or dummy"

--- a/Modelica/Mechanics/MultiBody/Joints.mo
+++ b/Modelica/Mechanics/MultiBody/Joints.mo
@@ -1200,7 +1200,7 @@ s_y.start = 0.5, phi.start = 45<sup>o</sup>).
 
     parameter Boolean enforceStates=false
       "= true, if relative variables of spherical joint shall be used as states (StateSelect.always)"
-      annotation (Dialog(tab="Advanced"));
+      annotation (Evaluate=true, Dialog(tab="Advanced"));
     parameter Boolean useQuaternions=true
       "= true, if quaternions shall be used as states otherwise use 3 angles as states (provided enforceStates=true)"
       annotation (Evaluate=true, Dialog(tab="Advanced", enable=enforceStates));
@@ -1477,7 +1477,7 @@ frame_b of the joint.
       annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
     parameter Boolean enforceStates=true
       "= true, if relative variables between frame_a and frame_b shall be used as states"
-      annotation (Dialog(tab="Advanced"));
+      annotation (Evaluate=true, Dialog(tab="Advanced"));
     parameter Boolean useQuaternions=true
       "= true, if quaternions shall be used as states otherwise use 3 angles as states"
       annotation (Evaluate=true, Dialog(tab="Advanced"));

--- a/Modelica/Mechanics/MultiBody/Joints.mo
+++ b/Modelica/Mechanics/MultiBody/Joints.mo
@@ -1203,7 +1203,7 @@ s_y.start = 0.5, phi.start = 45<sup>o</sup>).
       annotation (Dialog(tab="Advanced"));
     parameter Boolean useQuaternions=true
       "= true, if quaternions shall be used as states otherwise use 3 angles as states (provided enforceStates=true)"
-      annotation (Dialog(tab="Advanced", enable=enforceStates));
+      annotation (Evaluate=true, Dialog(tab="Advanced", enable=enforceStates));
     parameter Types.RotationSequence sequence_angleStates={1,2,3}
       "Sequence of rotations to rotate frame_a into frame_b around the 3 angles used as states"
        annotation (Evaluate=true, Dialog(tab="Advanced", enable=enforceStates
@@ -1480,7 +1480,7 @@ frame_b of the joint.
       annotation (Dialog(tab="Advanced"));
     parameter Boolean useQuaternions=true
       "= true, if quaternions shall be used as states otherwise use 3 angles as states"
-      annotation (Dialog(tab="Advanced"));
+      annotation (Evaluate=true, Dialog(tab="Advanced"));
     parameter Types.RotationSequence sequence_angleStates={1,2,3}
       "Sequence of rotations to rotate frame_a into frame_b around the 3 angles used as states"
        annotation (Evaluate=true, Dialog(tab="Advanced", enable=not

--- a/Modelica/Mechanics/MultiBody/Parts.mo
+++ b/Modelica/Mechanics/MultiBody/Parts.mo
@@ -618,10 +618,10 @@ the animation may be switched off via parameter animation = <strong>false</stron
         enable=animation));
     parameter Boolean enforceStates=false
       "= true, if absolute variables of body object shall be used as states (StateSelect.always)"
-      annotation (Evaluate=true,Dialog(tab="Advanced"));
+      annotation (Evaluate=true, Dialog(tab="Advanced"));
     parameter Boolean useQuaternions=true
       "= true, if quaternions shall be used as potential states otherwise use 3 angles as potential states"
-      annotation (Evaluate=true, Evaluate=true,Dialog(tab="Advanced"));
+      annotation (Evaluate=true, Dialog(tab="Advanced"));
     parameter Types.RotationSequence sequence_angleStates={1,2,3}
       "Sequence of rotations to rotate world frame into frame_a around the 3 angles used as potential states"
       annotation (Evaluate=true, Dialog(tab="Advanced", enable=not

--- a/Modelica/Mechanics/MultiBody/Parts.mo
+++ b/Modelica/Mechanics/MultiBody/Parts.mo
@@ -1032,7 +1032,7 @@ to the setting of parameters \"useQuaternions\" and
         enable=animation));
     parameter Boolean enforceStates=false
       "= true, if absolute variables of body object shall be used as states (StateSelect.always)"
-      annotation (Dialog(tab="Advanced"));
+      annotation (Evaluate=true, Dialog(tab="Advanced"));
     parameter Boolean useQuaternions=true
       "= true, if quaternions shall be used as potential states otherwise use 3 angles as potential states"
       annotation (Evaluate=true, Dialog(tab="Advanced"));
@@ -1294,7 +1294,7 @@ states and of the \"Advanced\" menu parameters, see model
 
     parameter Boolean enforceStates=false
       "= true, if absolute variables of body object shall be used as states (StateSelect.always)"
-      annotation (Dialog(tab="Advanced"));
+      annotation (Evaluate=true, Dialog(tab="Advanced"));
     parameter Boolean useQuaternions=true
       "= true, if quaternions shall be used as potential states otherwise use 3 angles as potential states"
       annotation (Evaluate=true, Dialog(tab="Advanced"));
@@ -1520,7 +1520,7 @@ states and of the \"Advanced\" menu parameters, see model
 
     parameter Boolean enforceStates=false
       "= true, if absolute variables of body object shall be used as states (StateSelect.always)"
-      annotation (Dialog(tab="Advanced"));
+      annotation (Evaluate=true, Dialog(tab="Advanced"));
     parameter Boolean useQuaternions=true
       "= true, if quaternions shall be used as potential states otherwise use 3 angles as potential states"
       annotation (Evaluate=true, Dialog(tab="Advanced"));

--- a/Modelica/Mechanics/MultiBody/Parts.mo
+++ b/Modelica/Mechanics/MultiBody/Parts.mo
@@ -1910,7 +1910,7 @@ November 3-4, 2003, pp. 149-158</p>
       annotation (Dialog(tab="Advanced"));
     parameter Boolean exact=true
       "= true, if exact calculations; false if influence of bearing on rotor acceleration is neglected to avoid an algebraic loop"
-      annotation (Dialog(tab="Advanced"));
+      annotation (Evaluate=true, Dialog(tab="Advanced"));
 
     SI.Angle phi(start=0, stateSelect=stateSelect)
       "Rotation angle of rotor with respect to frame_a (= flange_a.phi = flange_b.phi)";
@@ -1979,7 +1979,7 @@ November 3-4, 2003, pp. 149-158</p>
         annotation (Dialog(tab="Advanced"));
       parameter Boolean exact=true
         "= true, if exact calculations; false if influence of bearing on rotor acceleration is neglected to avoid an algebraic loop"
-        annotation (Dialog(tab="Advanced"));
+        annotation (Evaluate=true, Dialog(tab="Advanced"));
 
       SI.AngularVelocity w_a[3]
         "Angular velocity of frame_a, resolved in frame_a";

--- a/Modelica/Mechanics/MultiBody/Parts.mo
+++ b/Modelica/Mechanics/MultiBody/Parts.mo
@@ -621,7 +621,7 @@ the animation may be switched off via parameter animation = <strong>false</stron
       annotation (Evaluate=true,Dialog(tab="Advanced"));
     parameter Boolean useQuaternions=true
       "= true, if quaternions shall be used as potential states otherwise use 3 angles as potential states"
-      annotation (Evaluate=true,Dialog(tab="Advanced"));
+      annotation (Evaluate=true, Evaluate=true,Dialog(tab="Advanced"));
     parameter Types.RotationSequence sequence_angleStates={1,2,3}
       "Sequence of rotations to rotate world frame into frame_a around the 3 angles used as potential states"
       annotation (Evaluate=true, Dialog(tab="Advanced", enable=not
@@ -1035,7 +1035,7 @@ to the setting of parameters \"useQuaternions\" and
       annotation (Dialog(tab="Advanced"));
     parameter Boolean useQuaternions=true
       "= true, if quaternions shall be used as potential states otherwise use 3 angles as potential states"
-      annotation (Dialog(tab="Advanced"));
+      annotation (Evaluate=true, Dialog(tab="Advanced"));
     parameter Types.RotationSequence sequence_angleStates={1,2,3}
       "Sequence of rotations to rotate world frame into frame_a around the 3 angles used as potential states"
       annotation (Evaluate=true, Dialog(tab="Advanced", enable=not
@@ -1297,7 +1297,7 @@ states and of the \"Advanced\" menu parameters, see model
       annotation (Dialog(tab="Advanced"));
     parameter Boolean useQuaternions=true
       "= true, if quaternions shall be used as potential states otherwise use 3 angles as potential states"
-      annotation (Dialog(tab="Advanced"));
+      annotation (Evaluate=true, Dialog(tab="Advanced"));
     parameter Types.RotationSequence sequence_angleStates={1,2,3}
       "Sequence of rotations to rotate world frame into frame_a around the 3 angles used as potential states"
       annotation (Evaluate=true, Dialog(tab="Advanced", enable=not
@@ -1523,7 +1523,7 @@ states and of the \"Advanced\" menu parameters, see model
       annotation (Dialog(tab="Advanced"));
     parameter Boolean useQuaternions=true
       "= true, if quaternions shall be used as potential states otherwise use 3 angles as potential states"
-      annotation (Dialog(tab="Advanced"));
+      annotation (Evaluate=true, Dialog(tab="Advanced"));
     parameter Types.RotationSequence sequence_angleStates={1,2,3}
       "Sequence of rotations to rotate world frame into frame_a around the 3 angles used as potential states"
       annotation (Evaluate=true, Dialog(tab="Advanced", enable=not

--- a/Modelica/Mechanics/Rotational/Sources/Position.mo
+++ b/Modelica/Mechanics/Rotational/Sources/Position.mo
@@ -3,7 +3,8 @@ model Position
   "Forced movement of a flange according to a reference angle signal"
   extends Modelica.Mechanics.Rotational.Interfaces.PartialElementaryOneFlangeAndSupport2;
   parameter Boolean exact=false
-    "Is true/false for exact treatment/filtering of the input signal, respectively";
+    "Is true/false for exact treatment/filtering of the input signal, respectively"
+    annotation (Evaluate=true);
   parameter SI.Frequency f_crit=50
     "If exact=false, critical frequency of filter to filter input signal"
     annotation (Dialog(enable=not exact));

--- a/Modelica/Mechanics/Rotational/Sources/Speed.mo
+++ b/Modelica/Mechanics/Rotational/Sources/Speed.mo
@@ -4,7 +4,8 @@ model Speed
   extends
     Modelica.Mechanics.Rotational.Interfaces.PartialElementaryOneFlangeAndSupport2;
   parameter Boolean exact=false
-    "Is true/false for exact treatment/filtering of the input signal, respectively";
+    "Is true/false for exact treatment/filtering of the input signal, respectively"
+    annotation (Evaluate=true);
   parameter SI.Frequency f_crit=50
     "If exact=false, critical frequency of filter to filter input signal"
     annotation (Dialog(enable=not exact));

--- a/Modelica/Mechanics/Translational/Sources/Position.mo
+++ b/Modelica/Mechanics/Translational/Sources/Position.mo
@@ -5,7 +5,8 @@ model Position
     Modelica.Mechanics.Translational.Interfaces.PartialElementaryOneFlangeAndSupport2(
      s(stateSelect=if exact then StateSelect.default else StateSelect.prefer));
   parameter Boolean exact=false
-    "Is true/false for exact treatment/filtering of the input signal, respectively";
+    "Is true/false for exact treatment/filtering of the input signal, respectively"
+    annotation (Evaluate=true);
   parameter SI.Frequency f_crit=50
     "If exact=false, critical frequency of filter to filter input signal"
     annotation (Dialog(enable=not exact));

--- a/Modelica/Mechanics/Translational/Sources/Speed.mo
+++ b/Modelica/Mechanics/Translational/Sources/Speed.mo
@@ -7,7 +7,8 @@ model Speed "Forced movement of a flange according to a reference speed"
       fixed=true,
       stateSelect=StateSelect.prefer));
   parameter Boolean exact=false
-    "Is true/false for exact treatment/filtering of the input signal, respectively";
+    "Is true/false for exact treatment/filtering of the input signal, respectively"
+    annotation (Evaluate=true);
   parameter SI.Frequency f_crit=50
     "If exact=false, critical frequency of filter to filter input signal"
     annotation (Dialog(enable=not exact));


### PR DESCRIPTION
The PR is limited to `Modelica.Mechanics`.  It changes some components declared `parameter` to be `constant` instead in order to make clear to both users and tools that they can and are expected to be evaluated during translation.

This kind of change is an important part of making a library portable between tools, since differences in which parameters that are turned into constants during translation will lead to different equation systems in different tools.

By trying to do this systematically instead of case by case when needed, we get a consistent and predictable user experience when dealing with these variables.  Also, when all existing, say, `enforceStates` have the same variability, there is little risk of getting the wrong variability when creating a new component with an `enforceStates` variable.

That said, the variables affected by this PR have been selected based on improved compatibility with Wolfram SystemModeler.
