### PR TITLE
Add substrate (optional connector) to bipolar transistor models 

### DIFF
--- a/Modelica/Electrical/Analog/Semiconductors.mo
+++ b/Modelica/Electrical/Analog/Semiconductors.mo
@@ -129,14 +129,14 @@ The thermal power is calculated by <em>i*v</em>.
     Vt_applied = if useHeatPort then Modelica.Constants.R * T_heatPort/Modelica.Constants.F else Vt;
     id = smooth(1,
       if vd < -Bv / 2 then
+        //Lower half of reverse biased region including breakdown.
         -Ids * (exp(-(vd+Bv)/(N*Vt_applied)) + 1 - 2*exp(-Bv/(2*N*Vt_applied)))
       elseif vd < VdMax then
+        //Upper half of reverse biased region, and forward biased region before conduction.
         Ids * (exp(vd/(N*Vt_applied)) - 1)
       else
-        iVdMax + (vd - VdMax) * diVdMax);
-        //Lower half of reverse biased region including breakdown.
-        //Upper half of reverse biased region, and forward biased region before conduction.
         //Forward biased region after conduction
+        iVdMax + (vd - VdMax) * diVdMax);
 
     v = vd + id * Rs;
     i = id + v*Gp;

--- a/Modelica/Electrical/Analog/Semiconductors.mo
+++ b/Modelica/Electrical/Analog/Semiconductors.mo
@@ -129,14 +129,14 @@ The thermal power is calculated by <em>i*v</em>.
     Vt_applied = if useHeatPort then Modelica.Constants.R * T_heatPort/Modelica.Constants.F else Vt;
     id = smooth(1,
       if vd < -Bv / 2 then
-        //Lower half of reverse biased region including breakdown.
         -Ids * (exp(-(vd+Bv)/(N*Vt_applied)) + 1 - 2*exp(-Bv/(2*N*Vt_applied)))
       elseif vd < VdMax then
-        //Upper half of reverse biased region, and forward biased region before conduction.
         Ids * (exp(vd/(N*Vt_applied)) - 1)
       else
-        //Forward biased region after conduction
         iVdMax + (vd - VdMax) * diVdMax);
+        //Lower half of reverse biased region including breakdown.
+        //Upper half of reverse biased region, and forward biased region before conduction.
+        //Forward biased region after conduction
 
     v = vd + id * Rs;
     i = id + v*Gp;
@@ -569,7 +569,7 @@ Stefan Vorkoetter - new model proposed.</li>
     C.i = (ibe - ibc)*qbk - ibc/br_t - cbc*der(vbc) - iS;
     B.i = ibe/bf_t + ibc/br_t + cbc*der(vbc) + cbe*der(vbe);
     E.i = -B.i - C.i - iS;
-    iS = -Ccs * (der(C.v) - der(vS));
+    iS = -Ccs * der(vcs);
     if not useSubstrate then
       vS = 0;
     end if;
@@ -702,7 +702,7 @@ Stefan Vorkoetter - new model proposed.</li>
     C.i = icb/br_t + ccb*der(vcb) + (icb - ieb)*qbk - iS;
     B.i = -ieb/bf_t - icb/br_t - ceb*der(veb) - ccb*der(vcb);
     E.i = -B.i - C.i - iS;
-    iS = -Ccs * (der(C.v) - der(vS));
+    iS = -Ccs * der(vcs);
     if not useSubstrate then
       vS = 0;
     end if;
@@ -747,8 +747,8 @@ Stefan Vorkoetter - new model proposed.</li>
             pattern=LinePattern.Dash,
             visible = useSubstrate)}));
   end PNP;
-protected
 
+protected
         function pow "Just a helper function for x^y in order that a symbolic engine can apply some transformations more easily"
           extends Modelica.Icons.Function;
           input Real x;
@@ -785,8 +785,8 @@ protected
         algorithm
           z := if x < Minexp then exp(Minexp)*(1 + x - Minexp) else exlin(x, Maxexp);
         end exlin2;
-public
 
+public
   model Thyristor "Simple Thyristor Model"
     parameter SI.Voltage VDRM(final min=0) = 100
       "Forward breakthrough voltage";

