### PR TITLE
Add automaticLocalSeed in Math.Random and utilize in noise blocks

### DIFF
--- a/Modelica/Blocks/Interfaces.mo
+++ b/Modelica/Blocks/Interfaces.mo
@@ -1347,7 +1347,7 @@ converts from one unit into another one.
 
   partial block PartialNoise "Partial noise generator"
     import generator = Modelica.Math.Random.Generators.Xorshift128plus;
-    import Modelica.Math.Random.Utilities.impureRandomInteger;
+    import Modelica.Math.Random.Utilities.automaticLocalSeed;
     extends Modelica.Blocks.Interfaces.SO;
 
     // Main dialog menu
@@ -1382,7 +1382,7 @@ converts from one unit into another one.
     parameter Integer actualGlobalSeed = if useGlobalSeed then globalSeed.seed else 0
       "The global seed, which is actually used";
     parameter Boolean generateNoise = enableNoise and globalSeed.enableNoise
-      "= true if noise shall be generated, otherwise no noise";
+      "= true, if noise shall be generated, otherwise no noise";
 
     // Declare state and random number variables
     Integer state[generator.nState] "Internal state of random number generator";
@@ -1390,7 +1390,7 @@ converts from one unit into another one.
     discrete Real r_raw "Uniform random number in the range (0,1]";
 
   initial equation
-     localSeed = if useAutomaticLocalSeed then impureRandomInteger(globalSeed.id_impure) else fixedLocalSeed;
+     localSeed = if useAutomaticLocalSeed then automaticLocalSeed(getInstanceName()) else fixedLocalSeed;
      pre(state) = generator.initialState(localSeed, actualGlobalSeed);
      r_raw = generator.random(pre(state));
 

--- a/Modelica/Blocks/Noise.mo
+++ b/Modelica/Blocks/Noise.mo
@@ -589,14 +589,9 @@ the desired situation. For this purpose the following parameters can be defined:
          produce exactly the same random number values (so the same noise, if the other settings
          of the instances are the same).<br>
          If <strong>useAutomaticLocalSeed = true</strong>, the
