### PR TITLE
Add modified Akima interpolation (univariate) as known from MATLAB ≥ R2017b

### DIFF
--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -2655,6 +2655,10 @@ The table interpolation has the following properties:
              = 5: Steffen interpolation: Smooth interpolation by cubic Hermite
                   splines such that y preserves the monotonicity and der(y)
                   is continuous, also if extrapolated.
+             = 6: Modified Akima interpolation: Smooth interpolation by cubic
+                  Hermite splines such that der(y) is continuous, also if
+                  extrapolated. Additionally, overshoots and edge cases of the
+                  original Akima interpolation method are avoided.
 </pre></li>
 <li>Values <strong>outside</strong> of the table range, are computed by
     extrapolation according to the setting of parameter <strong>extrapolation</strong>:

--- a/Modelica/Blocks/Tables.mo
+++ b/Modelica/Blocks/Tables.mo
@@ -128,6 +128,10 @@ other columns contain the data to be interpolated. Example:
              = 5: Steffen interpolation: Smooth interpolation by cubic Hermite
                   splines such that y preserves the monotonicity and der(y)
                   is continuous, also if extrapolated.
+             = 6: Modified Akima interpolation: Smooth interpolation by cubic
+                  Hermite splines such that der(y) is continuous, also if
+                  extrapolated. Additionally, overshoots and edge cases of the
+                  original Akima interpolation method are avoided.
 </pre></li>
 <li>Values <strong>outside</strong> of the table range, are computed by
     extrapolation according to the setting of parameter <strong>extrapolation</strong>:
@@ -423,6 +427,10 @@ other columns contain the data to be interpolated. Example:
              = 5: Steffen interpolation: Smooth interpolation by cubic Hermite
                   splines such that y preserves the monotonicity and der(y)
                   is continuous, also if extrapolated.
+             = 6: Modified Akima interpolation: Smooth interpolation by cubic
+                  Hermite splines such that der(y) is continuous, also if
+                  extrapolated. Additionally, overshoots and edge cases of the
+                  original Akima interpolation method are avoided.
 </pre></li>
 <li>Values <strong>outside</strong> of the table range, are computed by
     extrapolation according to the setting of parameter <strong>extrapolation</strong>:
@@ -667,6 +675,7 @@ Example:
              = 3: Constant segments
              = 4: Fritsch-Butland interpolation: Not supported
              = 5: Steffen interpolation: Not supported
+             = 6: Modified Akima interpolation: Not supported
 </pre></li>
 <li>Values <strong>outside</strong> of the table range, are computed by
     extrapolation according to the setting of parameter <strong>extrapolation</strong>:
@@ -851,6 +860,7 @@ Example:
              = 3: Constant segments
              = 4: Fritsch-Butland interpolation: Not supported
              = 5: Steffen interpolation: Not supported
+             = 6: Modified Akima interpolation: Not supported
 </pre></li>
 <li>Values <strong>outside</strong> of the table range, are computed by
     extrapolation according to the setting of parameter <strong>extrapolation</strong>:

--- a/Modelica/Blocks/Types.mo
+++ b/Modelica/Blocks/Types.mo
@@ -12,7 +12,9 @@ package Types
       MonotoneContinuousDerivative1
         "Table points are interpolated (by Fritsch-Butland splines) such that the monotonicity is preserved and the first derivative is continuous",
       MonotoneContinuousDerivative2
