### PR TITLE
Fix definition of specificInternalEnergy in MoistAir

### DIFF
--- a/Modelica/Media/Air/MoistAir.mo
+++ b/Modelica/Media/Air/MoistAir.mo
@@ -943,7 +943,6 @@ Derivative function for <a href=\"modelica://Modelica.Media.Air.MoistAir.h_pTX\"
   redeclare function extends specificInternalEnergy
     "Return specific internal energy of moist air as a function of the thermodynamic state record"
     extends Modelica.Icons.Function;
-    output SI.SpecificInternalEnergy u "Specific internal energy";
   algorithm
     u := specificInternalEnergy_pTX(
           state.p,

--- a/ModelicaTest/Media.mo
+++ b/ModelicaTest/Media.mo
@@ -922,7 +922,9 @@ is given to compare the approximation.
       Modelica.SIunits.Temperature T = 273.15+100;
       Modelica.SIunits.AbsolutePressure p = 2E5-1.5e5*time;
       Medium.MassFraction X[Medium.nX] = {0.05,0.95};
-      Modelica.SIunits.SpecificEntropy s = Medium.specificEntropy(Medium.setState_pTX(p,T,X));
+      Medium.ThermodynamicState state = Medium.setState_pTX(p,T,X);
+      Modelica.SIunits.SpecificEntropy s = Medium.specificEntropy(state);
+      Modelica.SIunits.SpecificInternalEnergy u = Medium.specificInternalEnergy(state);
       annotation (experiment(StopTime=1));
     end MoistAir;
     annotation (Documentation(info="<html>


### PR DESCRIPTION
Back-port of #3204 to fix #3099 in maint/3.2.3.