### PR TITLE
Add User's Guide of Analog package

### DIFF
--- a/Modelica/Electrical/Analog/Basic.mo
+++ b/Modelica/Electrical/Analog/Basic.mo
@@ -1375,11 +1375,9 @@ the user has to allocate the parameter vector <em>L[6] </em>, since <em>Nv=(N*(N
 
     annotation (defaultComponentName="opAmp",
       Documentation(info="<html>
-<p>The OpAmpDetailed model is a general operational amplifier model. The emphasis is on separating each important data sheet parameter into a sub-circuit independent of the other parameters. The model is broken down into five functional stages <strong>input</strong>, <strong>frequency response</strong>, <strong>gain</strong>, <strong>slew rate</strong> and an <strong>output</strong> stage. Each stage contains data sheet parameters to be modeled. This partitioning and the modelling of the separate submodels are based on the description in <strong>[CP92]</strong>.</p>
-<p>Using <strong>[CP92]</strong> Joachim Haase (Fraunhofer Institute for Integrated Circuits, Design Automation Division) transferred 2001 operational amplifier models into VHDL-AMS. Now one of these models, the model &quot;amp(macro)&quot; was transferred into Modelica.</p>
-<dl><dt><strong>Reference:</strong> </dt>
-<dd><strong>[CP92]</strong> Conelly, J.A.; Choi, P.: Macromodelling with SPICE. Englewood Cliffs: Prentice-Hall, 1992 </dd>
-</dl></html>", revisions="<html>
+<p>The OpAmpDetailed model is a general operational amplifier model. The emphasis is on separating each important data sheet parameter into a sub-circuit independent of the other parameters. The model is broken down into five functional stages <strong>input</strong>, <strong>frequency response</strong>, <strong>gain</strong>, <strong>slew rate</strong> and an <strong>output</strong> stage. Each stage contains data sheet parameters to be modeled. This partitioning and the modelling of the separate submodels are based on the description in [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Conelly1992</a>].</p>
+<p>Using [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Conelly1992</a>] Joachim Haase (Fraunhofer Institute for Integrated Circuits, Design Automation Division) transferred 2001 operational amplifier models into VHDL-AMS. Now one of these models, the model &quot;amp(macro)&quot; was transferred into Modelica.</p>
+</html>",      revisions="<html>
 <dl>
 <dt><em>June 17, 2009</em></dt>
 <dd>by Susann Wolf initially implemented</dd>

--- a/Modelica/Electrical/Analog/Lines.mo
+++ b/Modelica/Electrical/Analog/Lines.mo
@@ -111,9 +111,8 @@ package Lines
 <p>The user has the possibility to enable a conditional heatport. If so, the OLine can be connected to a thermal network. When the parameter alpha is set to a value greater than zero, the OLine becomes temperature sensitive due to their resistors which resistances are calculated by <code>R_actual = R*(1 + alpha*(heatPort.T - T_ref))</code> and conductors calculated by <code> (G_actual = G/(1 + alpha*(heatPort.T - T_ref)).</code></p>
 <p>Note, this is different to the lumped line model of SPICE.</p>
 
-<dl><dt><strong>References:</strong> </dt>
-<dd>Johnson, B.; Quarles, T.; Newton, A. R.; Pederson, D. O.; Sangiovanni-Vincentelli, A.: SPICE3 Version 3e User&#39;s Manual (April 1, 1991). Department of Electrical Engineering and Computer Sciences, University of California, Berkley p. 12, p. 106 - 107 </dd>
-</dl></html>", revisions="<html>
+<p><strong>References:</strong> [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Johnson1991</a>]</p>
+</html>",      revisions="<html>
 <ul>
 <li><em> 2016   </em>
        by Christoph Clauss<br> resistance and inductance calculation revised<br>
@@ -598,10 +597,8 @@ The capacitances are calculated with: C=c*length/N.
 <br>For all capacitors and resistors the values of each segment are the same except for the first and last resistor, that only has the half of the above calculated value.<p>The user has the possibility to enable a conditional heatport. If so, the ULine can be connected to a thermal network. When the parameter alpha is set to a value greater than zero, the ULine becomes temperature sensitive</p>
 <p>due to their resistors which resistances are calculated by <code>R_actual= R*(1 + alpha*(heatPort.T - T_ref)).</code></p>
 <p>Note, this is different compared with the lumped line model of SPICE.</p>
-<p><strong>References</strong></p>
-<dl><dt>Johnson, B.; Quarles, T.; Newton, A. R.; Pederson, D. O.; Sangiovanni-Vincentelli, A.</dt>
-<dd>SPICE3 Version 3e User&#39;s Manual (April 1, 1991). Department of Electrical Engineering and Computer Sciences, University of California, Berkley p. 22, p. 124 </dd>
-</dl></html>", revisions="<html>
+<p><strong>References:</strong> [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Johnson1991</a>]</p>
+</html>",      revisions="<html>
 <dl>
 <dt><em>2016</em></dt>
 <dd>by Christoph Clauss resistance calculation revised</dd>
@@ -652,12 +649,11 @@ The capacitances are calculated with: C=c*length/N.
     annotation (defaultComponentName="line",
       Documentation(info="<html>
 <p>Lossless transmission line with characteristic impedance Z0 and transmission delay TD The lossless transmission line TLine1 is a two Port. Both port branches consist of a resistor with characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay TD. For further details see Branin&#39;s article below. The model parameters can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;) and TD = sqrt(L&#39;*C&#39;)*length_of_line. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero.</p>
-<p><strong>References:</strong></p>
-<dl><dt>Branin Jr., F. H.</dt>
-<dd>Transient Analysis of Lossless Transmission Lines. Proceedings of the IEEE 55(1967), 2012 - 2013</dd>
-<dt>Hoefer, E. E. E.; Nielinger, H.</dt>
-<dd>SPICE : Analyseprogramm fuer elektronische Schaltungen. Springer-Verlag, Berlin, Heidelberg, New York, Tokyo, 1985. </dd>
-</dl></html>", revisions="<html>
+
+<p><strong>References:</strong> 
+   [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin2012</a>],
+   [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Hoefer1985</a>]</p>
+</html>",      revisions="<html>
 <ul>
 <li><em> 1998   </em>
        by Joachim Haase<br> initially implemented<br>
@@ -722,12 +718,10 @@ The capacitances are calculated with: C=c*length/N.
     annotation (defaultComponentName="line",
       Documentation(info="<html>
 <p>Lossless transmission line with characteristic impedance Z0, frequency F and normalized length NL The lossless transmission line TLine2 is a two Port. Both port branches consist of a resistor with the value of the characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay. For further details see Branin&#39;s article below. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero. The characteristic impedance Z0 can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;). The normalized length NL is equal to the length of the line divided by the wavelength corresponding to the frequency F, i. e. the transmission delay TD is the quotient of NL and F.</p>
-<p><strong>References:</strong></p>
-<dl><dt>Branin Jr., F. H.</dt>
-<dd>Transient Analysis of Lossless Transmission Lines. Proceedings of the IEEE 55(1967), 2012 - 2013</dd>
-<dt>Hoefer, E. E. E.; Nielinger, H.</dt>
-<dd>SPICE : Analyseprogramm fuer elektronische Schaltungen. Springer-Verlag, Berlin, Heidelberg, New York, Tokyo, 1985. </dd>
-</dl></html>", revisions="<html>
+<p><strong>References:</strong> 
+   [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin2012</a>],
+   [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Hoefer1985</a>]</p>
+</html>",      revisions="<html>
 <dl>
 <dt><em>1998</em></dt>
 <dd>by Joachim Haase initially implemented</dd>
@@ -787,12 +781,10 @@ The capacitances are calculated with: C=c*length/N.
     annotation (defaultComponentName="line",
       Documentation(info="<html>
 <p>Lossless transmission line with characteristic impedance Z0 and frequency F The lossless transmission line TLine3 is a two Port. Both port branches consist of a resistor with value of the characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay. For further details see Branin&#39;s article below. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero. The characteristic impedance Z0 can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;). The length of the line is equal to a quarter of the wavelength corresponding to the frequency F, i. e. the transmission delay is the quotient of 4 and F. In this case, the characteristic impedance is called natural impedance.</p>
-<p><strong>References:</strong></p>
-<dl><dt>Branin Jr., F. H.</dt>
-<dd>Transient Analysis of Lossless Transmission Lines. Proceedings of the IEEE 55(1967), 2012 - 2013</dd>
-<dt>Hoefer, E. E. E.; Nielinger, H.</dt>
-<dd>SPICE : Analyseprogramm fuer elektronische Schaltungen. Springer-Verlag, Berlin, Heidelberg, New York, Tokyo, 1985. </dd>
-</dl></html>", revisions="<html>
+<p><strong>References:</strong> 
+   [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin2012</a>],
+   [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Hoefer1985</a>]</p>
+</html>",      revisions="<html>
 <ul>
 <li><em> 1998   </em>
        by Joachim Haase<br> initially implemented<br>

--- a/Modelica/Electrical/Analog/Lines.mo
+++ b/Modelica/Electrical/Analog/Lines.mo
@@ -648,10 +648,10 @@ The capacitances are calculated with: C=c*length/N.
     er = 2*delay(v1, TD) - delay(es, TD);
     annotation (defaultComponentName="line",
       Documentation(info="<html>
-<p>Lossless transmission line with characteristic impedance Z0 and transmission delay TD The lossless transmission line TLine1 is a two Port. Both port branches consist of a resistor with characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay TD. For further details see Branin&#39;s article below. The model parameters can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;) and TD = sqrt(L&#39;*C&#39;)*length_of_line. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero.</p>
+<p>Lossless transmission line with characteristic impedance Z0 and transmission delay TD The lossless transmission line TLine1 is a two Port. Both port branches consist of a resistor with characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay TD. For further details see [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>]. The model parameters can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;) and TD = sqrt(L&#39;*C&#39;)*length_of_line. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero.</p>
 
 <p><strong>References:</strong> 
-   [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin2012</a>],
+   [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>],
    [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Hoefer1985</a>]</p>
 </html>",      revisions="<html>
 <ul>
@@ -717,9 +717,9 @@ The capacitances are calculated with: C=c*length/N.
     er = 2*delay(v1, TD) - delay(es, TD);
     annotation (defaultComponentName="line",
       Documentation(info="<html>
-<p>Lossless transmission line with characteristic impedance Z0, frequency F and normalized length NL The lossless transmission line TLine2 is a two Port. Both port branches consist of a resistor with the value of the characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay. For further details see Branin&#39;s article below. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero. The characteristic impedance Z0 can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;). The normalized length NL is equal to the length of the line divided by the wavelength corresponding to the frequency F, i. e. the transmission delay TD is the quotient of NL and F.</p>
+<p>Lossless transmission line with characteristic impedance Z0, frequency F and normalized length NL The lossless transmission line TLine2 is a two Port. Both port branches consist of a resistor with the value of the characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay. For further details see [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>]. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero. The characteristic impedance Z0 can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;). The normalized length NL is equal to the length of the line divided by the wavelength corresponding to the frequency F, i. e. the transmission delay TD is the quotient of NL and F.</p>
 <p><strong>References:</strong> 
-   [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin2012</a>],
+   [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>],
    [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Hoefer1985</a>]</p>
 </html>",      revisions="<html>
 <dl>
@@ -780,9 +780,9 @@ The capacitances are calculated with: C=c*length/N.
     er = 2*delay(v1, TD) - delay(es, TD);
     annotation (defaultComponentName="line",
       Documentation(info="<html>
-<p>Lossless transmission line with characteristic impedance Z0 and frequency F The lossless transmission line TLine3 is a two Port. Both port branches consist of a resistor with value of the characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay. For further details see Branin&#39;s article below. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero. The characteristic impedance Z0 can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;). The length of the line is equal to a quarter of the wavelength corresponding to the frequency F, i. e. the transmission delay is the quotient of 4 and F. In this case, the characteristic impedance is called natural impedance.</p>
+<p>Lossless transmission line with characteristic impedance Z0 and frequency F The lossless transmission line TLine3 is a two Port. Both port branches consist of a resistor with value of the characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay. For further details see [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>]. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero. The characteristic impedance Z0 can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;). The length of the line is equal to a quarter of the wavelength corresponding to the frequency F, i. e. the transmission delay is the quotient of 4 and F. In this case, the characteristic impedance is called natural impedance.</p>
 <p><strong>References:</strong> 
-   [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin2012</a>],
+   [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>],
    [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Hoefer1985</a>]</p>
 </html>",      revisions="<html>
 <ul>
@@ -825,7 +825,6 @@ The capacitances are calculated with: C=c*length/N.
               textString="TLine3",
               textColor={0,0,255})}));
   end TLine3;
-
   annotation (Documentation(info="<html>
 <p>This package contains lossy and lossless segmented transmission lines, and LC distributed line models. The line models do not yet possess a conditional heating port.</p>
 </html>", revisions="<html>

--- a/Modelica/Electrical/Analog/Semiconductors.mo
+++ b/Modelica/Electrical/Analog/Semiconductors.mo
@@ -259,7 +259,7 @@ equation
 <p>
 The PMOS model is a simple model of a p-channel metal-oxide semiconductor
 FET. It differs slightly from the device used in the SPICE simulator.
-For more details please care for H. Spiro.
+For more details please care for [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Spiro1990</a>].
 </p>
 <p>
 The model does not consider capacitances. A high drain-source resistance RDS
@@ -269,11 +269,9 @@ is included to avoid numerical difficulties.
 In case of useHeatPort=true the temperature dependence of the electrical
 behavior is <strong>not</strong> modelled yet. The parameters are not temperature dependent.
 </p>
-<dl>
-<dt><strong>References:</strong></dt>
-<dd>Spiro, H.: Simulation integrierter Schaltungen. R. Oldenbourg Verlag
-  Muenchen Wien 1990.</dd>
-</dl>
+
+<p><strong>References:</strong> [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Spiro1990</a>]</p>
+
 <p>
 Some typical parameter sets are:
 </p>
@@ -379,7 +377,7 @@ equation
 <p>
 The NMOS model is a simple model of a n-channel metal-oxide semiconductor
 FET. It differs slightly from the device used in the SPICE simulator.
-For more details please care for H. Spiro.
+For more details please care for [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Spiro1990</a>].
 </p>
 <p>
 The model does not consider capacitances. A high drain-source resistance RDS
@@ -412,11 +410,7 @@ behavior is <strong>not</strong> modelled yet. The parameters are not temperatur
   20.e-6  6.e-6  0.022e-3     0.8     1      0.66     0        0
 </pre>
 
-<dl>
-<dt><strong>References:</strong></dt>
-<dd>Spiro, H.: Simulation integrierter Schaltungen. R. Oldenbourg Verlag
-Muenchen Wien 1990.</dd>
-</dl>
+<p><strong>References:</strong> [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Spiro1990</a>]</p>
 </html>",
  revisions="<html>
 <ul>
@@ -540,12 +534,8 @@ A typical parameter set is:
   -   -   A      V    s       s     F     F       F       V     -    V      -      mS     mS     V
   50  0.1 1e-16  0.02 0.12e-9 5e-9  1e-12 0.4e-12 0.5e-12 0.8   0.4  0.8    0.333  1e-15  1e-15  0.02585
 </pre>
-<dl>
-<dt><strong>References:</strong></dt>
-<dd>Vlach, J.; Singal, K.: Computer methods for circuit analysis and design.
-Van Nostrand Reinhold, New York 1983
-on page 317 ff.</dd>
-</dl>
+
+<p><strong>References:</strong> [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Vlach1993</a>, pp. 317]</p>
 </html>",
  revisions="<html>
 <ul>
@@ -656,12 +646,8 @@ A typical parameter set is:
   -   -   A      V    s       s     F     F       F       V     -    V      -      mS     mS     V
   50  0.1 1e-16  0.02 0.12e-9 5e-9  1e-12 0.4e-12 0.5e-12 0.8   0.4  0.8    0.333  1e-15  1e-15  0.02585
 </pre>
-<dl>
-<dt><strong>References:</strong></dt>
-<dd>Vlach, J.; Singal, K.: Computer methods for circuit analysis and design.
-Van Nostrand Reinhold, New York 1983
-on page 317 ff.</dd>
-</dl>
+
+<p><strong>References:</strong> [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Vlach1993</a>, pp. 317]</p>
 </html>",
  revisions="<html>
 <ul>
@@ -867,8 +853,7 @@ end HeatingDiode;
   12.e-6  4.e-6  0.038e-3    -0.8     0.33   0.6      0        0           zero
   20.e-6  6.e-6  0.022e-3     0.8     1      0.66     0        0
 </pre>
-<p><strong>References:</strong></p>
-<p>Spiro, H.: Simulation integrierter Schaltungen. R. Oldenbourg Verlag Muenchen Wien 1990.</p>
+<p><strong>References:</strong> [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Spiro1990</a>]</p>
 </html>",  revisions="<html>
 <ul>
 <li><em> March 11, 2009   </em>
@@ -966,9 +951,8 @@ end HeatingDiode;
 <p>The PMOS model is a simple model of a p-channel metal-oxide semiconductor FET. It differs slightly from the device used in the SPICE simulator. For more details please care for H. Spiro.
 <br>A heating port is added for thermal electric simulation. The heating port is defined in the Modelica.Thermal library.
 <br>The model does not consider capacitances. A high drain-source resistance RDS is included to avoid numerical difficulties.</p>
-<dl><dt><strong>References:</strong> </dt>
-<dd>Spiro, H.: Simulation integrierter Schaltungen. R. Oldenbourg Verlag Muenchen Wien 1990. </dd>
-</dl><p>Some typical parameter sets are:</p>
+<p><strong>References:</strong> [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Spiro1990</a>]</p>
+<p>Some typical parameter sets are:</p>
 <pre>
   W       L      Beta        Vt    K2     K5      DW       DL
   m       m      A/V^2       V     -      -       m        m
@@ -1095,8 +1079,7 @@ end HeatingDiode;
 <pre>  Bf  Br  Is     Vak  Tauf    Taur  Ccs   Cje     Cjc     Phie  Me   PHic   Mc     Gbc    Gbe
   -   -   A      V    s       s     F     F       F       V     -    V      -      mS     mS
   50  0.1 1e-16  0.02 0.12e-9 5e-9  1e-12 0.4e-12 0.5e-12 0.8   0.4  0.8    0.333  1e-15  1e-15</pre>
-<p><strong>References:</strong></p>
-<p>Vlach, J.; Singal, K.: Computer methods for circuit analysis and design. Van Nostrand Reinhold, New York 1983 on page 317 ff.</p>
+<p><strong>References:</strong> [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Vlach1983</a>]</p>
 </html>",  revisions="<html>
 <ul>
 <li><em> March 11, 2009   </em>
@@ -1206,8 +1189,7 @@ end HeatingDiode;
 <pre>  Bf  Br  Is     Vak  Tauf    Taur  Ccs   Cje     Cjc     Phie  Me   PHic   Mc     Gbc    Gbe
   -   -   A      V    s       s     F     F       F       V     -    V      -      mS     mS
   50  0.1 1e-16  0.02 0.12e-9 5e-9  1e-12 0.4e-12 0.5e-12 0.8   0.4  0.8    0.333  1e-15  1e-15</pre>
-<p><strong>References:</strong></p>
-<p>Vlach, J.; Singal, K.: Computer methods for circuit analysis and design. Van Nostrand Reinhold, New York 1983 on page 317 ff.</p>
+<p><strong>References:</strong> [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Vlach1983</a>]</p>
 </html>",  revisions="<html>
 <ul>
 <li><em> March 11, 2009   </em>

--- a/Modelica/Electrical/Analog/UsersGuide/Contact.mo
+++ b/Modelica/Electrical/Analog/UsersGuide/Contact.mo
@@ -1,0 +1,21 @@
+within Modelica.Electrical.Analog.UsersGuide;
+class Contact "Contact"
+  extends Modelica.Icons.Contact;
+  annotation (preferredView="info",Documentation(info="<html>
+<dl>
+<dt>
+<strong>Main Authors:</strong>
+</dt>
+<dd>
+Christoph Clau&szlig;
+    &lt;<a href=\"mailto:christoph@clauss-it.com\">christoph@clauss-it.com</a>&gt;<br>
+    Andr&eacute; Schneider
+    &lt;<a href=\"mailto:Andre.Schneider@eas.iis.fraunhofer.de\">Andre.Schneider@eas.iis.fraunhofer.de</a>&gt;<br>
+    Fraunhofer Institute for Integrated Circuits<br>
+    Design Automation Department<br>
+    Zeunerstra&szlig;e 38<br>
+    D-01069 Dresden, Germany
+</dd>
+</dl>
+</html>"));
+end Contact;

--- a/Modelica/Electrical/Analog/UsersGuide/References.mo
+++ b/Modelica/Electrical/Analog/UsersGuide/References.mo
@@ -31,11 +31,6 @@ class References "References"
   </tr>
 
   <tr>
-    <td>[<a href=\"http://brownwalker.com/book/1612335004\">Malaric2011</a>]</td>
-    <td>R. Malaric, <em>Instrumentation and Measurement in Electrical Engineering</em>, BrownWalker Press, 2011</td>
-  </tr>
-
-  <tr>
     <td>[Spiro1990]</td>
     <td>H. Spiro, H, <em>Simulation integrierter Schaltungen</em>, R. Oldenbourg Verlag M&uuml;nchen Wien, 1990</td>
   </tr>

--- a/Modelica/Electrical/Analog/UsersGuide/References.mo
+++ b/Modelica/Electrical/Analog/UsersGuide/References.mo
@@ -7,7 +7,7 @@ class References "References"
 
   <tr>
     <td>[<a href=\"https://ieeexplore.ieee.org/document/1447963\">Branin2012</a>]</td>
-    <td>F. H. Branin Jr., &quot;Transient Analysis of Lossless Transmission Lines&quot;, <em>Proceedings of the IEEE</em>, 
+    <td>F. H. Branin Jr., &quot;Transient Analysis of Lossless Transmission Lines&quot;, <em>Proceedings of the IEEE</em>,
         vol. 55, pp. 2012-2013, 1967</td>
   </tr>
 
@@ -17,16 +17,16 @@ class References "References"
   </tr>
 
   <tr>
-    <td>[<a href=\"https://www.springer.com/de/book/9783540151609\">Hoefer1985</a>]</td>
+    <td>[<a href=\"https://www.springer.com/us/book/9783540151609\">Hoefer1985</a>]</td>
     <td>E. E. E. Hoefer, H. Nielinger, <em>SPICE: Analyseprogramm f&uuml;r elektronische Schaltungen<em>,
-        Springer-Verlag, Berlin, Heidelberg, New York, Tokyo, 1985</td> 
+        Springer-Verlag, Berlin, Heidelberg, New York, Tokyo, 1985</td>
   </tr>
 
   <tr>
     <td>[Johnson1991]</td>
-    <td>B. Johnson, T. Quarles, A. R. Newton, D. O. Pederson, A. Sangiovanni-Vincentelli, 
-        <em>SPICE3 Version 3e User&#39;s Manual</em>, 
-        Department of Electrical Engineering and Computer Sciences, 
+    <td>B. Johnson, T. Quarles, A. R. Newton, D. O. Pederson, A. Sangiovanni-Vincentelli,
+        <em>SPICE3 Version 3e User&#39;s Manual</em>,
+        Department of Electrical Engineering and Computer Sciences,
         University of California, Berkley p. 12, p. 106 - 107, April 1, 1991</td>
   </tr>
 

--- a/Modelica/Electrical/Analog/UsersGuide/References.mo
+++ b/Modelica/Electrical/Analog/UsersGuide/References.mo
@@ -5,15 +5,35 @@ class References "References"
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
 
-    <tr>
-      <td>[Conelly1992]</td>
-      <td>J.A. Conelly, <em>Macromodelling with SPICE</em>, Englewood Cliffs: Prentice-Hall, 1992</td>
-    </tr>
+  <tr>
+    <td>[<a href=\"https://ieeexplore.ieee.org/document/1447963\">Branin2012</a>]</td>
+    <td>F. H. Branin Jr., &quot;Transient Analysis of Lossless Transmission Lines&quot;, <em>Proceedings of the IEEE</em>, 
+        vol. 55, pp. 2012-2013, 1967</td>
+  </tr>
 
-    <tr>
-      <td>[<a href=\"http://brownwalker.com/book/1612335004\">Malaric2011</a>]</td>
-      <td>R. Malaric, <em>Instrumentation and Measurement in Electrical Engineering</em>, BrownWalker Press, 2011</td>
-    </tr>
+  <tr>
+    <td>[Conelly1992]</td>
+    <td>J.A. Conelly, <em>Macromodelling with SPICE</em>, Englewood Cliffs: Prentice-Hall, 1992</td>
+  </tr>
+
+  <tr>
+    <td>[<a href=\"https://www.springer.com/de/book/9783540151609\">Hoefer1985</a>]</td>
+    <td>E. E. E. Hoefer, H. Nielinger, <em>SPICE: Analyseprogramm f&umlu;r elektronische Schaltungen<em>,
+        Springer-Verlag, Berlin, Heidelberg, New York, Tokyo, 1985</td> 
+  </tr>
+
+  <tr>
+    <td>[Johnson1991]</td>
+    <td>B. Johnson, T. Quarles, A. R. Newton, D. O. Pederson, A. Sangiovanni-Vincentelli, 
+        <em>SPICE3 Version 3e User&#39;s Manual</em>, 
+        Department of Electrical Engineering and Computer Sciences, 
+        University of California, Berkley p. 12, p. 106 - 107, April 1, 1991</td>
+  </tr>
+
+  <tr>
+    <td>[<a href=\"http://brownwalker.com/book/1612335004\">Malaric2011</a>]</td>
+    <td>R. Malaric, <em>Instrumentation and Measurement in Electrical Engineering</em>, BrownWalker Press, 2011</td>
+  </tr>
 
 </table>
 </html>"));

--- a/Modelica/Electrical/Analog/UsersGuide/References.mo
+++ b/Modelica/Electrical/Analog/UsersGuide/References.mo
@@ -1,0 +1,20 @@
+within Modelica.Electrical.Analog.UsersGuide;
+class References "References"
+  extends Modelica.Icons.References;
+  annotation (preferredView="info",Documentation(info="<html>
+
+<table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
+
+    <tr>
+      <td>[Conelly1992]</td>
+      <td>J.A. Conelly, <em>Macromodelling with SPICE</em>, Englewood Cliffs: Prentice-Hall, 1992</td>
+    </tr>
+
+    <tr>
+      <td>[<a href=\"http://brownwalker.com/book/1612335004\">Malaric2011</a>]</td>
+      <td>R. Malaric, <em>Instrumentation and Measurement in Electrical Engineering</em>, BrownWalker Press, 2011</td>
+    </tr>
+
+</table>
+</html>"));
+end References;

--- a/Modelica/Electrical/Analog/UsersGuide/References.mo
+++ b/Modelica/Electrical/Analog/UsersGuide/References.mo
@@ -18,7 +18,7 @@ class References "References"
 
   <tr>
     <td>[<a href=\"https://www.springer.com/de/book/9783540151609\">Hoefer1985</a>]</td>
-    <td>E. E. E. Hoefer, H. Nielinger, <em>SPICE: Analyseprogramm f&umlu;r elektronische Schaltungen<em>,
+    <td>E. E. E. Hoefer, H. Nielinger, <em>SPICE: Analyseprogramm f&uuml;r elektronische Schaltungen<em>,
         Springer-Verlag, Berlin, Heidelberg, New York, Tokyo, 1985</td> 
   </tr>
 
@@ -35,6 +35,15 @@ class References "References"
     <td>R. Malaric, <em>Instrumentation and Measurement in Electrical Engineering</em>, BrownWalker Press, 2011</td>
   </tr>
 
+  <tr>
+    <td>[Spiro1990]</td>
+    <td>H. Spiro, H, <em>Simulation integrierter Schaltungen</em>, R. Oldenbourg Verlag M&uuml;nchen Wien, 1990</td>
+  </tr>
+
+  <tr>
+    <td>[Vlach1983]</td>
+    <td>J. Vlach, K. Singal, <em>Computer methods for circuit analysis and design</em>, Van Nostrand Reinhold, New York 1983</td>
+  </tr>
 </table>
 </html>"));
 end References;

--- a/Modelica/Electrical/Analog/UsersGuide/References.mo
+++ b/Modelica/Electrical/Analog/UsersGuide/References.mo
@@ -6,7 +6,7 @@ class References "References"
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
 
   <tr>
-    <td>[<a href=\"https://ieeexplore.ieee.org/document/1447963\">Branin2012</a>]</td>
+    <td>[<a href=\"https://ieeexplore.ieee.org/document/1447963\">Branin1967</a>]</td>
     <td>F. H. Branin Jr., &quot;Transient analysis of lossless transmission lines&quot;, <em>Proceedings of the IEEE</em>,
         vol. 55, pp. 2012-2013, 1967</td>
   </tr>

--- a/Modelica/Electrical/Analog/UsersGuide/References.mo
+++ b/Modelica/Electrical/Analog/UsersGuide/References.mo
@@ -7,7 +7,7 @@ class References "References"
 
   <tr>
     <td>[<a href=\"https://ieeexplore.ieee.org/document/1447963\">Branin2012</a>]</td>
-    <td>F. H. Branin Jr., &quot;Transient Analysis of Lossless Transmission Lines&quot;, <em>Proceedings of the IEEE</em>,
+    <td>F. H. Branin Jr., &quot;Transient analysis of lossless transmission lines&quot;, <em>Proceedings of the IEEE</em>,
         vol. 55, pp. 2012-2013, 1967</td>
   </tr>
 

--- a/Modelica/Electrical/Analog/UsersGuide/ReleaseNotes.mo
+++ b/Modelica/Electrical/Analog/UsersGuide/ReleaseNotes.mo
@@ -1,0 +1,12 @@
+within Modelica.Electrical.Analog.UsersGuide;
+class ReleaseNotes "Release Notes"
+  extends Modelica.Icons.ReleaseNotes;
+  annotation (preferredView="info",Documentation(info="<html>
+
+<h5>Version 4.0.0, 2019-10-18</h5>
+<ul>
+  <li>Add User's Guide, see
+      <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/2990\">#2990</a></li>
+</ul>
+</html>"));
+end ReleaseNotes;

--- a/Modelica/Electrical/Analog/UsersGuide/package.mo
+++ b/Modelica/Electrical/Analog/UsersGuide/package.mo
@@ -1,10 +1,6 @@
 within Modelica.Electrical.Analog;
 package UsersGuide "User's Guide"
   extends Modelica.Icons.Information;
-
-
-
-
   annotation (
     preferredView="info",
     DocumentationClass=true,
@@ -23,7 +19,5 @@ The Analog package contains the following components:
 <li><a href=\"modelica://Modelica.Electrical.Analog.Sources\">Sources</a>: time-dependent and controlled voltage and current sources</li>
 <li><a href=\"modelica://Modelica.Electrical.Analog.Icons\">Icons</a>: domain specific icons</li>
 </ul>
-
-
 </html>"));
 end UsersGuide;

--- a/Modelica/Electrical/Analog/UsersGuide/package.mo
+++ b/Modelica/Electrical/Analog/UsersGuide/package.mo
@@ -1,0 +1,29 @@
+within Modelica.Electrical.Analog;
+package UsersGuide "User's Guide"
+  extends Modelica.Icons.Information;
+
+
+
+
+  annotation (
+    preferredView="info",
+    DocumentationClass=true,
+    Documentation(info="<html>
+<p>
+The Analog package contains the following components:
+</p>
+
+<ul>
+<li><a href=\"modelica://Modelica.Electrical.Analog.Basic\">Basic</a>: basic components (ground, resistor, capacitor, conductor, inductor, transformer, gyrator)</li>
+<li><a href=\"modelica://Modelica.Electrical.Analog.Ideal\">Ideal</a>: ideal elements (switches, diode, transformer, idle, short, ...)</li>
+<li><a href=\"modelica://Modelica.Electrical.Analog.Lines\">Lines</a>: transmission lines (lossy and lossless)</li>
+<li><a href=\"modelica://Modelica.Electrical.Analog.Semiconductors\">Semiconductors</a>: semiconductor devices (diode, bipolar and MOS transistors)</li>
+<li><a href=\"modelica://Modelica.Electrical.Analog.Interfaces\">Interfaces</a>: ideal elements (switches, diode, transformer, idle, short, ...)</li>
+<li><a href=\"modelica://Modelica.Electrical.Analog.Sensors\">Sensors</a>: sensors to measure potential, voltage, current and power</li>
+<li><a href=\"modelica://Modelica.Electrical.Analog.Sources\">Sources</a>: time-dependent and controlled voltage and current sources</li>
+<li><a href=\"modelica://Modelica.Electrical.Analog.Icons\">Icons</a>: domain specific icons</li>
+</ul>
+
+
+</html>"));
+end UsersGuide;

--- a/Modelica/Electrical/Analog/UsersGuide/package.order
+++ b/Modelica/Electrical/Analog/UsersGuide/package.order
@@ -1,0 +1,3 @@
+Contact
+ReleaseNotes
+References

--- a/Modelica/Electrical/Analog/package.mo
+++ b/Modelica/Electrical/Analog/package.mo
@@ -1,33 +1,13 @@
 within Modelica.Electrical;
 package Analog "Library for analog electrical models"
   import SI = Modelica.SIunits;
+
   extends Modelica.Icons.Package;
+
   annotation (Documentation(info="<html>
 <p>
-This package contains packages for analog electrical components:</p>
-<ul>
-<li>Basic: basic components (resistor, capacitor, conductor, inductor, transformer, gyrator)</li>
-<li>Semiconductors: semiconductor devices (diode, bipolar and MOS transistors)</li>
-<li>Lines: transmission lines (lossy and lossless)</li>
-<li>Ideal: ideal elements (switches, diode, transformer, idle, short, ...)</li>
-<li>Sources: time-dependent and controlled voltage and current sources</li>
-<li>Sensors: sensors to measure potential, voltage, and current</li>
-</ul>
-<dl>
-<dt>
-<strong>Main Authors:</strong>
-</dt>
-<dd>
-Christoph Clau&szlig;
-    &lt;<a href=\"mailto:christoph@clauss-it.com\">christoph@clauss-it.com</a>&gt;<br>
-    Andr&eacute; Schneider
-    &lt;<a href=\"mailto:Andre.Schneider@eas.iis.fraunhofer.de\">Andre.Schneider@eas.iis.fraunhofer.de</a>&gt;<br>
-    Fraunhofer Institute for Integrated Circuits<br>
-    Design Automation Department<br>
-    Zeunerstra&szlig;e 38<br>
-    D-01069 Dresden, Germany
-</dd>
-</dl>
+This package contains packages for single phase electrical components, see
+<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide\">User's Guide</a></p>
 </html>"), Icon(graphics={
         Line(
           points={{12,60},{12,-60}}),

--- a/Modelica/Electrical/Analog/package.mo
+++ b/Modelica/Electrical/Analog/package.mo
@@ -7,7 +7,7 @@ package Analog "Library for analog electrical models"
   annotation (Documentation(info="<html>
 <p>
 This package contains packages for single phase electrical components, see
-<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide\">User's Guide</a></p>
+<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide\">User&#39;s Guide</a></p>
 </html>"), Icon(graphics={
         Line(
           points={{12,60},{12,-60}}),

--- a/Modelica/Electrical/Analog/package.mo
+++ b/Modelica/Electrical/Analog/package.mo
@@ -6,7 +6,7 @@ package Analog "Library for analog electrical models"
 
   annotation (Documentation(info="<html>
 <p>
-This package contains packages for single phase electrical components, see
+This package contains packages for single-phase electrical components, see
 <a href=\"modelica://Modelica.Electrical.Analog.UsersGuide\">User&#39;s Guide</a></p>
 </html>"), Icon(graphics={
         Line(

--- a/Modelica/Electrical/Analog/package.order
+++ b/Modelica/Electrical/Analog/package.order
@@ -1,3 +1,4 @@
+UsersGuide
 Examples
 Basic
 Ideal


### PR DESCRIPTION
Refs #2990

The User's Guide missing the Analog package shall be added. All references are now included in line with guidelines of the Modelica Standard Library. Additional internet links to external literature is added where available. 