### PR TITLE
Fixes #778 by renaming "Commuting" to "TwoWay" 

### DIFF
--- a/Modelica/Electrical/Analog/Ideal.mo
+++ b/Modelica/Electrical/Analog/Ideal.mo
@@ -350,7 +350,7 @@ behavior is <strong>not</strong> modelled. The parameters are not temperature de
     annotation (defaultComponentName="switch",
       Documentation(info="<html>
 <p>
-The two way switch has a positive pin p and two negative pins n1 and n2.
+The two-way switch has a positive pin p and two negative pins n1 and n2.
 The switching behaviour is controlled
 by the control pin. If its voltage exceeds the value of the parameter level,
 the pin p is connected with the negative pin n2. Otherwise, the pin p is

--- a/Modelica/Electrical/Analog/Ideal.mo
+++ b/Modelica/Electrical/Analog/Ideal.mo
@@ -183,7 +183,7 @@ Otherwise, the GTO thyristor is locking.
     annotation (defaultComponentName="switch",
       Documentation(info="<html>
 <p>
-The two way switch has a positive pin p and two negative pins n1 and n2.
+The two-way switch has a positive pin p and two negative pins n1 and n2.
 The switching behaviour is controlled
 by the input signal control. If control is true, the pin p is connected
 with the negative pin n2. Otherwise, the pin p is connected to the negative pin n1.

--- a/Modelica/Electrical/Analog/Ideal.mo
+++ b/Modelica/Electrical/Analog/Ideal.mo
@@ -147,7 +147,7 @@ Otherwise, the GTO thyristor is locking.
               thickness=0.5)}));
   end IdealGTOThyristor;
 
-  model IdealTwoWaySwitch "Ideal commuting switch"
+  model IdealTwoWaySwitch "Ideal two-way switch"
     parameter SI.Resistance Ron(final min=0) = 1e-5 "Closed switch resistance";
     parameter SI.Conductance Goff(final min=0) = 1e-5
       "Opened switch conductance";
@@ -315,7 +315,7 @@ behavior is <strong>not</strong> modelled. The parameters are not temperature de
               100,100}})));
   end IdealIntermediateSwitch;
 
-  model ControlledIdealTwoWaySwitch "Controlled ideal commuting switch"
+  model ControlledIdealTwoWaySwitch "Controlled ideal two-way switch"
     parameter SI.Voltage level=0.5 "Switch level";
     parameter SI.Resistance Ron(final min=0) = 1e-5 "Closed switch resistance";
     parameter SI.Conductance Goff(final min=0) = 1e-5

--- a/Modelica/Electrical/Analog/Ideal.mo
+++ b/Modelica/Electrical/Analog/Ideal.mo
@@ -147,7 +147,7 @@ Otherwise, the GTO thyristor is locking.
               thickness=0.5)}));
   end IdealGTOThyristor;
 
-  model IdealCommutingSwitch "Ideal commuting switch"
+  model IdealTwoWaySwitch "Ideal commuting switch"
     parameter SI.Resistance Ron(final min=0) = 1e-5 "Closed switch resistance";
     parameter SI.Conductance Goff(final min=0) = 1e-5
       "Opened switch conductance";
@@ -183,7 +183,7 @@ Otherwise, the GTO thyristor is locking.
     annotation (defaultComponentName="switch",
       Documentation(info="<html>
 <p>
-The commuting switch has a positive pin p and two negative pins n1 and n2.
+The two way switch has a positive pin p and two negative pins n1 and n2.
 The switching behaviour is controlled
 by the input signal control. If control is true, the pin p is connected
 with the negative pin n2. Otherwise, the pin p is connected to the negative pin n1.
@@ -227,7 +227,7 @@ behavior is <strong>not</strong> modelled. The parameters are not temperature de
             extent={{-150,90},{150,50}},
             textString="%name",
             textColor={0,0,255})}));
-  end IdealCommutingSwitch;
+  end IdealTwoWaySwitch;
 
   model IdealIntermediateSwitch "Ideal intermediate switch"
     parameter SI.Resistance Ron(final min=0) = 1e-5 "Closed switch resistance";
@@ -315,7 +315,7 @@ behavior is <strong>not</strong> modelled. The parameters are not temperature de
               100,100}})));
   end IdealIntermediateSwitch;
 
-  model ControlledIdealCommutingSwitch "Controlled ideal commuting switch"
+  model ControlledIdealTwoWaySwitch "Controlled ideal commuting switch"
     parameter SI.Voltage level=0.5 "Switch level";
     parameter SI.Resistance Ron(final min=0) = 1e-5 "Closed switch resistance";
     parameter SI.Conductance Goff(final min=0) = 1e-5
@@ -350,7 +350,7 @@ behavior is <strong>not</strong> modelled. The parameters are not temperature de
     annotation (defaultComponentName="switch",
       Documentation(info="<html>
 <p>
-The commuting switch has a positive pin p and two negative pins n1 and n2.
+The two way switch has a positive pin p and two negative pins n1 and n2.
 The switching behaviour is controlled
 by the control pin. If its voltage exceeds the value of the parameter level,
 the pin p is connected with the negative pin n2. Otherwise, the pin p is
@@ -395,7 +395,7 @@ behavior is <strong>not</strong> modelled. The parameters are not temperature de
             extent={{-150,90},{150,50}},
             textString="%name",
             textColor={0,0,255})}));
-  end ControlledIdealCommutingSwitch;
+  end ControlledIdealTwoWaySwitch;
 
   model ControlledIdealIntermediateSwitch
     "Controlled ideal intermediate switch"

