### PR TITLE
Feature/phase constants

### DIFF
--- a/Modelica/Electrical/Machines/BasicMachines/Components/PartialAirGap.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/Components/PartialAirGap.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Machines.BasicMachines.Components;
 partial model PartialAirGap "Partial airgap model"
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter Integer p(min=1) "Number of pole pairs";
   output SI.Torque tauElectrical;
   SI.Angle gamma "Rotor displacement angle";

--- a/Modelica/Electrical/Machines/BasicMachines/Components/PartialCore.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/Components/PartialCore.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Machines.BasicMachines.Components;
 partial model PartialCore
   "Partial model of transformer core with 3 windings"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter Real n12(start=1) "Turns ratio 1:2";
   parameter Real n13(start=1) "Turns ratio 1:3";
   SI.Voltage v1[m]=plug_p1.pin.v - plug_n1.pin.v;

--- a/Modelica/Electrical/Machines/Interfaces/InductionMachines/PartialThermalAmbientInductionMachines.mo
+++ b/Modelica/Electrical/Machines/Interfaces/InductionMachines/PartialThermalAmbientInductionMachines.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Machines.Interfaces.InductionMachines;
 model PartialThermalAmbientInductionMachines
   "Partial thermal ambient for induction machines"
-  parameter Integer m=3 "Number of stator phases";
+  parameter Integer m=3 "Number of stator phases" annotation(Evaluate=true);
   parameter Boolean useTemperatureInputs=false
     "If true, temperature inputs are used; else, temperatures are constant"
     annotation (Evaluate=true);

--- a/Modelica/Electrical/Machines/Interfaces/InductionMachines/PartialThermalPortInductionMachines.mo
+++ b/Modelica/Electrical/Machines/Interfaces/InductionMachines/PartialThermalPortInductionMachines.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Machines.Interfaces.InductionMachines;
 connector PartialThermalPortInductionMachines
   "Partial thermal port of induction machines"
-  parameter Integer m=3 "Number of stator phases";
+  parameter Integer m=3 "Number of stator phases" annotation(Evaluate=true);
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a
     heatPortStatorWinding[m] "Heat port of stator windings"
     annotation (Placement(transformation(extent={{-20,10},{0,30}})));

--- a/Modelica/Electrical/Machines/Interfaces/InductionMachines/ThermalPortIMS.mo
+++ b/Modelica/Electrical/Machines/Interfaces/InductionMachines/ThermalPortIMS.mo
@@ -3,7 +3,7 @@ connector ThermalPortIMS
   "Thermal port of induction machine with slipring"
   extends
     Machines.Interfaces.InductionMachines.PartialThermalPortInductionMachines;
-  parameter Integer mr=m "Number of rotor phases";
+  parameter Integer mr=m "Number of rotor phases" annotation(Evaluate=true);
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a
     heatPortRotorWinding[mr] "Heat port of rotor windings"
     annotation (Placement(transformation(extent={{-20,-30},{0,-10}})));

--- a/Modelica/Electrical/Machines/Interfaces/PartialBasicInductionMachine.mo
+++ b/Modelica/Electrical/Machines/Interfaces/PartialBasicInductionMachine.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Machines.Interfaces;
 partial model PartialBasicInductionMachine
   "Partial model for induction machine"
-  final parameter Integer m=3 "Number of phases";
+  final parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter Integer p(min=1, start=2) "Number of pole pairs (Integer)";
   parameter SI.Frequency fsNominal(start=50)
     "Nominal frequency";

--- a/Modelica/Electrical/Machines/Interfaces/PartialBasicTransformer.mo
+++ b/Modelica/Electrical/Machines/Interfaces/PartialBasicTransformer.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.Machines.Interfaces;
 partial model PartialBasicTransformer
   "Partial model of three-phase transformer"
   extends Machines.Icons.TransientTransformer;
-  final parameter Integer m(min=1) = 3 "Number of phases";
+  final parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   constant String VectorGroup="Yy00";
   parameter Real n(start=1)
     "Ratio primary voltage (line-to-line) / secondary voltage (line-to-line)";

--- a/Modelica/Electrical/Machines/Interfaces/ThermalPortTransformer.mo
+++ b/Modelica/Electrical/Machines/Interfaces/ThermalPortTransformer.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Machines.Interfaces;
 connector ThermalPortTransformer "Thermal port of transformers"
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort1[m]
     "Heat port of primary windings"
     annotation (Placement(transformation(extent={{-20,10},{0,30}})));

--- a/Modelica/Electrical/Machines/Losses/InductionMachines/Core.mo
+++ b/Modelica/Electrical/Machines/Losses/InductionMachines/Core.mo
@@ -3,7 +3,7 @@ model Core "Model of core losses"
   parameter Machines.Losses.CoreParameters coreParameters(m=3)
     "Core parameters";
   //for backwards compatibility present but unused
-  final parameter Integer m=coreParameters.m "Number of phases";
+  final parameter Integer m=coreParameters.m "Number of phases" annotation(Evaluate=true);
   parameter Real turnsRatio(final min=Modelica.Constants.small)
     "Effective number of stator turns / effective number of rotor turns (if used as rotor core)";
   extends

--- a/Modelica/Electrical/Machines/Losses/InductionMachines/PermanentMagnetLosses.mo
+++ b/Modelica/Electrical/Machines/Losses/InductionMachines/PermanentMagnetLosses.mo
@@ -3,7 +3,7 @@ model PermanentMagnetLosses
   "Model of permanent magnet losses dependent on current and speed"
   extends Machines.Interfaces.FlangeSupport;
   import Modelica.Electrical.Polyphase.Functions.quasiRMS;
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter Machines.Losses.PermanentMagnetLossParameters permanentMagnetLossParameters
     "Permanent magnet loss parameters";
   extends

--- a/Modelica/Electrical/Machines/Sensors/RotorDisplacementAngle.mo
+++ b/Modelica/Electrical/Machines/Sensors/RotorDisplacementAngle.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Machines.Sensors;
 model RotorDisplacementAngle "Rotor lagging angle"
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter Integer p(min=1) "Number of pole pairs";
   parameter Boolean positiveRange=false "Use only positive output range, if true";
   parameter Real threshold(final min=0)=0 "Below threshold the voltage is considered as zero";

--- a/Modelica/Electrical/Machines/SpacePhasors/Blocks/FromSpacePhasor.mo
+++ b/Modelica/Electrical/Machines/SpacePhasors/Blocks/FromSpacePhasor.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.Machines.SpacePhasors.Blocks;
 block FromSpacePhasor
   "Conversion of space phasors to polyphase instantaneous values"
   extends Modelica.Blocks.Interfaces.MIMO(final nin=2, final nout=m);
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
 protected
   parameter SI.Angle phi[m]=
       Modelica.Electrical.Polyphase.Functions.symmetricOrientation(m);

--- a/Modelica/Electrical/Machines/SpacePhasors/Blocks/ToSpacePhasor.mo
+++ b/Modelica/Electrical/Machines/SpacePhasors/Blocks/ToSpacePhasor.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.Machines.SpacePhasors.Blocks;
 block ToSpacePhasor
   "Conversion of polyphase instantaneous values to space phasors"
   extends Modelica.Blocks.Interfaces.MIMO(final nin=m, final nout=2);
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
 protected
   parameter SI.Angle phi[m]=
       Modelica.Electrical.Polyphase.Functions.symmetricOrientation(m);

--- a/Modelica/Electrical/Machines/SpacePhasors/Functions/ToSpacePhasor.mo
+++ b/Modelica/Electrical/Machines/SpacePhasors/Functions/ToSpacePhasor.mo
@@ -7,7 +7,7 @@ function ToSpacePhasor
   output Real y[2] "Space phasor";
   output Real y0 "Zero sequence component (of voltage or current)";
 protected
-  parameter Integer m=size(x, 1) "Number of phases";
+  parameter Integer m=size(x, 1) "Number of phases" annotation(Evaluate=true);
   parameter SI.Angle phi[m]=
       Modelica.Electrical.Polyphase.Functions.symmetricOrientation(m);
   parameter Real TransformationMatrix[2, m]=2/m*{+cos(+phi),+sin(+phi)};

--- a/Modelica/Electrical/Machines/Thermal/InductionMachines/ThermalAmbientIMS.mo
+++ b/Modelica/Electrical/Machines/Thermal/InductionMachines/ThermalAmbientIMS.mo
@@ -5,7 +5,7 @@ model ThermalAmbientIMS
     Machines.Interfaces.InductionMachines.PartialThermalAmbientInductionMachines(
       redeclare final Machines.Interfaces.InductionMachines.ThermalPortIMS
       thermalPort(final mr=mr));
-  parameter Integer mr=m "Number of rotor phases";
+  parameter Integer mr=m "Number of rotor phases" annotation(Evaluate=true);
   parameter SI.Temperature Tr(start=TDefault)
     "Temperature of rotor windings"
     annotation (Dialog(enable=not useTemperatureInputs));

--- a/Modelica/Electrical/Machines/Thermal/ThermalAmbientTransformer.mo
+++ b/Modelica/Electrical/Machines/Thermal/ThermalAmbientTransformer.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Machines.Thermal;
 model ThermalAmbientTransformer "Thermal ambient for transformers"
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter Boolean useTemperatureInputs=false
     "If true, temperature inputs are used; else, temperatures are constant"
     annotation (Evaluate=true);

--- a/Modelica/Electrical/Machines/Utilities/DQToThreePhase.mo
+++ b/Modelica/Electrical/Machines/Utilities/DQToThreePhase.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Machines.Utilities;
 model DQToThreePhase "Transforms dq to three-phase"
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter Integer p "Number of pole pairs";
   parameter Boolean useRMS=true "If true, inputs dq are multiplied by sqrt(2)";
   extends Modelica.Blocks.Interfaces.MO(final nout=m);

