### PR TITLE
Fix for last-minute errors of #3133 pull request

### DIFF
--- a/Modelica/Mechanics/MultiBody/Examples/Loops/Engine1a.mo
+++ b/Modelica/Mechanics/MultiBody/Examples/Loops/Engine1a.mo
@@ -1,7 +1,7 @@
 within Modelica.Mechanics.MultiBody.Examples.Loops;
 model Engine1a "Model of one cylinder engine"
   extends Modelica.Icons.Example;
-  extends Utilities.Engine1bBase(inertia(phi(start=0), w(start=10)));
+  extends Utilities.Engine1Base;
   Modelica.Mechanics.MultiBody.Joints.Revolute b1(
     n={1,0,0},
     cylinderLength=0.02,
@@ -66,8 +66,7 @@ well-formed.
 </p>
 <p>
 An animation of this example is shown in the figure below.
-</p>
-
+</p><p>
 <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Loops/Engine.png\" alt=\"model Examples.Loops.Engine\">
-</html>"));
+</p></html>"));
 end Engine1a;

--- a/Modelica/Mechanics/MultiBody/Examples/Loops/Engine1b.mo
+++ b/Modelica/Mechanics/MultiBody/Examples/Loops/Engine1b.mo
@@ -2,7 +2,7 @@ within Modelica.Mechanics.MultiBody.Examples.Loops;
 model Engine1b
   "Model of one cylinder engine with gas force and preparation for assembly joint JointRRP"
   extends Modelica.Icons.Example;
-  extends Utilities.Engine1bBase(inertia(w(start=0)));
+  extends Utilities.Engine1bBase;
   Modelica.Mechanics.MultiBody.Joints.Revolute b1(
     n={1,0,0},
     cylinderLength=0.02,
@@ -28,11 +28,6 @@ model Engine1b
         origin={50,40},
         extent={{10,-10},{-10,10}},
         rotation=90)));
-  Utilities.GasForce2 gasForce(d=0.1, L=0.35)
-    annotation (Placement(transformation(
-        origin={90,80},
-        extent={{10,-10},{-10,10}},
-        rotation=90)));
 equation
   connect(cylinder.frame_b, rod3.frame_a) annotation (Line(
       points={{50,70},{50,50}},
@@ -42,9 +37,14 @@ equation
       points={{-70,50},{-70,94},{50,94},{50,90}},
       color={95,95,95},
       thickness=0.5));