--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -442,3 +442,7 @@ convertElement({"Modelica.Electrical.Machines.BasicMachines.SynchronousInduction
                 "Modelica.Electrical.Machines.BasicMachines.SynchronousInductionMachines.SM_ElectricalExcited",
                 "Modelica.Electrical.Machines.BasicMachines.SynchronousInductionMachines.SM_ReluctanceRotor"},
                 "airGapR", "airGap")
+convertClass("Modelica.Electrical.Analog.Ideal.IdealCommutingSwitch",
+             "Modelica.Electrical.Analog.Ideal.IdealTwoWaySwitch");
+convertClass("Modelica.Electrical.Analog.Ideal.ControlledIdealCommutingSwitch",
+             "Modelica.Electrical.Analog.Ideal.ControlledIdealTwoWaySwitch");

--- a/ModelicaTestConversion4.mo
+++ b/ModelicaTestConversion4.mo
@@ -349,6 +349,54 @@ Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrar
 </html>"));
       end Issue197;
 
+      model Issue778 "Conversion test for #778"
+        extends Modelica.Icons.Example;
+        Modelica.Electrical.Analog.Basic.Ground ground
+          annotation(Placement(transformation(extent={{-20,-100},{0,-80}})));
+        Modelica.Electrical.Analog.Sources.ConstantVoltage constantVoltage(V=1) annotation (Placement(transformation(
+              extent={{-10,-10},{10,10}},
+              rotation=270,
+              origin={-80,0})));
+        Modelica.Electrical.Analog.Basic.Resistor r1(R=2)
+          annotation(Placement(transformation(extent={{-10,-10},{10,10}},
+              rotation=270,
+              origin={20,20})));
+        Modelica.Electrical.Analog.Ideal.IdealCommutingSwitch twoWay annotation (Placement(transformation(extent={{-40,50},{-20,30}})));
+        Modelica.Electrical.Analog.Ideal.ControlledIdealCommutingSwitch controlledTwoWay annotation (Placement(transformation(extent={{40,70},{60,50}})));
+        Modelica.Electrical.Analog.Basic.Resistor r2(R=1)
+          annotation(Placement(transformation(extent={{-10,-10},{10,10}},
+              rotation=270,
+              origin={20,-20})));
+        Modelica.Blocks.Sources.BooleanStep booleanStep(startTime=0.5) annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
+        Modelica.Electrical.Analog.Basic.Resistor r3(R=1)
+          annotation(Placement(transformation(extent={{-10,-10},{10,10}},
+              rotation=270,
+              origin={80,20})));
+        Modelica.Electrical.Analog.Basic.Resistor r4(R=2)
+          annotation(Placement(transformation(extent={{-10,-10},{10,10}},
+              rotation=270,
+              origin={80,-20})));
+      equation
+        connect(ground.p, constantVoltage.n) annotation (Line(points={{-10,-80},{-80,-80},{-80,-10}}, color={0,0,255}));
+        connect(r1.n, r2.p) annotation (Line(points={{20,10},{20,-10}}, color={0,0,255}));
+        connect(r2.n, constantVoltage.n) annotation (Line(points={{20,-30},{20,-80},{-80,-80},{-80,-10}}, color={0,0,255}));
+        connect(constantVoltage.p, twoWay.p) annotation (Line(points={{-80,10},{-80,40},{-40,40}}, color={0,0,255}));
+        connect(twoWay.n2, r1.p) annotation (Line(points={{-20,40},{20,40},{20,30}}, color={0,0,255}));
+        connect(twoWay.n1, r2.p) annotation (Line(points={{-20,36},{-16,36},{-16,0},{20,0},{20,-10}}, color={0,0,255}));
+        connect(booleanStep.y, twoWay.control) annotation (Line(points={{-39,0},{-30,0},{-30,28}}, color={255,0,255}));
+        connect(controlledTwoWay.p, twoWay.p) annotation (Line(points={{40,60},{-80,60},{-80,40},{-40,40}}, color={0,0,255}));
+        connect(controlledTwoWay.control, r2.p) annotation (Line(points={{50,50},{50,0},{20,0},{20,-10}}, color={0,0,255}));
+        connect(controlledTwoWay.n2, r3.p) annotation (Line(points={{60,60},{80,60},{80,30}}, color={0,0,255}));
+        connect(controlledTwoWay.n1, r4.p) annotation (Line(points={{60,56},{68,56},{68,0},{80,0},{80,-10}}, color={0,0,255}));
+        connect(r3.n, r4.p) annotation (Line(points={{80,10},{80,-10}}, color={0,0,255}));
+        connect(r4.n, constantVoltage.n) annotation (Line(points={{80,-30},{80,-80},{-80,-80},{-80,-10}}, color={0,0,255}));
+        annotation(experiment(StopTime=1), Documentation(info="<html>
+<p>
+Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/778\">#778</a>.
+</p>
+</html>"));
+      end Issue778;
+
       model Issue2361 "Conversion test for #2361"
         extends Modelica.Icons.Example;
         Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimted opAmp(
@@ -1669,9 +1717,11 @@ Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrar
       package P6
         extends Modelica.Mechanics.MultiBody.Icons.MotorIcon;
       end P6;
+
       package P7
         extends Modelica.Icons.RotationalSensor;
       end P7;
+
       package P8
         extends Modelica.Icons.TranslationalSensor;
       end P8;


### PR DESCRIPTION
Also includes conversion script and test.
Note: The ticket suggests to replace "IdealCommuting" with  "TwoWay" instead of "IdealTwoWay" which is probably an oversight and would introduce inconsistency.

Fix #778.