### PR TITLE
Model stepped signals by constant interpolation of CombiTimeTable in MSL examples

### DIFF
--- a/Modelica/Electrical/Analog/Examples/BatteryDischargeCharge.mo
+++ b/Modelica/Electrical/Analog/Examples/BatteryDischargeCharge.mo
@@ -19,13 +19,13 @@ model BatteryDischargeCharge "Discharge and charge idealized battery"
         extent={{10,-10},{-10,10}},
         rotation=90,
         origin={-20,0})));
-  Modelica.Blocks.Sources.CombiTimeTable combiTimeTable(table=[0,0; 0,1; 60,1;
-        60,0; 120,0; 120,1; 180,1; 180,0; 240,0; 240,1; 300,1; 300,0; 360,0;
-        360,1; 420,1; 420,0; 480,0; 480,1; 540,1; 540,0; 600,0; 600,1; 660,1;
-        660,0; 720,0; 720,-1; 780,-1; 780,0; 840,0; 840,-1; 900,-1; 900,0;
-        960,0; 960,-1; 1020,-1; 1020,0; 1080,0; 1080,-1; 1140,-1; 1140,0;
-        1200,0; 1200,-1; 1260,-1; 1260,0; 1320,0; 1320,-1; 1380,-1; 1380,0;
-        1440,0],                extrapolation=Modelica.Blocks.Types.Extrapolation.Periodic)
+  Modelica.Blocks.Sources.CombiTimeTable combiTimeTable(
+        table=[0,0; 60,1; 120,0; 180,1; 240,0; 300,1; 360,0;
+        420,1; 480,0; 540,1; 600,0; 600,1; 660,0; 720,-1; 780,0;
+        840,-1; 900,0; 960,-1; 1020,0; 1080,-1; 1140,0; 1200,-1;
+        1260,0; 1320,-1; 1380,0; 1440,0],
+        extrapolation=Modelica.Blocks.Types.Extrapolation.Periodic,
+        smoothness=Modelica.Blocks.Types.Smoothness.ConstantSegments)
     annotation (Placement(transformation(extent={{-88,-10},{-68,10}})));
   Modelica.Blocks.Continuous.FirstOrder
     firstOrder(

--- a/Modelica/Electrical/Machines.mo
+++ b/Modelica/Electrical/Machines.mo
@@ -1168,9 +1168,9 @@ and accelerating inertias.<br>At time tStep a load step is applied.</p>
           annotation (Placement(transformation(
               extent={{-10,10},{10,-10}},
               rotation=270)));
-        Blocks.Sources.CombiTimeTable
-                                 dutyCycle(table=[0,0; 1,1; 4,1; 5,0; 10,0; 11,
-              -1; 14,-1; 15,0; 20,0], extrapolation=Modelica.Blocks.Types.Extrapolation.Periodic)
+        Blocks.Sources.CombiTimeTable dutyCycle(
+          table=[0,0; 1,1; 4,1; 5,0; 10,0; 11, -1; 14,-1; 15,0; 20,0],
+          extrapolation=Modelica.Blocks.Types.Extrapolation.Periodic)
           annotation (Placement(transformation(extent={{-100,50},{-80,70}})));
         Machines.Utilities.VfController vfController(
           final m=m,

--- a/Modelica/Fluid/Examples/TraceSubstances.mo
+++ b/Modelica/Fluid/Examples/TraceSubstances.mo
@@ -134,10 +134,10 @@ of magnitude.
       C={100},
       nPorts=1) "CO2 emitted by room occupants."
       annotation (Placement(transformation(extent={{-38,-98},{-18,-78}})));
-    Modelica.Blocks.Sources.CombiTimeTable NumberOfPeople(table=[0,0; 9*3600,0;
-          9*3600,10; 11*3600,10; 11*3600,2; 13*3600,2; 13*3600,15; 15*3600,15;
-          15*3600,5; 18*3600,5; 18*3600,0; 24*3600,0])
-      "Time table for number of people in the room"
+    Modelica.Blocks.Sources.CombiTimeTable numberOfPeople(
+      table=[0,0; 9,10; 11,2; 13,15; 15,5; 18,0; 24,0],
+      smoothness=Modelica.Blocks.Types.Smoothness.ConstantSegments,
+      timeScale=3600) "Time table for number of people in the room"
       annotation (Placement(transformation(extent={{-100,-90},{-80,-70}})));
     Modelica.Blocks.Math.Gain gain(k=8.18E-6/100)
       "CO2 mass flow rate, released per 100 person (there is another 100 factor in peopleSource)"
@@ -173,12 +173,11 @@ of magnitude.
       "Trace substance at duct outlet"
       annotation (Placement(transformation(extent={{-20,0},{0,20}})));
   equation
-    connect(CAtm.y, freshAir.C_in[1])
-                                    annotation (Line(
+    connect(CAtm.y, freshAir.C_in[1]) annotation (Line(
         points={{-79,-38},{-70,-38}}, color={0,0,127}));
     connect(ductOut.port_b, boundary4.ports[1]) annotation (Line(
         points={{60,-30},{72,-30}}, color={0,127,255}));
-    connect(NumberOfPeople.y[1], gain.u) annotation (Line(
+    connect(numberOfPeople.y[1], gain.u) annotation (Line(
         points={{-79,-80},{-70,-80}}, color={0,0,127}));
     connect(gain.y, peopleSource.m_flow_in) annotation (Line(
         points={{-47,-80},{-38,-80}}, color={0,0,127}));
@@ -186,8 +185,7 @@ of magnitude.
         points={{41,10},{58,10}}, color={0,0,127}));
     connect(CO2Set.y, PID.u_s) annotation (Line(
         points={{-59,50},{-42,50}}, color={0,0,127}));
-    connect(gainSensor.y, PID.u_m)
-                              annotation (Line(
+    connect(gainSensor.y, PID.u_m) annotation (Line(
         points={{81,10},{90,10},{90,30},{-30,30},{-30,38}}, color={0,0,127}));
     connect(PID.y, gain1.u) annotation (Line(
         points={{-19,50},{-2,50}}, color={0,0,127}));

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Conveyor.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Conveyor.mo
@@ -41,8 +41,9 @@ model IMC_Conveyor
     annotation (Placement(transformation(extent={{60,10},{40,30}})));
   Modelica.Electrical.Machines.Sensors.CurrentQuasiRMSSensor currentQuasiRMSSensor
     annotation (Placement(transformation(extent={{20,100},{40,80}})));
-  Modelica.Blocks.Sources.CombiTimeTable dutyCycle(table=[0,0; 1,1; 4,1; 5,0;
-        10,0; 11,-1; 14,-1; 15,0; 20,0], extrapolation=Modelica.Blocks.Types.Extrapolation.Periodic)
+  Modelica.Blocks.Sources.CombiTimeTable dutyCycle(
+    table=[0,0; 1,1; 4,1; 5,0; 10,0; 11,-1; 14,-1; 15,0; 20,0],
+    extrapolation=Modelica.Blocks.Types.Extrapolation.Periodic)
     annotation (Placement(transformation(extent={{-100,40},{-80,60}})));
   Modelica.Electrical.Machines.Utilities.VfController vfController(
     final m=m,

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Conveyor.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Conveyor.mo
@@ -42,8 +42,9 @@ model IMC_Conveyor "Induction machine with squirrel cage and inverter driving a 
     annotation (Placement(transformation(extent={{60,10},{40,30}})));
   Modelica.Electrical.QuasiStatic.Polyphase.Sensors.CurrentQuasiRMSSensor currentQuasiRMSSensorQS(m=m)
     annotation (Placement(transformation(extent={{20,100},{40,80}})));
-  Modelica.Blocks.Sources.CombiTimeTable dutyCycle(table=[0,0; 1,1; 4,1; 5,0;
-        10,0; 11,-1; 14,-1; 15,0; 20,0], extrapolation=Modelica.Blocks.Types.Extrapolation.Periodic)
+  Modelica.Blocks.Sources.CombiTimeTable dutyCycle(
+    table=[0,0; 1,1; 4,1; 5,0; 10,0; 11,-1; 14,-1; 15,0; 20,0],
+    extrapolation=Modelica.Blocks.Types.Extrapolation.Periodic)
     annotation (Placement(transformation(extent={{-100,40},{-80,60}})));
   Utilities.VfController vfControllerQS(
     final m=m,

--- a/Modelica/Mechanics/MultiBody/Examples/Elementary/RollingWheelSetPulling.mo
+++ b/Modelica/Mechanics/MultiBody/Examples/Elementary/RollingWheelSetPulling.mo
@@ -28,11 +28,11 @@ model RollingWheelSetPulling "Rolling wheel set that is pulled by a force"
   Modelica.Mechanics.MultiBody.Parts.Body body(m=0.01, r_CM={0,0,0},
     animation=false)
     annotation (Placement(transformation(extent={{60,-10},{80,10}})));
-  Modelica.Blocks.Sources.CombiTimeTable combiTimeTable(table=[0,1,0,0; 1,1,
-        0,0; 2,0,2,0; 3,0,2,0])
+  Modelica.Blocks.Sources.CombiTimeTable combiTimeTable(
+    table=[0,1,0,0; 1,1,0,0; 2,0,2,0; 3,0,2,0])
     annotation (Placement(transformation(extent={{-20,30},{0,50}})));
   Modelica.Mechanics.MultiBody.Parts.FixedTranslation fixedTranslation(
-                       r={0.2,0,0},
+    r={0.2,0,0},
     animation=true,
     width=0.04)
     annotation (Placement(transformation(extent={{20,-10},{40,10}})));

--- a/Modelica/Thermal/FluidHeatFlow/Examples/TestCylinder.mo
+++ b/Modelica/Thermal/FluidHeatFlow/Examples/TestCylinder.mo
@@ -7,7 +7,8 @@ model TestCylinder "Two cylinder system"
   output Modelica.SIunits.Force f2=-cylinder2.f "Force on piston 2";
   output Modelica.SIunits.Force f=springDamper.f "Force of springDamper";
   Modelica.Blocks.Sources.CombiTimeTable combiTimeTable(
-    table=[0,0; 0.25,0; 0.25,-1; 0.5,-1; 0.5,0; 0.75,0])
+    table=[0,0; 0.25,-1; 0.5,0; 0.75,0],
+    smoothness=Modelica.Blocks.Types.Smoothness.ConstantSegments)
     annotation (Placement(transformation(extent={{-90,-10},{-70,10}})));
   Modelica.Mechanics.Translational.Sources.Force force
     annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));

--- a/Modelica/Thermal/HeatTransfer/Examples/Motor.mo
+++ b/Modelica/Thermal/HeatTransfer/Examples/Motor.mo
@@ -4,10 +4,10 @@ model Motor "Second order thermal model of a motor"
   parameter Modelica.SIunits.Temperature TAmb(displayUnit="degC") = 293.15
     "Ambient temperature";
 
-  Modelica.Blocks.Sources.CombiTimeTable lossTable(extrapolation=Modelica.
-        Blocks.Types.Extrapolation.Periodic, smoothness=Modelica.Blocks.
-        Types.Smoothness.ConstantSegments, table=[0,100,500; 360,1000,500;
-        600,100,500]) annotation (Placement(transformation(
+  Modelica.Blocks.Sources.CombiTimeTable lossTable(
+    extrapolation=Modelica.Blocks.Types.Extrapolation.Periodic,
+    smoothness=Modelica.Blocks.Types.Smoothness.ConstantSegments,
+    table=[0,100,500; 360,1000,500; 600,100,500]) annotation (Placement(transformation(
         origin={-40,70},
         extent={{-10,-10},{10,10}},
         rotation=270)));


### PR DESCRIPTION
Model stepped signals by constant interpolation of CombiTimeTable and avoid misuse of linear interpolation with duplicated sample points.

See #3115.