--- a/Modelica/Electrical/Machines/Utilities/FromDQ.mo
+++ b/Modelica/Electrical/Machines/Utilities/FromDQ.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.Machines.Utilities;
 block FromDQ
   "Transform rotor fixed space phasor to instantaneous stator quantities"
   extends Modelica.Blocks.Interfaces.MIMO(final nin=2, final nout=m);
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter Integer p "Number of pole pairs";
   Modelica.Blocks.Math.Gain toGamma(final k=-p) annotation (Placement(
         transformation(

--- a/Modelica/Electrical/Machines/Utilities/MultiTerminalBox.mo
+++ b/Modelica/Electrical/Machines/Utilities/MultiTerminalBox.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Machines.Utilities;
 model MultiTerminalBox "Terminal box Y/D-connection"
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   final parameter Integer mSystems=
       Modelica.Electrical.Polyphase.Functions.numberOfSymmetricBaseSystems(
       m) "Number of symmetric base systems";

--- a/Modelica/Electrical/Machines/Utilities/ParameterRecords/InductionMachineData.mo
+++ b/Modelica/Electrical/Machines/Utilities/ParameterRecords/InductionMachineData.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.Machines.Utilities.ParameterRecords;
 record InductionMachineData "Common parameters for induction machines"
   extends Modelica.Icons.Record;
   import Modelica.Constants.pi;
-  final parameter Integer m=3 "Number of phases";
+  final parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Inertia Jr=0.29 "Rotor's moment of inertia";
   parameter SI.Inertia Js=Jr "Stator's moment of inertia";
   parameter Integer p(min=1) = 2 "Number of pole pairs (Integer)";

--- a/Modelica/Electrical/Machines/Utilities/RampedRheostat.mo
+++ b/Modelica/Electrical/Machines/Utilities/RampedRheostat.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Machines.Utilities;
 model RampedRheostat "Rheostat with linearly decreasing resistance"
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   Modelica.Electrical.Polyphase.Interfaces.PositivePlug plug_p(final m=m)
     "To positive rotor plug" annotation (Placement(transformation(extent={{
             90,70},{110,50}})));

--- a/Modelica/Electrical/Machines/Utilities/SwitchYD.mo
+++ b/Modelica/Electrical/Machines/Utilities/SwitchYD.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Machines.Utilities;
 model SwitchYD "Y-D-switch"
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Resistance Ron=1e-5 "Closed switch resistance";
   parameter SI.Conductance Goff=1e-5 "Opened switch conductance";
   parameter SI.Time delayTime(final min=0)=0 "Time delay";

--- a/Modelica/Electrical/Machines/Utilities/SwitchYDwithArc.mo
+++ b/Modelica/Electrical/Machines/Utilities/SwitchYDwithArc.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Machines.Utilities;
 model SwitchYDwithArc "Y-D-switch with arc"
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Resistance Ron=1e-5 "Closed switch resistance";
   parameter SI.Conductance Goff=1e-5 "Opened switch conductance";
   parameter SI.Time delayTime(final min=0)=0 "Time delay";

--- a/Modelica/Electrical/Machines/Utilities/SwitchedRheostat.mo
+++ b/Modelica/Electrical/Machines/Utilities/SwitchedRheostat.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Machines.Utilities;
 model SwitchedRheostat "Rheostat which is shortened after a given time"
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   Modelica.Electrical.Polyphase.Interfaces.PositivePlug plug_p(final m=m)
     "To positive rotor plug" annotation (Placement(transformation(extent={{
             90,70},{110,50}})));

--- a/Modelica/Electrical/Machines/Utilities/TerminalBox.mo
+++ b/Modelica/Electrical/Machines/Utilities/TerminalBox.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Machines.Utilities;
 model TerminalBox "Terminal box Y/D-connection"
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter String terminalConnection(start="Y") "Choose \"Y\" for star or \"D\" for delta connection"
     annotation (choices(choice="Y" "Star connection", choice="D"
         "Delta connection"));

--- a/Modelica/Electrical/Machines/Utilities/ToDQ.mo
+++ b/Modelica/Electrical/Machines/Utilities/ToDQ.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.Machines.Utilities;
 block ToDQ
   "Transform instantaneous stator inputs to rotor fixed space phasor"
   extends Modelica.Blocks.Interfaces.MIMO(final nin=m, final nout=2);
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter Integer p "Number of pole pairs";
   Modelica.Blocks.Math.Gain toGamma(final k=p) annotation (Placement(
         transformation(

--- a/Modelica/Electrical/Machines/Utilities/VfController.mo
+++ b/Modelica/Electrical/Machines/Utilities/VfController.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.Machines.Utilities;
 block VfController "Voltage-Frequency-Controller"
   import Modelica.Constants.pi;
   extends Modelica.Blocks.Interfaces.SIMO(u(unit="Hz"), final nout=m);
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Angle orientation[m]=-
       Modelica.Electrical.Polyphase.Functions.symmetricOrientation(m)
     "Orientation of phases";

--- a/Modelica/Electrical/Polyphase/Basic/Delta.mo
+++ b/Modelica/Electrical/Polyphase/Basic/Delta.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Polyphase.Basic;
 model Delta "Delta (polygon) connection"
-  parameter Integer m(final min=2) = 3 "Number of phases";
+  parameter Integer m(final min=2) = 3 "Number of phases" annotation(Evaluate=true);
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(
         transformation(extent={{-110,-10},{-90,10}})));
   Interfaces.NegativePlug plug_n(final m=m) annotation (Placement(

--- a/Modelica/Electrical/Polyphase/Basic/MultiDelta.mo
+++ b/Modelica/Electrical/Polyphase/Basic/MultiDelta.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.Polyphase.Basic;
 model MultiDelta
   "Delta (polygon) connection of polyphase systems consisting of multiple base systems"
   import Modelica.Electrical.Polyphase.Functions.numberOfSymmetricBaseSystems;
-  parameter Integer m(final min=2) = 3 "Number of phases";
+  parameter Integer m(final min=2) = 3 "Number of phases" annotation(Evaluate=true);
   parameter Integer kPolygon(final min=1)=1 "Alternative of polygon";
   final parameter Integer mSystems=numberOfSymmetricBaseSystems(m) "Number of base systems";
   final parameter Integer mBasic=integer(m/mSystems) "Phase number of base systems";

--- a/Modelica/Electrical/Polyphase/Basic/MultiStar.mo
+++ b/Modelica/Electrical/Polyphase/Basic/MultiStar.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.Polyphase.Basic;
 model MultiStar
   "Star connection of polyphase systems consisting of multiple base systems"
   import Modelica.Electrical.Polyphase.Functions.numberOfSymmetricBaseSystems;
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   final parameter Integer mSystems=numberOfSymmetricBaseSystems(m) "Number of base systems";
   final parameter Integer mBasic=integer(m/mSystems) "Phase number of base systems";
   Polyphase.Interfaces.PositivePlug plug_p(final m=m)

--- a/Modelica/Electrical/Polyphase/Basic/MultiStarResistance.mo
+++ b/Modelica/Electrical/Polyphase/Basic/MultiStarResistance.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Polyphase.Basic;
 model MultiStarResistance "Resistance connection of star points"
   import Modelica.Electrical.Polyphase.Functions.numberOfSymmetricBaseSystems;
-  parameter Integer m(final min=2) = 3 "Number of phases";
+  parameter Integer m(final min=2) = 3 "Number of phases" annotation(Evaluate=true);
   final parameter Integer mBasic=numberOfSymmetricBaseSystems(m) "Number of symmetric base systems";
   parameter SI.Resistance R=1e6 "Insulation resistance between base systems";
   Polyphase.Interfaces.PositivePlug plug(m=m)

--- a/Modelica/Electrical/Polyphase/Basic/PlugToPin_n.mo
+++ b/Modelica/Electrical/Polyphase/Basic/PlugToPin_n.mo
@@ -1,10 +1,10 @@
 within Modelica.Electrical.Polyphase.Basic;
 model PlugToPin_n "Connect one (negative) Pin"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter Integer k(
     final min=1,
     final max=m,
-    start=1) "Phase index";
+    start=1) "Phase index" annotation(Evaluate=true);
   Interfaces.NegativePlug plug_n(final m=m) annotation (Placement(
         transformation(extent={{-30,-10},{-10,10}})));
   Modelica.Electrical.Analog.Interfaces.NegativePin pin_n annotation (

--- a/Modelica/Electrical/Polyphase/Basic/PlugToPin_p.mo
+++ b/Modelica/Electrical/Polyphase/Basic/PlugToPin_p.mo
@@ -1,10 +1,10 @@
 within Modelica.Electrical.Polyphase.Basic;
 model PlugToPin_p "Connect one (positive) Pin"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter Integer k(
     final min=1,
     final max=m,
-    start=1) "Phase index";
+    start=1) "Phase index" annotation(Evaluate=true);
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(
         transformation(extent={{-30,-10},{-10,10}})));
   Modelica.Electrical.Analog.Interfaces.PositivePin pin_p annotation (

--- a/Modelica/Electrical/Polyphase/Basic/PlugToPins_n.mo
+++ b/Modelica/Electrical/Polyphase/Basic/PlugToPins_n.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Polyphase.Basic;
 model PlugToPins_n "Connect all (negative) Pins"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Interfaces.NegativePlug plug_n(final m=m) annotation (Placement(
         transformation(extent={{-30,-10},{-10,10}})));
   Modelica.Electrical.Analog.Interfaces.NegativePin pin_n[m] annotation (

--- a/Modelica/Electrical/Polyphase/Basic/PlugToPins_p.mo
+++ b/Modelica/Electrical/Polyphase/Basic/PlugToPins_p.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Polyphase.Basic;
 model PlugToPins_p "Connect all (positive) Pins"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(
         transformation(extent={{-30,-10},{-10,10}})));
   Modelica.Electrical.Analog.Interfaces.PositivePin pin_p[m] annotation (

--- a/Modelica/Electrical/Polyphase/Basic/SplitToSubsystems.mo
+++ b/Modelica/Electrical/Polyphase/Basic/SplitToSubsystems.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Polyphase.Basic;
 model SplitToSubsystems "Split m phases to subsystems"
   import Modelica.Electrical.Polyphase.Functions.numberOfSymmetricBaseSystems;
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   final parameter Integer mSystems=numberOfSymmetricBaseSystems(m)
     "Number of base systems";
   final parameter Integer mBasic=integer(m/mSystems)

--- a/Modelica/Electrical/Polyphase/Basic/Star.mo
+++ b/Modelica/Electrical/Polyphase/Basic/Star.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Polyphase.Basic;
 model Star "Star-connection"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(
         transformation(extent={{-110,-10},{-90,10}})));
   Modelica.Electrical.Analog.Interfaces.NegativePin pin_n annotation (

--- a/Modelica/Electrical/Polyphase/Blocks/QuasiRMS.mo
+++ b/Modelica/Electrical/Polyphase/Blocks/QuasiRMS.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Polyphase.Blocks;
 block QuasiRMS
   extends Modelica.Blocks.Interfaces.SO;
-  parameter Integer m(min=2) = 3 "Number of phases";
+  parameter Integer m(min=2) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.Blocks.Interfaces.RealInput u[m]
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
 equation

--- a/Modelica/Electrical/Polyphase/Examples/Rectifier.mo
+++ b/Modelica/Electrical/Polyphase/Examples/Rectifier.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.Polyphase.Examples;
 model Rectifier "Test example with polyphase components"
   extends Modelica.Icons.Example;
   import Modelica.Electrical.Polyphase.Functions.factorY2DC;
-  final parameter Integer m=3 "Number of phases";
+  final parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage V=100 "RMS of Star-Voltage";
   parameter SI.Frequency f=50 "Frequency";
   parameter SI.Inductance L=0.0001 "Line Inductance";

--- a/Modelica/Electrical/Polyphase/Examples/TransformerYD.mo
+++ b/Modelica/Electrical/Polyphase/Examples/TransformerYD.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Polyphase.Examples;
 model TransformerYD "Test example with polyphase components"
   extends Modelica.Icons.Example;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage V=1 "Amplitude of Star-Voltage";
   parameter SI.Frequency f=5 "Frequency";
   parameter SI.Inductance Lm=1 "Transformer main inductance";

--- a/Modelica/Electrical/Polyphase/Examples/TransformerYY.mo
+++ b/Modelica/Electrical/Polyphase/Examples/TransformerYY.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Polyphase.Examples;
 model TransformerYY "Test example with polyphase components"
   extends Modelica.Icons.Example;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage V=1 "Amplitude of Star-Voltage";
   parameter SI.Frequency f=5 "Frequency";
   parameter SI.Inductance Lm=1 "Transformer main inductance";

--- a/Modelica/Electrical/Polyphase/Examples/Utilities/PolyphaseRectifierData.mo
+++ b/Modelica/Electrical/Polyphase/Examples/Utilities/PolyphaseRectifierData.mo
@@ -3,7 +3,7 @@ record PolyphaseRectifierData "Data record for polyphase rectifier"
   extends Icons.Record;
   import Modelica.Electrical.Polyphase.Functions.numberOfSymmetricBaseSystems;
   import Modelica.Math.isPowerOf2;
-  parameter Integer m(final min=2)=6 "Number of phases";
+  parameter Integer m(final min=2)=6 "Number of phases" annotation(Evaluate=true);
   parameter Integer mSystems=numberOfSymmetricBaseSystems(m)
     "Number of base systems"
     annotation(Dialog(enable=false));

--- a/Modelica/Electrical/Polyphase/Ideal/IdealCommutingSwitch.mo
+++ b/Modelica/Electrical/Polyphase/Ideal/IdealCommutingSwitch.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Polyphase.Ideal;
 model IdealCommutingSwitch "Polyphase ideal commuting switch"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Resistance Ron[m](final min=zeros(m), start=
         fill(1e-5, m)) "Closed switch resistance";
   parameter SI.Conductance Goff[m](final min=zeros(m), start=

--- a/Modelica/Electrical/Polyphase/Ideal/IdealIntermediateSwitch.mo
+++ b/Modelica/Electrical/Polyphase/Ideal/IdealIntermediateSwitch.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Polyphase.Ideal;
 model IdealIntermediateSwitch "Polyphase ideal intermediate switch"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Resistance Ron[m](final min=zeros(m), start=
         fill(1e-5, m)) "Closed switch resistance";
   parameter SI.Conductance Goff[m](final min=zeros(m), start=

--- a/Modelica/Electrical/Polyphase/Interfaces/FourPlug.mo
+++ b/Modelica/Electrical/Polyphase/Interfaces/FourPlug.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Polyphase.Interfaces;
 partial model FourPlug "Component with two polyphase electrical ports"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   SI.Voltage v1[m] "Voltage drops of port 1";
   SI.Voltage v2[m] "Voltage drops of port 2";
   SI.Current i1[m]

--- a/Modelica/Electrical/Polyphase/Interfaces/Plug.mo
+++ b/Modelica/Electrical/Polyphase/Interfaces/Plug.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Polyphase.Interfaces;
 connector Plug "Polyphase electrical plug with m pins"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.Electrical.Analog.Interfaces.Pin pin[m] "Pins of the plug";
 
   annotation (Documentation(info="<html>

--- a/Modelica/Electrical/Polyphase/Interfaces/TwoPlug.mo
+++ b/Modelica/Electrical/Polyphase/Interfaces/TwoPlug.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Polyphase.Interfaces;
 partial model TwoPlug "Component with one polyphase electrical port"
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   SI.Voltage v[m] "Voltage drops of the two polyphase plugs";
   SI.Current i[m] "Currents flowing into positive polyphase plugs";
   PositivePlug plug_p(final m=m) "Positive polyphase electrical plug with m pins" annotation (Placement(transformation(

--- a/Modelica/Electrical/Polyphase/Sensors/AronSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/AronSensor.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Polyphase.Sensors;
 model AronSensor "Three-phase Aron sensor for active power"
   extends Modelica.Icons.RoundSensor;
-  final parameter Integer m(final min=1) = 3 "Number of phases";
+  final parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(
         transformation(extent={{-110,-10},{-90,10}})));
   Interfaces.NegativePlug plug_n(final m=m) annotation (Placement(

--- a/Modelica/Electrical/Polyphase/Sensors/CurrentQuasiRMSSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/CurrentQuasiRMSSensor.mo
@@ -3,7 +3,7 @@ model CurrentQuasiRMSSensor
   "Continuous quasi current RMS sensor for polyphase system"
   extends Modelica.Icons.RoundSensor;
   extends Polyphase.Interfaces.TwoPlug;
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.Blocks.Interfaces.RealOutput I(unit="A")
     "Continuous quasi average RMS of current" annotation (Placement(
         transformation(

--- a/Modelica/Electrical/Polyphase/Sensors/CurrentSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/CurrentSensor.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Polyphase.Sensors;
 model CurrentSensor "Polyphase current sensor"
   extends Modelica.Icons.RoundSensor;
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(
         transformation(extent={{-110,-10},{-90,10}})));
   Interfaces.NegativePlug plug_n(final m=m) annotation (Placement(

--- a/Modelica/Electrical/Polyphase/Sensors/MultiSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/MultiSensor.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Polyphase.Sensors;
 model MultiSensor "Polyphase sensor to measure current, voltage and power"
   extends Modelica.Icons.RoundSensor;
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Polyphase.Interfaces.PositivePlug pc(final m=m) "Positive plug, current path"
     annotation (Placement(transformation(extent={{-90,-10},{-110,10}})));
   Polyphase.Interfaces.NegativePlug nc(final m=m) "Negative plug, current path"

--- a/Modelica/Electrical/Polyphase/Sensors/PotentialSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/PotentialSensor.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Polyphase.Sensors;
 model PotentialSensor "Polyphase potential sensor"
   extends Modelica.Icons.RoundSensor;
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(
         transformation(extent={{-110,-10},{-90,10}})));
   Modelica.Blocks.Interfaces.RealOutput phi[m](each unit="V")

--- a/Modelica/Electrical/Polyphase/Sensors/PowerSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/PowerSensor.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Polyphase.Sensors;
 model PowerSensor "Polyphase instantaneous power sensor"
   extends Modelica.Icons.RoundSensor;
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Polyphase.Interfaces.PositivePlug pc(final m=m) "Positive plug, current path"
     annotation (Placement(transformation(extent={{-110,10},{-90,-10}})));
   Polyphase.Interfaces.NegativePlug nc(final m=m) "Negative plug, current path"

--- a/Modelica/Electrical/Polyphase/Sensors/ReactivePowerSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/ReactivePowerSensor.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Polyphase.Sensors;
 model ReactivePowerSensor "Three-phase sensor for reactive power"
   extends Modelica.Icons.RoundSensor;
-  final parameter Integer m(final min=1) = 3 "Number of phases";
+  final parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(
         transformation(extent={{-110,-10},{-90,10}})));
   Interfaces.NegativePlug plug_n(final m=m) annotation (Placement(

--- a/Modelica/Electrical/Polyphase/Sensors/VoltageQuasiRMSSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/VoltageQuasiRMSSensor.mo
@@ -3,7 +3,7 @@ model VoltageQuasiRMSSensor
   "Continuous quasi voltage RMS sensor for polyphase system"
   extends Modelica.Icons.RoundSensor;
   extends Polyphase.Interfaces.TwoPlug;
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
 
   Modelica.Blocks.Interfaces.RealOutput V(unit="V") "Continuous quasi RMS of voltage"
     annotation (Placement(transformation(

--- a/Modelica/Electrical/Polyphase/Sensors/VoltageSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/VoltageSensor.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Polyphase.Sensors;
 model VoltageSensor "Polyphase voltage sensor"
   extends Modelica.Icons.RoundSensor;
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(
         transformation(extent={{-110,-10},{-90,10}})));
   Interfaces.NegativePlug plug_n(final m=m) annotation (Placement(

--- a/Modelica/Electrical/Polyphase/Sources/SignalCurrent.mo
+++ b/Modelica/Electrical/Polyphase/Sources/SignalCurrent.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Polyphase.Sources;
 model SignalCurrent "Polyphase signal current source"
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   SI.Voltage v[m]=plug_p.pin.v - plug_n.pin.v
     "Voltage drops between the two plugs";
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(

--- a/Modelica/Electrical/Polyphase/Sources/SignalVoltage.mo
+++ b/Modelica/Electrical/Polyphase/Sources/SignalVoltage.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Polyphase.Sources;
 model SignalVoltage "Polyphase signal voltage source"
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   SI.Current i[m]=plug_p.pin.i
     "Currents flowing into positive plugs";
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(

--- a/Modelica/Electrical/PowerConverters/ACDC/Control/Signal2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/Control/Signal2mPulse.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.PowerConverters.ACDC.Control;
 block Signal2mPulse "Generic control of 2*m pulse rectifiers"
   import Modelica.Constants.pi;
   extends PowerConverters.Icons.Control;
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter Boolean useConstantFiringAngle=true
     "Use constant firing angle instead of signal input";
   parameter SI.Angle constantFiringAngle=0 "Firing angle"

--- a/Modelica/Electrical/PowerConverters/ACDC/Control/VoltageBridge2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/Control/VoltageBridge2mPulse.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.PowerConverters.ACDC.Control;
 model VoltageBridge2mPulse "Control of 2*m pulse bridge rectifier"
   import Modelica.Constants.pi;
   extends Icons.Control;
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Frequency f=50 "Frequency";
   parameter Boolean useConstantFiringAngle=true
     "Use constant firing angle instead of signal input";

--- a/Modelica/Electrical/PowerConverters/ACDC/Control/VoltageCenterTap2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/Control/VoltageCenterTap2mPulse.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.PowerConverters.ACDC.Control;
 model VoltageCenterTap2mPulse "Control of 2*m pulse center tap rectifier"
   extends Icons.Control;
   import Modelica.Constants.pi;
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Frequency f=50 "Frequency";
   parameter Boolean useConstantFiringAngle=true
     "Use constant firing angle instead of signal input";

--- a/Modelica/Electrical/PowerConverters/ACDC/DiodeBridge2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/DiodeBridge2mPulse.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.PowerConverters.ACDC;
 model DiodeBridge2mPulse "2*m pulse diode rectifier bridge"
   extends Icons.Converter;
   import Modelica.Constants.pi;
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Resistance RonDiode(final min=0) = 1e-05
     "Closed diode resistance";
   parameter SI.Conductance GoffDiode(final min=0) = 1e-05

--- a/Modelica/Electrical/PowerConverters/ACDC/DiodeCenterTap2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/DiodeCenterTap2mPulse.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.PowerConverters.ACDC;
 model DiodeCenterTap2mPulse "2*m pulse diode rectifier with center tap"
   extends Icons.Converter;
   import Modelica.Constants.pi;
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Resistance RonDiode(final min=0) = 1e-05
     "Closed diode resistance";
   parameter SI.Conductance GoffDiode(final min=0) = 1e-05

--- a/Modelica/Electrical/PowerConverters/ACDC/DiodeCenterTapmPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/DiodeCenterTapmPulse.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.PowerConverters.ACDC;
 model DiodeCenterTapmPulse "m pulse diode rectifier with center tap"
   import Modelica.Constants.pi;
   extends Icons.Converter;
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Resistance RonDiode(final min=0) = 1e-05
     "Closed diode resistance";
   parameter SI.Conductance GoffDiode(final min=0) = 1e-05

--- a/Modelica/Electrical/PowerConverters/ACDC/HalfControlledBridge2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/HalfControlledBridge2mPulse.mo
@@ -3,7 +3,7 @@ model HalfControlledBridge2mPulse
   "2*m pulse half controlled rectifier bridge"
   extends Icons.Converter;
   import Modelica.Constants.pi;
-  // parameter Integer m(final min=3) = 3 "Number of phases";
+  // parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Resistance RonDiode(final min=0) = 1e-05
     "Closed diode resistance";
   parameter SI.Conductance GoffDiode(final min=0) = 1e-05

--- a/Modelica/Electrical/PowerConverters/ACDC/ThyristorBridge2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/ThyristorBridge2mPulse.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.PowerConverters.ACDC;
 model ThyristorBridge2mPulse "2*m pulse thyristor rectifier bridge"
   extends Icons.Converter;
   import Modelica.Constants.pi;
-  // parameter Integer m(final min=3) = 3 "Number of phases";
+  // parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Resistance RonThyristor(final min=0) = 1e-05
     "Closed thyristor resistance";
   parameter SI.Conductance GoffThyristor(final min=0) = 1e-05

--- a/Modelica/Electrical/PowerConverters/ACDC/ThyristorCenterTap2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/ThyristorCenterTap2mPulse.mo
@@ -3,7 +3,7 @@ model ThyristorCenterTap2mPulse
   "2*m pulse thyristor rectifier with center tap"
   extends Icons.Converter;
   import Modelica.Constants.pi;
-  // parameter Integer m(final min=3) = 3 "Number of phases";
+  // parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Resistance RonThyristor(final min=0) = 1e-05
     "Closed thyristor resistance";
   parameter SI.Conductance GoffThyristor(final min=0) = 1e-05

--- a/Modelica/Electrical/PowerConverters/ACDC/ThyristorCenterTapmPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/ThyristorCenterTapmPulse.mo
@@ -3,7 +3,7 @@ model ThyristorCenterTapmPulse
   "m pulse thyristor rectifier with center tap"
   extends Icons.Converter;
   import Modelica.Constants.pi;
-  // parameter Integer m(final min=3) = 3 "Number of phases";
+  // parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Resistance RonThyristor(final min=0) = 1e-05
     "Closed thyristor resistance";
   parameter SI.Conductance GoffThyristor(final min=0) = 1e-05

--- a/Modelica/Electrical/PowerConverters/Enable/EnableLogic.mo
+++ b/Modelica/Electrical/PowerConverters/Enable/EnableLogic.mo
@@ -6,7 +6,7 @@ model EnableLogic
   parameter Boolean constantEnable=true
     "Constant enabling of firing signals"
     annotation (Dialog(enable=useConstantEnable));
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.Blocks.Sources.BooleanConstant enableConstantSource(final k=
         constantEnable) if useConstantEnable
     "Constant enable signal of fire and notFire" annotation (Placement(

--- a/Modelica/Electrical/PowerConverters/Examples/ACDC/ExampleTemplates/ThyristorBridge2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/ACDC/ExampleTemplates/ThyristorBridge2mPulse.mo
@@ -3,7 +3,7 @@ partial model ThyristorBridge2mPulse
   "Template of 2*m pulse bridge thyristor rectifier"
   extends Icons.ExampleTemplate;
   import Modelica.Constants.pi;
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage Vrms=110 "RMS supply voltage";
   parameter SI.Frequency f=50 "Frequency";
 

--- a/Modelica/Electrical/PowerConverters/Examples/ACDC/ExampleTemplates/ThyristorCenterTap2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/ACDC/ExampleTemplates/ThyristorCenterTap2mPulse.mo
@@ -3,7 +3,7 @@ partial model ThyristorCenterTap2mPulse
   "Template of 2*m pulse thyristor rectifier with center tap"
   extends Icons.ExampleTemplate;
   import Modelica.Constants.pi;
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage Vrms=110 "RMS supply voltage";
   parameter SI.Frequency f=50 "Frequency";
 

--- a/Modelica/Electrical/PowerConverters/Examples/ACDC/ExampleTemplates/ThyristorCenterTapmPulse.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/ACDC/ExampleTemplates/ThyristorCenterTapmPulse.mo
@@ -3,7 +3,7 @@ partial model ThyristorCenterTapmPulse
   "Template of 2*m pulse rectifier with center tap"
   extends Icons.ExampleTemplate;
   import Modelica.Constants.pi;
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage Vrms=110 "RMS supply voltage";
   parameter SI.Frequency f=50 "Frequency";
 

--- a/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierBridge2mPulse/DiodeBridge2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierBridge2mPulse/DiodeBridge2mPulse.mo
@@ -3,7 +3,7 @@ model DiodeBridge2mPulse
   "2*m pulse diode rectifier bridge with resistive load"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage Vrms=110 "RMS supply voltage";
   parameter SI.Frequency f=50 "Frequency";
   parameter SI.Resistance R=20 "Load resistance";

--- a/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierBridge2mPulse/HalfControlledBridge2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierBridge2mPulse/HalfControlledBridge2mPulse.mo
@@ -3,7 +3,7 @@ model HalfControlledBridge2mPulse
   "2*m pulse half controlled rectifier bridge with resistive load"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage Vrms=110 "RMS supply voltage";
   parameter SI.Frequency f=50 "Frequency";
   parameter SI.Angle constantFiringAngle=30*pi/180

--- a/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierBridge2mPulse/ThyristorBridge2mPulse_DC_Drive.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierBridge2mPulse/ThyristorBridge2mPulse_DC_Drive.mo
@@ -3,7 +3,7 @@ model ThyristorBridge2mPulse_DC_Drive
   "2*m pulse thyristor bridge feeding a DC drive"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage Vrms=dcpmData.VaNominal/
       Modelica.Electrical.Polyphase.Functions.factorY2DC(m)
     "RMS supply voltage";

--- a/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierCenterTap2mPulse/DiodeCenterTap2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierCenterTap2mPulse/DiodeCenterTap2mPulse.mo
@@ -3,7 +3,7 @@ model DiodeCenterTap2mPulse
   "2*m pulse diode center tap rectifier with resistive load"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage Vrms=110 "RMS supply voltage";
   parameter SI.Frequency f=50 "Frequency";
   parameter SI.Resistance R=20 "Load resistance";

--- a/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierCenterTapmPulse/DiodeCenterTapmPulse.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierCenterTapmPulse/DiodeCenterTapmPulse.mo
@@ -3,7 +3,7 @@ model DiodeCenterTapmPulse
   "2*m pulse diode rectifier with center tap with resistive load"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage Vrms=110 "RMS supply voltage";
   parameter SI.Frequency f=50 "Frequency";
   parameter SI.Resistance R=20 "Load resistance";

--- a/Modelica/Electrical/PowerConverters/Examples/DCAC/PolyphaseTwoLevel/PolyphaseTwoLevel_R.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCAC/PolyphaseTwoLevel/PolyphaseTwoLevel_R.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.PowerConverters.Examples.DCAC.PolyphaseTwoLevel;
 model PolyphaseTwoLevel_R "Polyphase DC to AC converter with R load"
   extends Modelica.Icons.Example;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Frequency f=1000 "Switching frequency";
   parameter SI.Frequency f1=50
     "Fundamental wave AC frequency";

--- a/Modelica/Electrical/PowerConverters/Examples/DCAC/PolyphaseTwoLevel/PolyphaseTwoLevel_RL.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCAC/PolyphaseTwoLevel/PolyphaseTwoLevel_RL.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.PowerConverters.Examples.DCAC.PolyphaseTwoLevel;
 model PolyphaseTwoLevel_RL
   "Polyphase DC to AC converter with R-L load"
   extends Modelica.Icons.Example;
-  parameter Integer m=6 "Number of phases";
+  parameter Integer m=6 "Number of phases" annotation(Evaluate=true);
   parameter SI.Frequency f=1000 "Switching frequency";
   parameter SI.Frequency f1=50
     "Fundamental wave AC frequency";

--- a/Modelica/Electrical/PowerConverters/Interfaces/ACDC/ACplug.mo
+++ b/Modelica/Electrical/PowerConverters/Interfaces/ACDC/ACplug.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.PowerConverters.Interfaces.ACDC;
 partial model ACplug "AC polyphase plug"
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.Electrical.Polyphase.Interfaces.PositivePlug ac(final m=m)
     "AC input"
     annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));

--- a/Modelica/Electrical/PowerConverters/Interfaces/ACDC/ACtwoPlug.mo
+++ b/Modelica/Electrical/PowerConverters/Interfaces/ACDC/ACtwoPlug.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.PowerConverters.Interfaces.ACDC;
 partial model ACtwoPlug "Two AC polyphase plugs"
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.Electrical.Polyphase.Interfaces.PositivePlug ac_p(final m=m)
     "Positive potential AC input"
     annotation (Placement(transformation(extent={{-110,50},{-90,70}})));

--- a/Modelica/Electrical/PowerConverters/Interfaces/DCAC/ACplug.mo
+++ b/Modelica/Electrical/PowerConverters/Interfaces/DCAC/ACplug.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.PowerConverters.Interfaces.DCAC;
 partial model ACplug "AC polyphase plug"
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.Electrical.Polyphase.Interfaces.PositivePlug ac(final m=m)
     "AC output"
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));

--- a/Modelica/Electrical/PowerConverters/Interfaces/Enable/Enable.mo
+++ b/Modelica/Electrical/PowerConverters/Interfaces/Enable/Enable.mo
@@ -7,7 +7,7 @@ partial model Enable
   parameter Boolean constantEnable=true
     "Constant enabling of firing signals"
     annotation (Dialog(tab="Enable", enable=useConstantEnable));
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   PowerConverters.Enable.EnableLogic enableLogic(
     final useConstantEnable=useConstantEnable,
     final constantEnable=constantEnable,

--- a/Modelica/Electrical/PowerConverters/Interfaces/Enable/Enable1m.mo
+++ b/Modelica/Electrical/PowerConverters/Interfaces/Enable/Enable1m.mo
@@ -7,7 +7,7 @@ partial model Enable1m
   parameter Boolean constantEnable=true
     "Constant enabling of firing signals"
     annotation (Dialog(tab="Enable", enable=useConstantEnable));
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.Blocks.Logical.And andCondition_p[m]
     "And condition for m positive firing signals" annotation (Placement(
         transformation(

--- a/Modelica/Electrical/QuasiStatic/Machines/BasicMachines/Components/PartialCore.mo
+++ b/Modelica/Electrical/QuasiStatic/Machines/BasicMachines/Components/PartialCore.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.QuasiStatic.Machines.BasicMachines.Components;
 partial model PartialCore
   "Partial model of transformer core with 3 windings"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter Real n12(start=1) "Turns ratio 1:2";
   parameter Real n13(start=1) "Turns ratio 1:3";
   SI.ComplexVoltage v1[m];

--- a/Modelica/Electrical/QuasiStatic/Machines/Examples/TransformerTestbench.mo
+++ b/Modelica/Electrical/QuasiStatic/Machines/Examples/TransformerTestbench.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.QuasiStatic.Machines.Examples;
 model TransformerTestbench "Transformer test bench"
   extends Modelica.Icons.Example;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Resistance RL[m]=fill(1/3, m)
     "Load resistance";
   output SI.Voltage VS=polarVS.len "Grid voltage";

--- a/Modelica/Electrical/QuasiStatic/Machines/SpacePhasors/Blocks/FromSpacePhasor.mo
+++ b/Modelica/Electrical/QuasiStatic/Machines/SpacePhasors/Blocks/FromSpacePhasor.mo
@@ -3,7 +3,7 @@ block FromSpacePhasor "Conversion: space phasor -> three-phase"
   extends Modelica.Blocks.Icons.Block;
   import Modelica.ComplexMath.j;
   import Modelica.ComplexMath.exp;
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.Blocks.Interfaces.RealInput u[2]
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Modelica.ComplexBlocks.Interfaces.ComplexOutput y[m]

--- a/Modelica/Electrical/QuasiStatic/Machines/SpacePhasors/Blocks/ToSpacePhasor.mo
+++ b/Modelica/Electrical/QuasiStatic/Machines/SpacePhasors/Blocks/ToSpacePhasor.mo
@@ -4,7 +4,7 @@ block ToSpacePhasor "Conversion: three-phase -> space phasor"
   import Modelica.ComplexMath.j;
   import Modelica.ComplexMath.exp;
   import Modelica.ComplexMath.sum;
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.ComplexBlocks.Interfaces.ComplexInput u[m]
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Modelica.Blocks.Interfaces.RealOutput y[2]

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/Delta.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/Delta.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Basic;
 model Delta "Delta (polygon) connection"
-  parameter Integer m(final min=2) = 3 "Number of phases";
+  parameter Integer m(final min=2) = 3 "Number of phases" annotation(Evaluate=true);
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(
         transformation(extent={{-110,-10},{-90,10}})));
   Interfaces.NegativePlug plug_n(final m=m) annotation (Placement(

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/MultiDelta.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/MultiDelta.mo
@@ -3,7 +3,7 @@ model MultiDelta
   "Delta (polygon) connection of polyphase systems consisting of multiple base systems"
   import Modelica.Electrical.Polyphase.Functions.numberOfSymmetricBaseSystems;
   import Modelica.Utilities.Streams.print;
-  parameter Integer m(final min=2) = 3 "Number of phases";
+  parameter Integer m(final min=2) = 3 "Number of phases" annotation(Evaluate=true);
   parameter Integer kPolygon=1 "Alternative of polygon";
   final parameter Integer mSystems=numberOfSymmetricBaseSystems(m) "Number of base systems";
   final parameter Integer mBasic=integer(m/mSystems) "Phase number of base systems";

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/MultiStar.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/MultiStar.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.QuasiStatic.Polyphase.Basic;
 model MultiStar
   "Star connection of polyphase systems consisting of multiple base systems"
   import Modelica.Electrical.Polyphase.Functions.numberOfSymmetricBaseSystems;
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   final parameter Integer mSystems=numberOfSymmetricBaseSystems(m) "Number of base systems";
   final parameter Integer mBasic=integer(m/mSystems) "Phase number of base systems";
   QuasiStatic.Polyphase.Interfaces.PositivePlug plug_p(final m=m)

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/MultiStarResistance.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/MultiStarResistance.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Basic;
 model MultiStarResistance "Resistance connection of star points"
-  parameter Integer m(final min=3) = 3 "Number of phases";
+  parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
   final parameter Integer mBasic=
       Modelica.Electrical.Polyphase.Functions.numberOfSymmetricBaseSystems(
       m) "Number of symmetric base systems";

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/PlugToPin_n.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/PlugToPin_n.mo
@@ -1,9 +1,9 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Basic;
 model PlugToPin_n "Connect one (negative) pin"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter Integer k(
     final min=1,
-    final max=m) = 1 "Phase index";
+    final max=m) = 1 "Phase index" annotation(Evaluate=true);
   Interfaces.NegativePlug plug_n(final m=m) annotation (Placement(
         transformation(extent={{-30,-10},{-10,10}})));
   QuasiStatic.SinglePhase.Interfaces.NegativePin pin_n

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/PlugToPin_p.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/PlugToPin_p.mo
@@ -1,9 +1,9 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Basic;
 model PlugToPin_p "Connect one (positive) pin"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter Integer k(
     final min=1,
-    final max=m) = 1 "Phase index";
+    final max=m) = 1 "Phase index" annotation(Evaluate=true);
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(
         transformation(extent={{-30,-10},{-10,10}})));
   QuasiStatic.SinglePhase.Interfaces.PositivePin pin_p

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/PlugToPins_n.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/PlugToPins_n.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Basic;
 model PlugToPins_n "Connect all (negative) pins"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Interfaces.NegativePlug plug_n(final m=m) annotation (Placement(
         transformation(extent={{-30,-10},{-10,10}})));
   QuasiStatic.SinglePhase.Interfaces.NegativePin pin_n[m]

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/PlugToPins_p.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/PlugToPins_p.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Basic;
 model PlugToPins_p "Connect all (positive) pins"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(
         transformation(extent={{-30,-10},{-10,10}})));
   QuasiStatic.SinglePhase.Interfaces.PositivePin pin_p[m]

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/Star.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/Star.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Basic;
 model Star "Star connection"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(
         transformation(extent={{-110,-10},{-90,10}})));
   QuasiStatic.SinglePhase.Interfaces.NegativePin pin_n

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Blocks/FromSpacePhasor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Blocks/FromSpacePhasor.mo
@@ -3,7 +3,7 @@ block FromSpacePhasor "Conversion: space phasor -> m phase"
   extends Modelica.Blocks.Icons.Block;
   import Modelica.ComplexMath.j;
   import Modelica.ComplexMath.exp;
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.Blocks.Interfaces.RealInput u[2]
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Modelica.ComplexBlocks.Interfaces.ComplexOutput y[m]

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Blocks/FromSymmetricalComponents.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Blocks/FromSymmetricalComponents.mo
@@ -4,7 +4,7 @@ block FromSymmetricalComponents
   extends Modelica.ComplexBlocks.Interfaces.ComplexMIMOs(final n=m,final useConjugateInput=fill(false,m));
   import Modelica.ComplexMath.abs;
   import Modelica.ComplexMath.arg;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   output Real abs_u[m] = abs(u) "Absolute of input";
   output SI.Angle arg_u[m](displayUnit="deg") = arg(u)
     "Argument of input";

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Blocks/QuasiRMS.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Blocks/QuasiRMS.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Blocks;
 block QuasiRMS
   extends Modelica.Blocks.Interfaces.SO;
-  parameter Integer m(min=2) = 3 "Number of phases";
+  parameter Integer m(min=2) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.ComplexBlocks.Interfaces.ComplexInput u[m]
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
 equation

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Blocks/SingleToPolyphase.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Blocks/SingleToPolyphase.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.QuasiStatic.Polyphase.Blocks;
 block SingleToPolyphase
   "Extends complex phase signal to complex polyphase signals using symmetricOrientation"
   extends Modelica.ComplexBlocks.Interfaces.ComplexSIMO(final nout=m,final useConjugateInput=false);
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
 equation
   y = u*Modelica.ComplexMath.fromPolar(fill(1, m), -
     Modelica.Electrical.Polyphase.Functions.symmetricOrientation(m));

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Blocks/SymmetricalComponents.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Blocks/SymmetricalComponents.mo
@@ -4,7 +4,7 @@ block SymmetricalComponents
   extends Modelica.ComplexBlocks.Interfaces.ComplexMIMOs(final n=m,final useConjugateInput=fill(false,m));
   import Modelica.ComplexMath.abs;
   import Modelica.ComplexMath.arg;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   output Real abs_u[m] = abs(u) "Absolute of input";
   output SI.Angle arg_u[m](each displayUnit="deg") = arg(u)
     "Argument of input";

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Blocks/ToSpacePhasor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Blocks/ToSpacePhasor.mo
@@ -6,7 +6,7 @@ block ToSpacePhasor "Conversion: m phase -> space phasor"
   // import Modelica.ComplexMath.sum;
   // The import of sum goes along with the original complex equation:
   // c = sqrt(2)/m*sum({u[k]*exp(j*phi[k]) for k in 1:m});
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.ComplexBlocks.Interfaces.ComplexInput u[m]
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Modelica.Blocks.Interfaces.RealOutput y[2]

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Examples/BalancingDelta.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Examples/BalancingDelta.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Examples;
 model BalancingDelta "Balancing an unsymmetrical delta-connected load"
   extends Modelica.Icons.Example;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage V_LL=100 "Source voltage line-to-line";
   parameter SI.Frequency f=50 "Source frequency";
   parameter SI.Resistance R=10 "Load resistance";

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Ideal/IdealCommutingSwitch.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Ideal/IdealCommutingSwitch.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Ideal;
 model IdealCommutingSwitch "Polyphase ideal commuting switch"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Resistance Ron[m](final min=zeros(m), start=
         fill(1e-5, m)) "Closed switch resistance";
   parameter SI.Conductance Goff[m](final min=zeros(m), start=

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Ideal/IdealIntermediateSwitch.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Ideal/IdealIntermediateSwitch.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Ideal;
 model IdealIntermediateSwitch "Polyphase ideal intermediate switch"
-  parameter Integer m(final min=1) = 3 "Number of phases";
+  parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Resistance Ron[m](final min=zeros(m), start=
         fill(1e-5, m)) "Closed switch resistance";
   parameter SI.Conductance Goff[m](final min=zeros(m), start=

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Interfaces/AbsoluteSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Interfaces/AbsoluteSensor.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Interfaces;
 partial model AbsoluteSensor "Partial potential sensor"
   extends Modelica.Icons.RoundSensor;
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   SI.AngularVelocity omega;
   PositivePlug plug_p(final m=m)
     "Positive quasi-static polyphase plug" annotation (Placement(

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Interfaces/OnePort.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Interfaces/OnePort.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Interfaces;
 partial model OnePort "Two plugs, reference connection and declaration of voltage and current"
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   SI.ComplexVoltage v[m] "Complex voltage";
   SI.Voltage abs_v[m]=Modelica.ComplexMath.abs(v)
     "Magnitude of complex voltage";

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Interfaces/Plug.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Interfaces/Plug.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Interfaces;
 connector Plug "Quasi-static polyphase plug"
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   QuasiStatic.SinglePhase.Interfaces.Pin pin[m] "Pins of plug";
   annotation (Documentation(info="<html>
 

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Interfaces/TwoPlugElementary.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Interfaces/TwoPlugElementary.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Interfaces;
 partial model TwoPlugElementary "Two plugs with pin-adapter and reference connection, without declaration of voltage and current"
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   SI.AngularVelocity omega "Angular velocity of reference frame";
 
   PositivePlug plug_p(final m=m)

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/AronSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/AronSensor.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Sensors;
 model AronSensor "Three-phase Aron sensor for active power"
   extends Modelica.Icons.RoundSensor;
-  final parameter Integer m(final min=1) = 3 "Number of phases";
+  final parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.Electrical.QuasiStatic.Polyphase.Interfaces.PositivePlug plug_p(final m=m)
     annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
   Modelica.Electrical.QuasiStatic.Polyphase.Interfaces.NegativePlug plug_n(final m=m)

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/CurrentQuasiRMSSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/CurrentQuasiRMSSensor.mo
@@ -3,7 +3,7 @@ model CurrentQuasiRMSSensor
   "Continuous quasi current RMS sensor for polyphase system"
   extends Modelica.Electrical.QuasiStatic.Polyphase.Interfaces.RelativeSensorElementary;
 
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.Blocks.Interfaces.RealOutput I(unit="A")
     "Continuous quasi average RMS of current" annotation (Placement(
         transformation(

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/MultiSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/MultiSensor.mo
@@ -4,7 +4,7 @@ model MultiSensor "Polyphase sensor to measure current, voltage and power"
   import Modelica.ComplexMath.conj;
   import Modelica.ComplexMath.abs;
   import Modelica.ComplexMath.arg;
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   QuasiStatic.Polyphase.Interfaces.PositivePlug pc(final m=m)
     "Positive plug, current path"
     annotation (Placement(transformation(extent={{-90,-10},{-110,10}})));

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/PowerSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/PowerSensor.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Sensors;
 model PowerSensor "Power sensor"
   extends Modelica.Icons.RoundSensor;
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   SI.AngularVelocity omega=der(currentP.reference.gamma);
   Interfaces.PositivePlug currentP(final m=m) annotation (Placement(
         transformation(extent={{-110,-10},{-90,10}})));

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/ReactivePowerSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/ReactivePowerSensor.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Sensors;
 model ReactivePowerSensor "Three-phase sensor for reactive power"
   extends Modelica.Icons.RoundSensor;
-  final parameter Integer m(final min=1) = 3 "Number of phases";
+  final parameter Integer m(final min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.Electrical.QuasiStatic.Polyphase.Interfaces.PositivePlug plug_p(final m=m)
     annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
   Modelica.Electrical.QuasiStatic.Polyphase.Interfaces.NegativePlug plug_n(final m=m)

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/VoltageQuasiRMSSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/VoltageQuasiRMSSensor.mo
@@ -3,7 +3,7 @@ model VoltageQuasiRMSSensor
   "Continuous quasi voltage RMS sensor for polyphase system"
   extends Modelica.Electrical.QuasiStatic.Polyphase.Interfaces.RelativeSensorElementary;
 
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   Modelica.Blocks.Interfaces.RealOutput V
     "Continuous quasi average RMS of current" annotation (Placement(
         transformation(

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sources/FrequencySweepCurrentSource.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sources/FrequencySweepCurrentSource.mo
@@ -3,7 +3,7 @@ model FrequencySweepCurrentSource "Current source with integrated frequency swee
   extends Interfaces.TwoPlug;
   import Modelica.Constants.eps;
   SI.Angle gamma(start=0) = plug_p.reference.gamma;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Frequency fStart(final min=eps, start=1) "Start sweep frequency";
   parameter SI.Frequency fStop(final min=eps, start=1) "Stop sweep frequency";
   parameter SI.Time startTime=0 "Start time of frequency sweep";

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sources/FrequencySweepVoltageSource.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sources/FrequencySweepVoltageSource.mo
@@ -3,7 +3,7 @@ model FrequencySweepVoltageSource "Voltage source with integrated frequency swee
   extends Interfaces.TwoPlug;
   import Modelica.Constants.eps;
   SI.Angle gamma(start=0) = plug_p.reference.gamma;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Frequency fStart(final min=eps, start=1) "Start sweep frequency";
   parameter SI.Frequency fStop(final min=eps, start=1) "Stop sweep frequency";
   parameter SI.Time startTime=0 "Start time of frequency sweep";

--- a/Modelica/Magnetic/FundamentalWave/BaseClasses/Machine.mo
+++ b/Modelica/Magnetic/FundamentalWave/BaseClasses/Machine.mo
@@ -2,7 +2,7 @@ within Modelica.Magnetic.FundamentalWave.BaseClasses;
 partial model Machine "Base model of machines"
   constant SI.Angle pi = Modelica.Constants.pi;
   extends Modelica.Electrical.Machines.Icons.FundamentalWaveMachine;
-  parameter Integer m(min=3) = 3 "Number of stator phases";
+  parameter Integer m(min=3) = 3 "Number of stator phases" annotation(Evaluate=true);
   // Mechanical parameters
   parameter SI.Inertia Jr(start=0.29) "Rotor inertia";
   parameter Boolean useSupport=false

--- a/Modelica/Magnetic/FundamentalWave/BasicMachines/Components/SymmetricPolyphaseCageWinding.mo
+++ b/Modelica/Magnetic/FundamentalWave/BasicMachines/Components/SymmetricPolyphaseCageWinding.mo
@@ -2,7 +2,7 @@ within Modelica.Magnetic.FundamentalWave.BasicMachines.Components;
 model SymmetricPolyphaseCageWinding "Symmetrical rotor cage"
   import Modelica.Constants.pi;
   extends Magnetic.FundamentalWave.Interfaces.TwoPortExtended;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter Boolean useHeatPort=false
     "Enable / disable (=fixed temperatures) thermal port"
     annotation (Evaluate=true);

--- a/Modelica/Magnetic/FundamentalWave/BasicMachines/Components/SymmetricPolyphaseWinding.mo
+++ b/Modelica/Magnetic/FundamentalWave/BasicMachines/Components/SymmetricPolyphaseWinding.mo
@@ -18,7 +18,7 @@ model SymmetricPolyphaseWinding
   Magnetic.FundamentalWave.Interfaces.PositiveMagneticPort port_p
     "Positive complex magnetic port"
     annotation (Placement(transformation(extent={{90,90},{110,110}})));
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter Boolean useHeatPort=false
     "Enable / disable (=fixed temperatures) thermal port"
     annotation (Evaluate=true);

--- a/Modelica/Magnetic/FundamentalWave/BasicMachines/InductionMachines/IM_SlipRing.mo
+++ b/Modelica/Magnetic/FundamentalWave/BasicMachines/InductionMachines/IM_SlipRing.mo
@@ -1,6 +1,6 @@
 within Modelica.Magnetic.FundamentalWave.BasicMachines.InductionMachines;
 model IM_SlipRing "Induction machine with slip ring rotor"
-  parameter Integer mr(min=3) = m "Number of rotor phases";
+  parameter Integer mr(min=3) = m "Number of rotor phases" annotation(Evaluate=true);
   extends Magnetic.FundamentalWave.BaseClasses.Machine(
     is(start=zeros(m)),
     Rs(start=0.03),

--- a/Modelica/Magnetic/FundamentalWave/Components/PolyphaseElectroMagneticConverter.mo
+++ b/Modelica/Magnetic/FundamentalWave/Components/PolyphaseElectroMagneticConverter.mo
@@ -37,7 +37,7 @@ model PolyphaseElectroMagneticConverter
   Magnetic.FundamentalWave.Interfaces.NegativeMagneticPort port_n
     "Negative complex magnetic port"
     annotation (Placement(transformation(extent={{90,-110},{110,-90}})));
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter Real effectiveTurns[m] "Effective number of turns";
   parameter SI.Angle orientation[m]
     "Orientation of the resulting fundamental wave field phasor";

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/ComparisonPolyphase/IMC_DOL_Polyphase.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/ComparisonPolyphase/IMC_DOL_Polyphase.mo
@@ -3,7 +3,7 @@ model IMC_DOL_Polyphase
   "Direct on line start of polyphase induction machine with squirrel cage"
   extends Modelica.Icons.Example;
   constant Integer m3=3 "Number of stator phases of three-phase system";
-  parameter Integer m=5 "Number of stator phases";
+  parameter Integer m=5 "Number of stator phases" annotation(Evaluate=true);
   parameter SI.Voltage VsNominal=100
     "Nominal RMS voltage per phase";
   parameter SI.Frequency fNominal=aimcData.fsNominal "Nominal frequency";

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/ComparisonPolyphase/IMS_Start_Polyphase.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/ComparisonPolyphase/IMS_Start_Polyphase.mo
@@ -4,8 +4,8 @@ model IMS_Start_Polyphase
 
   extends Modelica.Icons.Example;
   constant Integer m3=3 "Number of stator phases of three-phase system";
-  parameter Integer m=5 "Number of stator phases";
-  parameter Integer mr=5 "Number of rotor phases";
+  parameter Integer m=5 "Number of stator phases" annotation(Evaluate=true);
+  parameter Integer mr=5 "Number of rotor phases" annotation(Evaluate=true);
   parameter SI.Voltage VsNominal=100
     "Nominal RMS voltage per phase";
   parameter SI.Frequency fNominal=aimsData.fsNominal "Nominal frequency";

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/ComparisonPolyphase/SMEE_Generator_Polyphase.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/ComparisonPolyphase/SMEE_Generator_Polyphase.mo
@@ -5,7 +5,7 @@ model SMEE_Generator_Polyphase
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
   constant Integer m3=3 "Number of stator phases of three-phase system";
-  parameter Integer m=5 "Number of stator phases";
+  parameter Integer m=5 "Number of stator phases" annotation(Evaluate=true);
   parameter SI.Voltage VsNominal=100
     "Nominal RMS voltage per phase";
   parameter SI.Frequency fsNominal=smeeData.fsNominal "Nominal frequency";

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/ComparisonPolyphase/SMPM_Inverter_Polyphase.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/ComparisonPolyphase/SMPM_Inverter_Polyphase.mo
@@ -4,7 +4,7 @@ model SMPM_Inverter_Polyphase
 
   extends Modelica.Icons.Example;
   constant Integer m3=3 "Number of stator phases of three-phase system";
-  parameter Integer m=5 "Number of stator phases";
+  parameter Integer m=5 "Number of stator phases" annotation(Evaluate=true);
   parameter SI.Voltage VsNominal=100
     "Nominal RMS voltage per phase";
   parameter SI.Frequency fsNominal=smpmData.fsNominal "Nominal frequency";

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/ComparisonPolyphase/SMR_Inverter_Polyphase.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/ComparisonPolyphase/SMR_Inverter_Polyphase.mo
@@ -4,7 +4,7 @@ model SMR_Inverter_Polyphase
 
   extends Modelica.Icons.Example;
   constant Integer m3=3 "Number of stator phases of three-phase system";
-  parameter Integer m=5 "Number of stator phases";
+  parameter Integer m=5 "Number of stator phases" annotation(Evaluate=true);
   parameter SI.Voltage VsNominal=100
     "Nominal RMS voltage per phase";
   parameter SI.Frequency fsNominal=smrData.fsNominal "Nominal frequency";

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMEE_DOL.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMEE_DOL.mo
@@ -2,7 +2,7 @@ within Modelica.Magnetic.FundamentalWave.Examples.BasicMachines.SynchronousMachi
 model SMEE_DOL
   "ElectricalExcitedSynchronousMachine starting direct on line"
   extends Modelica.Icons.Example;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage VNominal=100 "Nominal RMS voltage per phase";
   parameter SI.Frequency fNominal=50 "Nominal frequency";
   parameter SI.Voltage Ve=smeeData.Re*smeeData.IeOpenCircuit "Excitation current";

--- a/Modelica/Magnetic/FundamentalWave/Examples/Components/EddyCurrentLosses.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/Components/EddyCurrentLosses.mo
@@ -2,7 +2,7 @@ within Modelica.Magnetic.FundamentalWave.Examples.Components;
 model EddyCurrentLosses
   "Comparison of equivalent circuits of eddy current loss models"
   extends Modelica.Icons.Example;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Resistance R=0.1
     "Resistance of leader cables";
   parameter SI.Conductance Gc=1 "Loss conductance";

--- a/Modelica/Magnetic/FundamentalWave/Examples/Components/PolyphaseInductance.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/Components/PolyphaseInductance.mo
@@ -1,7 +1,7 @@
 within Modelica.Magnetic.FundamentalWave.Examples.Components;
 model PolyphaseInductance "Polyphase inductance"
   extends Modelica.Icons.Example;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Frequency f=1 "Supply frequency";
   parameter SI.Voltage VRMS=100 "RMS supply voltage";
   parameter SI.Resistance R=0.1 "Leader cable resistance";

--- a/Modelica/Magnetic/FundamentalWave/Interfaces/StateSelector.mo
+++ b/Modelica/Magnetic/FundamentalWave/Interfaces/StateSelector.mo
@@ -2,7 +2,7 @@ within Modelica.Magnetic.FundamentalWave.Interfaces;
 model StateSelector
   "Transform instantaneous values to space phasors and select states"
   import Modelica.Constants.pi;
-  parameter Integer m(min=3) = 3 "Number of phases";
+  parameter Integer m(min=3) = 3 "Number of phases" annotation(Evaluate=true);
   input Real xi[m](each stateSelect=StateSelect.avoid)
     "Instantaneous values" annotation (Dialog);
   input SI.Angle gamma "Angle of rotation" annotation (Dialog);

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/BaseClasses/Machine.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/BaseClasses/Machine.mo
@@ -2,7 +2,7 @@ within Modelica.Magnetic.QuasiStatic.FundamentalWave.BaseClasses;
 partial model Machine "Base model of machines"
   constant SI.Angle pi = Modelica.Constants.pi;
   extends Modelica.Electrical.Machines.Icons.QuasiStaticFundamentalWaveMachine;
-  parameter Integer m(min=3) = 3 "Number of stator phases";
+  parameter Integer m(min=3) = 3 "Number of stator phases" annotation(Evaluate=true);
   // Mechanical parameters
   parameter SI.Inertia Jr(start=0.29) "Rotor inertia";
   parameter Boolean useSupport=false

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/Components/SymmetricPolyphaseCageWinding.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/Components/SymmetricPolyphaseCageWinding.mo
@@ -2,7 +2,7 @@ within Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.Components;
 model SymmetricPolyphaseCageWinding "Symmetrical rotor cage"
   import Modelica.Constants.pi;
   extends Magnetic.QuasiStatic.FundamentalWave.Interfaces.TwoPortExtended;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter Boolean useHeatPort=false
     "Enable / disable (=fixed temperatures) thermal port"
     annotation (Evaluate=true);

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/Components/SymmetricPolyphaseWinding.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/Components/SymmetricPolyphaseWinding.mo
@@ -18,7 +18,7 @@ model SymmetricPolyphaseWinding
     annotation (Placement(transformation(extent={{90,-110},{110,-90}})));
   Interfaces.PositiveMagneticPort port_p "Positive complex magnetic port"
     annotation (Placement(transformation(extent={{90,90},{110,110}})));
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter Boolean useHeatPort=false
     "Enable / disable (=fixed temperatures) thermal port"
     annotation (Evaluate=true);

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/InductionMachines/IM_SlipRing.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/InductionMachines/IM_SlipRing.mo
@@ -1,6 +1,6 @@
 within Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.InductionMachines;
 model IM_SlipRing "Induction machine with slip ring rotor"
-  parameter Integer mr(min=3) = m "Number of rotor phases";
+  parameter Integer mr(min=3) = m "Number of rotor phases" annotation(Evaluate=true);
   extends BaseClasses.Machine(
     Rs(start=0.03),
     Lssigma(start=3*(1 - sqrt(1 - 0.0667))/(2*pi*fsNominal)),

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Components/PolyphaseElectroMagneticConverter.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Components/PolyphaseElectroMagneticConverter.mo
@@ -19,7 +19,7 @@ model PolyphaseElectroMagneticConverter
   FundamentalWave.Interfaces.NegativeMagneticPort port_n
     "Negative complex magnetic port" annotation (Placement(transformation(
           extent={{90,-110},{110,-90}})));
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter Real effectiveTurns "Effective number of turns";
   constant SI.Angle orientation=0
     "Orientation of the first winding axis";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Characteristics.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Characteristics.mo
@@ -2,7 +2,7 @@ within Modelica.Magnetic.QuasiStatic.FundamentalWave.Examples.BasicMachines.Indu
 model IMC_Characteristics "Characteristic curves of Induction machine with squirrel cage"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage VsNominal=100
     "Nominal RMS voltage per phase";
   parameter SI.Frequency fNominal=imcData.fsNominal "Nominal frequency";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Conveyor.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Conveyor.mo
@@ -2,7 +2,7 @@ within Modelica.Magnetic.QuasiStatic.FundamentalWave.Examples.BasicMachines.Indu
 model IMC_Conveyor "Induction machine with squirrel cage and inverter driving a conveyor"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   constant SI.Frequency unitFrequency=1 annotation(HideResult=true);
   parameter SI.Voltage VNominal=100
     "Nominal RMS voltage per phase";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_DOL.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_DOL.mo
@@ -3,7 +3,7 @@ model IMC_DOL
   "Induction machine with squirrel cage started directly on line (DOL)"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage VsNominal=100
     "Nominal RMS voltage per phase";
   parameter SI.Frequency fNominal=imc.fsNominal "Nominal frequency";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Initialize.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Initialize.mo
@@ -2,7 +2,7 @@ within Modelica.Magnetic.QuasiStatic.FundamentalWave.Examples.BasicMachines.Indu
 model IMC_Initialize "Steady-state initialization of induction machine with squirrel cage"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage VNominal=100
     "Nominal RMS voltage per phase";
   parameter SI.Frequency fNominal=imc.fsNominal "Nominal frequency";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMS_Characteristics.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMS_Characteristics.mo
@@ -2,8 +2,8 @@ within Modelica.Magnetic.QuasiStatic.FundamentalWave.Examples.BasicMachines.Indu
 model IMS_Characteristics "Characteristic curves of induction machine with slip rings"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m=3 "Number of stator phases";
-  parameter Integer mr=3 "Number of rotor phases";
+  parameter Integer m=3 "Number of stator phases" annotation(Evaluate=true);
+  parameter Integer mr=3 "Number of rotor phases" annotation(Evaluate=true);
   parameter SI.Voltage VsNominal=100
     "Nominal RMS voltage per phase";
   parameter SI.Frequency fNominal=imsData.fsNominal "Nominal frequency";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMS_Start.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMS_Start.mo
@@ -2,8 +2,8 @@ within Modelica.Magnetic.QuasiStatic.FundamentalWave.Examples.BasicMachines.Indu
 model IMS_Start "Starting of induction machine with slip rings"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m=3 "Number of stator phases";
-  parameter Integer mr=3 "Number of rotor phases";
+  parameter Integer m=3 "Number of stator phases" annotation(Evaluate=true);
+  parameter Integer mr=3 "Number of rotor phases" annotation(Evaluate=true);
   parameter SI.Voltage VsNominal=100
     "Nominal RMS voltage per phase";
   parameter SI.Frequency fNominal=ims.fsNominal "Nominal frequency";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMEE_Generator.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMEE_Generator.mo
@@ -3,7 +3,7 @@ model SMEE_Generator
   "Electrical excited synchronous machine operating as generator"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m=3 "Number of stator phases";
+  parameter Integer m=3 "Number of stator phases" annotation(Evaluate=true);
   parameter SI.Voltage VsNominal=100
     "Nominal RMS voltage per phase";
   parameter SI.Frequency fsNominal=smeeData.fsNominal "Nominal frequency";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_CurrentSource.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_CurrentSource.mo
@@ -3,7 +3,7 @@ model SMPM_CurrentSource
   "Test example: PermanentMagnetSynchronousMachine fed by current source"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage VNominal=100
     "Nominal RMS voltage per phase";
   parameter SI.Frequency fNominal=smpmData.fsNominal "Nominal frequency";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_MTPA.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_MTPA.mo
@@ -2,7 +2,7 @@ within Modelica.Magnetic.QuasiStatic.FundamentalWave.Examples.BasicMachines.Sync
 model SMPM_MTPA "Test example: PermanentMagnetSynchronousMachine, investigating maximum torque per Amps"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage VNominal=100 "Nominal RMS voltage per phase";
   parameter SI.Frequency fNominal=50 "Nominal frequency";
   parameter SI.Frequency f=50 "Actual frequency";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_Mains.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_Mains.mo
@@ -3,7 +3,7 @@ model SMPM_Mains
   "Permanent magnet synchronous machine operated at mains with step torque load"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Frequency f=50 "Supply frequency";
   parameter SI.Voltage V=112.3 "Supply voltage";
   parameter SI.Torque T_Load=181.4 "Nominal load torque";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_OpenCircuit.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_OpenCircuit.mo
@@ -3,7 +3,7 @@ model SMPM_OpenCircuit
   "Test example: PermanentMagnetSynchronousMachine with inverter"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   output SI.Voltage Vtr=potentialSensor.phi[1]
     "Transient voltage";
   output SI.Voltage Vqs=potentialSensorQS.abs_v[1]

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMR_CurrentSource.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMR_CurrentSource.mo
@@ -3,7 +3,7 @@ model SMR_CurrentSource
   "Test example: Synchronous reluctance machine fed by current source"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage VNominal=100
     "Nominal RMS voltage per phase";
   parameter SI.Frequency fNominal=smrData.fsNominal "Nominal frequency";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/Components/PolyphaseInductance.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/Components/PolyphaseInductance.mo
@@ -1,7 +1,7 @@
 within Modelica.Magnetic.QuasiStatic.FundamentalWave.Examples.Components;
 model PolyphaseInductance "Polyphase inductance"
   extends Modelica.Icons.Example;
-  parameter Integer m=5 "Number of phases";
+  parameter Integer m=5 "Number of phases" annotation(Evaluate=true);
   parameter SI.Frequency f=1 "Supply frequency";
   parameter SI.Voltage VRMS=100 "RMS supply voltage";
   parameter SI.Resistance R=1E-5 "Resistance";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Losses/PermanentMagnetLosses.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Losses/PermanentMagnetLosses.mo
@@ -3,7 +3,7 @@ model PermanentMagnetLosses
   "Model of permanent magnet losses dependent on current and speed"
   extends Modelica.Electrical.Machines.Interfaces.FlangeSupport;
   import Modelica.Electrical.QuasiStatic.Polyphase.Functions.quasiRMS;
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter
     Modelica.Electrical.Machines.Losses.PermanentMagnetLossParameters
     permanentMagnetLossParameters "Permanent magnet loss parameters";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Sensors/RotorDisplacementAngle.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Sensors/RotorDisplacementAngle.mo
@@ -1,6 +1,6 @@
 within Modelica.Magnetic.QuasiStatic.FundamentalWave.Sensors;
 model RotorDisplacementAngle "Rotor lagging angle"
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter Integer p(min=1) "Number of pole pairs";
   parameter Boolean positiveRange=false "Use only positive output range, if true";
   parameter Boolean useSupport=false "Use support or fixed housing"

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Utilities/CurrentController.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Utilities/CurrentController.mo
@@ -1,6 +1,6 @@
 within Modelica.Magnetic.QuasiStatic.FundamentalWave.Utilities;
 model CurrentController "Current controller"
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter Integer p "Number of pole pairs";
   parameter SI.Angle gamma0=0
     "Offset added to electrical rotor angle";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Utilities/MultiTerminalBox.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Utilities/MultiTerminalBox.mo
@@ -1,10 +1,10 @@
 within Modelica.Magnetic.QuasiStatic.FundamentalWave.Utilities;
 model MultiTerminalBox "Terminal box Y/D-connection"
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   final parameter Integer mSystems=
       Modelica.Electrical.Polyphase.Functions.numberOfSymmetricBaseSystems(
                                                                   m) "Number of symmetric base systems";
-  final parameter Integer mBasic=integer(m/mSystems) "Number of phases of basic system";
+  final parameter Integer mBasic=integer(m/mSystems) "Number of phases of basic system" annotation(Evaluate=true);
   parameter String terminalConnection(start="Y") "Choose \"Y\" for star or \"D\" for delta connection"
     annotation (choices(choice="Y" "Star connection", choice="D"
         "Delta connection"));

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Utilities/SwitchYD.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Utilities/SwitchYD.mo
@@ -1,6 +1,6 @@
 within Modelica.Magnetic.QuasiStatic.FundamentalWave.Utilities;
 model SwitchYD "Y-D-switch"
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Resistance Ron=1e-5 "Closed switch resistance";
   parameter SI.Conductance Goff=1e-5 "Opened switch conductance";
   parameter SI.Time delayTime(final min=0)=0 "Time delay";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Utilities/SwitchedRheostat.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Utilities/SwitchedRheostat.mo
@@ -1,6 +1,6 @@
 within Modelica.Magnetic.QuasiStatic.FundamentalWave.Utilities;
 model SwitchedRheostat "Rheostat which is shortened after a given time"
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   Modelica.Electrical.QuasiStatic.Polyphase.Interfaces.PositivePlug
     plug_p(final m=m) "To positive rotor plug" annotation (Placement(
         transformation(extent={{90,70},{110,50}})));

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Utilities/TerminalBox.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Utilities/TerminalBox.mo
@@ -1,6 +1,6 @@
 within Modelica.Magnetic.QuasiStatic.FundamentalWave.Utilities;
 model TerminalBox "Terminal box Y/D-connection"
-  parameter Integer m(min=1) = 3 "Number of phases";
+  parameter Integer m(min=1) = 3 "Number of phases" annotation(Evaluate=true);
   parameter String terminalConnection(start="Y") "Choose \"Y\" for star or \"D\" for delta connection"
     annotation (choices(choice="Y" "Star connection", choice="D"
         "Delta connection"));

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Utilities/VfController.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Utilities/VfController.mo
@@ -1,7 +1,7 @@
 within Modelica.Magnetic.QuasiStatic.FundamentalWave.Utilities;
 block VfController "Voltage-Frequency-Controller"
   import Modelica.Constants.pi;
-  parameter Integer m=3 "Number of phases";
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Angle orientation[m]=-
       Modelica.Electrical.Polyphase.Functions.symmetricOrientation(m)
     "Orientation of phases";

--- a/ModelicaTest/Electrical/MultiSensorTest.mo
+++ b/ModelicaTest/Electrical/MultiSensorTest.mo
@@ -2,7 +2,7 @@ within ModelicaTest.Electrical;
 model MultiSensorTest
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Integer m = 3 "Number of phases";
+  parameter Integer m = 3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Voltage Vrms = 100 "RMS supply voltage";
   parameter SI.Frequency f = 50 "Frequency";
   parameter SI.Resistance R = 10 "Resistance";

--- a/ModelicaTest/Electrical/PowerConverters.mo
+++ b/ModelicaTest/Electrical/PowerConverters.mo
@@ -7,7 +7,7 @@ package PowerConverters
       Modelica.Electrical.PowerConverters;
     extends Modelica.Icons.Example;
     import Modelica.Constants.pi;
-    parameter Integer m(final min=3) = 3 "Number of phases";
+    parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
     parameter SI.Voltage Vrms=110 "RMS supply voltage";
     parameter SI.Frequency f=50 "Frequency";
     parameter SI.Angle constantFiringAngle=30*pi/180
@@ -157,7 +157,7 @@ package PowerConverters
       "Template of 2*m pulse bridge thyristor rectifier"
       extends Modelica.Electrical.PowerConverters.Icons.ExampleTemplate;
       import Modelica.Constants.pi;
-      parameter Integer m(final min=3) = 3 "Number of phases";
+      parameter Integer m(final min=3) = 3 "Number of phases" annotation(Evaluate=true);
       parameter SI.Voltage Vrms=110 "RMS supply voltage";
       parameter SI.Frequency f=50 "Frequency";
 

--- a/ModelicaTest/Electrical/QuasiStatic/Polyphase.mo
+++ b/ModelicaTest/Electrical/QuasiStatic/Polyphase.mo
@@ -3,7 +3,7 @@ package Polyphase "Polyphase quasi-static package"
   extends Modelica.Icons.ExamplesPackage;
   model SerialConnection "Example of serial connections"
     extends Modelica.Icons.Example;
-    parameter Integer m = 3 "Number of phases";
+    parameter Integer m = 3 "Number of phases" annotation(Evaluate=true);
     output SI.ComplexVoltage v[m] = voltageSensor.v "Total voltage";
     Modelica.Electrical.QuasiStatic.Polyphase.Sources.VariableCurrentSource currentSource(gamma(fixed=true, start=0), m=m)                                             annotation (Placement(transformation(
           extent={{-10,-10},{10,10}},
@@ -92,7 +92,7 @@ package Polyphase "Polyphase quasi-static package"
 
   model Ideal "Ideal components"
     extends Modelica.Icons.Example;
-    parameter Integer m = 3 "Number of phases";
+    parameter Integer m = 3 "Number of phases" annotation(Evaluate=true);
     output SI.ComplexCurrent I[m] = currentSensor.i "Current";
     Modelica.Electrical.QuasiStatic.Polyphase.Ideal.Idle idle(m=m)
                                                                    annotation (Placement(transformation(


### PR DESCRIPTION
This PR is limited to `Modelica.Electrical` and `Modelica.Magnetic`.  It does for these sub-libraries what #3113 does for `Modelica.Mechanics`, namely change some components declared `parameter` to be `constant` instead in order to make clear to both users and tools that they can and are expected to be evaluated during translation.

There is ongoing discussion in #3113 whether the right way to do this would be with `Evaluate=true` instead of `constant`, and the two PRs should be settled the same way.

Note connection to #1966, which is fixed by the first commit.

Fix #1966.