### PR TITLE
Improve upper Hessenberg; document and test ilo/ihi

### DIFF
--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -9323,9 +9323,9 @@ For details of the arguments, see documentation of dgbsv.
       input String side="L";
       input String trans="N";
       input Integer ilo=1
-        "Lowest index where the original matrix had been Hessenberg form";
+        "Lowest index where the original matrix is not in upper triangular form";
       input Integer ihi=if side == "L" then size(C, 1) else size(C, 2)
-        "Highest index where the original matrix had been Hessenberg form";
+        "Highest index where the original matrix is not in upper triangular form";
       output Real Cout[size(C, 1), size(C, 2)]=C
         "Contains the Hessenberg form in the upper triangle and the first subdiagonal and below the first subdiagonal it contains the elementary reflectors which represents (with array tau) as a product the orthogonal matrix Q";
 
@@ -9955,9 +9955,9 @@ For details of the arguments, see documentation of dgbsv.
       input Real A[:, size(A, 1)]
         "Square matrix with the elementary reflectors";
       input Integer ilo=1
-        "Lowest index where the original matrix had been Hessenberg form - ilo must have the same value as in the previous call of DGEHRD";
+        "Lowest index where the original matrix is not in upper triangular form - ilo must have the same value as in the previous call of DGEHRD";
       input Integer ihi=size(A, 1)
-        "Highest index where the original matrix had been Hessenberg form - ihi must have the same value as in the previous call of DGEHRD";
+        "Highest index where the original matrix is not in upper triangular form - ihi must have the same value as in the previous call of DGEHRD";
       input Real tau[max(0, size(A, 1) - 1)]
         "Scalar factors of the elementary reflectors";
       output Real Aout[size(A, 1), size(A, 2)]=A

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -10454,7 +10454,7 @@ The algorithm is taken from [1] and [2].
 Function <strong>toUpperHessenberg</strong> computes a upper Hessenberg form <strong>H</strong> of a matrix <strong>A</strong> by orthogonal similarity transformation:  <strong>Q</strong>' * <strong>A</strong> * <strong>Q</strong> = <strong>H</strong>.
 The optional inputs <strong>ilo</strong> and <strong>ihi</strong> improve efficiency if the matrix is already partially converted to Hessenberg form; it is assumed
 that matrix <strong>A</strong> is already upper Hessenberg for rows and columns <strong>1:(ilo-1)</strong> and <strong>(ihi+1):size(A, 1)</strong>.
-The function calls LAPACK function DGEHRD.
+The function calls <a href=\"modelica://Modelica.Math.Matrices.LAPACK.dgehrd\">LAPACK.dgehrd</a>.
 See <a href=\"modelica://Modelica.Math.Matrices.LAPACK.dgehrd\">Matrices.LAPACK.dgehrd</a> for more information about the additional outputs V, tau, info and inputs ilo, ihi.
 </p>
 

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -8000,9 +8000,9 @@ For details of the arguments, see documentation of dgbsv.
 
       input Real A[:, size(A, 1)];
       input Integer ilo=1
-        "Lowest index where the original matrix had been Hessenberg form";
+        "Lowest index where the original matrix have not been in Hessenberg form";
       input Integer ihi=size(A, 1)
-        "Highest index where the original matrix had been Hessenberg form";
+        "Highest index where the original matrix have not been in Hessenberg form";
       output Real Aout[size(A, 1), size(A, 2)]=A
         "Contains the Hessenberg form in the upper triangle and the first subdiagonal and below the first subdiagonal it contains the elementary reflectors which represents (with array tau) as a product the orthogonal matrix Q";
       output Real tau[max(size(A, 1), 1) - 1]
@@ -10405,9 +10405,9 @@ The algorithm is taken from [1] and [2].
 
       input Real A[:, size(A, 1)] "Square matrix A";
       input Integer ilo=1
-        "Lowest index where the original matrix had been Hessenberg form";
+        "Lowest index where the original matrix have not been in Hessenberg form";
       input Integer ihi=size(A, 1)
-        "Highest index where the original matrix had been Hessenberg form";
+        "Highest index where the original matrix have not been in Hessenberg form";
       output Real H[size(A, 1), size(A, 2)] "Upper Hessenberg form";
       output Real V[size(A, 1), size(A, 2)]
         "V=[v1,v2,..vn-1,0] with vi are vectors which define the elementary reflectors";
@@ -10452,7 +10452,9 @@ The algorithm is taken from [1] and [2].
 <h4>Description</h4>
 <p>
 Function <strong>toUpperHessenberg</strong> computes a upper Hessenberg form <strong>H</strong> of a matrix <strong>A</strong> by orthogonal similarity transformation:  <strong>Q</strong>' * <strong>A</strong> * <strong>Q</strong> = <strong>H</strong>.