-  connect(gasForce.flange_a, cylinder.support) annotation (Line(points={{90,90},{60,90},{60,84},{56,84}},
-                                                      color={0,127,0}));
-  connect(cylinder.axis, gasForce.flange_b) annotation (Line(points={{56,72},{60,72},{60,70},{90,70}}, color={0,127,0}));
+  connect(gasForce.flange_a, cylinder.support)
+    annotation (Line(
+      points={{90,90},{74,90},{74,84},{56,84}},
+      color={0,127,0}));
+  connect(gasForce.flange_b, cylinder.axis)
+    annotation (Line(
+      points={{90,70},{74,70},{74,72},{56,72}},
+      color={0,127,0}));
   connect(piston.frame_a, cylinder.frame_b) annotation (Line(
       points={{90,50},{90,60},{50,60},{50,70}},
       color={95,95,95},
@@ -102,8 +102,7 @@ not numerically as in this model (Engine1b).
 </p>
 <p>
 An animation of this example is shown in the figure below.
-</p>
-
+</p><p>
 <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Loops/Engine.png\" alt=\"model Examples.Loops.Engine\">
-</html>"));
+</p></html>"));
 end Engine1b;

--- a/Modelica/Mechanics/MultiBody/Examples/Loops/Engine1b_analytic.mo
+++ b/Modelica/Mechanics/MultiBody/Examples/Loops/Engine1b_analytic.mo
@@ -2,7 +2,7 @@ within Modelica.Mechanics.MultiBody.Examples.Loops;
 model Engine1b_analytic
   "Model of one cylinder engine with gas force and analytic loop handling"
   extends Modelica.Icons.Example;
-  extends Utilities.Engine1bBase(inertia(w(start=0)));
+  extends Utilities.Engine1bBase;
   Joints.Assemblies.JointRRP jointRRP(
     n_a={1,0,0},
     n_b={0,-1,0},
@@ -11,11 +11,6 @@ model Engine1b_analytic
     rRod2_ib={0,-0.1,0}) annotation (Placement(transformation(
         origin={40,20},
         extent={{-20,20},{20,-20}},
-        rotation=90)));
-  Utilities.GasForce2 gasForce(d=0.1, L=0.35)
-    annotation (Placement(transformation(
-        origin={90,80},
-        extent={{10,-10},{-10,10}},
         rotation=90)));
 equation
   connect(mid.frame_b, jointRRP.frame_a) annotation (Line(
@@ -26,10 +21,14 @@ equation
       points={{40,40},{40,60},{-70,60},{-70,50}},
       color={95,95,95},
       thickness=0.5));
-  connect(jointRRP.axis, gasForce.flange_b)
-    annotation (Line(points={{56,40},{56,70},{90,70}}, color={0,127,0}));
-  connect(jointRRP.bearing, gasForce.flange_a)
-    annotation (Line(points={{48,40},{48,90},{90,90}}, color={0,127,0}));
+  connect(gasForce.flange_a, jointRRP.bearing)
+    annotation (Line(
+      points={{90,90},{48,90},{48,40}},
+      color={0,127,0}));
+  connect(gasForce.flange_b, jointRRP.axis)
+    annotation (Line(
+      points={{90,70},{56,70},{56,40}},
+      color={0,127,0}));
   connect(jointRRP.frame_ib, piston.frame_a) annotation (Line(
       points={{60,36},{60,60},{90,60},{90,50}},
       color={95,95,95},
@@ -52,8 +51,8 @@ not numerically as in
 </p>
 <p>
 An animation of this example is shown in the figure below.
-</p>
-
+</p><p>
 <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Loops/Engine.png\" alt=\"model Examples.Loops.Engine\">
+</p>
 </html>"));
 end Engine1b_analytic;

--- a/Modelica/Mechanics/MultiBody/Examples/Loops/Utilities.mo
+++ b/Modelica/Mechanics/MultiBody/Examples/Loops/Utilities.mo
@@ -798,8 +798,11 @@ solved analytically.
 </html>"));
   end EngineV6_analytic;
 
-  partial model Engine1bBase "Model of one cylinder engine with gas force"
+  partial block Engine1Base
+    "Base model for one cylinder engine"
 
+    inner Modelica.Mechanics.MultiBody.World world
+      annotation (Placement(transformation(extent= {{-100,-100},{-80,-80}})));
     Modelica.Mechanics.MultiBody.Parts.BodyCylinder piston(diameter=0.1, r={0,-0.1,0})
       annotation (Placement(transformation(
           origin={90,40},
@@ -819,15 +822,14 @@ solved analytically.
       n={1,0,0},
       cylinderLength=0.02,
       cylinderDiameter=0.05) annotation (Placement(transformation(extent={{-60,-100},{-40,-80}})));
-    inner Modelica.Mechanics.MultiBody.World world annotation (Placement(
-          transformation(extent={{-100,-100},{-80,-80}})));
     Modelica.Mechanics.Rotational.Components.Inertia inertia(
       stateSelect=StateSelect.always,
       J=1,
-      w(fixed=true),
+      w(fixed=true,
+        start = 10),
       phi(
         fixed=true,
-        start=0.001,
+        start=0.0,
         displayUnit="rad")) annotation (Placement(transformation(
             extent={{-60,-60},{-40,-40}})));
     Modelica.Mechanics.MultiBody.Parts.BodyCylinder crank1(diameter=0.05, r={0.1,0,0})
@@ -855,8 +857,9 @@ solved analytically.
       annotation (Placement(transformation(extent={{-10,10},{10,-10}},
           rotation=0,
           origin={20,-40})));
-    Modelica.Mechanics.MultiBody.Parts.FixedTranslation cylPosition(animation=false, r={0.15,
-          0.45,0})
+    Modelica.Mechanics.MultiBody.Parts.FixedTranslation cylPosition(
+      animation=false,
+      r = {0.15,0.45,0})
       annotation (Placement(transformation(extent={{-10,-10},{10,10}},
           rotation=90,
           origin={-70,40})));
@@ -882,13 +885,17 @@ solved analytically.
         points={{60,-66},{90,-66},{90,-70}},
         color={95,95,95},
         thickness=0.5));
-    connect(inertia.flange_b, bearing.axis) annotation (Line(points={{-40,-50},{-40,-70},{-50,-70},{-50,-80}}));
-    connect(crank2.frame_b, crank3.frame_a) annotation (Line(
-        points={{6.66134e-16,-70},{6.66134e-16,-66},{40,-66}},
+    connect(inertia.flange_b, bearing.axis)
+      annotation (Line(
+        points={{-40,-50},{-30,-50},{-30,-70},{-50,-70},{-50,-80}}));
+    connect(crank2.frame_b, crank3.frame_a)
+      annotation (Line(
+        points={{0,-70},{0,-66},{40,-66}},
         color={95,95,95},
         thickness=0.5));
-    connect(crank2.frame_b, mid.frame_a) annotation (Line(
-        points={{6.66134e-16,-70},{6.66134e-16,-40},{10,-40}},
+    connect(crank2.frame_b, mid.frame_a)
+      annotation (Line(
+        points={{0,-70},{0,-40},{10,-40}},
         color={95,95,95},
         thickness=0.5));
     annotation (
@@ -914,10 +921,20 @@ well-formed.
 </p>
 <p>
 An animation of this example is shown in the figure below.
-</p>
-
+</p><p>
 <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Loops/Engine.png\" alt=\"model Examples.Loops.Engine\">
-</html>"));
+</p></html>"));
+  end Engine1Base;
+
+  partial block Engine1bBase
+    "Base model for one cylinder engine with gas force"
+    extends Engine1Base;
+
+    GasForce2 gasForce(d=0.1, L=0.35)
+      annotation (Placement(transformation(
+        origin={90,80},
+        extent={{10,-10},{-10,10}},
+        rotation=90)));
   end Engine1bBase;
   annotation (Documentation(info="<html>
 <p>


### PR DESCRIPTION
This is a fix for erroneous last-minute changes of the #3133 pull request. The problems of these are discussed at the end of #3133.

In summary, fa754542104e5042916d0cc5ef7c67dbd1033bbb made `Engine1a` also inherit from `Engine1bBase`, deleting the gas force in `Engine1bBase` and instead adding it separately to `Engine1b` and `Engine1b_analytic`. This is not right for the following reasons:
 1. As the name `Engine1bBase` suggests, it is the base-class for `Engine1b` and `Engine1b_analytic`, not  `Engine1a`.
 2. The description of `Engine1bBase` is erroneous now, because it refers to it introducing a gas-force.
 3. The idea of the whole scenario is to go from an engine without gas-force to one with it to finally an analytic solution. The challenge however is, that the required changes to do so are non-monotonic and therefore _cannot_ be modeled as a single inheritance sequence; this is problem inherent and explained in my [Modelica language extensions for practical non-monotonic modelling: on the need for selective model extension](https://modelica.org/events/modelica2019/proceedings/html/papers/Modelica2019paper3B1.pdf) paper. Any inheritance-based solution must split-off the inheritance tree at some point such that  `Engine1b` and `Engine1b_analytic` are not directly inheriting from `Engine1a` nor from each other.

This fix therefore does the following:
 1. `Engine1bBase` is the base class for `Engine1b` and `Engine1b_analytic` only. Its description is _"Common model of one cylinder engine with gas force."_ (**with** gas force). A gas force has been reintroduced in it.
 2. A new base class `Engine1aBase` is introduced. It encapsulates all common things and is the base for `Engine1a`. `Engine1bBase` inherits from it and just adds the gas force. The description of `Engine1aBase` is _"Common model of one cylinder engine without gas force."_ (**without** gas force).

Further, all code has been properly formatted.