--- a/Modelica/Electrical/Analog/Semiconductors.mo
+++ b/Modelica/Electrical/Analog/Semiconductors.mo
@@ -129,14 +129,14 @@ The thermal power is calculated by <em>i*v</em>.
     Vt_applied = if useHeatPort then Modelica.Constants.R * T_heatPort/Modelica.Constants.F else Vt;
     id = smooth(1,
       if vd < -Bv / 2 then
+        //Lower half of reverse biased region including breakdown.
         -Ids * (exp(-(vd+Bv)/(N*Vt_applied)) + 1 - 2*exp(-Bv/(2*N*Vt_applied)))
       elseif vd < VdMax then
+        //Upper half of reverse biased region, and forward biased region before conduction.
         Ids * (exp(vd/(N*Vt_applied)) - 1)
       else
-        iVdMax + (vd - VdMax) * diVdMax);
-        //Lower half of reverse biased region including breakdown.
-        //Upper half of reverse biased region, and forward biased region before conduction.
         //Forward biased region after conduction
+        iVdMax + (vd - VdMax) * diVdMax);
 
     v = vd + id * Rs;
     i = id + v*Gp;
@@ -516,6 +516,7 @@ Stefan Vorkoetter - new model proposed.</li>
 
     SI.Voltage vbc "Base-collector voltage";
     SI.Voltage vbe "Base-emitter voltage";
+    SI.Voltage vcs "Collector-substrate voltage";
     Real qbk "Relative majority carrier charge, inverse";
     SI.Current ibc "Base-collector diode current";
     SI.Current ibe "Base-emitter diode current";
@@ -542,12 +543,13 @@ Stefan Vorkoetter - new model proposed.</li>
       annotation (Placement(transformation(extent={{110,-10},{90,10}})));
   initial equation
     if UIC then
-      C.v - vS = IC;
+      vcs = IC;
     end if;
   equation
     assert(T_heatPort > 0,"Temperature must be positive");
     vbc = B.v - C.v;
     vbe = B.v - E.v;
+    vcs = C.v - vS;
     qbk = 1 - vbc*Vak;
 
     hexp = (T_heatPort/Tnom - 1)*EG/vt_t;
@@ -647,6 +649,7 @@ Stefan Vorkoetter - new model proposed.</li>
 
     SI.Voltage vcb "Collector-base voltage";
     SI.Voltage veb "Emitter-base voltage";
+    SI.Voltage vcs "Collector-substrate voltage";
     Real qbk "Relative majority carrier charge, inverse";
     SI.Current icb "Collector-base diode current";
     SI.Current ieb "Emitter-base diode current";
@@ -673,12 +676,13 @@ Stefan Vorkoetter - new model proposed.</li>
       annotation (Placement(transformation(extent={{110,-10},{90,10}})));
   initial equation
     if UIC then
-      C.v - vS = IC;
+      vcs = IC;
     end if;
   equation
     assert(T_heatPort > 0,"Temperature must be positive");
     vcb = C.v - B.v;
     veb = E.v - B.v;
+    vcs = C.v - vS;
     qbk = 1 - vcb*Vak;
 
     hexp = (T_heatPort/Tnom - 1)*EG/vt_t;
@@ -743,8 +747,8 @@ Stefan Vorkoetter - new model proposed.</li>
             pattern=LinePattern.Dash,
             visible = useSubstrate)}));
   end PNP;
-
 protected
+
         function pow "Just a helper function for x^y in order that a symbolic engine can apply some transformations more easily"
           extends Modelica.Icons.Function;
           input Real x;
@@ -781,8 +785,8 @@ protected
         algorithm
           z := if x < Minexp then exp(Minexp)*(1 + x - Minexp) else exlin(x, Maxexp);
         end exlin2;
-
 public
+
   model Thyristor "Simple Thyristor Model"
     parameter SI.Voltage VDRM(final min=0) = 100
       "Forward breakthrough voltage";
@@ -1064,7 +1068,6 @@ public
 </ul>
 </html>"));
   end SimpleTriac;