-        "Table points are interpolated (by Steffen splines) such that the monotonicity is preserved and the first derivative is continuous")
+        "Table points are interpolated (by Steffen splines) such that the monotonicity is preserved and the first derivative is continuous",
+      ModifiedContinuousDerivative
+        "Table points are interpolated (by modified Akima splines) such that the first derivative is continuous and shortcomings of the original Akima method are avoided")
     "Enumeration defining the smoothness of table interpolation";
 
     type Extrapolation = enumeration(

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -38,6 +38,9 @@
       Modelica.Blocks.Tables.CombiTable2D
 
    Release Notes:
+      Nov. 01, 2019: by Thomas Beutlich
+                     Added univariate Makima-spline interpolation (ticket #1039)
+
       Aug. 03, 2019: by Thomas Beutlich
                      Added second derivatives (ticket #2901)
 
@@ -186,6 +189,7 @@ enum Smoothness {
     CONSTANT_SEGMENTS,
     FRITSCH_BUTLAND_MONOTONE_C1,
     STEFFEN_MONOTONE_C1,
+    MAKIMA_C1,
     AKIMA_C1 = CONTINUOUS_DERIVATIVE
 };
 
@@ -249,7 +253,7 @@ typedef struct CombiTimeTable {
     double startTime; /* Start time of inter-/extrapolation */
     double shiftTime; /* Shift time of first table column */
     CubicHermite1D* spline; /* Pre-calculated cubic Hermite spline coefficients,
-        only used if smoothness is AKIMA_C1 or
+        only used if smoothness is AKIMA_C1 or MAKIMA_C1 or
         FRITSCH_BUTLAND_MONOTONE_C1 or STEFFEN_MONOTONE_C1 */
     size_t nEvent; /* Time event counter, discrete */
     double preNextTimeEvent; /* Time of previous time event, discrete */
@@ -276,7 +280,7 @@ typedef struct CombiTable1D {
     int* cols; /* Columns of table to be interpolated */
     size_t nCols; /* Number of columns of table to be interpolated */
     CubicHermite1D* spline; /* Pre-calculated cubic Hermite spline coefficients,
-        only used if smoothness is AKIMA_C1 or
+        only used if smoothness is AKIMA_C1 or MAKIMA_C1 or
         FRITSCH_BUTLAND_MONOTONE_C1 or STEFFEN_MONOTONE_C1 */
 } CombiTable1D;
 
@@ -530,6 +534,15 @@ static CubicHermite1D* akimaSpline1DInit(_In_ const double* table, size_t nRow,
      <- RETURN: Pointer to array of coefficients
   */
 
+static CubicHermite1D* makimaSpline1DInit(_In_ const double* table, size_t nRow,
+                                         size_t nCol, _In_ const int* cols,
+                                         size_t nCols) MODELICA_NONNULLATTR;
+  /* Calculate the coefficients for univariate cubic Hermite spline
+     interpolation with the modified Akima slope approximation
+
+     <- RETURN: Pointer to array of coefficients
+  */
+
 static CubicHermite1D* fritschButlandSpline1DInit(_In_ const double* table,
                                                   size_t nRow, size_t nCol,
                                                   _In_ const int* cols,
@@ -753,6 +766,7 @@ void* ModelicaStandardTables_CombiTimeTable_init2(_In_z_ const char* fileName,
 
     if (tableID->nRow <= 2) {
         if (tableID->smoothness == AKIMA_C1 ||
+            tableID->smoothness == MAKIMA_C1 ||
             tableID->smoothness == FRITSCH_BUTLAND_MONOTONE_C1 ||
             tableID->smoothness == STEFFEN_MONOTONE_C1) {
             tableID->smoothness = LINEAR_SEGMENTS;
@@ -761,6 +775,11 @@ void* ModelicaStandardTables_CombiTimeTable_init2(_In_z_ const char* fileName,
     /* Initialization of the cubic Hermite spline coefficients */
     if (tableID->smoothness == AKIMA_C1) {
         tableID->spline = akimaSpline1DInit(
+            (const double*)tableID->table, tableID->nRow,
+            tableID->nCol, (const int*)tableID->cols, tableID->nCols);
+    }
+    else if (tableID->smoothness == MAKIMA_C1) {
+        tableID->spline = makimaSpline1DInit(
             (const double*)tableID->table, tableID->nRow,
             tableID->nCol, (const int*)tableID->cols, tableID->nCols);
     }
@@ -775,6 +794,7 @@ void* ModelicaStandardTables_CombiTimeTable_init2(_In_z_ const char* fileName,
             tableID->nCol, (const int*)tableID->cols, tableID->nCols);
     }
     if (tableID->smoothness == AKIMA_C1 ||
+        tableID->smoothness == MAKIMA_C1 ||
         tableID->smoothness == FRITSCH_BUTLAND_MONOTONE_C1 ||
         tableID->smoothness == STEFFEN_MONOTONE_C1) {
         if (NULL == tableID->spline) {
@@ -1023,6 +1043,7 @@ double ModelicaStandardTables_CombiTimeTable_getValue(void* _tableID, int iCol,
                             break;
 
                         case AKIMA_C1:
+                        case MAKIMA_C1:
                         case FRITSCH_BUTLAND_MONOTONE_C1:
                         case STEFFEN_MONOTONE_C1:
                             if (NULL != tableID->spline) {
@@ -1061,6 +1082,7 @@ double ModelicaStandardTables_CombiTimeTable_getValue(void* _tableID, int iCol,
                                 }
 
                                 case AKIMA_C1:
+                                case MAKIMA_C1:
                                 case FRITSCH_BUTLAND_MONOTONE_C1:
                                 case STEFFEN_MONOTONE_C1:
                                     if (NULL != tableID->spline) {
@@ -1284,6 +1306,7 @@ double ModelicaStandardTables_CombiTimeTable_getDerValue(void* _tableID, int iCo
                             break;
 
                         case AKIMA_C1:
+                        case MAKIMA_C1:
                         case FRITSCH_BUTLAND_MONOTONE_C1:
                         case STEFFEN_MONOTONE_C1:
                             if (NULL != tableID->spline) {
@@ -1318,6 +1341,7 @@ double ModelicaStandardTables_CombiTimeTable_getDerValue(void* _tableID, int iCo
                                 }
 
                                 case AKIMA_C1:
+                                case MAKIMA_C1:
                                 case FRITSCH_BUTLAND_MONOTONE_C1:
                                 case STEFFEN_MONOTONE_C1:
                                     if (NULL != tableID->spline) {
@@ -1541,6 +1565,7 @@ double ModelicaStandardTables_CombiTimeTable_getDer2Value(void* _tableID, int iC
                             break;
 
                         case AKIMA_C1:
+                        case MAKIMA_C1:
                         case FRITSCH_BUTLAND_MONOTONE_C1:
                         case STEFFEN_MONOTONE_C1:
                             if (NULL != tableID->spline) {
@@ -1576,6 +1601,7 @@ double ModelicaStandardTables_CombiTimeTable_getDer2Value(void* _tableID, int iC
                                 }
 
                                 case AKIMA_C1:
+                                case MAKIMA_C1:
                                 case FRITSCH_BUTLAND_MONOTONE_C1:
                                 case STEFFEN_MONOTONE_C1:
                                     if (NULL != tableID->spline) {
@@ -1798,6 +1824,7 @@ double ModelicaStandardTables_CombiTimeTable_nextTimeEvent(void* _tableID,
                     iEnd = 0;
                 }
                 else if (tableID->smoothness == AKIMA_C1 ||
+                    tableID->smoothness == MAKIMA_C1 ||
                     tableID->smoothness == FRITSCH_BUTLAND_MONOTONE_C1 ||
                     tableID->smoothness == STEFFEN_MONOTONE_C1) {
                     iStart = nRow - 1;
@@ -1959,6 +1986,7 @@ double ModelicaStandardTables_CombiTimeTable_read(void* _tableID, int force,
             }
             if (tableID->nRow <= 2) {
                 if (tableID->smoothness == AKIMA_C1 ||
+                    tableID->smoothness == MAKIMA_C1 ||
                     tableID->smoothness == FRITSCH_BUTLAND_MONOTONE_C1 ||
                     tableID->smoothness == STEFFEN_MONOTONE_C1) {
                     tableID->smoothness = LINEAR_SEGMENTS;
@@ -1968,6 +1996,12 @@ double ModelicaStandardTables_CombiTimeTable_read(void* _tableID, int force,
             if (tableID->smoothness == AKIMA_C1) {
                 spline1DClose(&tableID->spline);
                 tableID->spline = akimaSpline1DInit(
+                    (const double*)tableID->table, tableID->nRow,
+                    tableID->nCol, (const int*)tableID->cols, tableID->nCols);
+            }
+            else if (tableID->smoothness == MAKIMA_C1) {
+                spline1DClose(&tableID->spline);
+                tableID->spline = makimaSpline1DInit(
                     (const double*)tableID->table, tableID->nRow,
                     tableID->nCol, (const int*)tableID->cols, tableID->nCols);
             }
@@ -1984,6 +2018,7 @@ double ModelicaStandardTables_CombiTimeTable_read(void* _tableID, int force,
                     tableID->nCol, (const int*)tableID->cols, tableID->nCols);
             }
             if (tableID->smoothness == AKIMA_C1 ||
+                tableID->smoothness == MAKIMA_C1 ||
                 tableID->smoothness == FRITSCH_BUTLAND_MONOTONE_C1 ||
                 tableID->smoothness == STEFFEN_MONOTONE_C1) {
                 if (NULL == tableID->spline) {
@@ -2169,6 +2204,7 @@ void* ModelicaStandardTables_CombiTable1D_init2(_In_z_ const char* fileName,
 
     if (tableID->nRow <= 2) {
         if (tableID->smoothness == AKIMA_C1 ||
+            tableID->smoothness == MAKIMA_C1 ||
             tableID->smoothness == FRITSCH_BUTLAND_MONOTONE_C1 ||
             tableID->smoothness == STEFFEN_MONOTONE_C1) {
             tableID->smoothness = LINEAR_SEGMENTS;
@@ -2177,6 +2213,11 @@ void* ModelicaStandardTables_CombiTable1D_init2(_In_z_ const char* fileName,
     /* Initialization of the cubic Hermite spline coefficients */
     if (tableID->smoothness == AKIMA_C1) {
         tableID->spline = akimaSpline1DInit(
+            (const double*)tableID->table, tableID->nRow,
+            tableID->nCol, (const int*)tableID->cols, tableID->nCols);
+    }
+    else if (tableID->smoothness == MAKIMA_C1) {
+        tableID->spline = makimaSpline1DInit(
             (const double*)tableID->table, tableID->nRow,
             tableID->nCol, (const int*)tableID->cols, tableID->nCols);
     }
@@ -2191,6 +2232,7 @@ void* ModelicaStandardTables_CombiTable1D_init2(_In_z_ const char* fileName,
             tableID->nCol, (const int*)tableID->cols, tableID->nCols);
     }
     if (tableID->smoothness == AKIMA_C1 ||
+        tableID->smoothness == MAKIMA_C1 ||
         tableID->smoothness == FRITSCH_BUTLAND_MONOTONE_C1 ||
         tableID->smoothness == STEFFEN_MONOTONE_C1) {
         if (NULL == tableID->spline) {
@@ -2319,6 +2361,7 @@ double ModelicaStandardTables_CombiTable1D_getValue(void* _tableID, int iCol,
                         break;
 
                     case AKIMA_C1:
+                    case MAKIMA_C1:
                     case FRITSCH_BUTLAND_MONOTONE_C1:
                     case STEFFEN_MONOTONE_C1:
                         if (NULL != tableID->spline) {
@@ -2351,6 +2394,7 @@ double ModelicaStandardTables_CombiTable1D_getValue(void* _tableID, int iCol,
                             }
 
                             case AKIMA_C1:
+                            case MAKIMA_C1:
                             case FRITSCH_BUTLAND_MONOTONE_C1:
                             case STEFFEN_MONOTONE_C1:
                                 if (NULL != tableID->spline) {
@@ -2460,6 +2504,7 @@ double ModelicaStandardTables_CombiTable1D_getDerValue(void* _tableID, int iCol,
                         break;
 
                     case AKIMA_C1:
+                    case MAKIMA_C1:
                     case FRITSCH_BUTLAND_MONOTONE_C1:
                     case STEFFEN_MONOTONE_C1:
                         if (NULL != tableID->spline) {
@@ -2491,6 +2536,7 @@ double ModelicaStandardTables_CombiTable1D_getDerValue(void* _tableID, int iCol,
                             }
 
                             case AKIMA_C1:
+                            case MAKIMA_C1:
                             case FRITSCH_BUTLAND_MONOTONE_C1:
                             case STEFFEN_MONOTONE_C1:
                                 if (NULL != tableID->spline) {
@@ -2600,6 +2646,7 @@ double ModelicaStandardTables_CombiTable1D_getDer2Value(void* _tableID, int iCol
                         break;
 
                     case AKIMA_C1:
+                    case MAKIMA_C1:
                     case FRITSCH_BUTLAND_MONOTONE_C1:
                     case STEFFEN_MONOTONE_C1:
                         if (NULL != tableID->spline) {
@@ -2632,6 +2679,7 @@ double ModelicaStandardTables_CombiTable1D_getDer2Value(void* _tableID, int iCol
                             }
 
                             case AKIMA_C1:
+                            case MAKIMA_C1:
                             case FRITSCH_BUTLAND_MONOTONE_C1:
                             case STEFFEN_MONOTONE_C1:
                                 if (NULL != tableID->spline) {
@@ -2735,6 +2783,7 @@ double ModelicaStandardTables_CombiTable1D_read(void* _tableID, int force,
             }
             if (tableID->nRow <= 2) {
                 if (tableID->smoothness == AKIMA_C1 ||
+                    tableID->smoothness == MAKIMA_C1 ||
                     tableID->smoothness == FRITSCH_BUTLAND_MONOTONE_C1 ||
                     tableID->smoothness == STEFFEN_MONOTONE_C1) {
                     tableID->smoothness = LINEAR_SEGMENTS;
@@ -2744,6 +2793,12 @@ double ModelicaStandardTables_CombiTable1D_read(void* _tableID, int force,
             if (tableID->smoothness == AKIMA_C1) {
                 spline1DClose(&tableID->spline);
                 tableID->spline = akimaSpline1DInit(
+                    (const double*)tableID->table, tableID->nRow,
+                    tableID->nCol, (const int*)tableID->cols, tableID->nCols);
+            }
+            else if (tableID->smoothness == MAKIMA_C1) {
+                spline1DClose(&tableID->spline);
+                tableID->spline = makimaSpline1DInit(
                     (const double*)tableID->table, tableID->nRow,
                     tableID->nCol, (const int*)tableID->cols, tableID->nCols);
             }
@@ -2760,6 +2815,7 @@ double ModelicaStandardTables_CombiTable1D_read(void* _tableID, int force,
                     tableID->nCol, (const int*)tableID->cols, tableID->nCols);
             }
             if (tableID->smoothness == AKIMA_C1 ||
+                tableID->smoothness == MAKIMA_C1 ||
                 tableID->smoothness == FRITSCH_BUTLAND_MONOTONE_C1 ||
                 tableID->smoothness == STEFFEN_MONOTONE_C1) {
                 if (NULL == tableID->spline) {
@@ -3068,6 +3124,11 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                             }
                             break;
 
+                        case MAKIMA_C1:
+                            ModelicaError("Bivariate modified Akima interpolation is "
+                                "not implemented\n");
+                            return y;
+
                         case FRITSCH_BUTLAND_MONOTONE_C1:
                         case STEFFEN_MONOTONE_C1:
                             ModelicaError("Bivariate monotone C1 interpolation is "
@@ -3107,6 +3168,11 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                                         }
                                     }
                                     break;
+
+                                case MAKIMA_C1:
+                                    ModelicaError("Bivariate modified Akima interpolation is "
+                                        "not implemented\n");
+                                    return y;
 
                                 case FRITSCH_BUTLAND_MONOTONE_C1:
                                 case STEFFEN_MONOTONE_C1:
@@ -3209,6 +3275,11 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                             }
                             break;
 
+                        case MAKIMA_C1:
+                            ModelicaError("Bivariate modified Akima interpolation is "
+                                "not implemented\n");
+                            return y;
+
                         case FRITSCH_BUTLAND_MONOTONE_C1:
                         case STEFFEN_MONOTONE_C1:
                             ModelicaError("Bivariate monotone C1 interpolation is "
@@ -3248,6 +3319,11 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                                         }
                                     }
                                     break;
+
+                                case MAKIMA_C1:
+                                    ModelicaError("Bivariate modified Akima interpolation is "
+                                        "not implemented\n");
+                                    return y;
 
                                 case FRITSCH_BUTLAND_MONOTONE_C1:
                                 case STEFFEN_MONOTONE_C1:
@@ -3355,6 +3431,11 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                                 }
                                 break;
 
+                            case MAKIMA_C1:
+                                ModelicaError("Bivariate modified Akima interpolation is "
+                                    "not implemented\n");
+                                return y;
+
                             case FRITSCH_BUTLAND_MONOTONE_C1:
                             case STEFFEN_MONOTONE_C1:
                                 ModelicaError("Bivariate monotone C1 interpolation is "
@@ -3387,6 +3468,11 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                                             y += der_y2*(u2 - u2Min);
                                         }
                                         break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -3427,6 +3513,11 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                                             y += ((c[3]*u1 + c[7])*u1 + c[11])*u1;
                                         }
                                         break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -3488,6 +3579,11 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                                         }
                                         break;
 
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return y;
+
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
                                         ModelicaError("Bivariate monotone C1 interpolation is "
@@ -3533,6 +3629,11 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                                             y += ((p1*u1 + p2)*u1 + p3)*u1;
                                         }
                                         break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -3585,6 +3686,11 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                                         }
                                         break;
 
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return y;
+
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
                                         ModelicaError("Bivariate monotone C1 interpolation is "
@@ -3624,6 +3730,11 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                                             y += ((c[12]*u2 + c[13])*u2 + c[14])*u2; /* p4 */
                                         }
                                         break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -3671,6 +3782,11 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                                             y += c[11]*u1 + c[14]*u2 + c[10]*u1*u2;
                                         }
                                         break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -3730,6 +3846,11 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                                             y += der_y1*u1 + der_y2*u2 + der_y12*u1*u2;
                                         }
                                         break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -3795,6 +3916,11 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                                         }
                                         break;
 
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return y;
+
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
                                         ModelicaError("Bivariate monotone C1 interpolation is "
@@ -3840,6 +3966,11 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                                             y += ((p1*v1 + p2)*v1 + p3)*v1;
                                         }
                                         break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -3893,6 +4024,10 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                                         }
                                         break;
 
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -3962,6 +4097,11 @@ double ModelicaStandardTables_CombiTable2D_getValue(void* _tableID, double u1,
                                             y += der_y1*u1 + der_y2*u2 + der_y12*u1*u2;
                                         }
                                         break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -4076,6 +4216,11 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                             }
                             break;
 
+                        case MAKIMA_C1:
+                            ModelicaError("Bivariate modified Akima interpolation is "
+                                "not implemented\n");
+                            return der_y;
+
                         case FRITSCH_BUTLAND_MONOTONE_C1:
                         case STEFFEN_MONOTONE_C1:
                             ModelicaError("Bivariate monotone C1 interpolation is "
@@ -4114,6 +4259,11 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                                         der_y *= der_u2;
                                     }
                                     break;
+
+                                case MAKIMA_C1:
+                                    ModelicaError("Bivariate modified Akima interpolation is "
+                                        "not implemented\n");
+                                    return der_y;
 
                                 case FRITSCH_BUTLAND_MONOTONE_C1:
                                 case STEFFEN_MONOTONE_C1:
@@ -4208,6 +4358,11 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                             }
                             break;
 
+                        case MAKIMA_C1:
+                            ModelicaError("Bivariate modified Akima interpolation is "
+                                "not implemented\n");
+                            return der_y;
+
                         case FRITSCH_BUTLAND_MONOTONE_C1:
                         case STEFFEN_MONOTONE_C1:
                             ModelicaError("Bivariate monotone C1 interpolation is "
@@ -4246,6 +4401,11 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                                         der_y *= der_u1;
                                     }
                                     break;
+
+                                case MAKIMA_C1:
+                                    ModelicaError("Bivariate modified Akima interpolation is "
+                                        "not implemented\n");
+                                    return der_y;
 
                                 case FRITSCH_BUTLAND_MONOTONE_C1:
                                 case STEFFEN_MONOTONE_C1:
@@ -4350,6 +4510,11 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                                  }
                                  break;
 
+                            case MAKIMA_C1:
+                                ModelicaError("Bivariate modified Akima interpolation is "
+                                    "not implemented\n");
+                                return der_y;
+
                             case FRITSCH_BUTLAND_MONOTONE_C1:
                             case STEFFEN_MONOTONE_C1:
                                 ModelicaError("Bivariate monotone C1 interpolation is "
@@ -4383,6 +4548,11 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                                             der_y = der_y1*der_u1 + der_y2*der_u2;
                                          }
                                          break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return der_y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -4447,6 +4617,11 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                                          }
                                          break;
 
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return der_y;
+
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
                                         ModelicaError("Bivariate monotone C1 interpolation is "
@@ -4502,6 +4677,11 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                                          }
                                          break;
 
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return der_y;
+
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
                                         ModelicaError("Bivariate monotone C1 interpolation is "
@@ -4551,6 +4731,11 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                                             der_y += (c[14] + c[10]*u1)*der_u2;
                                          }
                                          break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return der_y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -4609,6 +4794,11 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                                             der_y += (der_y2 + der_y12*u1)*der_u2;
                                          }
                                          break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return der_y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -4678,6 +4868,11 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                                          }
                                          break;
 
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return der_y;
+
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
                                         ModelicaError("Bivariate monotone C1 interpolation is "
@@ -4732,6 +4927,11 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                                             der_y += (der_y2 + der_y12*u1)*der_u2;
                                          }
                                          break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return der_y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -4800,6 +5000,11 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                                             der_y += (der_y2 + der_y12*u1)*der_u2;
                                          }
                                          break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return der_y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -4915,6 +5120,11 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                             }
                             break;
 
+                        case MAKIMA_C1:
+                            ModelicaError("Bivariate modified Akima interpolation is "
+                                "not implemented\n");
+                            return der2_y;
+
                         case FRITSCH_BUTLAND_MONOTONE_C1:
                         case STEFFEN_MONOTONE_C1:
                             ModelicaError("Bivariate monotone C1 interpolation is "
@@ -4953,6 +5163,11 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                                         der2_y *= der2_u2;
                                     }
                                     break;
+
+                                case MAKIMA_C1:
+                                    ModelicaError("Bivariate modified Akima interpolation is "
+                                        "not implemented\n");
+                                    return der2_y;
 
                                 case FRITSCH_BUTLAND_MONOTONE_C1:
                                 case STEFFEN_MONOTONE_C1:
@@ -5048,6 +5263,11 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                             }
                             break;
 
+                        case MAKIMA_C1:
+                            ModelicaError("Bivariate modified Akima interpolation is "
+                                "not implemented\n");
+                            return der2_y;
+
                         case FRITSCH_BUTLAND_MONOTONE_C1:
                         case STEFFEN_MONOTONE_C1:
                             ModelicaError("Bivariate monotone C1 interpolation is "
@@ -5086,6 +5306,11 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                                         der2_y *= der2_u1;
                                     }
                                     break;
+
+                                case MAKIMA_C1:
+                                    ModelicaError("Bivariate modified Akima interpolation is "
+                                        "not implemented\n");
+                                    return der2_y;
 
                                 case FRITSCH_BUTLAND_MONOTONE_C1:
                                 case STEFFEN_MONOTONE_C1:
@@ -5199,6 +5424,11 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                                  }
                                  break;
 
+                            case MAKIMA_C1:
+                                ModelicaError("Bivariate modified Akima interpolation is "
+                                    "not implemented\n");
+                                return der2_y;
+
                             case FRITSCH_BUTLAND_MONOTONE_C1:
                             case STEFFEN_MONOTONE_C1:
                                 ModelicaError("Bivariate monotone C1 interpolation is "
@@ -5235,6 +5465,11 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                                             der2_y += der_y2*der2_u2;
                                          }
                                          break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return der2_y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -5301,6 +5536,11 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                                          }
                                          break;
 
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return der2_y;
+
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
                                         ModelicaError("Bivariate monotone C1 interpolation is "
@@ -5358,6 +5598,11 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                                          }
                                          break;
 
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return der2_y;
+
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
                                         ModelicaError("Bivariate monotone C1 interpolation is "
@@ -5408,6 +5653,11 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                                             der2_y += (c[14] + c[10]*u1)*der2_u2;
                                          }
                                          break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return der2_y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -5467,6 +5717,11 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                                             der2_y += (der_y2 + der_y12*u1)*der2_u2;
                                          }
                                          break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return der2_y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -5543,6 +5798,11 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                                          }
                                          break;
 
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return der2_y;
+
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
                                         ModelicaError("Bivariate monotone C1 interpolation is "
@@ -5598,6 +5858,11 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                                             der2_y += (der_y2 + der_y12*u1)*der2_u2;
                                          }
                                          break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return der2_y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -5667,6 +5932,11 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                                             der2_y += (der_y2 + der_y12*u1)*der2_u2;
                                          }
                                          break;
+
+                                    case MAKIMA_C1:
+                                        ModelicaError("Bivariate modified Akima interpolation is "
+                                            "not implemented\n");
+                                        return der2_y;
 
                                     case FRITSCH_BUTLAND_MONOTONE_C1:
                                     case STEFFEN_MONOTONE_C1:
@@ -5934,6 +6204,7 @@ static int isValidCombiTimeTable(CombiTimeTable* tableID,
             /* Check, whether first column values are monotonically or strictly
                increasing */
             if (tableID->smoothness == AKIMA_C1 ||
+                tableID->smoothness == MAKIMA_C1 ||
                 tableID->smoothness == FRITSCH_BUTLAND_MONOTONE_C1 ||
                 tableID->smoothness == STEFFEN_MONOTONE_C1) {
                 size_t i;
@@ -6216,6 +6487,85 @@ static CubicHermite1D* akimaSpline1DInit(_In_ const double* table, size_t nRow,
             }
             else {
                 c2 = 0.5*d[i + 2] + 0.5*d[i + 3];
+            }
+            c[1] = (3*d[i + 2] - 2*c[2] - c2)/dx;
+            c[0] = (c[2] + c2 - 2*d[i + 2])/(dx*dx);
+            /* No need to store the absolute term y0 */
+            /* c[3] = TABLE(i, cols[col] - 1); */
+        }
+    }
+
+    free(d);
+    return spline;
+}
+
+static CubicHermite1D* makimaSpline1DInit(_In_ const double* table, size_t nRow,
+                                         size_t nCol, _In_ const int* cols,
+                                         size_t nCols) {
+  /* Reference:
+
+     Cosmin Ionita. Makima piecewise cubic interpolation, April 2019.
+     (https://blogs.mathworks.com/cleve/2019/04/29/makima-piecewise-cubic-interpolation/)
+  */
+
+    CubicHermite1D* spline = NULL;
+    double* d; /* Divided differences */
+    size_t col;
+
+    /* Actually there is no need for consecutive memory */
+    spline = (CubicHermite1D*)malloc((nRow - 1)*nCols*sizeof(CubicHermite1D));
+    if (NULL == spline) {
+        return NULL;
+    }
+
+    d = (double*)malloc((nRow + 3)*sizeof(double));
+    if (NULL == d) {
+        free(spline);
+        return NULL;
+    }
+
+    for (col = 0; col < nCols; col++) {
+        size_t i;
+        double c2;
+
+        /* Calculation of the divided differences */
+        for (i = 0; i < nRow - 1; i++) {
+            size_t c = (size_t)(cols[col] - 1);
+            d[i + 2] = (TABLE(i + 1, c) - TABLE(i, c))/
+                (TABLE_COL0(i + 1) - TABLE_COL0(i));
+        }
+
+        /* Extrapolation using non-periodic boundary conditions */
+        d[0] = 3*d[2] - 2*d[3];
+        d[1] = 2*d[2] - d[3];
+        d[nRow + 1] = 2*d[nRow] - d[nRow - 1];
+        d[nRow + 2] = 3*d[nRow] - 2*d[nRow - 1];
+
+        /* Initialization of the left boundary slope */
+        c2 = fabs(d[3] - d[2]) + fabs(d[1] - d[0]);
+        c2 += 0.5*fabs(d[3] + d[2]) + 0.5*fabs(d[1] + d[0]);
+        if (c2 > 0) {
+            const double a = (fabs(d[1] - d[0]) + 0.5*fabs(d[1] + d[0]))/c2;
+            c2 = (1 - a)*d[1] + a*d[2];
+        }
+        else {
+            c2 = 0.0;
+        }
+
+        /* Calculation of the 3(4) coefficients per interval */
+        for (i = 0; i < nRow - 1; i++) {
+            const double dx = TABLE_COL0(i + 1) - TABLE_COL0(i);
+            double* c = spline[IDX(i, col, nCols)];
+
+            c[2] = c2;
+            c2 = fabs(d[i + 4] - d[i + 3]) + fabs(d[i + 2] - d[i + 1]);
+            c2 += 0.5*fabs(d[i + 4] + d[i + 3]) + 0.5*fabs(d[i + 2] + d[i + 1]);
+            if (c2 > 0) {
+                const double a = (fabs(d[i + 2] - d[i + 1]) + 0.5*fabs(d[i + 2] + d[i + 1]))/c2;
+                c2 = (1 - a)*d[i + 2] + a*d[i + 3];
+            }
+            else {
+                c2 = 0;
             }
             c[1] = (3*d[i + 2] - 2*c[2] - c2)/dx;
             c[0] = (c[2] + c2 - 2*d[i + 2])/(dx*dx);

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -6503,9 +6503,10 @@ static CubicHermite1D* makimaSpline1DInit(_In_ const double* table, size_t nRow,
                                          size_t nCol, _In_ const int* cols,
                                          size_t nCols) {
   /* Reference:
+     Method description taken from section "Modified Akima formula" of:
 
      Cosmin Ionita. Makima piecewise cubic interpolation, April 2019.
-     (https://blogs.mathworks.com/cleve/2019/04/29/makima-piecewise-cubic-interpolation/)
+     (https://blogs.mathworks.com/cleve/?p=4707)
   */
 
     CubicHermite1D* spline = NULL;

--- a/ModelicaTest/Tables/CombiTable1Ds.mo
+++ b/ModelicaTest/Tables/CombiTable1Ds.mo
@@ -309,9 +309,17 @@ double mydummyfunc(double* dummy_in) {
   model Test33 "Text file with UTF-8 BOM and comments (Ticket #2404)"
     extends Modelica.Icons.Example;
     extends TestDer(t_new(
-        tableOnFile=true,
-        tableName="a",
-        fileName=loadResource("modelica://ModelicaTest/Resources/Data/Tables/test_utf8.txt")));
+      tableOnFile=true,
+      tableName="a",
+      fileName=loadResource("modelica://ModelicaTest/Resources/Data/Tables/test_utf8.txt")));
     annotation (experiment(StartTime=0, StopTime=100));
   end Test33;
+
+  model Test34 "Modified Akima, test data set (Ticket #1039)"
+    extends Modelica.Icons.Example;
+    extends TestDer2(t_new(
+      table=[0,5;1,3;2,1;3,1;4,1;5,3],
+      smoothness=Modelica.Blocks.Types.Smoothness.ModifiedContinuousDerivative));
+    annotation (experiment(StartTime=0, StopTime=4));
+  end Test34;
 end CombiTable1Ds;

--- a/ModelicaTest/Tables/CombiTable1Dv.mo
+++ b/ModelicaTest/Tables/CombiTable1Dv.mo
@@ -310,9 +310,17 @@ double mydummyfunc(double* dummy_in) {
   model Test33 "Text file with UTF-8 BOM and comments (Ticket #2404)"
     extends Modelica.Icons.Example;
     extends TestDer(t_new(
-        tableOnFile=true,
-        tableName="a",
-        fileName=loadResource("modelica://ModelicaTest/Resources/Data/Tables/test_utf8.txt")));
+      tableOnFile=true,
+      tableName="a",
+      fileName=loadResource("modelica://ModelicaTest/Resources/Data/Tables/test_utf8.txt")));
     annotation (experiment(StartTime=0, StopTime=100));
   end Test33;
+
+  model Test34 "Modified Akima, test data set (Ticket #1039)"
+    extends Modelica.Icons.Example;
+    extends TestDer2(t_new(
+      table=[0,5;1,3;2,1;3,1;4,1;5,3],
+      smoothness=Modelica.Blocks.Types.Smoothness.ModifiedContinuousDerivative));
+    annotation (experiment(StartTime=0, StopTime=4));
+  end Test34;
 end CombiTable1Dv;

--- a/ModelicaTest/Tables/CombiTimeTable.mo
+++ b/ModelicaTest/Tables/CombiTimeTable.mo
@@ -1096,4 +1096,66 @@ double mydummyfunc(double* dummy_in) {
       smoothness=Modelica.Blocks.Types.Smoothness.ConstantSegments));
     annotation (experiment(StartTime=0, StopTime=3));
   end Test86;
+
+  model Test87 "Modified Akima, comparison, first test data set (Ticket #1039)"
+    extends Modelica.Icons.Example;
+    final constant Real table[:,2] = [1,0;2,0;3,0;4,0.5;5,0.5;5.5,1.2;7,1.2;8,0.1;9,0;9.5,0.3;10,0.6] "Table data";
+    extends TestDer2(t_new(
+      table=table,
+      smoothness=Modelica.Blocks.Types.Smoothness.ModifiedContinuousDerivative));
+    Modelica.Blocks.Sources.CombiTimeTable t_new_2(
+      table=table,
+      smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative) annotation(Placement(transformation(extent={{-40,-30},{-20,-10}})));
+    Modelica.Blocks.Sources.CombiTimeTable t_new_3(
+      table=table,
+      smoothness=Modelica.Blocks.Types.Smoothness.MonotoneContinuousDerivative1) annotation(Placement(transformation(extent={{-40,-60},{-20,-40}})));
+    Modelica.Blocks.Sources.CombiTimeTable t_new_4(
+      table=table,
+      smoothness=Modelica.Blocks.Types.Smoothness.MonotoneContinuousDerivative2) annotation(Placement(transformation(extent={{-40,-90},{-20,-70}})));
+    Modelica.Blocks.Continuous.Der d_t_new_2 annotation(Placement(transformation(extent={{0,-30},{20,-10}})));
+    Modelica.Blocks.Continuous.Der d2_t_new_2 annotation(Placement(transformation(extent={{40,-30},{60,-10}})));
+    Modelica.Blocks.Continuous.Der d_t_new_3 annotation(Placement(transformation(extent={{0,-60},{20,-40}})));
+    Modelica.Blocks.Continuous.Der d2_t_new_3 annotation(Placement(transformation(extent={{40,-60},{60,-40}})));
+    Modelica.Blocks.Continuous.Der d_t_new_4 annotation(Placement(transformation(extent={{0,-90},{20,-70}})));
+    Modelica.Blocks.Continuous.Der d2_t_new_4 annotation(Placement(transformation(extent={{40,-90},{60,-70}})));
+    equation
+      connect(t_new_2.y[1], d_t_new_2.u) annotation(Line(points={{-19,-20},{-2,-20}}, color={0,0,127}));
+      connect(d_t_new_2.y, d2_t_new_2.u) annotation(Line(points={{21,-20},{26,-20},{33,-20},{38,-20}}, color={0,0,127}));
+      connect(d_t_new_3.y,d2_t_new_3.u) annotation(Line(points={{21,-50},{26,-50},{33,-50},{38,-50}},   color={0,0,127}));
+      connect(t_new_3.y[1],d_t_new_3.u) annotation(Line(points={{-19,-50},{-2,-50}}, color={0,0,127}));
+      connect(d_t_new_4.y,d2_t_new_4.u) annotation(Line(points={{21,-80},{26,-80},{33,-80},{38,-80}},   color={0,0,127}));
+      connect(t_new_4.y[1],d_t_new_4.u) annotation(Line(points={{-19,-80},{-2,-80}}, color={0,0,127}));
+    annotation (experiment(StartTime=0, StopTime=11));
+  end Test87;
+
+  model Test88 "Modified Akima, comparison, second test data set (Ticket #1039)"
+    extends Modelica.Icons.Example;
+    final constant Real table[:,2] = [1,-1;2,-1;3,-1;4,0;5,1;6,1+1e-15;7,1;8,1] "Table data";
+    extends TestDer2(t_new(
+      table=table,
+      smoothness=Modelica.Blocks.Types.Smoothness.ModifiedContinuousDerivative));
+    Modelica.Blocks.Sources.CombiTimeTable t_new_2(
+      table=table,
+      smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative) annotation(Placement(transformation(extent={{-40,-30},{-20,-10}})));
+    Modelica.Blocks.Sources.CombiTimeTable t_new_3(
+      table=table,
+      smoothness=Modelica.Blocks.Types.Smoothness.MonotoneContinuousDerivative1) annotation(Placement(transformation(extent={{-40,-60},{-20,-40}})));
+    Modelica.Blocks.Sources.CombiTimeTable t_new_4(
+      table=table,
+      smoothness=Modelica.Blocks.Types.Smoothness.MonotoneContinuousDerivative2) annotation(Placement(transformation(extent={{-40,-90},{-20,-70}})));
+    Modelica.Blocks.Continuous.Der d_t_new_2 annotation(Placement(transformation(extent={{0,-30},{20,-10}})));
+    Modelica.Blocks.Continuous.Der d2_t_new_2 annotation(Placement(transformation(extent={{40,-30},{60,-10}})));
+    Modelica.Blocks.Continuous.Der d_t_new_3 annotation(Placement(transformation(extent={{0,-60},{20,-40}})));
+    Modelica.Blocks.Continuous.Der d2_t_new_3 annotation(Placement(transformation(extent={{40,-60},{60,-40}})));
+    Modelica.Blocks.Continuous.Der d_t_new_4 annotation(Placement(transformation(extent={{0,-90},{20,-70}})));
+    Modelica.Blocks.Continuous.Der d2_t_new_4 annotation(Placement(transformation(extent={{40,-90},{60,-70}})));
+    equation
+      connect(t_new_2.y[1], d_t_new_2.u) annotation(Line(points={{-19,-20},{-2,-20}}, color={0,0,127}));
+      connect(d_t_new_2.y, d2_t_new_2.u) annotation(Line(points={{21,-20},{26,-20},{33,-20},{38,-20}}, color={0,0,127}));
+      connect(d_t_new_3.y,d2_t_new_3.u) annotation(Line(points={{21,-50},{26,-50},{33,-50},{38,-50}},   color={0,0,127}));
+      connect(t_new_3.y[1],d_t_new_3.u) annotation(Line(points={{-19,-50},{-2,-50}}, color={0,0,127}));
+      connect(d_t_new_4.y,d2_t_new_4.u) annotation(Line(points={{21,-80},{26,-80},{33,-80},{38,-80}},   color={0,0,127}));
+      connect(t_new_4.y[1],d_t_new_4.u) annotation(Line(points={{-19,-80},{-2,-80}}, color={0,0,127}));
+    annotation (experiment(StartTime=0, StopTime=9));
+  end Test88;
 end CombiTimeTable;


### PR DESCRIPTION
The _modified_ Akima interpolation (aka. _Makima_) avoids overshoots/undershoots and edge cases of identical slopes that are present in the original Akima method. It is documented in [Cleve's corner](https://blogs.mathworks.com/cleve/2019/04/29/makima-piecewise-cubic-interpolation/) by Cosmin Ionita from The MathWorks and also available since MATLAB R2017b.

This properly resolves #1039, which previously was closed as wontfix.