### PR TITLE
Add DOI and ISBN number to reference examples

### DIFF
--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -1452,9 +1452,8 @@ This class summarizes general information about the implementation which is not 
   &lt;tr&gt;
     &lt;td&gt;[Gao2008]&lt;/td&gt;
     &lt;td&gt;Z. Gao, T. G. Habetler, R. G. Harley, and R. S. Colby,
-        &amp;quot;A sensorless rotor temperature estimator for induction
-        machines based on a current harmonic spectral
-        estimation scheme&amp;quot;,
+        &amp;quot;&lt;a href=&quot;https://ieeexplore.ieee.org/document/4401132&quot;&gt;A sensorless rotor temperature estimator for induction
+        machines based on a current harmonic spectral estimation scheme&lt;/a&gt;&amp;quot;,
         &lt;em&gt;IEEE Transactions on Industrial Electronics&lt;/em&gt;,
         vol. 55, no. 1, pp. 407-416, Jan. 2008.
     &lt;/td&gt;
@@ -1491,7 +1490,8 @@ This class summarizes general information about the implementation which is not 
       &amp;quot;Oak ridge national laboratory annual progress report for the
       power electronics and electric machinery program&amp;quot;,
       Oak Ridge National Laboratory, prepared for the U.S. Department of Energy,
-      Tennessee, USA, Tech. Rep. FY2004 Progress Report, January 2005.
+      Tennessee, USA, Tech. Rep. FY2004 Progress Report, January 2005,
+      &lt;a href=&quot;https://doi.org/10.2172/974618&quot;&gt;DOI 10.2172/974618&lt;/a&gt;.
     &lt;/td&gt;
   &lt;/tr&gt;
 &lt;/table&gt;
@@ -1503,9 +1503,8 @@ This class summarizes general information about the implementation which is not 
   <tr>
     <td>[Gao2008]</td>
     <td>Z. Gao, T. G. Habetler, R. G. Harley, and R. S. Colby,
-        &quot;A sensorless rotor temperature estimator for induction
-        machines based on a current harmonic spectral
-        estimation scheme&quot;,
+        &quot;<a href=\"https://ieeexplore.ieee.org/document/4401132\">A sensorless rotor temperature estimator for induction
+        machines based on a current harmonic spectral estimation scheme</a>&quot;,
         <em>IEEE Transactions on Industrial Electronics</em>,
         vol. 55, no. 1, pp. 407-416, Jan. 2008.
     </td>
@@ -1542,7 +1541,8 @@ This class summarizes general information about the implementation which is not 
       &quot;Oak ridge national laboratory annual progress report for the
       power electronics and electric machinery program&quot;,
       Oak Ridge National Laboratory, prepared for the U.S. Department of Energy,
-      Tennessee, USA, Tech. Rep. FY2004 Progress Report, January 2005.
+      Tennessee, USA, Tech. Rep. FY2004 Progress Report, January 2005,
+      <a href=\"https://doi.org/10.2172/974618\">DOI 10.2172/974618</a>.
     </td>
   </tr>
 </table>

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -1547,8 +1547,6 @@ This class summarizes general information about the implementation which is not 
   </tr>
 </table>
 
-<p>If available the DOI links, followed by the ISBN numbers may be added to a book reference</p>
-
 </html>"));
       end References;
 

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -1437,7 +1437,7 @@ This class summarizes general information about the implementation which is not 
 
 <ul>
 <li> Journal (or conference) [Gao2008]</li>
-<li> Book [Andronov1973]</li>
+<li> Book [Kral2018]</li>
 <li> Master&apos;s thesis [Woehrnschimmel1998]</li>
 <li> PhD thesis [Farnleitner1999]</li>
 <li> Technical report [Marlino2005]</li>
@@ -1460,10 +1460,11 @@ This class summarizes general information about the implementation which is not 
     &lt;/td&gt;
   &lt;/tr&gt;
   &lt;tr&gt;
-    &lt;td&gt;[Andronov1973]&lt;/td&gt;
-    &lt;td&gt;A. Andronov, E. Leontovich, I. Gordon, and A. Maier,
-        &lt;em&gt;Theory of  Bifurcations of Dynamic Systems on a plane&lt;/em&gt;,
-        1st ed. New York: J. Wiley &amp;amp; Sons, 1973.
+    &lt;td&gt;[Kral2018]&lt;/td&gt;
+    &lt;td&gt;C. Kral,
+        &lt;em&gt;Modelica - object oriented modeling of polyphase electric machines&lt;/em&gt; (in German),
+        M&amp;uuml;nchen: Hanser Verlag, 2018, &lt;a href=&quot;https://doi.org/10.3139/9783446457331&quot;&gt;DOI 10.3139/9783446457331&lt;/a&gt;,
+        ISBN 978-3-446-45551-1.
     &lt;/td&gt;
   &lt;/tr&gt;
   &lt;tr&gt;
@@ -1510,10 +1511,11 @@ This class summarizes general information about the implementation which is not 
     </td>
   </tr>
   <tr>
-    <td>[Andronov1973]</td>
-    <td>A. Andronov, E. Leontovich, I. Gordon, and A. Maier,
-        <em>Theory of  Bifurcations of Dynamic Systems on a plane</em>,
-        1st ed. New York: J. Wiley &amp; Sons, 1973.
+    <td>[Kral2018]</td>
+    <td>C. Kral,
+        <em>Modelica - object oriented modeling of polyphase electric machines</em> (in German),
+        M&uuml;nchen: Hanser Verlag, 2018, <a href=\"https://doi.org/10.3139/9783446457331\">DOI 10.3139/9783446457331</a>,
+        ISBN 978-3-446-45551-1.
     </td>
   </tr>
   <tr>
@@ -1544,6 +1546,9 @@ This class summarizes general information about the implementation which is not 
     </td>
   </tr>
 </table>
+
+<p>If available the DOI links, followed by the ISBN numbers may be added to a book reference</p>
+
 </html>"));
       end References;
 


### PR DESCRIPTION
So far, DOI (and ISBN) numbers are not yet included in reference examples. This PR fixes this shortcoming. I therefore replaced [Andronov1973] (for which could neither find an ISBN nor a DOI) by my own book on Modelica. I searched for the DOIs and ISBNs of a couple other references already used in the MSL, but finally gave up as this took too long without having a result. If someone prefers another reference I am perfectly fine with any other proposal. 