-
   annotation (
     Documentation(info="<html>
 <p>This package contains semiconductor devices:</p>

--- a/Modelica/Electrical/Analog/Semiconductors.mo
+++ b/Modelica/Electrical/Analog/Semiconductors.mo
@@ -20,7 +20,7 @@ package Semiconductors
 
     SI.Voltage vt_t "Temperature voltage";
     SI.Current id "Diode current";
-    protected
+  protected
     SI.Temperature htemp "Auxiliary temperature";
     Real aux;
     Real auxp;
@@ -129,14 +129,14 @@ The thermal power is calculated by <em>i*v</em>.
     Vt_applied = if useHeatPort then Modelica.Constants.R * T_heatPort/Modelica.Constants.F else Vt;
     id = smooth(1,
       if vd < -Bv / 2 then
-        //Lower half of reverse biased region including breakdown.
         -Ids * (exp(-(vd+Bv)/(N*Vt_applied)) + 1 - 2*exp(-Bv/(2*N*Vt_applied)))
       elseif vd < VdMax then
-        //Upper half of reverse biased region, and forward biased region before conduction.
         Ids * (exp(vd/(N*Vt_applied)) - 1)
       else
-        //Forward biased region after conduction
         iVdMax + (vd - VdMax) * diVdMax);
+        //Lower half of reverse biased region including breakdown.
+        //Upper half of reverse biased region, and forward biased region before conduction.
+        //Forward biased region after conduction
 
     v = vd + id * Rs;
     i = id + v*Gp;
@@ -509,8 +509,9 @@ Stefan Vorkoetter - new model proposed.</li>
     parameter SI.Voltage EG=1.11 "Energy gap for temperature effect on Is" annotation(Dialog(enable=useTemperatureDependency));
     parameter Real NF=1.0 "Forward current emission coefficient";
     parameter Real NR=1.0 "Reverse current emission coefficient";
-    parameter SI.Voltage IC=0 "Initial value" annotation(Dialog(enable=UIC));
-    parameter Boolean UIC = false "Decision if initial value should be used";
+    parameter SI.Voltage IC=0 "Initial value of collector to substrate voltage" annotation(Dialog(enable=UIC));
+    parameter Boolean UIC = false "Decision if initial value IC should be used";
+    parameter Boolean useSubstrate = false "= false, if substrate is implicitly grounded";
     extends Modelica.Electrical.Analog.Interfaces.ConditionalHeatPort(useHeatPort=useTemperatureDependency);
 
     SI.Voltage vbc "Base-collector voltage";
@@ -598,7 +599,12 @@ Stefan Vorkoetter - new model proposed.</li>
       lineColor={0,0,255}),
     Text(extent={{-150,130},{150,90}},
       textString="%name",
-      textColor={0,0,255})}));
+      textColor={0,0,255}),
+          Line(
+            points={{0,0},{90,0}},
+            color={0,0,255},
+            pattern=LinePattern.Dash,
+            visible = useSubstrate)}));
   end NPN;
 
   model PNP "Simple PNP BJT according to Ebers-Moll with heating port"
@@ -627,6 +633,9 @@ Stefan Vorkoetter - new model proposed.</li>
     parameter SI.Voltage EG=1.11 "Energy gap for temperature effect on Is" annotation(Dialog(enable=useTemperatureDependency));
     parameter Real NF=1.0 "Forward current emission coefficient";
     parameter Real NR=1.0 "Reverse current emission coefficient";
+    parameter SI.Voltage IC=0 "Initial value of collector to substrate voltage" annotation(Dialog(enable=UIC));
+    parameter Boolean UIC = false "Decision if initial value IC should be used";
+    parameter Boolean useSubstrate = false "= false, if substrate is implicitly grounded";
     extends Modelica.Electrical.Analog.Interfaces.ConditionalHeatPort(useHeatPort=useTemperatureDependency);
 
     SI.Voltage vcb "Collector-base voltage";
@@ -710,7 +719,11 @@ Stefan Vorkoetter - new model proposed.</li>
       lineColor={0,0,255}),
     Text(extent={{-150,130},{150,90}},
       textString="%name",
-      textColor={0,0,255})}));
+      textColor={0,0,255}),
+      Line( points={{0,0},{90,0}},
+            color={0,0,255},
+            pattern=LinePattern.Dash,
+            visible = useSubstrate)}));
   end PNP;
 
 protected

--- a/Modelica/Electrical/Analog/Semiconductors.mo
+++ b/Modelica/Electrical/Analog/Semiconductors.mo
@@ -529,6 +529,8 @@ Stefan Vorkoetter - new model proposed.</li>
     SI.Voltage vt_t "Voltage equivalent of effective temperature";
     Real hexp "Auxiliary quantity temperature dependent exponent";
     Real htempexp "Auxiliary quantity exp(hexp)";
+    SI.Voltage vS "Substrate potential";
+    SI.Current iS "Substrate current";
 
     Modelica.Electrical.Analog.Interfaces.Pin C "Collector"
       annotation (Placement(transformation(extent={{90,50},{110,70}}), iconTransformation(extent={{90,50},{110,70}})));
@@ -536,9 +538,11 @@ Stefan Vorkoetter - new model proposed.</li>
       annotation (Placement(transformation(extent={{-90,-10},{-110,10}})));
     Modelica.Electrical.Analog.Interfaces.Pin E "Emitter"
       annotation (Placement(transformation(extent={{90,-50},{110,-70}}), iconTransformation(extent={{90,-50},{110,-70}})));
+    Modelica.Electrical.Analog.Interfaces.NegativePin S(final i = iS, final v = vS) if useSubstrate "Substrate"
+      annotation (Placement(transformation(extent={{110,-10},{90,10}})));
   initial equation
     if UIC then