-         local seed is determined automatically from an impure random number generator that
-         produces Integer random values (<a href=\"modelica://Modelica.Math.Random.Utilities.impureRandomInteger\">impureRandomInteger</a>). This is the default.
-         Note, this means that the noise might change if function randomInteger() is called
-         more or less often in the overall model (e.g. because an additional noise block is
-         introduced or removed). It is planned to change the automatic local seed function
-         in a future version of package Modelica, once Modelica Language 3.3 language elements
-         can be used (by using a hash value of the instance name of the model that is
-         inquired with the Modelica Language 3.3 function getInstanceName()).<br>
+         local seed is determined automatically using a hash value of the instance name of the model that is
+         inquired with the Modelica built-in operator <a href=\"https://specification.modelica.org/v3.4/Ch3.html#getinstancename\">getInstanceName()</a>.
+         Note, this means that the noise changes if the component is renamed.<br>
          If <strong>useAutomaticLocalSeed = false</strong>, the local seed is defined
          explicitly by parameter fixedLocalSeed. It is then guaranteed that the generated noise
          remains always the same (provided the other parameter values are the same).</td></tr>

--- a/Modelica/Math/Random.mo
+++ b/Modelica/Math/Random.mo
@@ -968,6 +968,10 @@ This function should be only called once during initialization.
                                    Random.Utilities.automaticGlobalSeed() <strong>else</strong> fixedSeed;
 </pre>
 
+<h4>See also</h4>
+<p>
+<a href=\"modelica://Modelica.Math.Random.Utilities.automaticLocalSeed\">automaticLocalSeed</a>.
+</p>
 <h4>Note</h4>
 <p>This function is impure!</p>
 </html>",     revisions="<html>

--- a/Modelica/Math/Random.mo
+++ b/Modelica/Math/Random.mo
@@ -991,6 +991,79 @@ This function should be only called once during initialization.
 </html>"));
     end automaticGlobalSeed;
 
+    function automaticLocalSeed
+      "Creates an automatic local seed from the instance name"
+      extends Modelica.Icons.Function;
+      input String path
+        "Full path name of the instance (inquire with getInstanceName())";
+      output Integer seed "Automatically generated seed";
+    protected
+      Integer pos;
+      Integer len;
+      String str;
+    algorithm
+      // Remove first name from the path, because all instances have the same root name
+      pos := Modelica.Utilities.Strings.find(path, ".");
+      len := Modelica.Utilities.Strings.length(path);
+      if pos > 0 and pos < len then
+        str := Modelica.Utilities.Strings.substring(path, pos+1, len);
+      else
+        str := path;
+      end if;
+
+      // Generate a hash value from the generated string
+      seed := Modelica.Utilities.Strings.hashString(str);
+
+     annotation (Documentation(info="<html>
+<h4>Syntax</h4>
+<blockquote><pre>
+seed = Utilities.<strong>automaticLocalSeed</strong>(path);
+</pre></blockquote>
+
+<h4>Description</h4>
+<p>
+Returns an automatically computed seed (Integer) from the hash value of
+the full path name of an instance (has to be inquired in the model or block
+where this function is called by getInstanceName()). Contrary to automaticGlobalSeed(),
+this is a pure function, that is, the same seed is returned, if an identical
+path is provided.
+</p>
+
+<h4>Example</h4>
+<blockquote><pre>
+<strong>parameter</strong> Boolean useAutomaticLocalSeed = true;
+<strong>parameter</strong> Integer fixedLocalSeed        = 10;
+<strong>final parameter</strong> Integer localSeed = <strong>if</strong> useAutomaticLocalSeed <strong>then</strong>
+                                   automaticLocalSeed(getInstanceName())
+                                 <strong>else</strong>
+                                   fixedLocalSeed;
+</pre></blockquote>
+
+<h4>See also</h4>
+<p>
+<a href=\"modelica://Modelica.Math.Random.Utilities.automaticGlobalSeed\">automaticGlobalSeed</a>.
+</p>
+</html>",     revisions="<html>
+<table border=1 cellspacing=0 cellpadding=2>
+<tr><th>Date</th> <th align=\"left\">Description</th></tr>
+
+<tr><td> June 22, 2015 </td>
+    <td>
+
+<table border=0>
+<tr><td>
+         <img src=\"modelica://Modelica/Resources/Images/Logos/dlr_logo.png\">
+</td><td valign=\"bottom\">
+         Initial version implemented by
+         A. Kl&ouml;ckner, F. v.d. Linden, D. Zimmer, M. Otter.<br>
+         <a href=\"http://www.dlr.de/rmc/sr/en\">DLR Institute of System Dynamics and Control</a>
+</td></tr></table>
+</td></tr>
+
+</table>
+</html>"));
+    end automaticLocalSeed;
+
     function initializeImpureRandom
       "Initializes the internal state of the impure random number generator"
       extends Modelica.Icons.Function;

--- a/Modelica/Math/Random.mo
+++ b/Modelica/Math/Random.mo
@@ -1001,22 +1001,9 @@ This function should be only called once during initialization.
       input String path
         "Full path name of the instance (inquire with getInstanceName())";
       output Integer seed "Automatically generated seed";
-    protected
-      Integer pos;
-      Integer len;
-      String str;
     algorithm
-      // Remove first name from the path, because all instances have the same root name
-      pos := Modelica.Utilities.Strings.find(path, ".");
-      len := Modelica.Utilities.Strings.length(path);
-      if pos > 0 and pos < len then
-        str := Modelica.Utilities.Strings.substring(path, pos+1, len);
-      else
-        str := path;
-      end if;
-
-      // Generate a hash value from the generated string
-      seed := Modelica.Utilities.Strings.hashString(str);
+      // Generate a hash value from the instance name
+      seed := Modelica.Utilities.Strings.hashString(path);
 
      annotation (Documentation(info="<html>
 <h4>Syntax</h4>

--- a/Modelica/Math/Random.mo
+++ b/Modelica/Math/Random.mo
@@ -1015,7 +1015,8 @@ seed = Utilities.<strong>automaticLocalSeed</strong>(path);
 <p>
 Returns an automatically computed seed (Integer) from the hash value of
 the full path name of an instance (has to be inquired in the model or block
-where this function is called by getInstanceName()). Contrary to automaticGlobalSeed(),
+where this function is called by the Modelica built-in operator <a href=\"https://specification.modelica.org/v3.4/Ch3.html#getinstancename\">getInstanceName()</a>).
+Contrary to <a href=\"modelica://Modelica.Math.Random.Utilities.automaticGlobalSeed\">automaticGlobalSeed()</a>,
 this is a pure function, that is, the same seed is returned, if an identical
 path is provided.
 </p>
@@ -1032,7 +1033,7 @@ path is provided.
 
 <h4>See also</h4>
 <p>
-<a href=\"modelica://Modelica.Math.Random.Utilities.automaticGlobalSeed\">automaticGlobalSeed</a>.
+<a href=\"modelica://Modelica.Math.Random.Utilities.automaticGlobalSeed\">automaticGlobalSeed</a>, <a href=\"modelica://Modelica.Utilities.Strings.hashString\">hashString</a> and <a href=\"https://specification.modelica.org/v3.4/Ch3.html#getinstancename\">getInstanceName</a>.
 </p>
 </html>",     revisions="<html>
 <table border=1 cellspacing=0 cellpadding=2>

--- a/ModelicaTest/Math.mo
+++ b/ModelicaTest/Math.mo
@@ -844,6 +844,7 @@ extends Modelica.Icons.ExamplesPackage;
       "Demonstrate the generation of uniform random numbers in the range 0..1"
       import Modelica.Math.Random.Generators;
       import Modelica.Utilities.Streams.print;
+      import Modelica.Math.Random.Utilities.automaticLocalSeed;
       extends Modelica.Icons.Function;
       input Integer localSeed = 614657;
       input Integer globalSeed = 30020;
@@ -862,8 +863,8 @@ extends Modelica.Icons.ExamplesPackage;
       constant Integer nRandom = 5;
       constant String name1="Modelica.Blocks.Examples.NoiseExamples.AutomaticSeed.automaticSeed1";
       constant String name2="Modelica.Blocks.Examples.NoiseExamples.AutomaticSeed.automaticSeed2";
-      constant Integer localSeed1 = Modelica.Utilities.Strings.hashString(name1);
-      constant Integer localSeed2 = Modelica.Utilities.Strings.hashString(name2);
+      constant Integer localSeed1 = automaticLocalSeed(name1);
+      constant Integer localSeed2 = automaticLocalSeed(name2);
     algorithm
       print("\n... Demonstrate how to generate uniform random numbers with xorshift64*:");
 


### PR DESCRIPTION
There was some in and out development going on in #1957 when the noise blocks and functions were introduced in MSL v3.2.2 with the automaticLocalSeed left to do. This pull request fixes #1861.

@akloeckner @dzimmer @fvanderlinden FYI
