### PR TITLE
Replace Modelica.Media.Common.OneNonLinearEquation by Modelica.Math.Nonlinear.solveOneNonlinearEquation

### DIFF
--- a/Modelica/Math/Nonlinear.mo
+++ b/Modelica/Math/Nonlinear.mo
@@ -802,13 +802,14 @@ functions.
 For details about how to define and to use functions as input arguments
 to functions, see
 <a href=\"modelica://ModelicaReference.Classes.'function'\">ModelicaReference.Classes.'function'</a>
-or the Modelica Language  Specification, Chapter 12.4.2.
+or <a href=\"https://specification.modelica.org/v3.4/Ch12.html#functional-input-arguments-to-functions\">Section 12.4.2
+(Functional Input Arguments to Functions) of the Modelica 3.4 specification</a>.
 </p>
 
 </html>", revisions="<html>
 <ul>
 <li><em>July 2010 </em> by Martin Otter (DLR-RM):<br>
-    Included in MSL3.2, adapted, and documentation improved</li>
+    Included in MSL 3.2, adapted, and documentation improved</li>
 
 <li><em>March 2010 </em> by Andreas Pfeiffer (DLR-RM):<br>
     Adapted the quadrature function from Gerhard Schillhuber and

--- a/Modelica/Media/Air/MoistAir.mo
+++ b/Modelica/Media/Air/MoistAir.mo
@@ -490,31 +490,18 @@ Derivative function of <a href=\"modelica://Modelica.Media.Air.MoistAir.saturati
     output SI.Temperature T "Saturation temperature";
 
   protected
-    package Internal
-      extends Modelica.Media.Common.OneNonLinearEquation;
+    function f_nonlinear "Solve p(T) for T with given p"
+      extends Modelica.Math.Nonlinear.Interfaces.partialScalarFunction;
+      input SI.Pressure p "Pressure";
+    algorithm
+      y := saturationPressure(Tsat=u) - p;
+    end f_nonlinear;
 
-      redeclare record extends f_nonlinear_Data
-        // Define data to be passed to user function
-      end f_nonlinear_Data;
-
-      redeclare function extends f_nonlinear
-      algorithm
-        y := saturationPressure(x);
-        // Compute the non-linear equation: y = f(x, Data)
-      end f_nonlinear;
-
-      // Dummy definition
-      redeclare function extends solve
-      end solve;
-    end Internal;
   algorithm