-      C.v = IC;
+      C.v - vS = IC;
     end if;
   equation
     assert(T_heatPort > 0,"Temperature must be positive");
@@ -560,10 +564,13 @@ Stefan Vorkoetter - new model proposed.</li>
     Capcje = smooth(1, Cje*powlin(vbe/Phie, Me));
     cbc = smooth(1, Taur*is_t/(NR*vt_t)*exlin2(vbc/(NR*vt_t), EMin, EMax) + Capcjc);
     cbe = smooth(1, Tauf*is_t/(NF*vt_t)*exlin2(vbe/(NF*vt_t), EMin, EMax) + Capcje);
-    C.i = (ibe - ibc)*qbk - ibc/br_t - cbc*der(vbc) + Ccs*der(C.v);
+    C.i = (ibe - ibc)*qbk - ibc/br_t - cbc*der(vbc) - iS;
     B.i = ibe/bf_t + ibc/br_t + cbc*der(vbc) + cbe*der(vbe);
-    E.i = -B.i - C.i + Ccs*der(C.v);
-
+    E.i = -B.i - C.i - iS;
+    iS = -Ccs * (der(C.v) - der(vS));
+    if not useSubstrate then
+      vS = 0;
+    end if;
     LossPower = vbc*ibc/br_t + vbe*ibe/bf_t + (ibe - ibc)*qbk*(C.v - E.v);
     annotation (defaultComponentName="npn",
       Documentation(info="<html>
@@ -653,6 +660,8 @@ Stefan Vorkoetter - new model proposed.</li>
     SI.Voltage vt_t "Voltage equivalent of effective temperature";
     Real hexp "Auxiliary quantity temperature dependent exponent";
     Real htempexp "Auxiliary quantity exp(hexp)";
+    SI.Voltage vS "Substrate potential";
+    SI.Current iS "Substrate current";
 
     Modelica.Electrical.Analog.Interfaces.Pin C "Collector"
       annotation (Placement(transformation(extent={{90,50},{110,70}}), iconTransformation(extent={{90,50},{110,70}})));
@@ -660,6 +669,12 @@ Stefan Vorkoetter - new model proposed.</li>
       annotation (Placement(transformation(extent={{-90,-10},{-110,10}})));
     Modelica.Electrical.Analog.Interfaces.Pin E "Emitter"
       annotation (Placement(transformation(extent={{90,-50},{110,-70}}), iconTransformation(extent={{90,-50},{110,-70}})));
+    Modelica.Electrical.Analog.Interfaces.NegativePin S(final i = iS, final v = vS) if useSubstrate "Substrate"
+      annotation (Placement(transformation(extent={{110,-10},{90,10}})));
+  initial equation
+    if UIC then
+      C.v - vS = IC;
+    end if;
   equation
     assert(T_heatPort > 0,"Temperature must be positive");
     vcb = C.v - B.v;
@@ -680,10 +695,13 @@ Stefan Vorkoetter - new model proposed.</li>
     Capcje = smooth(1, Cje*powlin(veb/Phie, Me));
     ccb = smooth(1, Taur*is_t/(NR*vt_t)*exlin2(vcb/(NR*vt_t), EMin, EMax) + Capcjc);
     ceb = smooth(1, Tauf*is_t/(NF*vt_t)*exlin2(veb/(NF*vt_t), EMin, EMax) + Capcje);
-    C.i = icb/br_t + ccb*der(vcb) + Ccs*der(C.v) + (icb - ieb)*qbk;
+    C.i = icb/br_t + ccb*der(vcb) + (icb - ieb)*qbk - iS;
     B.i = -ieb/bf_t - icb/br_t - ceb*der(veb) - ccb*der(vcb);
-    E.i = -B.i - C.i + Ccs*der(C.v);
-
+    E.i = -B.i - C.i - iS;
+    iS = -Ccs * (der(C.v) - der(vS));
+    if not useSubstrate then
+      vS = 0;
+    end if;
     LossPower = vcb*icb/br_t + veb*ieb/bf_t + (icb - ieb)*qbk*(C.v- E.v);
     annotation (defaultComponentName="pnp",
       Documentation(info="<html>


### PR DESCRIPTION
Refs #2146 and  #3178. This PR does not (yet) handle #3168.

This ticket covers two issues:

1. I actually consider using only implicit grounding to be a bug. This PR now includes a conditional substrate connector. The substrate connector is not available by default for compatibility reasons.  

2. I implemented initial conditions of the PNP transistor model and consider this as enhancement. Now the NPN and PNP transistor models are build with equal features. 