-With the optional inputs ilo and ihi, also partial transformation is possible. The function calls LAPACK function DGEHRD.
+The optional inputs <strong>ilo</strong> and <strong>ihi</strong> improve efficiency if the matrix is already partially converted to Hessenberg form; it is assumed
+that matrix <strong>A</strong> is already upper Hessenberg for rows and columns <strong>1:(ilo-1)</strong> and <strong>(ihi+1):size(A, 1)</strong>.
+The function calls LAPACK function DGEHRD.
 See <a href=\"modelica://Modelica.Math.Matrices.LAPACK.dgehrd\">Matrices.LAPACK.dgehrd</a> for more information about the additional outputs V, tau, info and inputs ilo, ihi.
 </p>
 

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -8000,9 +8000,9 @@ For details of the arguments, see documentation of dgbsv.
 
       input Real A[:, size(A, 1)];
       input Integer ilo=1
-        "Lowest index where the original matrix have not been in Hessenberg form";
+        "Lowest index where the original matrix have not been in upper triangular form";
       input Integer ihi=size(A, 1)
-        "Highest index where the original matrix have not been in Hessenberg form";
+        "Highest index where the original matrix have not been in upper triangular form";
       output Real Aout[size(A, 1), size(A, 2)]=A
         "Contains the Hessenberg form in the upper triangle and the first subdiagonal and below the first subdiagonal it contains the elementary reflectors which represents (with array tau) as a product the orthogonal matrix Q";
       output Real tau[max(size(A, 1), 1) - 1]
@@ -10405,9 +10405,9 @@ The algorithm is taken from [1] and [2].
 
       input Real A[:, size(A, 1)] "Square matrix A";
       input Integer ilo=1
-        "Lowest index where the original matrix have not been in Hessenberg form";
+        "Lowest index where the original matrix have not been in upper triangular form";
       input Integer ihi=size(A, 1)
-        "Highest index where the original matrix have not been in Hessenberg form";
+        "Highest index where the original matrix have not been in upper triangular form";
       output Real H[size(A, 1), size(A, 2)] "Upper Hessenberg form";
       output Real V[size(A, 1), size(A, 2)]
         "V=[v1,v2,..vn-1,0] with vi are vectors which define the elementary reflectors";

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -8000,9 +8000,9 @@ For details of the arguments, see documentation of dgbsv.
 
       input Real A[:, size(A, 1)];
       input Integer ilo=1
-        "Lowest index where the original matrix have not been in upper triangular form";
+        "Lowest index where the original matrix is not in upper triangular form";
       input Integer ihi=size(A, 1)
-        "Highest index where the original matrix have not been in upper triangular form";
+        "Highest index where the original matrix is not in upper triangular form";
       output Real Aout[size(A, 1), size(A, 2)]=A
         "Contains the Hessenberg form in the upper triangle and the first subdiagonal and below the first subdiagonal it contains the elementary reflectors which represents (with array tau) as a product the orthogonal matrix Q";
       output Real tau[max(size(A, 1), 1) - 1]
@@ -10405,9 +10405,9 @@ The algorithm is taken from [1] and [2].
 
       input Real A[:, size(A, 1)] "Square matrix A";
       input Integer ilo=1
-        "Lowest index where the original matrix have not been in upper triangular form";
+        "Lowest index where the original matrix is not in upper triangular form";
       input Integer ihi=size(A, 1)
-        "Highest index where the original matrix have not been in upper triangular form";
+        "Highest index where the original matrix is not in upper triangular form";
       output Real H[size(A, 1), size(A, 2)] "Upper Hessenberg form";
       output Real V[size(A, 1), size(A, 2)]
         "V=[v1,v2,..vn-1,0] with vi are vectors which define the elementary reflectors";

--- a/ModelicaTest/Math.mo
+++ b/ModelicaTest/Math.mo
@@ -297,6 +297,9 @@ extends Modelica.Icons.ExamplesPackage;
     Real sigma8[0];
     Real U8[0,0];
     Real VT8[0,0];
+    Real TA1[5,5]=[4,1,2,3,5;0,1,2,3,5;0,4,5,6,8;0,7,8,9,1;0,0,0,0,2]; // In block Hessenberg form
+    Real TH1[5,5];
+    Real TH2[5,5];
   algorithm
   //  ##########   continuous Lyapunov   ##########
     X1 := Matrices.continuousLyapunov(A1,C1);// benchmark example from SLICOT
@@ -461,6 +464,12 @@ extends Modelica.Icons.ExamplesPackage;
 
     Xn := Modelica.Math.Matrices.hessenberg(N);
     Xn := Modelica.Math.Matrices.realSchur(N);
+
+    TH1 := Modelica.Math.Matrices.Utilities.toUpperHessenberg(TA1);
+    TH2 := Modelica.Math.Matrices.Utilities.toUpperHessenberg(TA1,2,4);
+    r := Matrices.norm(TH1-TH2);
+    Modelica.Utilities.Streams.print("Optimized toUpperHessenberg: r = "+String(r));
+    assert(r<eps, "\"toUpperHessenberg with ilo and ihi\"");
 
   //  ##########   Singular values   ##########
     (sigma7, U7, VT7) := Matrices.singularValues(A7);


### PR DESCRIPTION
Closes #2692.
I believe this new documentation is more understandable - even if I don't see the obvious reason for exposing ilo/ihi.

