### PR TITLE
maint/3.2.3: Fix diode current formula of HeatingDiode

### DIFF
--- a/Modelica/Electrical/Analog/Semiconductors.mo
+++ b/Modelica/Electrical/Analog/Semiconductors.mo
@@ -725,12 +725,12 @@ equation
   htemp = T_heatPort;
   vt_t = k*htemp/q;
 
-  id = exlin((v/(N*vt_t)), Maxexp) - 1;
+  id = Ids*(exlin(v/(N*vt_t), Maxexp) - 1);
 
   aux = (htemp/TNOM - 1)*EG/(N*vt_t);
   auxp = exp(aux);
 
-  i = Ids*id*pow(htemp/TNOM, XTI/N)*auxp + v/R;
+  i = id*pow(htemp/TNOM, XTI/N)*auxp + v/R;
 
   LossPower = i*v;
   annotation (defaultComponentName="diode",


### PR DESCRIPTION
As reported by https://github.com/modelica/ModelicaStandardLibrary/pull/3010#pullrequestreview-301912956, the diode current formula does not satisfy the unit check. This fix is similar to Diode2 where the diode current `id` already is multiplied by the saturation current `Ids`.