### PR TITLE
Add User's Guide of HeatTransfer

### DIFF
--- a/Modelica/Thermal/HeatTransfer/Components/Convection.mo
+++ b/Modelica/Thermal/HeatTransfer/Components/Convection.mo
@@ -85,7 +85,7 @@ from properties of the fluid flowing over the solid. Examples:
 </p>
 <p>
 <strong>Machines cooled by air</strong> (empirical, very rough approximation according
-to [<a href=\"Modelica.Thermal.HeatTransfer.UsersGuide.References\">Fischer1999</a>, p. 378]:
+to [<a href=\"Modelica.Thermal.HeatTransfer.UsersGuide.References\">Fischer2017</a>, p. 452]:
 </p>
 <pre>
     h = 7.8*v^0.78 [W/(m2.K)] (forced convection)

--- a/Modelica/Thermal/HeatTransfer/Components/Convection.mo
+++ b/Modelica/Thermal/HeatTransfer/Components/Convection.mo
@@ -85,8 +85,7 @@ from properties of the fluid flowing over the solid. Examples:
 </p>
 <p>
 <strong>Machines cooled by air</strong> (empirical, very rough approximation according
-to R. Fischer: Elektrische Maschinen, 10th edition, Hanser-Verlag 1999,
-p. 378):
+to [<a href=\"Modelica.Thermal.HeatTransfer.UsersGuide.References\">Fischer1999</a>, p. 378]:
 </p>
 <pre>
     h = 7.8*v^0.78 [W/(m2.K)] (forced convection)
@@ -97,8 +96,7 @@ p. 378):
 <p><strong>Laminar</strong> flow with constant velocity of a fluid along a
 <strong>flat plate</strong> where the heat flow rate from the plate
 to the fluid (= solid.Q_flow) is kept constant
-(according to J.P.Holman: Heat Transfer, 8th edition,
-McGraw-Hill, 1997, p.270):
+(according to [<a href=\"Modelica.Thermal.HeatTransfer.UsersGuide.References\">Holman1997</a>, p.270]):
 </p>
 <pre>
    h  = Nu*k/x;

--- a/Modelica/Thermal/HeatTransfer/Components/Convection.mo
+++ b/Modelica/Thermal/HeatTransfer/Components/Convection.mo
@@ -96,7 +96,7 @@ to [<a href=\"Modelica.Thermal.HeatTransfer.UsersGuide.References\">Fischer1999<
 <p><strong>Laminar</strong> flow with constant velocity of a fluid along a
 <strong>flat plate</strong> where the heat flow rate from the plate
 to the fluid (= solid.Q_flow) is kept constant
-(according to [<a href=\"Modelica.Thermal.HeatTransfer.UsersGuide.References\">Holman1997</a>, p.270]):
+(according to [<a href=\"Modelica.Thermal.HeatTransfer.UsersGuide.References\">Holman2010</a>, p.265]):
 </p>
 <pre>
    h  = Nu*k/x;

--- a/Modelica/Thermal/HeatTransfer/UsersGuide/Contact.mo
+++ b/Modelica/Thermal/HeatTransfer/UsersGuide/Contact.mo
@@ -19,12 +19,13 @@ Copyright &copy; 2001-2019, Modelica Association and contributors
 
 <p>
 <strong>Acknowledgements:</strong><br>
-Several helpful remarks from the following persons are acknowledged:
-John Batteh, Ford Motors, Dearborn, U.S.A;
-<a href=\"https://www.haumer.at/\">Anton Haumer</a>, Technical Consulting &amp; Electrical Engineering, Germany;
-Ludwig Marvan, VA TECH ELIN EBG Elektronik GmbH, Wien, Austria;
-Hans Olsson, Dassault Syst&egrave;mes AB, Sweden;
-Hubertus Tummescheit, Lund Institute of Technology, Lund, Sweden.
-</p>
+Several helpful remarks from the following persons are acknowledged:</p>
+<ul>
+<li>John Batteh, previously at Ford Motors, Dearborn, U.S.A</li>
+<li><a href=\"https://www.haumer.at/\">Anton Haumer</a>, Technical Consulting &amp; Electrical Engineering, Germany</li>
+<li>Ludwig Marvan, VA TECH ELIN EBG Elektronik GmbH, Wien, Austria</li>
+<li>Hans Olsson, Dassault Syst&egrave;mes AB, Sweden</li>
+<li>Hubertus Tummescheit, previously at Lund Institute of Technology, Lund, Sweden</li>
+</ul>
 </html>"));
 end Contact;

--- a/Modelica/Thermal/HeatTransfer/UsersGuide/Contact.mo
+++ b/Modelica/Thermal/HeatTransfer/UsersGuide/Contact.mo
@@ -1,0 +1,30 @@
+within Modelica.Thermal.HeatTransfer.UsersGuide;
+class Contact "Contact"
+  extends Modelica.Icons.Contact;
+  annotation (preferredView="info",Documentation(info="<html>
+<dl>
+  <dt><strong>Main Authors:</strong></dt>
+  <dd>
+  <p>
+  <a href=\"https://www.haumer.at/\">Anton Haumer</a><br>
+  Technical Consulting &amp; Electrical Engineering<br>
+  D-93049 Regensburg, Germany<br>
+  email: <a href=\"mailto:a.haumer@haumer.at\">a.haumer@haumer.at</a>
+</p>
+  </dd>
+</dl>
+<p>
+Copyright &copy; 2001-2019, Modelica Association and contributors
+</p>
+
+<p>
+<strong>Acknowledgements:</strong><br>
+Several helpful remarks from the following persons are acknowledged:
+John Batteh, Ford Motors, Dearborn, U.S.A;
+<a href=\"https://www.haumer.at/\">Anton Haumer</a>, Technical Consulting &amp; Electrical Engineering, Germany;
+Ludwig Marvan, VA TECH ELIN EBG Elektronik GmbH, Wien, Austria;
+Hans Olsson, Dassault Syst&egrave;mes AB, Sweden;
+Hubertus Tummescheit, Lund Institute of Technology, Lund, Sweden.
+</p>
+</html>"));
+end Contact;

--- a/Modelica/Thermal/HeatTransfer/UsersGuide/References.mo
+++ b/Modelica/Thermal/HeatTransfer/UsersGuide/References.mo
@@ -1,0 +1,24 @@
+within Modelica.Thermal.HeatTransfer.UsersGuide;
+class References "References"
+  extends Modelica.Icons.References;
+  annotation (preferredView="info",Documentation(info="<html>
+
+<table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
+
+  <tr>
+    <td>[Fischer1999]</td>
+    <td>R. Fischer, <em>Elektrische Maschinen</em> (in German), 10th edition, Hanser-Verlag, 1999</td>
+  </tr>
+
+  <tr>
+    <td>[Holman1997]</td>
+    <td>J. P. Holman, <em>Heat Transfer</em>, 8th edition, McGraw-Hill, 1997</td>
+  </tr>
+  <tr>
+    <td>[<a href=\"https://www.springer.com/us/book/9780792373674\">Tiller2001</a>]</td>
+    <td>Michael Tiller, <em>Introduction to Physical Modeling with Modelica</em>, Kluwer Academic Publishers Boston, 2001</td>
+  </tr>
+
+</table>
+</html>"));
+end References;

--- a/Modelica/Thermal/HeatTransfer/UsersGuide/References.mo
+++ b/Modelica/Thermal/HeatTransfer/UsersGuide/References.mo
@@ -11,8 +11,8 @@ class References "References"
   </tr>
 
   <tr>
-    <td>[Holman1997]</td>
-    <td>J. P. Holman, <em>Heat Transfer</em>, 8th edition, McGraw-Hill, 1997</td>
+    <td>[<a href=\"https://www.academia.edu/38166004/Heat_Transfer_10thEdition_by_JP_Holman.pdf\">Holman2010</a>]</td>
+    <td>J. P. Holman, <em>Heat Transfer</em>, 10th edition, McGraw-Hill, 2010</td>
   </tr>
   <tr>
     <td>[<a href=\"https://www.springer.com/us/book/9780792373674\">Tiller2001</a>]</td>

--- a/Modelica/Thermal/HeatTransfer/UsersGuide/References.mo
+++ b/Modelica/Thermal/HeatTransfer/UsersGuide/References.mo
@@ -6,8 +6,8 @@ class References "References"
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
 
   <tr>
-    <td>[Fischer1999]</td>
-    <td>R. Fischer, <em>Elektrische Maschinen</em> (in German), 10th edition, Hanser-Verlag, 1999</td>
+    <td>[<a href=\"https://www.hanser-elibrary.com/isbn/9783446452183\">Fischer2017</a>]</td>
+    <td>R. Fischer, <em>Elektrische Maschinen</em> (in German), 17th edition, Hanser-Verlag, 2017</td>
   </tr>
 
   <tr>

--- a/Modelica/Thermal/HeatTransfer/UsersGuide/ReleaseNotes.mo
+++ b/Modelica/Thermal/HeatTransfer/UsersGuide/ReleaseNotes.mo
@@ -1,0 +1,12 @@
+within Modelica.Thermal.HeatTransfer.UsersGuide;
+class ReleaseNotes "Release Notes"
+  extends Modelica.Icons.ReleaseNotes;
+  annotation (preferredView="info",Documentation(info="<html>
+
+<h5>Version 4.0.0, 2019-10-18</h5>
+<ul>
+  <li>Add User's Guide, see
+      <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/2990\">#2990</a></li>
+</ul>
+</html>"));
+end ReleaseNotes;

--- a/Modelica/Thermal/HeatTransfer/UsersGuide/package.mo
+++ b/Modelica/Thermal/HeatTransfer/UsersGuide/package.mo
@@ -1,6 +1,7 @@
 within Modelica.Thermal.HeatTransfer;
 package UsersGuide "User's Guide"
   extends Modelica.Icons.Information;
+
   annotation (
     preferredView="info",
     DocumentationClass=true,
@@ -50,7 +51,7 @@ respectively. Additionally, in package <strong>SIunits.Conversions</strong> conv
 functions between the units Kelvin and Celsius, Fahrenheit, Rankine are
 provided. These functions may be used in the following way:
 </p>
-<pre>  <strong>import</strong> SI=Modelica.SIunits;
+<pre>  <strong>import</strong> Modelica.SIunits;
   <strong>import</strong> Modelica.SIunits.Conversions.*;
      ...
   <strong>parameter</strong> SI.Temperature T = from_degC(25);  // convert 25 degree Celsius to Kelvin

--- a/Modelica/Thermal/HeatTransfer/UsersGuide/package.mo
+++ b/Modelica/Thermal/HeatTransfer/UsersGuide/package.mo
@@ -1,0 +1,73 @@
+within Modelica.Thermal.HeatTransfer;
+package UsersGuide "User's Guide"
+  extends Modelica.Icons.Information;
+
+
+
+
+  annotation (
+    preferredView="info",
+    DocumentationClass=true,
+    Documentation(info="<html>
+<p>
+This package contains components to model <strong>1-dimensional heat transfer</strong>
+with lumped elements. This allows especially to model heat transfer in
+machines provided the parameters of the lumped elements, such as
+the heat capacity of a part, can be determined by measurements
+(due to the complex geometries and many materials used in machines,
+calculating the lumped element parameters from some basic analytic
+formulas is usually not possible).
+</p>
+<p>
+Example models how to use this library are given in subpackage <strong>Examples</strong>.<br>
+For a first simple example, see <strong>Examples.TwoMasses</strong> where two masses
+with different initial temperatures are getting in contact to each
+other and arriving after some time at a common temperature.<br>
+<strong>Examples.ControlledTemperature</strong> shows how to hold a temperature
+within desired limits by switching on and off an electric resistor.<br>
+A more realistic example is provided in <strong>Examples.Motor</strong> where the
+heating of an electrical motor is modelled, see the following screen shot
+of this example:
+</p>
+
+<p>
+<img src=\"modelica://Modelica/Resources/Images/Thermal/HeatTransfer/driveWithHeatTransfer.png\" alt=\"driveWithHeatTransfer\">
+</p>
+
+<p>
+The <strong>filled</strong> and <strong>non-filled red squares</strong> at the left and
+right side of a component represent <strong>thermal ports</strong> (connector HeatPort).
+Drawing a line between such squares means that they are thermally connected.
+The variables of a HeatPort connector are the temperature <strong>T</strong> at the port
+and the heat flow rate <strong>Q_flow</strong> flowing into the component (if Q_flow is positive,
+the heat flows into the element, otherwise it flows out of the element):
+</p>
+<pre>   Modelica.SIunits.Temperature  T  \"absolute temperature at port in Kelvin\";
+   Modelica.SIunits.HeatFlowRate Q_flow  \"flow rate at the port in Watt\";
+</pre>
+<p>
+Note, that all temperatures of this package, including initial conditions,
+are given in Kelvin. For convenience, in subpackages <strong>HeatTransfer.Celsius</strong>,
+ <strong>HeatTransfer.Fahrenheit</strong> and <strong>HeatTransfer.Rankine</strong> components are provided such that source and
+sensor information is available in degree Celsius, degree Fahrenheit, or degree Rankine,
+respectively. Additionally, in package <strong>SIunits.Conversions</strong> conversion
+functions between the units Kelvin and Celsius, Fahrenheit, Rankine are
+provided. These functions may be used in the following way:
+</p>
+<pre>  <strong>import</strong> SI=Modelica.SIunits;
+  <strong>import</strong> Modelica.SIunits.Conversions.*;
+     ...
+  <strong>parameter</strong> SI.Temperature T = from_degC(25);  // convert 25 degree Celsius to Kelvin
+</pre>
+
+<p>
+There are several other components available, such as AxialConduction (discretized PDE in
+axial direction), which have been temporarily removed from this library. The reason is that
+these components reference material properties, such as thermal conductivity, and currently
+the Modelica design group is discussing a general scheme to describe material properties.
+</p>
+<p>
+For technical details in the design of this library, see 
+[<a href=\"Modelica.Thermal.HeatTransfer.UsersGuide.References\">Tiller2001</a>].</p>
+</html>"));
+end UsersGuide;

--- a/Modelica/Thermal/HeatTransfer/UsersGuide/package.mo
+++ b/Modelica/Thermal/HeatTransfer/UsersGuide/package.mo
@@ -54,7 +54,7 @@ provided. These functions may be used in the following way:
 <pre>  <strong>import</strong> Modelica.SIunits;
   <strong>import</strong> Modelica.SIunits.Conversions.*;
      ...
-  <strong>parameter</strong> SI.Temperature T = from_degC(25);  // convert 25 degree Celsius to Kelvin
+  <strong>parameter</strong> SIunits.Temperature T = from_degC(25);  // convert 25 degree Celsius to Kelvin
 </pre>
 
 <p>

--- a/Modelica/Thermal/HeatTransfer/UsersGuide/package.order
+++ b/Modelica/Thermal/HeatTransfer/UsersGuide/package.order
@@ -1,0 +1,3 @@
+Contact
+ReleaseNotes
+References

--- a/Modelica/Thermal/HeatTransfer/package.mo
+++ b/Modelica/Thermal/HeatTransfer/package.mo
@@ -1,6 +1,7 @@
 within Modelica.Thermal;
 package HeatTransfer "Library of 1-dimensional heat transfer with lumped elements"
   extends Modelica.Icons.Package;
+
   annotation (
      Icon(coordinateSystem(preserveAspectRatio = true, extent = {{-100,-100},{100,100}}), graphics={
       Polygon(
@@ -50,90 +51,7 @@ package HeatTransfer "Library of 1-dimensional heat transfer with lumped element
                             Documentation(info="<html>
 <p>
 This package contains components to model <strong>1-dimensional heat transfer</strong>
-with lumped elements. This allows especially to model heat transfer in
-machines provided the parameters of the lumped elements, such as
-the heat capacity of a part, can be determined by measurements
-(due to the complex geometries and many materials used in machines,
-calculating the lumped element parameters from some basic analytic
-formulas is usually not possible).
-</p>
-<p>
-Example models how to use this library are given in subpackage <strong>Examples</strong>.<br>
-For a first simple example, see <strong>Examples.TwoMasses</strong> where two masses
-with different initial temperatures are getting in contact to each
-other and arriving after some time at a common temperature.<br>
-<strong>Examples.ControlledTemperature</strong> shows how to hold a temperature
-within desired limits by switching on and off an electric resistor.<br>
-A more realistic example is provided in <strong>Examples.Motor</strong> where the
-heating of an electrical motor is modelled, see the following screen shot
-of this example:
-</p>
-
-<p>
-<img src=\"modelica://Modelica/Resources/Images/Thermal/HeatTransfer/driveWithHeatTransfer.png\" alt=\"driveWithHeatTransfer\">
-</p>
-
-<p>
-The <strong>filled</strong> and <strong>non-filled red squares</strong> at the left and
-right side of a component represent <strong>thermal ports</strong> (connector HeatPort).
-Drawing a line between such squares means that they are thermally connected.
-The variables of a HeatPort connector are the temperature <strong>T</strong> at the port
-and the heat flow rate <strong>Q_flow</strong> flowing into the component (if Q_flow is positive,
-the heat flows into the element, otherwise it flows out of the element):
-</p>
-<pre>   Modelica.SIunits.Temperature  T  \"absolute temperature at port in Kelvin\";
-   Modelica.SIunits.HeatFlowRate Q_flow  \"flow rate at the port in Watt\";
-</pre>
-<p>
-Note, that all temperatures of this package, including initial conditions,
-are given in Kelvin. For convenience, in subpackages <strong>HeatTransfer.Celsius</strong>,
- <strong>HeatTransfer.Fahrenheit</strong> and <strong>HeatTransfer.Rankine</strong> components are provided such that source and
-sensor information is available in degree Celsius, degree Fahrenheit, or degree Rankine,
-respectively. Additionally, in package <strong>SIunits.Conversions</strong> conversion
-functions between the units Kelvin and Celsius, Fahrenheit, Rankine are
-provided. These functions may be used in the following way:
-</p>
-<pre>  <strong>import</strong> SI=Modelica.SIunits;
-  <strong>import</strong> Modelica.SIunits.Conversions.*;
-     ...
-  <strong>parameter</strong> SI.Temperature T = from_degC(25);  // convert 25 degree Celsius to Kelvin
-</pre>
-
-<p>
-There are several other components available, such as AxialConduction (discretized PDE in
-axial direction), which have been temporarily removed from this library. The reason is that
-these components reference material properties, such as thermal conductivity, and currently
-the Modelica design group is discussing a general scheme to describe material properties.
-</p>
-<p>
-For technical details in the design of this library, see the following reference:<br>
-<strong>Michael Tiller (2001)</strong>: <a href=\"http://www.amazon.de\">
-Introduction to Physical Modeling with Modelica</a>.
-Kluwer Academic Publishers Boston.
-</p>
-<p>
-<strong>Acknowledgements:</strong><br>
-Several helpful remarks from the following persons are acknowledged:
-John Batteh, Ford Motors, Dearborn, U.S.A;
-<a href=\"https://www.haumer.at/\">Anton Haumer</a>, Technical Consulting &amp; Electrical Engineering, Germany;
-Ludwig Marvan, VA TECH ELIN EBG Elektronik GmbH, Wien, Austria;
-Hans Olsson, Dassault Syst&egrave;mes AB, Sweden;
-Hubertus Tummescheit, Lund Institute of Technology, Lund, Sweden.
-</p>
-<dl>
-  <dt><strong>Main Authors:</strong></dt>
-  <dd>
-  <p>
-  <a href=\"https://www.haumer.at/\">Anton Haumer</a><br>
-  Technical Consulting &amp; Electrical Engineering<br>
-  D-93049 Regensburg, Germany<br>
-  email: <a href=\"mailto:a.haumer@haumer.at\">a.haumer@haumer.at</a>
-</p>
-  </dd>
-</dl>
-<p>
-Copyright &copy; 2001-2019, Modelica Association and contributors
-</p>
+with lumped elements.</p>
 </html>", revisions="<html>
 <ul>
 <li><em>July 15, 2002</em>

--- a/Modelica/Thermal/HeatTransfer/package.order
+++ b/Modelica/Thermal/HeatTransfer/package.order
@@ -1,3 +1,4 @@
+UsersGuide
 Examples
 Components
 Sensors


### PR DESCRIPTION
Refs #2990: User's Guide added to HeatTransfer package. All references are moved to `Modelica.Thermal.HeatTransfer.UsersGuide.References`, links are applied where available.