-    T := Internal.solve(
-          p,
-          T_min,
-          T_max,
-          f_nonlinear_data=Internal.f_nonlinear_Data());
+    T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(
+      function f_nonlinear(p=p), T_min, T_max);
     annotation (Documentation(info="<html>
- Computes saturation temperature from (partial) pressure via numerical inversion of the function <a href=\"modelica://Modelica.Media.Air.MoistAir.saturationPressure\">saturationPressure</a>. Therefore additional inputs are required (or the defaults are used) for upper and lower temperature bounds.
+Computes saturation temperature from (partial) pressure via numerical inversion of the function <a href=\"modelica://Modelica.Media.Air.MoistAir.saturationPressure\">saturationPressure</a>. Therefore additional inputs are required (or the defaults are used) for upper and lower temperature bounds.
 </html>"));
   end saturationTemperature;
 
@@ -663,9 +650,9 @@ Specific enthalpy of dry air is computed from temperature.
     annotation (derivative=enthalpyOfWater_der, Documentation(info="<html>
 Specific enthalpy of water (liquid and solid) is computed from temperature using constant properties as follows:<br>
 <ul>
-<li>  heat capacity of liquid water:4200 J/kg</li>
-<li>  heat capacity of solid water: 2050 J/kg</li>
-<li>  enthalpy of fusion (liquid=>solid): 333000 J/kg</li>
+<li>heat capacity of liquid water:4200 J/kg</li>
+<li>heat capacity of solid water: 2050 J/kg</li>
+<li>enthalpy of fusion (liquid=>solid): 333000 J/kg</li>
 </ul>
 Pressure is assumed to be around 1 bar. This function is usually used to determine the specific enthalpy of the liquid or solid fraction of moist air.
 </html>"));
@@ -727,35 +714,18 @@ Temperature is returned from the thermodynamic state record input as a simple as
     output Temperature T "Temperature";
 
   protected
-    package Internal
-      "Solve h(data,T) for T with given h (use only indirectly via temperature_phX)"
-      extends Modelica.Media.Common.OneNonLinearEquation;
-      redeclare record extends f_nonlinear_Data
-        "Data to be passed to non-linear function"
-        extends Modelica.Media.IdealGases.Common.DataRecord;
-      end f_nonlinear_Data;
-
-      redeclare function extends f_nonlinear
-      algorithm
-        y := h_pTX(
-                  p,
-                  x,
-                  X);
-      end f_nonlinear;
-
-      // Dummy definition has to be added for current Dymola
-      redeclare function extends solve
-      end solve;
-    end Internal;
+    function f_nonlinear "Solve h_pTX(p,T,X) for T with given h"
+      extends Modelica.Math.Nonlinear.Interfaces.partialScalarFunction;
+      input AbsolutePressure p "Pressure";
+      input SpecificEnthalpy h "Specific enthalpy";
+      input MassFraction[:] X "Mass fractions of composition";
+    algorithm
+      y := h_pTX(p=p, T=u, X=X) - h;
+    end f_nonlinear;
 
   algorithm
-    T := Internal.solve(
-          h,
-          190,
-          647,
-          p,
-          X[1:nXi],
-          steam);
+    T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(
+      function f_nonlinear(p=p, h=h, X=X[1:nXi]), 190, 647);
     annotation (Documentation(info="<html>
 Temperature is computed from pressure, specific enthalpy and composition via numerical inversion of function <a href=\"modelica://Modelica.Media.Air.MoistAir.h_pTX\">h_pTX</a>.
 </html>"));
@@ -1290,36 +1260,20 @@ end thermalConductivity;
     output Temperature T "Temperature";
 
   protected
-    package Internal "Solve s(data,T) for T with given s"
-      extends Modelica.Media.Common.OneNonLinearEquation;
-      redeclare record extends f_nonlinear_Data
-        "Data to be passed to non-linear function"
-        extends Modelica.Media.IdealGases.Common.DataRecord;
-      end f_nonlinear_Data;
-
-      redeclare function extends f_nonlinear
-      algorithm
-        y := s_pTX(
-                  p,
-                  x,
-                  X);
-      end f_nonlinear;
-
-      // Dummy definition has to be added for current Dymola
-      redeclare function extends solve
-      end solve;
-    end Internal;
+    function f_nonlinear "Solve s_pTX(p,T,X) for T with given s"
+      extends Modelica.Math.Nonlinear.Interfaces.partialScalarFunction;
+      input AbsolutePressure p "Pressure";
+      input SpecificEntropy s "Specific entropy";
+      input MassFraction[:] X "Mass fractions of composition";
+    algorithm
+      y := s_pTX(p=p, T=u, X=X) - s;
+    end f_nonlinear;
 
   algorithm
-    T := Internal.solve(
-          s,
-          190,
-          647,
-          p,
-          X[1:nX],
-          steam);
+    T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(
+      function f_nonlinear(p=p, s=s, X=X[1:nXi]), 190, 647);
     annotation (Documentation(info="<html>
-Temperature is computed from pressure, specific entropy and composition via numerical inversion of function <a href=\"modelica://Modelica.Media.Air.MoistAir.specificEntropy\">specificEntropy</a>.
+Temperature is computed from pressure, specific entropy and composition via numerical inversion of function <a href=\"modelica://Modelica.Media.Air.MoistAir.s_pTX\">s_pTX</a>.
 </html>",
         revisions="<html>
 <p>2012-01-12        Stefan Wischhusen: Initial Release.</p>

--- a/Modelica/Media/Incompressible.mo
+++ b/Modelica/Media/Incompressible.mo
@@ -222,7 +222,7 @@ density and heat capacity as functions of temperature.</li>
       R_s = Modelica.Constants.R/MM_const;
       cp = Polynomials.evaluate(poly_Cp,if TinK then T else T_degC);
       h = if enthalpyOfT then h_T(T) else  h_pT(p,T,densityOfT);
-      u = h - (if singleState then  reference_p/d else state.p/d);
+      u = h - (if singleState then reference_p/d else state.p/d);
       d = Polynomials.evaluate(poly_rho,if TinK then T else T_degC);
       state.T = T;
       state.p = p;
@@ -469,7 +469,7 @@ which is only exactly true for a fluid with constant density d=d0.
     redeclare function extends specificInternalEnergy
       "Return specific internal energy as a function of the thermodynamic state record"
     algorithm
-      u := (if enthalpyOfT then h_T(state.T) else h_pT(state.p,state.T)) - (if singleState then  reference_p else state.p)/density(state);
+      u := (if enthalpyOfT then h_T(state.T) else h_pT(state.p,state.T)) - (if singleState then reference_p else state.p)/density(state);
      annotation(Inline=true,smoothOrder=2);
     end specificInternalEnergy;
 
@@ -478,51 +478,39 @@ which is only exactly true for a fluid with constant density d=d0.
       input AbsolutePressure p "Pressure";
       input SpecificEnthalpy h "Specific enthalpy";
       output Temperature T "Temperature";
+
     protected
-      package Internal
-        "Solve h(T) for T with given h (use only indirectly via temperature_phX)"
-        extends Modelica.Media.Common.OneNonLinearEquation;
+      function f_nonlinear "Solve h_T(T) or h_pT(p,T) for T with given h"
+        extends Modelica.Math.Nonlinear.Interfaces.partialScalarFunction;
+        input AbsolutePressure p "Pressure";
+        input SpecificEnthalpy h "Specific enthalpy";
+      algorithm
+        y := (if singleState then h_T(T=u) else h_pT(p=p, T=u)) - h;
+      end f_nonlinear;
 
-        redeclare record extends f_nonlinear_Data
-          "Superfluous record, fix later when better structure of inverse functions exists"
-            constant Real[5] dummy = {1,2,3,4,5};
-        end f_nonlinear_Data;
-
-        redeclare function extends f_nonlinear "P is smuggled in via vector"
-        algorithm
-          y := if singleState then h_T(x) else h_pT(p,x);
-        end f_nonlinear;
-
-      end Internal;
     algorithm
-     T := Internal.solve(h, T_min, T_max, p, {1}, Internal.f_nonlinear_Data());
+      T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(
+        function f_nonlinear(p=p, h=h), T_min, T_max);
       annotation(Inline=false, LateInline=true, inverse(h=h_pT(p,T)));
     end T_ph;
 
     function T_ps "Compute temperature from pressure and specific enthalpy"
       extends Modelica.Icons.Function;
-
-      input AbsolutePressure p "Pressure";
+      input AbsolutePressure p "Pressure (unused)";
       input SpecificEntropy s "Specific entropy";
       output Temperature T "Temperature";
+
     protected
-      package Internal
-        "Solve h(T) for T with given h (use only indirectly via temperature_phX)"
-        extends Modelica.Media.Common.OneNonLinearEquation;
+      function f_nonlinear "Solve s_T(T) for T with given s"
+        extends Modelica.Math.Nonlinear.Interfaces.partialScalarFunction;
+        input SpecificEntropy s "Specific entropy";
+      algorithm
+        y := s_T(T=u) - s;
+      end f_nonlinear;
 
-        redeclare record extends f_nonlinear_Data
-          "Superfluous record, fix later when better structure of inverse functions exists"
-            constant Real[5] dummy = {1,2,3,4,5};
-        end f_nonlinear_Data;
-
-        redeclare function extends f_nonlinear "P is smuggled in via vector"
-        algorithm
-          y := s_T(x);
-        end f_nonlinear;
-
-      end Internal;
     algorithm
-     T := Internal.solve(s, T_min, T_max, p, {1}, Internal.f_nonlinear_Data());
+      T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(
+        function f_nonlinear(s=s), T_min, T_max);
     end T_ps;
 
   annotation(Documentation(info="<html>
@@ -535,7 +523,7 @@ of density and heat capacity as functions of temperature.
 <p>It should be noted that incompressible media only have 1 state per control volume (usually T),
 but have both T and p as inputs for fully correct properties. The error of using only T-dependent
 properties is small, therefore a Boolean flag enthalpyOfT exists. If it is true, the
-enumeration Choices.independentVariables  is set to  Choices.independentVariables.T otherwise
+enumeration Choices.independentVariables is set to Choices.independentVariables.T otherwise
 it is set to Choices.independentVariables.pT.</p>
 
 <h4>Using the package TableBased</h4>
@@ -578,9 +566,9 @@ in terms of tables, functions or polynomial coefficients.
 The common meaning of <em>incompressible</em> is that properties like density
 and enthalpy are independent of pressure. Thus properties are conveniently
 described as functions of temperature, e.g., as polynomials density(T) and cp(T).
-However, enthalpy and inner energy can not both be independent of pressure since h = u + p/d. 
-(Normally when T is held constant dh/dp&ge;0 and du/dp&le;0.) 
-For liquids it is anyway common to neglect this dependence for 
+However, enthalpy and inner energy can not both be independent of pressure since h = u + p/d.
+(Normally when T is held constant dh/dp&ge;0 and du/dp&le;0.)
+For liquids it is anyway common to neglect this dependence for
 both of them since for constant density the neglected term is (p - p0)/d,
 which in comparison with cp is very small for most liquids. For
 water, the equivalent change of temperature to increasing pressure 1 bar is

--- a/Modelica/Media/package.mo
+++ b/Modelica/Media/package.mo
@@ -2918,47 +2918,23 @@ points, e.g., when an isentropic reference state is computed.
       parameter Real x_max=1.7 "Maximum value of x_zero";
       parameter Real A=1 "Amplitude of sine";
       parameter Real w=1 "Angular frequency of sine";
-      parameter Inverse_sine_definition.f_nonlinear_Data data=
-          Inverse_sine_definition.f_nonlinear_Data(A=A, w=w) "Data record";
       Real x_zero "y_zero = A*sin(w*x_zero)";
 
-      encapsulated package Inverse_sine_definition
-        "Define sine as non-linear equation to be solved"
-        import Modelica;
-        extends Modelica.Media.Common.OneNonLinearEquation;
-
-        redeclare record extends f_nonlinear_Data "Data for nonlinear equation"
-          Real A "Amplitude";
-          Real w "Angular frequency";
-          annotation (Documentation(info="<html>
-
-</html>"));
-        end f_nonlinear_Data;
-
-        redeclare function extends f_nonlinear
-          "Non-linear equation to be solved"
-        algorithm
-          y := f_nonlinear_data.A*Modelica.Math.sin(f_nonlinear_data.w*x);
-        end f_nonlinear;
-
-        // Dummy definition has to be added for current Dymola (advice from Hans)
-        redeclare function extends solve
-          "Solution algorithm of non-linear equation"
-        end solve;
-        annotation (Documentation(info="<html>
-
-</html>"));
-      end Inverse_sine_definition;
+      function f_nonlinear "Define sine as non-linear equation to be solved"
+        extends Modelica.Math.Nonlinear.Interfaces.partialScalarFunction;
+        input Real A=1 "Amplitude of sine";
+        input Real w=1 "Angular frequency of sine";
+        input Real s=0 "Shift of sine";
+      algorithm
+        y := A*Modelica.Math.sin(w*u) + s;
+      end f_nonlinear;
 
     equation
-      x_zero = Inverse_sine_definition.solve(
-              y_zero,
-              x_min,
-              x_max,
-              f_nonlinear_data=data);
+      x_zero = Modelica.Math.Nonlinear.solveOneNonlinearEquation(
+        function f_nonlinear(A=A, w=w, s=-y_zero), x_min, x_max);
 
       print("x_zero = " + String(x_zero) + ", y_zero = " + String(y_zero) +
-        ", A*sin(w*x_zero) = " + String(data.A*Modelica.Math.sin(data.w*x_zero)));
+        ", A*sin(w*x_zero) = " + String(A*Modelica.Math.sin(w*x_zero)));
       annotation (experiment(StopTime=0), Documentation(info="<html>
 <p>
 This models solves the following non-linear equation
@@ -3017,23 +2993,13 @@ output window.
       der(s1) = if time < 1.0 then 1/timeUnit*(s_max - s_min) else 0.0;
 
       // Solve for temperature
-      Th = Medium.temperature_phX(
-              p,
-              h1,
-              fill(0.0, 0));
-      Ts = Medium.temperature_psX(
-              p,
-              s1,
-              fill(0.0, 0));
+      Th = Medium.temperature_phX(p, h1, fill(0.0, 0));
+      Ts = Medium.temperature_psX(p, s1, fill(0.0, 0));
 
       // Check (h2 must be identical to h1)
-      h2 = Medium.specificEnthalpy_pTX(
-              p,
-              Th,
-              fill(0.0, 0));
+      h2 = Medium.specificEnthalpy_pTX(p, Th, fill(0.0, 0));
       s2 = Medium.specificEntropy(Medium.setState_pT(p, Ts));
-      annotation (experiment(StopTime=1), Documentation(info="<html>
-                               </html>"));
+      annotation (experiment(StopTime=1), Documentation(info="<html></html>"));
     end Inverse_sh_T;
 
     model InverseIncompressible_sh_T
@@ -3077,24 +3043,13 @@ output window.
       der(s1) = if time < 1.0 then 1/timeUnit*(s_max - s_min) else 0.0;
 
       // Solve for temperature
-      Th = Medium.temperature_phX(
-              p,
-              h1,
-              fill(0.0, 0));
-      Ts = Medium.temperature_psX(
-              p,
-              s1,
-              fill(0.0, 0));
+      Th = Medium.temperature_phX(p, h1, fill(0.0, 0));
+      Ts = Medium.temperature_psX(p, s1, fill(0.0, 0));
 
       // Check (h2 must be identical to h1)
-      h2 = Medium.specificEnthalpy_pTX(
-              p,
-              Th,
-              fill(0.0, 0));
+      h2 = Medium.specificEnthalpy_pTX(p, Th, fill(0.0, 0));
       s2 = Medium.specificEntropy(Medium.setState_pT(p, Ts));
-      annotation (experiment(StopTime=1), Documentation(info="<html>
-
-                               </html>"));
+      annotation (experiment(StopTime=1), Documentation(info="<html></html>"));
     end InverseIncompressible_sh_T;
 
     model Inverse_sh_TX
@@ -3116,15 +3071,9 @@ output window.
       final parameter SI.SpecificEnthalpy h_max=Medium.h_TX(T_max, X)
         "Specific enthalpy at T_max";
       final parameter SI.SpecificEntropy s_min=Medium.specificEntropy(
-          Medium.setState_pTX(
-                p,
-                T_min,
-                Medium.reference_X)) "Specific entropy at T_min";
+        Medium.setState_pTX(p, T_min, Medium.reference_X)) "Specific entropy at T_min";
       final parameter SI.SpecificEntropy s_max=Medium.specificEntropy(
-          Medium.setState_pTX(
-                p,
-                T_max,
-                Medium.reference_X)) "Specific entropy at T_max";
+        Medium.setState_pTX(p, T_max, Medium.reference_X)) "Specific entropy at T_max";
       SI.SpecificEnthalpy h1(start=h_min, fixed=true)
         "Pre-defined specific enthalpy";
       SI.SpecificEnthalpy h2
@@ -3145,34 +3094,19 @@ output window.
       der(s1) = if time < 1.0 then 1/timeUnit*(s_max - s_min) else 0.0;
 
       // Solve for temperature
-      Th = Medium.temperature_phX(
-              p,
-              h1,
-              X);
-      Ts = Medium.temperature_psX(
-              p,
-              s1,
-              X);
+      Th = Medium.temperature_phX(p, h1, X);
+      Ts = Medium.temperature_psX(p, s1, X);
 
       // Check (h2 must be identical to h1)
-      h2 = Medium.specificEnthalpy_pTX(
-              p,
-              Th,
-              X);
-      s2 = Medium.specificEntropy(Medium.setState_pTX(
-              p,
-              Ts,
-              X));
-      annotation (experiment(StopTime=1), Documentation(info="<html>
-
-</html>"));
+      h2 = Medium.specificEnthalpy_pTX(p, Th, X);
+      s2 = Medium.specificEntropy(Medium.setState_pTX(p, Ts, X));
+      annotation (experiment(StopTime=1), Documentation(info="<html></html>"));
     end Inverse_sh_TX;
 
     annotation (Documentation(info="<html>
 <p>
 This package demonstrates how to solve one non-linear algebraic
-equation in one unknown with function
-Modelica.Media.Common.OneNonLinearEquation.
+equation in one unknown with function <a href=\"modelica://Modelica.Math.Nonlinear.solveOneNonlinearEquation\">solveOneNonlinearEquation</a>.
 </p>
 
 </html>"));
@@ -8439,233 +8373,6 @@ Summing all mass fractions together results in
     nderivs.sd := 0.0;
   end Gibbs2_ps;
 
-  package OneNonLinearEquation
-    "Determine solution of a non-linear algebraic equation in one unknown without derivatives in a reliable and efficient way"
-    extends Modelica.Icons.Package;
-
-    replaceable record f_nonlinear_Data
-      "Data specific for function f_nonlinear"
-      extends Modelica.Icons.Record;
-    end f_nonlinear_Data;
-
-    replaceable partial function f_nonlinear
-      "Nonlinear algebraic equation in one unknown: y = f_nonlinear(x,p,X)"
-      extends Modelica.Icons.Function;
-      input Real x "Independent variable of function";
-      input Real p=0.0 "Disregarded variables (here always used for pressure)";
-      input Real[:] X=fill(0, 0)
-        "Disregarded variables (her always used for composition)";
-      input f_nonlinear_Data f_nonlinear_data
-        "Additional data for the function";
-      output Real y "= f_nonlinear(x)";
-      // annotation(derivative(zeroDerivative=y)); // this must hold for all replaced functions
-    end f_nonlinear;
-
-    replaceable function solve
-      "Solve f_nonlinear(x_zero)=y_zero; f_nonlinear(x_min) - y_zero and f_nonlinear(x_max)-y_zero must have different sign"
-      import Modelica.Utilities.Streams.error;
-      extends Modelica.Icons.Function;
-      input Real y_zero
-        "Determine x_zero, such that f_nonlinear(x_zero) = y_zero";
-      input Real x_min "Minimum value of x";
-      input Real x_max "Maximum value of x";
-      input Real pressure=0.0
-        "Disregarded variables (here always used for pressure)";
-      input Real[:] X=fill(0, 0)
-        "Disregarded variables (here always used for composition)";
-      input f_nonlinear_Data f_nonlinear_data
-        "Additional data for function f_nonlinear";
-      input Real x_tol=100*Modelica.Constants.eps
-        "Relative tolerance of the result";
-      output Real x_zero "f_nonlinear(x_zero) = y_zero";
-    protected
-      constant Real eps=Modelica.Constants.eps "Machine epsilon";
-      constant Real x_eps=1e-10
-        "Slight modification of x_min, x_max, since x_min, x_max are usually exactly at the borders T_min/h_min and then small numeric noise may make the interval invalid";
-      Real x_min2=x_min - x_eps;
-      Real x_max2=x_max + x_eps;
-      Real a=x_min2 "Current best minimum interval value";
-      Real b=x_max2 "Current best maximum interval value";
-      Real c "Intermediate point a <= c <= b";
-      Real d;
-      Real e "b - a";
-      Real m;
-      Real s;
-      Real p;
-      Real q;
-      Real r;
-      Real tol;
-      Real fa "= f_nonlinear(a) - y_zero";
-      Real fb "= f_nonlinear(b) - y_zero";
-      Real fc;
-      Boolean found=false;
-    algorithm
-      // Check that f(x_min) and f(x_max) have different sign
-      fa := f_nonlinear(
-              x_min2,
-              pressure,
-              X,
-              f_nonlinear_data) - y_zero;
-      fb := f_nonlinear(
-              x_max2,
-              pressure,
-              X,
-              f_nonlinear_data) - y_zero;
-      fc := fb;
-      if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
-        error(
-          "The arguments x_min and x_max to OneNonLinearEquation.solve(..)\n"
-           + "do not bracket the root of the single non-linear equation:\n" +
-          "  x_min  = " + String(x_min2) + "\n" + "  x_max  = " + String(x_max2)
-           + "\n" + "  y_zero = " + String(y_zero) + "\n" +
-          "  fa = f(x_min) - y_zero = " + String(fa) + "\n" +
-          "  fb = f(x_max) - y_zero = " + String(fb) + "\n" +
-          "fa and fb must have opposite sign which is not the case");
-      end if;
-
-      // Initialize variables
-      c := a;
-      fc := fa;
-      e := b - a;
-      d := e;
-
-      // Search loop
-      while not found loop
-        if abs(fc) < abs(fb) then
-          a := b;
-          b := c;
-          c := a;
-          fa := fb;
-          fb := fc;
-          fc := fa;
-        end if;
-
-        tol := 2*eps*abs(b) + x_tol;
-        m := (c - b)/2;
-
-        if abs(m) <= tol or fb == 0.0 then
-          // root found (interval is small enough)
-          found := true;
-          x_zero := b;
-        else
-          // Determine if a bisection is needed
-          if abs(e) < tol or abs(fa) <= abs(fb) then
-            e := m;
-            d := e;
-          else
-            s := fb/fa;
-            if a == c then
-              // linear interpolation
-              p := 2*m*s;
-              q := 1 - s;
-            else
-              // inverse quadratic interpolation
-              q := fa/fc;
-              r := fb/fc;
-              p := s*(2*m*q*(q - r) - (b - a)*(r - 1));
-              q := (q - 1)*(r - 1)*(s - 1);
-            end if;
-
-            if p > 0 then
-              q := -q;
-            else
-              p := -p;
-            end if;
-
-            s := e;
-            e := d;
-            if 2*p < 3*m*q - abs(tol*q) and p < abs(0.5*s*q) then
-              // interpolation successful
-              d := p/q;
-            else
-              // use bi-section
-              e := m;
-              d := e;
-            end if;
-          end if;
-
-          // Best guess value is defined as "a"
-          a := b;
-          fa := fb;
-          b := b + (if abs(d) > tol then d else if m > 0 then tol else -tol);
-          fb := f_nonlinear(
-                  b,
-                  pressure,
-                  X,
-                  f_nonlinear_data) - y_zero;
-
-          if fb > 0 and fc > 0 or fb < 0 and fc < 0 then
-            // initialize variables
-            c := a;
-            fc := fa;
-            e := b - a;
-            d := e;
-          end if;
-        end if;
-      end while;
-    end solve;
-
-    annotation (Documentation(info="<html>
-<p>
-This function should currently only be used in Modelica.Media,
-since it might be replaced in the future by another strategy,
-where the tool is responsible for the solution of the non-linear
-equation.
-</p>
-
-<p>
-This library determines the solution of one non-linear algebraic equation \"y=f(x)\"
-in one unknown \"x\" in a reliable way. As input, the desired value y of the
-non-linear function has to be given, as well as an interval x_min, x_max that
-contains the solution, i.e., \"f(x_min) - y\" and \"f(x_max) - y\" must
-have a different sign. If possible, a smaller interval is computed by
-inverse quadratic interpolation (interpolating with a quadratic polynomial
-through the last 3 points and computing the zero). If this fails,
-bisection is used, which always reduces the interval by a factor of 2.
-The inverse quadratic interpolation method has superlinear convergence.
-This is roughly the same convergence rate as a globally convergent Newton
-method, but without the need to compute derivatives of the non-linear
-function. The solver function is a direct mapping of the Algol 60 procedure
-\"zero\" to Modelica, from:
-</p>
-
-<dl>
-<dt> Brent R.P.:</dt>
-<dd> <strong>Algorithms for Minimization without derivatives</strong>.
-     Prentice Hall, 1973, pp. 58-59.</dd>
-</dl>
-
-<p>
-Due to current limitations of the
-Modelica language (not possible to pass a function reference to a function),
-the construction to use this solver on a user-defined function is a bit
-complicated (this method is from Hans Olsson, Dassault Syst&egrave;mes AB). A user has to
-provide a package in the following way:
-</p>
-
-<pre>
-  <strong>package</strong> MyNonLinearSolver
-    <strong>extends</strong> OneNonLinearEquation;
-
-    <strong>redeclare record extends</strong> Data
-      // Define data to be passed to user function
-      ...
-    <strong>end</strong> Data;
-
-    <strong>redeclare function extends</strong> f_nonlinear
-    <strong>algorithm</strong>
-       // Compute the non-linear equation: y = f(x, Data)
-    <strong>end</strong> f_nonlinear;
-
-    // Dummy definition that has to be present for current Dymola
-    <strong>redeclare function extends</strong> solve
-    <strong>end</strong> solve;
-  <strong>end</strong> MyNonLinearSolver;
-
-  x_zero = MyNonLinearSolver.solve(y_zero, x_min, x_max, data=data);
-</pre>
-</html>"));
-  end OneNonLinearEquation;
   annotation (Documentation(info="<html><h4>Package description</h4>
       <p>Package Modelica.Media.Common provides records and functions shared by many of the property sub-packages.
       High accuracy fluid property models share a lot of common structure, even if the actual models are different.

--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -277,6 +277,8 @@ convertClass("Modelica.Electrical.Machines.Utilities.CurrentController",
               "Modelica.Electrical.Machines.Utilities.DQToThreePhase");
 convertClass("Modelica.Electrical.Machines.Utilities.VoltageController",
               "Modelica.Electrical.Machines.Utilities.DQCurrentController");
+convertClass("Modelica.Media.Common.OneNonLinearEquation",
+              "ObsoleteModelica4.Media.Common.OneNonLinearEquation");
 
 // Change renamed elements of classes
 // mue -> mu

--- a/ModelicaTest/Media.mo
+++ b/ModelicaTest/Media.mo
@@ -925,6 +925,7 @@ is given to compare the approximation.
       Medium.ThermodynamicState state = Medium.setState_pTX(p,T,X);
       Modelica.SIunits.SpecificEntropy s = Medium.specificEntropy(state);
       Modelica.SIunits.SpecificInternalEnergy u = Medium.specificInternalEnergy(state);
+      Modelica.SIunits.Temperature Tsat = Medium.saturationTemperature(p);
       annotation (experiment(StopTime=1));
     end MoistAir;
     annotation (Documentation(info="<html>

--- a/ModelicaTestConversion4.mo
+++ b/ModelicaTestConversion4.mo
@@ -1891,6 +1891,46 @@ Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrar
 </p>
 </html>"));
     end Issue3037;
+
+    model Issue3205 "Conversion test for #3205"
+      extends Modelica.Icons.Example;
+
+      parameter Real y_zero=0.5 "Desired value of A*sin(w*x)";
+      parameter Real x_min=-1.7 "Minimum value of x_zero";
+      parameter Real x_max=1.7 "Maximum value of x_zero";
+      parameter Real A=1 "Amplitude of sine";
+      parameter Real w=1 "Angular frequency of sine";
+      parameter Inverse_sine_definition.f_nonlinear_Data data=
+        Inverse_sine_definition.f_nonlinear_Data(A=A, w=w) "Data record";
+      Real x_zero "y_zero = A*sin(w*x_zero)";
+
+      package Inverse_sine_definition "Define sine as non-linear equation to be solved"
+        extends Modelica.Media.Common.OneNonLinearEquation;
+
+        redeclare record extends f_nonlinear_Data "Data for non-linear equation"
+          Real A "Amplitude";
+          Real w "Angular frequency";
+        end f_nonlinear_Data;
+
+        redeclare function extends f_nonlinear "Non-linear equation to be solved"
+        algorithm
+          y := f_nonlinear_data.A*Modelica.Math.sin(f_nonlinear_data.w*x);
+        end f_nonlinear;
+
+        // Dummy definition had to be added for older Dymola
+        redeclare function extends solve "Solution algorithm of non-linear equation"
+        end solve;
+      end Inverse_sine_definition;
+
+    equation
+      x_zero = Inverse_sine_definition.solve(y_zero, x_min, x_max, f_nonlinear_data=data);
+
+      annotation(experiment(StopTime=1), Documentation(info="<html>
+<p>
+Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/3205\">#3205</a>.
+</p>
+</html>"));
+    end Issue3205;
   end Media;
 
   package Thermal

--- a/ObsoleteModelica4.mo
+++ b/ObsoleteModelica4.mo
@@ -1092,6 +1092,244 @@ connector is not connected).
     end Translational;
   end Mechanics;
 
+  package Media "Library of media property models"
+    extends Modelica.Icons.Package;
+    package Common "Data structures and fundamental functions for fluid properties"
+      extends Modelica.Icons.Package;
+      package OneNonLinearEquation "Determine solution of a non-linear algebraic equation in one unknown without derivatives in a reliable and efficient way"
+        extends Modelica.Icons.Package;
+        extends Modelica.Icons.ObsoleteModel;
+
+        replaceable record f_nonlinear_Data
+          "Data specific for function f_nonlinear"
+          extends Modelica.Icons.Record;
+          extends Modelica.Icons.ObsoleteModel;
+        end f_nonlinear_Data;
+
+        replaceable partial function f_nonlinear
+          "Nonlinear algebraic equation in one unknown: y = f_nonlinear(x,p,X)"
+          extends Modelica.Icons.Function;
+          extends Modelica.Icons.ObsoleteModel;
+          input Real x "Independent variable of function";
+          input Real p=0.0 "Disregarded variables (here always used for pressure)";
+          input Real[:] X=fill(0, 0)
+            "Disregarded variables (her always used for composition)";
+          input f_nonlinear_Data f_nonlinear_data
+            "Additional data for the function";
+          output Real y "= f_nonlinear(x)";
+          // annotation(derivative(zeroDerivative=y)); // this must hold for all replaced functions
+        end f_nonlinear;
+
+        replaceable function solve
+          "Solve f_nonlinear(x_zero)=y_zero; f_nonlinear(x_min) - y_zero and f_nonlinear(x_max)-y_zero must have different sign"
+          import Modelica.Utilities.Streams.error;
+          extends Modelica.Icons.Function;
+          extends Modelica.Icons.ObsoleteModel;
+          input Real y_zero
+            "Determine x_zero, such that f_nonlinear(x_zero) = y_zero";
+          input Real x_min "Minimum value of x";
+          input Real x_max "Maximum value of x";
+          input Real pressure=0.0
+            "Disregarded variables (here always used for pressure)";
+          input Real[:] X=fill(0, 0)
+            "Disregarded variables (here always used for composition)";
+          input f_nonlinear_Data f_nonlinear_data
+            "Additional data for function f_nonlinear";
+          input Real x_tol=100*Modelica.Constants.eps
+            "Relative tolerance of the result";
+          output Real x_zero "f_nonlinear(x_zero) = y_zero";
+        protected
+          constant Real eps=Modelica.Constants.eps "Machine epsilon";
+          constant Real x_eps=1e-10
+            "Slight modification of x_min, x_max, since x_min, x_max are usually exactly at the borders T_min/h_min and then small numeric noise may make the interval invalid";
+          Real x_min2=x_min - x_eps;
+          Real x_max2=x_max + x_eps;
+          Real a=x_min2 "Current best minimum interval value";
+          Real b=x_max2 "Current best maximum interval value";
+          Real c "Intermediate point a <= c <= b";
+          Real d;
+          Real e "b - a";
+          Real m;
+          Real s;
+          Real p;
+          Real q;
+          Real r;
+          Real tol;
+          Real fa "= f_nonlinear(a) - y_zero";
+          Real fb "= f_nonlinear(b) - y_zero";
+          Real fc;
+          Boolean found=false;
+        algorithm
+          // Check that f(x_min) and f(x_max) have different sign
+          fa := f_nonlinear(
+                  x_min2,
+                  pressure,
+                  X,
+                  f_nonlinear_data) - y_zero;
+          fb := f_nonlinear(
+                  x_max2,
+                  pressure,
+                  X,
+                  f_nonlinear_data) - y_zero;
+          fc := fb;
+          if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
+            error(
+              "The arguments x_min and x_max to OneNonLinearEquation.solve(..)\n"
+               + "do not bracket the root of the single non-linear equation:\n" +
+              "  x_min  = " + String(x_min2) + "\n" + "  x_max  = " + String(x_max2)
+               + "\n" + "  y_zero = " + String(y_zero) + "\n" +
+              "  fa = f(x_min) - y_zero = " + String(fa) + "\n" +
+              "  fb = f(x_max) - y_zero = " + String(fb) + "\n" +
+              "fa and fb must have opposite sign which is not the case");
+          end if;
+
+          // Initialize variables
+          c := a;
+          fc := fa;
+          e := b - a;
+          d := e;
+
+          // Search loop
+          while not found loop
+            if abs(fc) < abs(fb) then
+              a := b;
+              b := c;
+              c := a;
+              fa := fb;
+              fb := fc;
+              fc := fa;
+            end if;
+
+            tol := 2*eps*abs(b) + x_tol;
+            m := (c - b)/2;
+
+            if abs(m) <= tol or fb == 0.0 then
+              // root found (interval is small enough)
+              found := true;
+              x_zero := b;
+            else
+              // Determine if a bisection is needed
+              if abs(e) < tol or abs(fa) <= abs(fb) then
+                e := m;
+                d := e;
+              else
+                s := fb/fa;
+                if a == c then
+                  // linear interpolation
+                  p := 2*m*s;
+                  q := 1 - s;
+                else
+                  // inverse quadratic interpolation
+                  q := fa/fc;
+                  r := fb/fc;
+                  p := s*(2*m*q*(q - r) - (b - a)*(r - 1));
+                  q := (q - 1)*(r - 1)*(s - 1);
+                end if;
+
+                if p > 0 then
+                  q := -q;
+                else
+                  p := -p;
+                end if;
+
+                s := e;
+                e := d;
+                if 2*p < 3*m*q - abs(tol*q) and p < abs(0.5*s*q) then
+                  // interpolation successful
+                  d := p/q;
+                else
+                  // use bi-section
+                  e := m;
+                  d := e;
+                end if;
+              end if;
+
+              // Best guess value is defined as "a"
+              a := b;
+              fa := fb;
+              b := b + (if abs(d) > tol then d else if m > 0 then tol else -tol);
+              fb := f_nonlinear(
+                      b,
+                      pressure,
+                      X,
+                      f_nonlinear_data) - y_zero;
+
+              if fb > 0 and fc > 0 or fb < 0 and fc < 0 then
+                // initialize variables
+                c := a;
+                fc := fa;
+                e := b - a;
+                d := e;
+              end if;
+            end if;
+          end while;
+          annotation (obsolete = "Obsolete function - use Modelica.Math.Nonlinear.solveOneNonlinearEquation instead");
+        end solve;
+
+        annotation (
+          obsolete = "Obsolete package - use Modelica.Math.Nonlinear.solveOneNonlinearEquation instead",
+          Documentation(info="<html>
+<p>
+This package was used in Modelica.Media of MSL &le; 3.2.3 and was replaced by
+by function <a href=\"modelica://Modelica.Math.Nonlinear.solveOneNonlinearEquation\">Modelica.Math.Nonlinear.solveOneNonlinearEquation</a>.
+</p>
+
+<p>
+This library determines the solution of one non-linear algebraic equation \"y=f(x)\"
+in one unknown \"x\" in a reliable way. As input, the desired value y of the
+non-linear function has to be given, as well as an interval x_min, x_max that
+contains the solution, i.e., \"f(x_min) - y\" and \"f(x_max) - y\" must
+have a different sign. If possible, a smaller interval is computed by
+inverse quadratic interpolation (interpolating with a quadratic polynomial
+through the last 3 points and computing the zero). If this fails,
+bisection is used, which always reduces the interval by a factor of 2.
+The inverse quadratic interpolation method has superlinear convergence.
+This is roughly the same convergence rate as a globally convergent Newton
+method, but without the need to compute derivatives of the non-linear
+function. The solver function is a direct mapping of the Algol 60 procedure
+\"zero\" to Modelica, from:
+</p>
+
+<dl>
+<dt> Brent R.P.:</dt>
+<dd> <strong>Algorithms for Minimization without derivatives</strong>.
+     Prentice Hall, 1973, pp. 58-59.</dd>
+</dl>
+
+<p>
+Due to current limitations of the
+Modelica language (not possible to pass a function reference to a function),
+the construction to use this solver on a user-defined function is a bit
+complicated (this method is from Hans Olsson, Dassault Syst&egrave;mes AB). A user has to
+provide a package in the following way:
+</p>
+
+<pre>
+  <strong>package</strong> MyNonLinearSolver
+    <strong>extends</strong> OneNonLinearEquation;
+
+    <strong>redeclare record extends</strong> Data
+      // Define data to be passed to user function
+      ...
+    <strong>end</strong> Data;
+
+    <strong>redeclare function extends</strong> f_nonlinear
+    <strong>algorithm</strong>
+       // Compute the non-linear equation: y = f(x, Data)
+    <strong>end</strong> f_nonlinear;
+
+    // Dummy definition that has to be present for current Dymola
+    <strong>redeclare function extends</strong> solve
+    <strong>end</strong> solve;
+  <strong>end</strong> MyNonLinearSolver;
+
+  x_zero = MyNonLinearSolver.solve(y_zero, x_min, x_max, data=data);
+</pre>
+</html>"));
+      end OneNonLinearEquation;
+    end Common;
+  end Media;
+
   package Math "Library of mathematical functions (e.g., sin, cos) and of functions operating on vectors and matrices"
     extends Modelica.Icons.Package;
     package Vectors "Library of functions operating on vectors"

--- a/ObsoleteModelica4.mo
+++ b/ObsoleteModelica4.mo
@@ -1107,7 +1107,7 @@ connector is not connected).
         end f_nonlinear_Data;
 
         replaceable partial function f_nonlinear
-          "Nonlinear algebraic equation in one unknown: y = f_nonlinear(x,p,X)"
+          "Non-linear algebraic equation in one unknown: y = f_nonlinear(x,p,X)"
           extends Modelica.Icons.Function;
           extends Modelica.Icons.ObsoleteModel;
           input Real x "Independent variable of function";
@@ -1271,7 +1271,8 @@ connector is not connected).
           Documentation(info="<html>
 <p>
 This package was used in Modelica.Media of MSL &le; 3.2.3 and was replaced by
-by function <a href=\"modelica://Modelica.Math.Nonlinear.solveOneNonlinearEquation\">Modelica.Math.Nonlinear.solveOneNonlinearEquation</a>.
+by function <a href=\"modelica://Modelica.Math.Nonlinear.solveOneNonlinearEquation\">
+Modelica.Math.Nonlinear.solveOneNonlinearEquation</a>.
 </p>
 
 <p>
@@ -1297,9 +1298,9 @@ function. The solver function is a direct mapping of the Algol 60 procedure
 </dl>
 
 <p>
-Due to current limitations of the
-Modelica language (not possible to pass a function reference to a function),
-the construction to use this solver on a user-defined function is a bit
+Due to limitations of the
+Modelica language &le; 3.1 (not possible to pass a function reference to a function),
+the construction to use this solver on a user-defined function was a bit
 complicated (this method is from Hans Olsson, Dassault Syst&egrave;mes AB). A user has to
 provide a package in the following way:
 </p>
@@ -1318,7 +1319,7 @@ provide a package in the following way:
        // Compute the non-linear equation: y = f(x, Data)
     <strong>end</strong> f_nonlinear;
 
-    // Dummy definition that has to be present for current Dymola
+    // Dummy definition that had to be present for older version of Dymola
     <strong>redeclare function extends</strong> solve
     <strong>end</strong> solve;
   <strong>end</strong> MyNonLinearSolver;


### PR DESCRIPTION
Deleting package OneNonLinearEquation breaks with the backward compatibility, which however never was intended.

Resolves #3205.