### PR TITLE
Update IdealCommutingSwitch to IdealTwoWaySwitch

### DIFF
--- a/Modelica/Electrical/Analog/Examples/Utilities/RealSwitch.mo
+++ b/Modelica/Electrical/Analog/Examples/Utilities/RealSwitch.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Analog.Examples.Utilities;
 model RealSwitch "Ideal switch with resistance"
 
-  Ideal.ControlledIdealCommutingSwitch S(level=2.5) annotation (Placement(
+  Ideal.ControlledIdealTwoWaySwitch S(level=2.5) annotation (Placement(
         transformation(extent={{11.3333,-46},{58,0.6667}})));
   Basic.Resistor R(R=0.01) annotation (Placement(transformation(extent={{-66,-48},
             {-19.3333,-1.3333}})));

--- a/Modelica/Electrical/Analog/Examples/Utilities/SwitchedCapacitor.mo
+++ b/Modelica/Electrical/Analog/Examples/Utilities/SwitchedCapacitor.mo
@@ -6,12 +6,12 @@ model SwitchedCapacitor "Switched capacitor which can represent a positive or ne
   Modelica.Blocks.Sources.BooleanPulse BooleanPulse(period=clock) annotation (Placement(transformation(extent={{-8,70},{12,90}})));
   Modelica.Electrical.Analog.Basic.Capacitor Capacitor(C=clock/max(Modelica.Constants.eps*oneOhm,abs(R)))
                                                                   annotation (Placement(transformation(extent={{-20,-20},{20,20}})));
-  Modelica.Electrical.Analog.Ideal.IdealCommutingSwitch IdealCommutingSwitch1
+  Modelica.Electrical.Analog.Ideal.IdealTwoWaySwitch IdealCommutingSwitch1
     annotation (Placement(transformation(
           origin={-50,0},
           extent={{-10,10},{10,-10}},
           rotation=180)));
-  Modelica.Electrical.Analog.Ideal.IdealCommutingSwitch IdealCommutingSwitch2
+  Modelica.Electrical.Analog.Ideal.IdealTwoWaySwitch IdealCommutingSwitch2
     annotation (Placement(transformation(extent={{40,-10},{60,10}})));
   Modelica.Electrical.Analog.Basic.Ground Ground1
     annotation (Placement(transformation(

--- a/Modelica/Electrical/Polyphase/Ideal/IdealCommutingSwitch.mo
+++ b/Modelica/Electrical/Polyphase/Ideal/IdealCommutingSwitch.mo
@@ -19,7 +19,7 @@ model IdealCommutingSwitch "Polyphase ideal commuting switch"
         transformation(extent={{90,-10},{110,10}})));
   Interfaces.NegativePlug plug_n1(final m=m) annotation (Placement(
         transformation(extent={{90,30},{110,50}}), iconTransformation(extent={{90,30},{110,50}})));
-  Modelica.Electrical.Analog.Ideal.IdealCommutingSwitch idealCommutingSwitch[m](
+  Modelica.Electrical.Analog.Ideal.IdealTwoWaySwitch idealCommutingSwitch[m](
     final Ron=Ron,
     final Goff=Goff,
     each final useHeatPort=useHeatPort) annotation (Placement(
@@ -52,7 +52,7 @@ equation
           textString="m=%m")}), Documentation(info=
          "<html>
 <p>
-Contains m ideal commuting switches (Modelica.Electrical.Analog.Ideal.IdealCommutingSwitch).
+Contains m ideal commuting switches (Modelica.Electrical.Analog.Ideal.IdealTwoWaySwitch).
 </p>
 </html>"));
 end IdealCommutingSwitch;


### PR DESCRIPTION
The `IdealCommutingSwitch` and `ControlledCommutingSwitch` in `Modelica.Electrical.Analog.Ideal` was renamed to `IdealTwoWaySwitch/ControlledTwoWaySwitch` in 6348e322 for #778, but the change was not applied in models that used those classes.

This change only fixes the names of the used classes so that the models work again, I did not change the name of the components since I don't know what impact that might have.