### PR TITLE
assert of parameter values being positive moved to an initial equation section instead of equation

### DIFF
--- a/Modelica/Electrical/Analog/Lines.mo
+++ b/Modelica/Electrical/Analog/Lines.mo
@@ -1,44 +1,74 @@
 within Modelica.Electrical.Analog;
-
-package Lines "Lossy and lossless segmented transmission lines, and LC distributed line models"
+package Lines
+  "Lossy and lossless segmented transmission lines, and LC distributed line models"
   extends Modelica.Icons.Package;
 
   model OLine "Lossy Transmission Line"
     //extends Interfaces.ThreePol;
-    Modelica.Electrical.Analog.Interfaces.Pin p1 annotation(
-      Placement(transformation(extent = {{-110, -10}, {-90, 10}})));
-    Modelica.Electrical.Analog.Interfaces.Pin p2 annotation(
-      Placement(transformation(extent = {{90, -10}, {110, 10}})));
-    Modelica.Electrical.Analog.Interfaces.Pin p3 annotation(
-      Placement(transformation(extent = {{-10, -110}, {10, -90}})));
+    Modelica.Electrical.Analog.Interfaces.Pin p1 annotation (Placement(
+          transformation(extent={{-110,-10},{-90,10}})));
+    Modelica.Electrical.Analog.Interfaces.Pin p2 annotation (Placement(
+          transformation(extent={{90,-10},{110,10}})));
+    Modelica.Electrical.Analog.Interfaces.Pin p3 annotation (Placement(
+          transformation(extent={{-10,-110},{10,-90}})));
     SI.Voltage v13;
     SI.Voltage v23;
     SI.Current i1;
     SI.Current i2;
-    parameter Real r(final min = Modelica.Constants.small, unit = "Ohm/m", start = 1) "Resistance per meter";
-    parameter Real l(final min = Modelica.Constants.small, unit = "H/m", start = 1) "Inductance per meter";
-    parameter Real g(final min = Modelica.Constants.small, unit = "S/m", start = 1) "Conductance per meter";
-    parameter Real c(final min = Modelica.Constants.small, unit = "F/m", start = 1) "Capacitance per meter";
-    parameter SI.Length length(final min = Modelica.Constants.small, start = 1) "Length of line";
-    parameter Integer N(final min = 1, start = 1) "Number of lumped segments";
-    parameter SI.LinearTemperatureCoefficient alpha_R = 0 "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
-    parameter SI.LinearTemperatureCoefficient alpha_G = 0 "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref))";
-    parameter Boolean useHeatPort = false "= true, if heatPort is enabled" annotation(
-      Evaluate = true,
-      HideResult = true,
-      choices(checkBox = true));
-    parameter SI.Temperature T = 293.15 "Fixed device temperature if useHeatPort = false" annotation(
-      Dialog(enable = not useHeatPort));
-    parameter SI.Temperature T_ref = 300.15 "Reference temperature";
-    Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort annotation(
-      Placement(transformation(extent = {{-10, -110}, {10, -90}}), iconTransformation(extent = {{-110, -110}, {-90, -90}})));
+    parameter Real r(
+      final min=Modelica.Constants.small,
+      unit="Ohm/m",
+      start=1) "Resistance per meter";
+    parameter Real l(
+      final min=Modelica.Constants.small,
+      unit="H/m",
+      start=1) "Inductance per meter";
+    parameter Real g(
+      final min=Modelica.Constants.small,
+      unit="S/m",
+      start=1) "Conductance per meter";
+    parameter Real c(
+      final min=Modelica.Constants.small,
+      unit="F/m",
+      start=1) "Capacitance per meter";
+    parameter SI.Length length(final min=Modelica.Constants.small,
+        start=1) "Length of line";
+    parameter Integer N(final min=1, start=1) "Number of lumped segments";
+    parameter SI.LinearTemperatureCoefficient alpha_R=0
+      "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
+    parameter SI.LinearTemperatureCoefficient alpha_G=0
+      "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref))";
+    parameter Boolean useHeatPort=false "= true, if heatPort is enabled"
+      annotation (
+      Evaluate=true,
+      HideResult=true,
+      choices(checkBox=true));
+    parameter SI.Temperature T=293.15
+      "Fixed device temperature if useHeatPort = false"
+      annotation (Dialog(enable=not useHeatPort));
+    parameter SI.Temperature T_ref=300.15 "Reference temperature";
+    Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort
+      annotation (Placement(transformation(extent={{-10,-110},{10,-90}}),
+          iconTransformation(extent={{-110,-110},{-90,-90}})));
   protected
-    parameter Modelica.SIunits.Resistance rm[N + 1] = {if i == 1 or i == N + 1 then r * length / (N * 2) else r * length / N for i in 1:N + 1};
-    Modelica.Electrical.Analog.Basic.Resistor R[N + 1](R = rm, T_ref = fill(T_ref, N + 1), alpha = fill(alpha_R, N + 1), useHeatPort = fill(useHeatPort, N + 1), T = fill(T, N + 1));
-    parameter Modelica.SIunits.Inductance lm[N + 1] = {if i == 1 or i == N + 1 then l * length / (N * 2) else l * length / N for i in 1:N + 1};
-    Modelica.Electrical.Analog.Basic.Inductor L[N + 1](L = lm);
-    Modelica.Electrical.Analog.Basic.Capacitor C[N](C = fill(c * length / N, N));
-    Modelica.Electrical.Analog.Basic.Conductor G[N](G = fill(g * length / N, N), T_ref = fill(T_ref, N), alpha = fill(alpha_G, N), useHeatPort = fill(useHeatPort, N), T = fill(T, N));
+    parameter Modelica.SIunits.Resistance rm[N + 1]=
+    {if i==1 or i==N + 1 then r*length/(N*2) else r*length/N for i in 1:N+1};
+    Modelica.Electrical.Analog.Basic.Resistor R[N + 1](
+      R=rm,
+      T_ref=fill(T_ref, N + 1),
+      alpha=fill(alpha_R, N + 1),
+      useHeatPort=fill(useHeatPort, N + 1),
+      T=fill(T, N + 1));
+    parameter Modelica.SIunits.Inductance lm[N + 1]=
+    {if i==1 or i==N + 1 then l*length/(N*2) else l*length/N for i in 1:N+1};
+    Modelica.Electrical.Analog.Basic.Inductor L[N + 1](L=lm);
+    Modelica.Electrical.Analog.Basic.Capacitor C[N](C=fill(c*length/(N), N));
+    Modelica.Electrical.Analog.Basic.Conductor G[N](
+      G=fill(g*length/(N), N),
+      T_ref=fill(T_ref, N),
+      alpha=fill(alpha_G, N),
+      useHeatPort=fill(useHeatPort, N),
+      T=fill(T, N));
   equation
     v13 = p1.v - p3.v;
     v23 = p2.v - p3.v;
@@ -63,9 +93,8 @@ package Lines "Lossy and lossless segmented transmission lines, and LC distribut
         connect(heatPort, G[i].heatPort);
       end for;
     end if;
-    annotation(
-      defaultComponentName = "line",
-      Documentation(info = "<html>
+    annotation (defaultComponentName="line",
+      Documentation(info="<html>
 <p>Like in the picture below, the lossy transmission line OLine is a single-conductor lossy transmission line which consists of segments of lumped resistors and inductors in series and conductor and capacitors that are connected with the reference pin p3. The precision of the model depends on the number N of lumped segments.</p>
 <p>To get a symmetric line model, the first resistor and inductor are cut into two parts (R1 and R_Nplus1, L1 and L_Nplus1). These two new resistors and inductors have the half of the resistance respectively inductance the original resistor respectively inductor.</p>
 
@@ -83,7 +112,7 @@ package Lines "Lossy and lossless segmented transmission lines, and LC distribut
 <p>Note, this is different to the lumped line model of SPICE.</p>
 
 <p><strong>References:</strong> [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Johnson1991</a>]</p>
-</html>", revisions = "<html>
+</html>",      revisions="<html>
 <ul>
 <li><em> 2016   </em>
        by Christoph Clauss<br> resistance and inductance calculation revised<br>
@@ -93,70 +122,143 @@ package Lines "Lossy and lossless segmented transmission lines, and LC distribut
        </li>
 </ul>
 </html>"),
-      Icon(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Rectangle(extent = {{-80, 80}, {80, -80}}, fillColor = {255, 255, 255}, fillPattern = FillPattern.Solid, lineColor = {0, 0, 255}), Line(points = {{0, -80}, {0, -90}}, color = {0, 0, 255}), Line(points = {{80, 0}, {90, 0}}, color = {0, 0, 255}), Line(points = {{-80, 0}, {-90, 0}}, color = {0, 0, 255}), Text(extent = {{-150, 130}, {150, 90}}, textString = "%name", textColor = {0, 0, 255}), Line(points = {{40, 30}, {-40, 30}}), Line(points = {{-40, 40}, {-40, 20}}), Line(points = {{40, 40}, {40, 20}})}));
+      Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Rectangle(
+            extent={{-80,80},{80,-80}},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid,
+            lineColor={0,0,255}),
+          Line(points={{0,-80},{0,-90}}, color={0,0,255}),
+          Line(points={{80,0},{90,0}}, color={0,0,255}),
+          Line(points={{-80,0},{-90,0}}, color={0,0,255}),
+          Text(
+            extent={{-150,130},{150,90}},
+            textString="%name",
+            textColor={0,0,255}),
+          Line(points={{40,30},{-40,30}}),
+          Line(points={{-40,40},{-40,20}}),
+          Line(points={{40,40},{40,20}})}));
   end OLine;
 
   model M_OLine "Multiple OLine"
-    parameter SI.Length length(final min = Modelica.Constants.small) = 0.1 "Length of line";
-    parameter Integer N(final min = 2) = 5 "Number of lumped segments";
-    parameter Integer lines(final min = 2) = 4 "Number of lines";
-    parameter Real r[lines](each final min = Modelica.Constants.small, each unit = "Ohm/m") = {4.76e5, 1.72e5, 1.72e5, 1.72e5} "Resistance per meter";
-    parameter Real l[dim_vector_lgc](each final min = Modelica.Constants.small, each unit = "H/m") = {5.98e-7, 4.44e-7, 4.39e-7, 3.99e-7, 5.81e-7, 4.09e-7, 4.23e-7, 5.96e-7, 4.71e-7, 6.06e-7} "Inductance per meter";
-    parameter Real g[dim_vector_lgc](each final min = Modelica.Constants.small, each unit = "S/m") = {8.05e-6, 3.42e-5, 2.91e-5, 1.76e-6, 9.16e-6, 7.12e-6, 2.43e-5, 5.93e-6, 4.19e-5, 6.64e-6} "Conductance per meter";
-    parameter Real c[dim_vector_lgc](each final min = Modelica.Constants.small, each unit = "F/m") = {2.38e-11, 1.01e-10, 8.56e-11, 5.09e-12, 2.71e-11, 2.09e-11, 7.16e-11, 1.83e-11, 1.23e-10, 2.07e-11} "Capacitance per meter";
-    parameter SI.LinearTemperatureCoefficient alpha_R = 0 "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
-    parameter SI.LinearTemperatureCoefficient alpha_G = 0 "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref))";
-    parameter Boolean useHeatPort = false "= true, if heatPort is enabled" annotation(
-      Evaluate = true,
-      HideResult = true,
-      choices(checkBox = true));
-    parameter SI.Temperature T = 293.15 "Fixed device temperature if useHeatPort = false" annotation(
-      Dialog(enable = not useHeatPort));
-    parameter SI.Temperature T_ref = 300.15 "Reference temperature";
-    Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort annotation(
-      Placement(transformation(extent = {{-110, -110}, {-90, -90}}), iconTransformation(extent = {{-110, -110}, {-90, -90}})));
 
+    parameter SI.Length length(final min=Modelica.Constants.small)=
+         0.1 "Length of line";
+    parameter Integer N(final min=2) = 5 "Number of lumped segments";
+    parameter Integer lines(final min=2) = 4 "Number of lines";
+  protected
+    parameter Integer dim_vector_lgc=div(lines*(lines + 1), 2);
+  public
+    parameter Real r[lines](
+      each final min=Modelica.Constants.small,
+      each unit="Ohm/m") = {4.76e5,1.72e5,1.72e5,1.72e5} "Resistance per meter";
+
+    parameter Real l[dim_vector_lgc](
+      each final min=Modelica.Constants.small,
+      each unit="H/m") = {5.98e-7,4.44e-7,4.39e-7,3.99e-7,5.81e-7,4.09e-7,
+      4.23e-7,5.96e-7,4.71e-7,6.06e-7} "Inductance per meter";
+
+    parameter Real g[dim_vector_lgc](
+      each final min=Modelica.Constants.small,
+      each unit="S/m") = {8.05e-6,3.42e-5,2.91e-5,1.76e-6,9.16e-6,7.12e-6,
+      2.43e-5,5.93e-6,4.19e-5,6.64e-6} "Conductance per meter";
+
+    parameter Real c[dim_vector_lgc](
+      each final min=Modelica.Constants.small,
+      each unit="F/m") = {2.38e-11,1.01e-10,8.56e-11,5.09e-12,2.71e-11,2.09e-11,
+      7.16e-11,1.83e-11,1.23e-10,2.07e-11} "Capacitance per meter";
+    parameter SI.LinearTemperatureCoefficient alpha_R=0
+      "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
+    parameter SI.LinearTemperatureCoefficient alpha_G=0
+      "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref))";
+    parameter Boolean useHeatPort=false "= true, if heatPort is enabled"
+      annotation (
+      Evaluate=true,
+      HideResult=true,
+      choices(checkBox=true));
+    parameter SI.Temperature T=293.15
+      "Fixed device temperature if useHeatPort = false"
+      annotation (Dialog(enable=not useHeatPort));
+    parameter SI.Temperature T_ref=300.15 "Reference temperature";
+    Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort
+      annotation (Placement(transformation(extent={{-110,-110},{-90,-90}}),
+          iconTransformation(extent={{-110,-110},{-90,-90}})));
     model segment "Multiple line segment model"
-      parameter Integer lines(final min = 1) = 3 "Number of lines";
-      parameter Integer dim_vector_lgc = div(lines * (lines + 1), 2) "Length of the vectors for l, g, c";
-      Modelica.Electrical.Analog.Interfaces.PositivePin p[lines] "Positive pin" annotation(
-        Placement(transformation(extent = {{-110, -10}, {-90, 10}}), iconTransformation(extent = {{-110, -10}, {-90, 10}})));
-      Modelica.Electrical.Analog.Interfaces.NegativePin n[lines] "Negative pin" annotation(
-        Placement(transformation(extent = {{90, -10}, {110, 10}}), iconTransformation(extent = {{90, -10}, {110, 10}})));
-      parameter Real Cl[dim_vector_lgc] = fill(1, dim_vector_lgc) "Capacitance matrix";
-      parameter Real Rl[lines] = fill(7, lines) "Resistance matrix";
-      parameter Real Ll[dim_vector_lgc] = fill(2, dim_vector_lgc) "Inductance matrix";
-      parameter Real Gl[dim_vector_lgc] = fill(1, dim_vector_lgc) "Conductance matrix";
-      parameter SI.LinearTemperatureCoefficient alpha_R "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
-      parameter SI.LinearTemperatureCoefficient alpha_G "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref))";
-      parameter Boolean useHeatPort = false "= true, if heatPort is enabled" annotation(
-        Evaluate = true,
-        HideResult = true,
-        choices(checkBox = true));
-      parameter SI.Temperature T = 293.15 "Fixed device temperature if useHeatPort = false" annotation(
-        Dialog(enable = not useHeatPort));
+
+      parameter Integer lines(final min=1) = 3 "Number of lines";
+      parameter Integer dim_vector_lgc=div(lines*(lines + 1), 2)
+        "Length of the vectors for l, g, c";
+      Modelica.Electrical.Analog.Interfaces.PositivePin p[lines] "Positive pin"
+        annotation (Placement(transformation(extent={{-110,-10},{-90,10}}), iconTransformation(extent={{-110,-10},{-90,10}})));
+      Modelica.Electrical.Analog.Interfaces.NegativePin n[lines] "Negative pin"
+        annotation (Placement(transformation(extent={{90,-10},{110,10}}), iconTransformation(extent={{90,-10},{110,10}})));
+
+      parameter Real Cl[dim_vector_lgc]=fill(1, dim_vector_lgc)
+        "Capacitance matrix";
+      parameter Real Rl[lines]=fill(7, lines) "Resistance matrix";
+      parameter Real Ll[dim_vector_lgc]=fill(2, dim_vector_lgc)
+        "Inductance matrix";
+      parameter Real Gl[dim_vector_lgc]=fill(1, dim_vector_lgc)
+        "Conductance matrix";
+      parameter SI.LinearTemperatureCoefficient alpha_R
+        "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
+      parameter SI.LinearTemperatureCoefficient alpha_G
+        "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref))";
+      parameter Boolean useHeatPort=false "= true, if heatPort is enabled"
+        annotation (
+        Evaluate=true,
+        HideResult=true,
+        choices(checkBox=true));
+      parameter SI.Temperature T=293.15
+        "Fixed device temperature if useHeatPort = false"
+        annotation (Dialog(enable=not useHeatPort));
       parameter SI.Temperature T_ref;
-      Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort annotation(
-        Placement(transformation(extent = {{-10, -110}, {10, -90}}), iconTransformation(extent = {{-110, -110}, {-90, -90}})));
-      Modelica.Electrical.Analog.Basic.Capacitor C[dim_vector_lgc](C = Cl);
-      Modelica.Electrical.Analog.Basic.Resistor R[lines](R = Rl, T_ref = fill(T_ref, lines), alpha = fill(alpha_R, lines), useHeatPort = fill(useHeatPort, lines), T = fill(T, lines));
-      Modelica.Electrical.Analog.Basic.Conductor G[dim_vector_lgc](G = Gl, T_ref = fill(T_ref, dim_vector_lgc), alpha = fill(alpha_G, dim_vector_lgc), useHeatPort = fill(useHeatPort, dim_vector_lgc), T = fill(T, dim_vector_lgc));
-      Modelica.Electrical.Analog.Basic.M_Transformer inductance(N = lines, L = Ll);
+
+      Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if
+        useHeatPort annotation (Placement(transformation(extent={{-10,-110},{10,
+                -90}}), iconTransformation(extent={{-110,-110},{-90,-90}})));
+
+      Modelica.Electrical.Analog.Basic.Capacitor C[dim_vector_lgc](C=Cl);
+      Modelica.Electrical.Analog.Basic.Resistor R[lines](
+        R=Rl,
+        T_ref=fill(T_ref, lines),
+        alpha=fill(alpha_R, lines),
+        useHeatPort=fill(useHeatPort, lines),
+        T=fill(T, lines));
+      Modelica.Electrical.Analog.Basic.Conductor G[dim_vector_lgc](
+        G=Gl,
+        T_ref=fill(T_ref, dim_vector_lgc),
+        alpha=fill(alpha_G, dim_vector_lgc),
+        useHeatPort=fill(useHeatPort, dim_vector_lgc),
+        T=fill(T, dim_vector_lgc));
+      Modelica.Electrical.Analog.Basic.M_Transformer inductance(N=lines, L=Ll);
       Modelica.Electrical.Analog.Basic.Ground M;
+
     equation
       for j in 1:lines - 1 loop
+
         connect(R[j].p, p[j]);
         connect(R[j].n, inductance.p[j]);
         connect(inductance.n[j], n[j]);
-        connect(inductance.n[j], C[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2)].p);
-        connect(C[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2)].n, M.p);
-        connect(inductance.n[j], G[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2)].p);
-        connect(G[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2)].n, M.p);
+        connect(inductance.n[j], C[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)),
+          2))].p);
+        connect(C[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)), 2))].n, M.p);
+        connect(inductance.n[j], G[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)),
+          2))].p);
+        connect(G[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)), 2))].n, M.p);
+
         for i in j + 1:lines loop
-          connect(inductance.n[j], C[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2) + 1 + i - (j + 1)].p);
-          connect(C[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2) + 1 + i - (j + 1)].n, inductance.n[i]);
-          connect(inductance.n[j], G[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2) + 1 + i - (j + 1)].p);
-          connect(G[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2) + 1 + i - (j + 1)].n, inductance.n[i]);
+          connect(inductance.n[j], C[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)),
+            2)) + 1 + i - (j + 1)].p);
+          connect(C[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)), 2)) + 1 + i
+             - (j + 1)].n, inductance.n[i]);
+          connect(inductance.n[j], G[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)),
+            2)) + 1 + i - (j + 1)].p);
+          connect(G[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)), 2)) + 1 + i
+             - (j + 1)].n, inductance.n[i]);
+
         end for;
       end for;
       connect(R[lines].p, p[lines]);
@@ -166,79 +268,132 @@ package Lines "Lossy and lossless segmented transmission lines, and LC distribut
       connect(C[dim_vector_lgc].n, M.p);
       connect(inductance.n[lines], G[dim_vector_lgc].p);
       connect(G[dim_vector_lgc].n, M.p);
+
       if useHeatPort then
+
         for j in 1:lines - 1 loop
           connect(heatPort, R[j].heatPort);
-          connect(heatPort, G[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2)].heatPort);
+          connect(heatPort, G[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)), 2))].heatPort);
           for i in j + 1:lines loop
-            connect(heatPort, G[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2) + 1 + i - (j + 1)].heatPort);
+            connect(heatPort, G[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)), 2))
+               + 1 + i - (j + 1)].heatPort);
           end for;
         end for;
         connect(heatPort, R[lines].heatPort);
         connect(heatPort, G[dim_vector_lgc].heatPort);
       end if;
-      annotation(
-        defaultComponentName = "segment",
-        Icon(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}}), graphics = {Rectangle(extent = {{40, -40}, {-40, 40}}, lineColor = {0, 0, 255}), Text(extent = {{-150, 90}, {150, 50}}, textString = "%name", textColor = {0, 0, 255})}),
-        Documentation(info = "<html>
+
+      annotation (defaultComponentName="segment", Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
+                -100},{100,100}}), graphics={Rectangle(extent={{40,-40},{-40,40}},
+              lineColor={0,0,255}),
+            Text(
+              extent={{-150,90},{150,50}},
+              textString="%name",
+              textColor={0,0,255})}), Documentation(info="<html>
 <p>The segment model is part of the multiple line model. It describes one line segment as outlined in the M_OLine description. Using the loop possibilities of Modelica it is formulated by connecting components the number of which depends on the number of lines.</p>
 </html>"));
     end segment;
 
     model segment_last "Multiple line last segment model"
-      Modelica.Electrical.Analog.Interfaces.PositivePin p[lines] "Positive pin" annotation(
-        Placement(transformation(extent = {{-110, -10}, {-90, 10}}), iconTransformation(extent = {{-110, -10}, {-90, 10}})));
-      Modelica.Electrical.Analog.Interfaces.NegativePin n[lines] "Negative pin" annotation(
-        Placement(transformation(extent = {{90, -10}, {110, 10}}), iconTransformation(extent = {{90, -10}, {110, 10}})));
-      parameter Integer lines(final min = 1) = 3 "Number of lines";
-      parameter Integer dim_vector_lgc = div(lines * (lines + 1), 2) "Length of the vectors for l, g, c";
-      parameter Real Rl[lines] = fill(1, lines) "Resistance matrix";
-      parameter Real Ll[dim_vector_lgc] = fill(1, dim_vector_lgc) "Inductance matrix";
-      parameter SI.LinearTemperatureCoefficient alpha_R "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
-      parameter Boolean useHeatPort = false "= true, if HeatPort is enabled" annotation(
-        Evaluate = true,
-        HideResult = true,
-        choices(checkBox = true));
-      parameter SI.Temperature T = 293.15 "Fixed device temperature if useHeatPort = false" annotation(
-        Dialog(enable = not useHeatPort));
+
+      Modelica.Electrical.Analog.Interfaces.PositivePin p[lines] "Positive pin"
+        annotation (Placement(transformation(extent={{-110,-10},{-90,10}}), iconTransformation(extent={{-110,-10},{-90,10}})));
+      Modelica.Electrical.Analog.Interfaces.NegativePin n[lines] "Negative pin"
+        annotation (Placement(transformation(extent={{90,-10},{110,10}}), iconTransformation(extent={{90,-10},{110,10}})));
+      parameter Integer lines(final min=1) = 3 "Number of lines";
+      parameter Integer dim_vector_lgc=div(lines*(lines + 1), 2)
+        "Length of the vectors for l, g, c";
+      parameter Real Rl[lines]=fill(1, lines) "Resistance matrix";
+      parameter Real Ll[dim_vector_lgc]=fill(1, dim_vector_lgc)
+        "Inductance matrix";
+      parameter SI.LinearTemperatureCoefficient alpha_R
+        "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
+      parameter Boolean useHeatPort=false "= true, if HeatPort is enabled"
+        annotation (
+        Evaluate=true,
+        HideResult=true,
+        choices(checkBox=true));
+      parameter SI.Temperature T=293.15
+        "Fixed device temperature if useHeatPort = false"
+        annotation (Dialog(enable=not useHeatPort));
       parameter SI.Temperature T_ref;
-      Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort annotation(
-        Placement(transformation(extent = {{-10, -110}, {10, -90}}), iconTransformation(extent = {{-110, -110}, {-90, -90}})));
-      Modelica.Electrical.Analog.Basic.Resistor R[lines](R = Rl, T_ref = fill(T_ref, lines), useHeatPort = fill(useHeatPort, lines), T = fill(T, lines));
-      Modelica.Electrical.Analog.Basic.M_Transformer inductance(N = lines, L = Ll);
+      Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if
+        useHeatPort annotation (Placement(transformation(extent={{-10,-110},{10,
+                -90}}), iconTransformation(extent={{-110,-110},{-90,-90}})));
+      Modelica.Electrical.Analog.Basic.Resistor R[lines](
+        R=Rl,
+        T_ref=fill(T_ref, lines),
+        useHeatPort=fill(useHeatPort, lines),
+        T=fill(T, lines));
+      Modelica.Electrical.Analog.Basic.M_Transformer inductance(N=lines, L=Ll);
       Modelica.Electrical.Analog.Basic.Ground M;
+
     equation
       for j in 1:lines - 1 loop
+
         connect(p[j], inductance.p[j]);
         connect(inductance.n[j], R[j].p);
         connect(R[j].n, n[j]);
+
       end for;
       connect(p[lines], inductance.p[lines]);
       connect(inductance.n[lines], R[lines].p);
       connect(R[lines].n, n[lines]);
+
       if useHeatPort then
         for j in 1:lines - 1 loop
           connect(heatPort, R[j].heatPort);
         end for;
         connect(heatPort, R[lines].heatPort);
       end if;
-      annotation(
-        defaultComponentName = "segment",
-        Icon(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}}), graphics = {Rectangle(extent = {{20, -40}, {-20, 40}}, lineColor = {0, 0, 255}), Text(extent = {{-150, 90}, {150, 50}}, textString = "%name", textColor = {0, 0, 255})}),
-        Documentation(info = "<html>
+      annotation (defaultComponentName="segment", Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
+                -100},{100,100}}), graphics={Rectangle(extent={{20,-40},{-20,40}},
+              lineColor={0,0,255}),
+            Text(
+              extent={{-150,90},{150,50}},
+              textString="%name",
+              textColor={0,0,255})}), Documentation(info="<html>
 <p>The segment_last model is part of the multiple line model. It describes the special  line segment which is used to get the line symmetrical as outlined in the M_OLine description. Using the loop possibilities of Modelica it is formulated by connecting components the number of which depends on the number of lines.</p>
 </html>"));
     end segment_last;
 
-    segment s[N - 1](lines = fill(lines, N - 1), dim_vector_lgc = fill(dim_vector_lgc, N - 1), Rl = fill(r * length / N, N - 1), Ll = fill(l * length / N, N - 1), Cl = fill(c * length / N, N - 1), Gl = fill(g * length / N, N - 1), alpha_R = fill(alpha_R, N - 1), alpha_G = fill(alpha_G, N - 1), T_ref = fill(T_ref, N - 1), useHeatPort = fill(useHeatPort, N - 1), T = fill(T, N - 1));
-    segment s_first(lines = lines, dim_vector_lgc = dim_vector_lgc, Rl = r * length / (2 * N), Cl = c * length / N, Ll = l * length / (2 * N), Gl = g * length / N, alpha_R = alpha_R, alpha_G = alpha_G, T_ref = T_ref, useHeatPort = useHeatPort, T = T);
-    segment_last s_last(lines = lines, Rl = r * length / (2 * N), Ll = l * length / (2 * N), alpha_R = alpha_R, T_ref = T_ref, useHeatPort = useHeatPort, T = T);
-    Modelica.Electrical.Analog.Interfaces.PositivePin p[lines] "Positive pin" annotation(
-      Placement(transformation(extent = {{-110, -60}, {-90, 60}})));
-    Modelica.Electrical.Analog.Interfaces.NegativePin n[lines] "Negative pin" annotation(
-      Placement(transformation(extent = {{90, -60}, {110, 60}})));
-  protected
-    parameter Integer dim_vector_lgc = div(lines * (lines + 1), 2);
+    segment s[N - 1](
+      lines=fill(lines, N - 1),
+      dim_vector_lgc=fill(dim_vector_lgc, N - 1),
+      Rl=fill(r*length/N, N - 1),
+      Ll=fill(l*length/N, N - 1),
+      Cl=fill(c*length/N, N - 1),
+      Gl=fill(g*length/N, N - 1),
+      alpha_R=fill(alpha_R, N - 1),
+      alpha_G=fill(alpha_G, N - 1),
+      T_ref=fill(T_ref, N - 1),
+      useHeatPort=fill(useHeatPort, N - 1),
+      T=fill(T, N - 1));
+    segment s_first(
+      lines=lines,
+      dim_vector_lgc=dim_vector_lgc,
+      Rl=r*length/(2*N),
+      Cl=c*length/(N),
+      Ll=l*length/(2*N),
+      Gl=g*length/(N),
+      alpha_R=alpha_R,
+      alpha_G=alpha_G,
+      T_ref=T_ref,
+      useHeatPort=useHeatPort,
+      T=T);
+    segment_last s_last(
+      lines=lines,
+      Rl=r*length/(2*N),
+      Ll=l*length/(2*N),
+      alpha_R=alpha_R,
+      T_ref=T_ref,
+      useHeatPort=useHeatPort,
+      T=T);
+    Modelica.Electrical.Analog.Interfaces.PositivePin p[lines] "Positive pin"
+      annotation (Placement(transformation(extent={{-110,-60},{-90,60}})));
+    Modelica.Electrical.Analog.Interfaces.NegativePin n[lines] "Negative pin"
+      annotation (Placement(transformation(extent={{90,-60},{110,60}})));
+
   equation
     connect(p, s_first.p);
     connect(s_first.n, s[1].p);
@@ -254,10 +409,31 @@ package Lines "Lossy and lossless segmented transmission lines, and LC distribut
       end for;
       connect(heatPort, s_last.heatPort);
     end if;
-    annotation(
-      defaultComponentName = "line",
-      Icon(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}}), graphics = {Rectangle(extent = {{80, 80}, {-80, -80}}, lineColor = {0, 0, 255}, fillPattern = FillPattern.Solid, fillColor = {255, 255, 255}), Line(points = {{40, 60}, {40, 40}}), Line(points = {{40, 50}, {-40, 50}}), Line(points = {{-40, 60}, {-40, 40}}), Line(points = {{40, -40}, {40, -60}}), Line(points = {{40, -50}, {-40, -50}}), Line(points = {{-40, -40}, {-40, -60}}), Line(points = {{40, 30}, {40, 10}}), Line(points = {{40, 20}, {-40, 20}}), Line(points = {{-40, 30}, {-40, 10}}), Line(points = {{0, 6}, {0, -34}}, color = {0, 0, 255}, pattern = LinePattern.Dot), Text(extent = {{-150, 130}, {150, 90}}, textString = "%name", textColor = {0, 0, 255})}),
-      Documentation(info = "<html>
+
+    annotation (defaultComponentName="line", Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
+              -100},{100,100}}), graphics={
+          Rectangle(
+            extent={{80,80},{-80,-80}},
+            lineColor={0,0,255},
+            fillPattern=FillPattern.Solid,
+            fillColor={255,255,255}),
+          Line(points={{40,60},{40,40}}),
+          Line(points={{40,50},{-40,50}}),
+          Line(points={{-40,60},{-40,40}}),
+          Line(points={{40,-40},{40,-60}}),
+          Line(points={{40,-50},{-40,-50}}),
+          Line(points={{-40,-40},{-40,-60}}),
+          Line(points={{40,30},{40,10}}),
+          Line(points={{40,20},{-40,20}}),
+          Line(points={{-40,30},{-40,10}}),
+          Line(
+            points={{0,6},{0,-34}},
+            color={0,0,255},
+            pattern=LinePattern.Dot),
+          Text(
+            extent={{-150,130},{150,90}},
+            textString="%name",
+            textColor={0,0,255})}), Documentation(info="<html>
 <p>The M_OLine is a multi line model which consists of several segments and several single lines. Each segment consists of resistors and inductors that are connected in series in each single line, and of capacitors and conductors both between the lines and to the ground. The inductors are coupled to each other like in the M_Transformer model. The following picture shows the schematic of a segment with four single lines (lines=4):</p>
 
 <blockquote>
@@ -303,7 +479,7 @@ package Lines "Lossy and lossless segmented transmission lines, and LC distribut
 </blockquote>
 
 <p>The user has the possibility to enable a conditional heatport. If so, the M_OLine can be connected to a thermal network. When the parameter alpha is set to a value greater than zero, the M_OLine becomes temperature sensitive due to their resistors which resistances are calculated by R_actual = R*(1 + alpha*(heatPort.T - T_ref)) and conductors calculated by (G_actual = G/(1 + alpha*(heatPort.T - T_ref)).</p>
-</html>", revisions = "<html>
+</html>", revisions="<html>
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
     <tr>
       <th>Version</th>
@@ -339,34 +515,52 @@ package Lines "Lossy and lossless segmented transmission lines, and LC distribut
 
   model ULine "Lossy RC Line"
     //extends Interfaces.ThreePol;
-    Modelica.Electrical.Analog.Interfaces.Pin p1 annotation(
-      Placement(transformation(extent = {{-110, -10}, {-90, 10}})));
-    Modelica.Electrical.Analog.Interfaces.Pin p2 annotation(
-      Placement(transformation(extent = {{90, -10}, {110, 10}})));
-    Modelica.Electrical.Analog.Interfaces.Pin p3 annotation(
-      Placement(transformation(extent = {{-10, -110}, {10, -90}}), iconTransformation(extent = {{-10, -110}, {10, -90}})));
+    Modelica.Electrical.Analog.Interfaces.Pin p1 annotation (Placement(
+          transformation(extent={{-110,-10},{-90,10}})));
+    Modelica.Electrical.Analog.Interfaces.Pin p2 annotation (Placement(
+          transformation(extent={{90,-10},{110,10}})));
+    Modelica.Electrical.Analog.Interfaces.Pin p3 annotation (Placement(
+          transformation(extent={{-10,-110},{10,-90}}),
+          iconTransformation(extent={{-10,-110},{10,-90}})));
     SI.Voltage v13;
     SI.Voltage v23;
     SI.Current i1;
     SI.Current i2;
-    parameter Real r(final min = Modelica.Constants.small, unit = "Ohm/m", start = 1) "Resistance per meter";
-    parameter Real c(final min = Modelica.Constants.small, unit = "F/m", start = 1) "Capacitance per meter";
-    parameter SI.Length length(final min = Modelica.Constants.small, start = 1) "Length of line";
-    parameter Integer N(final min = 1, start = 1) "Number of lumped segments";
-    parameter SI.LinearTemperatureCoefficient alpha = 0 "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
-    parameter Boolean useHeatPort = false "= true, if heatPort is enabled" annotation(
-      Evaluate = true,
-      HideResult = true,
-      choices(checkBox = true));
-    parameter SI.Temperature T = 293.15 "Fixed device temperature if useHeatPort = false" annotation(
-      Dialog(enable = not useHeatPort));
-    parameter SI.Temperature T_ref = 300.15 "Reference temperature";
-    Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort annotation(
-      Placement(transformation(extent = {{-10, -110}, {10, -90}}), iconTransformation(extent = {{-108, -110}, {-88, -90}})));
+    parameter Real r(
+      final min=Modelica.Constants.small,
+      unit="Ohm/m",
+      start=1) "Resistance per meter";
+    parameter Real c(
+      final min=Modelica.Constants.small,
+      unit="F/m",
+      start=1) "Capacitance per meter";
+    parameter SI.Length length(final min=Modelica.Constants.small,
+        start=1) "Length of line";
+    parameter Integer N(final min=1, start=1) "Number of lumped segments";
+    parameter SI.LinearTemperatureCoefficient alpha=0
+      "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
+    parameter Boolean useHeatPort=false "= true, if heatPort is enabled"
+      annotation (
+      Evaluate=true,
+      HideResult=true,
+      choices(checkBox=true));
+    parameter SI.Temperature T=293.15
+      "Fixed device temperature if useHeatPort = false"
+      annotation (Dialog(enable=not useHeatPort));
+    parameter SI.Temperature T_ref=300.15 "Reference temperature";
+    Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort
+      annotation (Placement(transformation(extent={{-10,-110},{10,-90}}),
+          iconTransformation(extent={{-108,-110},{-88,-90}})));
   protected
-    parameter Modelica.SIunits.Resistance rm[N + 1] = {if i == 1 or i == N + 1 then r * length / (N * 2) else r * length / N for i in 1:N + 1};
-    Modelica.Electrical.Analog.Basic.Resistor R[N + 1](R = rm, T_ref = fill(T_ref, N + 1), alpha = fill(alpha, N + 1), useHeatPort = fill(useHeatPort, N + 1), T = fill(T, N + 1));
-    Modelica.Electrical.Analog.Basic.Capacitor C[N](C = fill(c * length / N, N));
+     parameter Modelica.SIunits.Resistance rm[N + 1]=
+    {if i==1 or i==N + 1 then r*length/(N*2) else r*length/N for i in 1:N+1};
+    Modelica.Electrical.Analog.Basic.Resistor R[N + 1](
+      R=rm,
+      T_ref=fill(T_ref, N + 1),
+      alpha=fill(alpha, N + 1),
+      useHeatPort=fill(useHeatPort, N + 1),
+      T=fill(T, N + 1));
+    Modelica.Electrical.Analog.Basic.Capacitor C[N](C=fill(c*length/(N), N));
   equation
     v13 = p1.v - p3.v;
     v23 = p2.v - p3.v;
@@ -388,9 +582,8 @@ package Lines "Lossy and lossless segmented transmission lines, and LC distribut
         connect(heatPort, R[i].heatPort);
       end for;
     end if;
-    annotation(
-      defaultComponentName = "line",
-      Documentation(info = "<html>
+    annotation (defaultComponentName="line",
+      Documentation(info="<html>
 <p>As can be seen in the picture below, the lossy RC line ULine is a single conductor lossy transmission line which consists of segments of lumped series resistors and capacitors that are connected with the reference pin p3. The precision of the model depends on the number N of lumped segments.
 <br>To get a symmetric line model, the first resistor is cut into two parts (R1 and R_Nplus1). These two new resistors have the half of the resistance of the original resistor.
 </p>
@@ -405,7 +598,7 @@ The capacitances are calculated with: C=c*length/N.
 <p>due to their resistors which resistances are calculated by <code>R_actual= R*(1 + alpha*(heatPort.T - T_ref)).</code></p>
 <p>Note, this is different compared with the lumped line model of SPICE.</p>
 <p><strong>References:</strong> [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Johnson1991</a>]</p>
-</html>", revisions = "<html>
+</html>",      revisions="<html>
 <dl>
 <dt><em>2016</em></dt>
 <dd>by Christoph Clauss resistance calculation revised</dd>
@@ -413,13 +606,36 @@ The capacitances are calculated with: C=c*length/N.
 <dd>by Christoph Clauss initially implemented</dd>
 </dl>
 </html>"),
-      Icon(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Text(extent = {{-150, 130}, {150, 90}}, textString = "%name", textColor = {0, 0, 255}), Rectangle(extent = {{-80, 80}, {80, -80}}, lineColor = {0, 0, 255}, fillPattern = FillPattern.Solid, fillColor = {255, 255, 255}), Line(points = {{80, 0}, {100, 0}}, color = {0, 0, 255}), Line(points = {{-80, 0}, {-100, 0}}, color = {0, 0, 255}), Line(points = {{-40, 40}, {-40, 20}}), Line(points = {{40, 30}, {-40, 30}}), Line(points = {{40, 40}, {40, 20}}), Line(points = {{0, -80}, {0, -100}}, color = {0, 0, 255}), Text(extent = {{-70, -10}, {70, -50}}, textString = "ULine")}));
+      Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Text(
+            extent={{-150,130},{150,90}},
+            textString="%name",
+            textColor={0,0,255}),
+          Rectangle(
+            extent={{-80,80},{80,-80}},
+            lineColor={0,0,255},
+            fillPattern=FillPattern.Solid,
+            fillColor={255,255,255}),
+          Line(points={{80,0},{100,0}}, color={0,0,255}),
+          Line(points={{-80,0},{-100,0}}, color={0,0,255}),
+          Line(points={{-40,40},{-40,20}}),
+          Line(points={{40,30},{-40,30}}),
+          Line(points={{40,40},{40,20}}),
+          Line(points={{0,-80},{0,-100}}, color={0,0,255}),
+          Text(
+            extent={{-70,-10},{70,-50}},
+            textString="ULine")}));
   end ULine;
 
-  model TLine1 "Lossless transmission line with characteristic impedance Z0 and transmission delay TD"
+  model TLine1
+    "Lossless transmission line with characteristic impedance Z0 and transmission delay TD"
+
     extends Modelica.Electrical.Analog.Interfaces.TwoPort;
-    parameter SI.Resistance Z0(start = 1) "Characteristic impedance";
-    parameter SI.Time TD(start = 1) "Transmission delay";
+    parameter SI.Resistance Z0(start=1)
+      "Characteristic impedance";
+    parameter SI.Time TD(start=1) "Transmission delay";
   protected
     SI.Voltage er;
     SI.Voltage es;
@@ -427,110 +643,195 @@ The capacitances are calculated with: C=c*length/N.
     assert(Z0 > 0, "Z0 has to be positive");
     assert(TD > 0, "TD has to be positive");
   equation
-    i1 = (v1 - es) / Z0;
-    i2 = (v2 - er) / Z0;
-    es = 2 * delay(v2, TD) - delay(er, TD);
-    er = 2 * delay(v1, TD) - delay(es, TD);
-    annotation(
-      defaultComponentName = "line",
-      Documentation(info = "<html>
+    i1 = (v1 - es)/Z0;
+    i2 = (v2 - er)/Z0;
+    es = 2*delay(v2, TD) - delay(er, TD);
+    er = 2*delay(v1, TD) - delay(es, TD);
+    annotation (defaultComponentName="line",
+      Documentation(info="<html>
 <p>Lossless transmission line with characteristic impedance Z0 and transmission delay TD The lossless transmission line TLine1 is a two Port. Both port branches consist of a resistor with characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay TD. For further details see [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>]. The model parameters can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;) and TD = sqrt(L&#39;*C&#39;)*length_of_line. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero.</p>
 
 <p><strong>References:</strong> 
    [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>],
    [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Hoefer1985</a>]</p>
-</html>", revisions = "<html><head></head><body><ul>
-<li><em> 1998   </em>
-       by Joachim Haase<br> initially implemented<br></li>
-  <li><em> November 12, 2019 </em> 
-       by Atiyah Elsheikh, Mathemodica.com<br> assert of parameter values being positive moved to an initial equation section<br> 
-  </li>
+</html>",      revisions="<html>
+<ul>
+<li><i>1998 </i>by Joachim Haase<br>initially implemented</li>
+<li><i>November 12, 2019 </i>by Atiyah Elsheikh, Mathemodica.com<br>assert of parameter values being positive moved to an initial equation section<br></li>
 </ul>
-</body></html>"),
-      Icon(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Text(extent = {{-150, 150}, {150, 110}}, textString = "%name", textColor = {0, 0, 255}), Rectangle(extent = {{-80, 80}, {80, -80}}, lineColor = {0, 0, 255}, fillPattern = FillPattern.Solid, fillColor = {255, 255, 255}), Line(points = {{60, -100}, {90, -100}}, color = {0, 0, 255}), Line(points = {{60, 100}, {90, 100}}, color = {0, 0, 255}), Line(points = {{-60, 100}, {-90, 100}}, color = {0, 0, 255}), Line(points = {{-60, -100}, {-90, -100}}, color = {0, 0, 255}), Text(extent = {{-70, -10}, {70, -50}}, textString = "TLine1"), Line(points = {{-40, 40}, {-40, 20}}), Line(points = {{40, 30}, {-40, 30}}), Line(points = {{40, 40}, {40, 20}}), Line(points = {{-60, 100}, {-60, 80}}, color = {0, 0, 255}), Line(points = {{60, 100}, {60, 80}}, color = {0, 0, 255}), Line(points = {{60, -80}, {60, -100}}, color = {0, 0, 255}), Line(points = {{-60, -80}, {-60, -100}}, color = {0, 0, 255})}),
-      Diagram(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Text(extent = {{-100, 100}, {100, 70}}, textString = "TLine1", textColor = {0, 0, 255})}));
+</html>"),
+      Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Text(
+            extent={{-150,150},{150,110}},
+            textString="%name",
+            textColor={0,0,255}),
+          Rectangle(
+            extent={{-80,80},{80,-80}},
+            lineColor={0,0,255},
+            fillPattern=FillPattern.Solid,
+            fillColor={255,255,255}),
+          Line(points={{60,-100},{90,-100}}, color={0,0,255}),
+          Line(points={{60,100},{90,100}}, color={0,0,255}),
+          Line(points={{-60,100},{-90,100}}, color={0,0,255}),
+          Line(points={{-60,-100},{-90,-100}}, color={0,0,255}),
+          Text(
+            extent={{-70,-10},{70,-50}},
+            textString="TLine1"),
+          Line(points={{-40,40},{-40,20}}),
+          Line(points={{40,30},{-40,30}}),
+          Line(points={{40,40},{40,20}}),
+          Line(points={{-60,100},{-60,80}}, color={0,0,255}),
+          Line(points={{60,100},{60,80}}, color={0,0,255}),
+          Line(points={{60,-80},{60,-100}}, color={0,0,255}),
+          Line(points={{-60,-80},{-60,-100}}, color={0,0,255})}),
+      Diagram(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}),graphics={
+                                      Text(
+              extent={{-100,100},{100,70}},
+              textString="TLine1",
+              textColor={0,0,255})}));
   end TLine1;
 
-  model TLine2 "Lossless transmission line with characteristic impedance Z0, frequency F and normalized length NL"
+  model TLine2
+    "Lossless transmission line with characteristic impedance Z0, frequency F and normalized length NL"
+
     extends Modelica.Electrical.Analog.Interfaces.TwoPort;
-    parameter SI.Resistance Z0(start = 1) "Characteristic impedance";
-    parameter SI.Frequency F(start = 1) "Frequency";
-    parameter Real NL(start = 1) "Normalized length";
+    parameter SI.Resistance Z0(start=1)
+      "Characteristic impedance";
+    parameter SI.Frequency F(start=1) "Frequency";
+    parameter Real NL(start=1) "Normalized length";
   protected
     SI.Voltage er;
     SI.Voltage es;
-    parameter SI.Time TD = NL / F;
+    parameter SI.Time TD=NL/F;
   initial equation
     assert(Z0 > 0, "Z0 has to be positive");
     assert(NL > 0, "NL has to be positive");
     assert(F > 0, "F has to be positive");
   equation
-    i1 = (v1 - es) / Z0;
-    i2 = (v2 - er) / Z0;
-    es = 2 * delay(v2, TD) - delay(er, TD);
-    er = 2 * delay(v1, TD) - delay(es, TD);
-    annotation(
-      defaultComponentName = "line",
-      Documentation(info = "<html>
+    i1 = (v1 - es)/Z0;
+    i2 = (v2 - er)/Z0;
+    es = 2*delay(v2, TD) - delay(er, TD);
+    er = 2*delay(v1, TD) - delay(es, TD);
+    annotation (defaultComponentName="line",
+      Documentation(info="<html>
 <p>Lossless transmission line with characteristic impedance Z0, frequency F and normalized length NL The lossless transmission line TLine2 is a two Port. Both port branches consist of a resistor with the value of the characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay. For further details see [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>]. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero. The characteristic impedance Z0 can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;). The normalized length NL is equal to the length of the line divided by the wavelength corresponding to the frequency F, i. e. the transmission delay TD is the quotient of NL and F.</p>
 <p><strong>References:</strong> 
    [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>],
    [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Hoefer1985</a>]</p>
-</html>", revisions = "<html>
-  <ul>
-<li>
-<em>1998</em>
-by Joachim Haase <br>initially implemented</br>
-</li>
-  <li><em> November 12, 2019 </em> 
-       by Atiyah Elsheikh, Mathemodica.com<br> assert of parameter values being positive moved to an initial equation section<br> 
-  </li>
-  </ul>
+</html>",      revisions="<html>
+<ul>
+<li><i>1998 </i>by Joachim Haase<br>initially implemented</li>
+<li><i>November 12, 2019 </i>by Atiyah Elsheikh, Mathemodica.com<br>assert of parameter values being positive moved to an initial equation section<br></li>
+</ul>
 </html>"),
-      Icon(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Text(extent = {{-150, 150}, {150, 110}}, textString = "%name", textColor = {0, 0, 255}), Rectangle(extent = {{-80, 80}, {80, -80}}, lineColor = {0, 0, 255}, fillPattern = FillPattern.Solid, fillColor = {255, 255, 255}), Line(points = {{60, -100}, {90, -100}}, color = {0, 0, 255}), Line(points = {{60, 100}, {90, 100}}, color = {0, 0, 255}), Line(points = {{-60, 100}, {-90, 100}}, color = {0, 0, 255}), Line(points = {{-60, -100}, {-90, -100}}, color = {0, 0, 255}), Text(extent = {{-70, -10}, {70, -50}}, textString = "TLine2"), Line(points = {{-40, 40}, {-40, 20}}), Line(points = {{40, 30}, {-40, 30}}), Line(points = {{40, 40}, {40, 20}}), Line(points = {{-60, 100}, {-60, 80}}, color = {0, 0, 255}), Line(points = {{60, 100}, {60, 80}}, color = {0, 0, 255}), Line(points = {{60, -80}, {60, -100}}, color = {0, 0, 255}), Line(points = {{-60, -80}, {-60, -100}}, color = {0, 0, 255})}),
-      Diagram(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Text(extent = {{-100, 100}, {100, 70}}, textString = "TLine2", textColor = {0, 0, 255})}));
+      Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Text(
+            extent={{-150,150},{150,110}},
+            textString="%name",
+            textColor={0,0,255}),
+          Rectangle(
+            extent={{-80,80},{80,-80}},
+            lineColor={0,0,255},
+            fillPattern=FillPattern.Solid,
+            fillColor={255,255,255}),
+          Line(points={{60,-100},{90,-100}}, color={0,0,255}),
+          Line(points={{60,100},{90,100}}, color={0,0,255}),
+          Line(points={{-60,100},{-90,100}}, color={0,0,255}),
+          Line(points={{-60,-100},{-90,-100}}, color={0,0,255}),
+          Text(
+            extent={{-70,-10},{70,-50}},
+            textString="TLine2"),
+          Line(points={{-40,40},{-40,20}}),
+          Line(points={{40,30},{-40,30}}),
+          Line(points={{40,40},{40,20}}),
+          Line(points={{-60,100},{-60,80}}, color={0,0,255}),
+          Line(points={{60,100},{60,80}}, color={0,0,255}),
+          Line(points={{60,-80},{60,-100}}, color={0,0,255}),
+          Line(points={{-60,-80},{-60,-100}}, color={0,0,255})}),
+      Diagram(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+                                           Text(
+              extent={{-100,100},{100,70}},
+              textString="TLine2",
+              textColor={0,0,255})}));
   end TLine2;
 
-  model TLine3 "Lossless transmission line with characteristic impedance Z0 and frequency F"
+  model TLine3
+    "Lossless transmission line with characteristic impedance Z0 and frequency F"
     extends Modelica.Electrical.Analog.Interfaces.TwoPort;
-    parameter SI.Resistance Z0(start = 1) "Natural impedance";
-    parameter SI.Frequency F(start = 1) "Frequency";
+    parameter SI.Resistance Z0(start=1) "Natural impedance";
+    parameter SI.Frequency F(start=1) "Frequency";
   protected
     SI.Voltage er;
     SI.Voltage es;
-    parameter SI.Time TD = 1 / F / 4;
-  initial equation
+    parameter SI.Time TD=1/F/4;
+  equation
     assert(Z0 > 0, "Z0 has to be positive");
     assert(F > 0, "F has to be positive");
-  equation
-    i1 = (v1 - es) / Z0;
-    i2 = (v2 - er) / Z0;
-    es = 2 * delay(v2, TD) - delay(er, TD);
-    er = 2 * delay(v1, TD) - delay(es, TD);
-    annotation(
-      defaultComponentName = "line",
-      Documentation(info = "<html>
+    i1 = (v1 - es)/Z0;
+    i2 = (v2 - er)/Z0;
+    es = 2*delay(v2, TD) - delay(er, TD);
+    er = 2*delay(v1, TD) - delay(es, TD);
+    annotation (defaultComponentName="line",
+      Documentation(info="<html>
 <p>Lossless transmission line with characteristic impedance Z0 and frequency F The lossless transmission line TLine3 is a two Port. Both port branches consist of a resistor with value of the characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay. For further details see [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>]. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero. The characteristic impedance Z0 can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;). The length of the line is equal to a quarter of the wavelength corresponding to the frequency F, i. e. the transmission delay is the quotient of 4 and F. In this case, the characteristic impedance is called natural impedance.</p>
 <p><strong>References:</strong> 
    [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>],
    [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Hoefer1985</a>]</p>
-</html>", revisions = "<html>
+</html>",      revisions="<html>
 <ul>
 <li><em> 1998   </em>
        by Joachim Haase<br> initially implemented<br>
-  </li>
-  <li><em> November 12, 2019 </em> 
-       by Atiyah Elsheikh, Mathemodica.com<br> assert of parameter values being positive moved to an initial equation section<br> 
-  </li>
+</li>
+<li><em>November 12, 2019 </em>
+by Atiyah Elsheikh, Mathemodica.com<br>assert of parameter values being positive moved to an initial equation section<br>
+</li>
 </ul>
 </html>"),
-      Icon(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Rectangle(extent = {{-80, 80}, {80, -80}}, lineColor = {0, 0, 255}, fillPattern = FillPattern.Solid, fillColor = {255, 255, 255}), Line(points = {{60, -100}, {90, -100}}, color = {0, 0, 255}), Line(points = {{60, 100}, {90, 100}}, color = {0, 0, 255}), Line(points = {{-60, 100}, {-90, 100}}, color = {0, 0, 255}), Line(points = {{-60, -100}, {-90, -100}}, color = {0, 0, 255}), Text(extent = {{-70, -10}, {70, -50}}, textString = "TLine3"), Text(extent = {{-150, 150}, {150, 110}}, textString = "%name", textColor = {0, 0, 255}), Line(points = {{-40, 40}, {-40, 20}}), Line(points = {{40, 30}, {-40, 30}}), Line(points = {{40, 40}, {40, 20}}), Line(points = {{-60, 100}, {-60, 80}}, color = {0, 0, 255}), Line(points = {{60, 100}, {60, 80}}, color = {0, 0, 255}), Line(points = {{60, -80}, {60, -100}}, color = {0, 0, 255}), Line(points = {{-60, -80}, {-60, -100}}, color = {0, 0, 255})}),
-      Diagram(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Text(extent = {{-100, 100}, {100, 70}}, textString = "TLine3", textColor = {0, 0, 255})}));
+      Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Rectangle(
+            extent={{-80,80},{80,-80}},
+            lineColor={0,0,255},
+            fillPattern=FillPattern.Solid,
+            fillColor={255,255,255}),
+          Line(points={{60,-100},{90,-100}}, color={0,0,255}),
+          Line(points={{60,100},{90,100}}, color={0,0,255}),
+          Line(points={{-60,100},{-90,100}}, color={0,0,255}),
+          Line(points={{-60,-100},{-90,-100}}, color={0,0,255}),
+          Text(
+            extent={{-70,-10},{70,-50}},
+            textString="TLine3"),
+          Text(
+            extent={{-150,150},{150,110}},
+            textString="%name",
+            textColor={0,0,255}),
+          Line(points={{-40,40},{-40,20}}),
+          Line(points={{40,30},{-40,30}}),
+          Line(points={{40,40},{40,20}}),
+          Line(points={{-60,100},{-60,80}}, color={0,0,255}),
+          Line(points={{60,100},{60,80}}, color={0,0,255}),
+          Line(points={{60,-80},{60,-100}}, color={0,0,255}),
+          Line(points={{-60,-80},{-60,-100}}, color={0,0,255})}),
+      Diagram(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+                                           Text(
+              extent={{-100,100},{100,70}},
+              textString="TLine3",
+              textColor={0,0,255})}));
   end TLine3;
-  annotation(
-    Documentation(info = "<html>
+  annotation (Documentation(info="<html>
 <p>This package contains lossy and lossless segmented transmission lines, and LC distributed line models. The line models do not yet possess a conditional heating port.</p>
-</html>", revisions = "<html>
+</html>", revisions="<html>
 <dl>
 <dt>
 <strong>Main Authors:</strong>
@@ -552,6 +853,14 @@ Christoph Clau&szlig;
 <p>
 Copyright &copy; 1998-2019, Modelica Association and contributors
 </p>
-</html>"),
-    Icon(graphics = {Line(points = {{-60, 50}, {-90, 50}}), Rectangle(extent = {{-60, 60}, {60, -60}}), Line(points = {{-60, -50}, {-90, -50}}), Line(points = {{36, 20}, {-36, 20}}), Line(points = {{-36, 40}, {-36, 0}}), Line(points = {{36, 40}, {36, 0}}), Line(points = {{60, 50}, {90, 50}}), Line(points = {{60, -50}, {90, -50}})}));
+</html>"), Icon(graphics={
+        Line(points={{-60,50},{-90,50}}),
+        Rectangle(
+          extent={{-60,60},{60,-60}}),
+        Line(points={{-60,-50},{-90,-50}}),
+        Line(points={{36,20},{-36,20}}),
+        Line(points={{-36,40},{-36,0}}),
+        Line(points={{36,40},{36,0}}),
+        Line(points={{60,50},{90,50}}),
+        Line(points={{60,-50},{90,-50}})}));
 end Lines;

--- a/Modelica/Electrical/Analog/Lines.mo
+++ b/Modelica/Electrical/Analog/Lines.mo
@@ -1,74 +1,44 @@
 within Modelica.Electrical.Analog;
-package Lines
-  "Lossy and lossless segmented transmission lines, and LC distributed line models"
+
+package Lines "Lossy and lossless segmented transmission lines, and LC distributed line models"
   extends Modelica.Icons.Package;
 
   model OLine "Lossy Transmission Line"
     //extends Interfaces.ThreePol;
-    Modelica.Electrical.Analog.Interfaces.Pin p1 annotation (Placement(
-          transformation(extent={{-110,-10},{-90,10}})));
-    Modelica.Electrical.Analog.Interfaces.Pin p2 annotation (Placement(
-          transformation(extent={{90,-10},{110,10}})));
-    Modelica.Electrical.Analog.Interfaces.Pin p3 annotation (Placement(
-          transformation(extent={{-10,-110},{10,-90}})));
+    Modelica.Electrical.Analog.Interfaces.Pin p1 annotation(
+      Placement(transformation(extent = {{-110, -10}, {-90, 10}})));
+    Modelica.Electrical.Analog.Interfaces.Pin p2 annotation(
+      Placement(transformation(extent = {{90, -10}, {110, 10}})));
+    Modelica.Electrical.Analog.Interfaces.Pin p3 annotation(
+      Placement(transformation(extent = {{-10, -110}, {10, -90}})));
     SI.Voltage v13;
     SI.Voltage v23;
     SI.Current i1;
     SI.Current i2;
-    parameter Real r(
-      final min=Modelica.Constants.small,
-      unit="Ohm/m",
-      start=1) "Resistance per meter";
-    parameter Real l(
-      final min=Modelica.Constants.small,
-      unit="H/m",
-      start=1) "Inductance per meter";
-    parameter Real g(
-      final min=Modelica.Constants.small,
-      unit="S/m",
-      start=1) "Conductance per meter";
-    parameter Real c(
-      final min=Modelica.Constants.small,
-      unit="F/m",
-      start=1) "Capacitance per meter";
-    parameter SI.Length length(final min=Modelica.Constants.small,
-        start=1) "Length of line";
-    parameter Integer N(final min=1, start=1) "Number of lumped segments";
-    parameter SI.LinearTemperatureCoefficient alpha_R=0
-      "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
-    parameter SI.LinearTemperatureCoefficient alpha_G=0
-      "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref))";
-    parameter Boolean useHeatPort=false "= true, if heatPort is enabled"
-      annotation (
-      Evaluate=true,
-      HideResult=true,
-      choices(checkBox=true));
-    parameter SI.Temperature T=293.15
-      "Fixed device temperature if useHeatPort = false"
-      annotation (Dialog(enable=not useHeatPort));
-    parameter SI.Temperature T_ref=300.15 "Reference temperature";
-    Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort
-      annotation (Placement(transformation(extent={{-10,-110},{10,-90}}),
-          iconTransformation(extent={{-110,-110},{-90,-90}})));
+    parameter Real r(final min = Modelica.Constants.small, unit = "Ohm/m", start = 1) "Resistance per meter";
+    parameter Real l(final min = Modelica.Constants.small, unit = "H/m", start = 1) "Inductance per meter";
+    parameter Real g(final min = Modelica.Constants.small, unit = "S/m", start = 1) "Conductance per meter";
+    parameter Real c(final min = Modelica.Constants.small, unit = "F/m", start = 1) "Capacitance per meter";
+    parameter SI.Length length(final min = Modelica.Constants.small, start = 1) "Length of line";
+    parameter Integer N(final min = 1, start = 1) "Number of lumped segments";
+    parameter SI.LinearTemperatureCoefficient alpha_R = 0 "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
+    parameter SI.LinearTemperatureCoefficient alpha_G = 0 "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref))";
+    parameter Boolean useHeatPort = false "= true, if heatPort is enabled" annotation(
+      Evaluate = true,
+      HideResult = true,
+      choices(checkBox = true));
+    parameter SI.Temperature T = 293.15 "Fixed device temperature if useHeatPort = false" annotation(
+      Dialog(enable = not useHeatPort));
+    parameter SI.Temperature T_ref = 300.15 "Reference temperature";
+    Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort annotation(
+      Placement(transformation(extent = {{-10, -110}, {10, -90}}), iconTransformation(extent = {{-110, -110}, {-90, -90}})));
   protected
-    parameter Modelica.SIunits.Resistance rm[N + 1]=
-    {if i==1 or i==N + 1 then r*length/(N*2) else r*length/N for i in 1:N+1};
-    Modelica.Electrical.Analog.Basic.Resistor R[N + 1](
-      R=rm,
-      T_ref=fill(T_ref, N + 1),
-      alpha=fill(alpha_R, N + 1),
-      useHeatPort=fill(useHeatPort, N + 1),
-      T=fill(T, N + 1));
-    parameter Modelica.SIunits.Inductance lm[N + 1]=
-    {if i==1 or i==N + 1 then l*length/(N*2) else l*length/N for i in 1:N+1};
-    Modelica.Electrical.Analog.Basic.Inductor L[N + 1](L=lm);
-    Modelica.Electrical.Analog.Basic.Capacitor C[N](C=fill(c*length/(N), N));
-    Modelica.Electrical.Analog.Basic.Conductor G[N](
-      G=fill(g*length/(N), N),
-      T_ref=fill(T_ref, N),
-      alpha=fill(alpha_G, N),
-      useHeatPort=fill(useHeatPort, N),
-      T=fill(T, N));
+    parameter Modelica.SIunits.Resistance rm[N + 1] = {if i == 1 or i == N + 1 then r * length / (N * 2) else r * length / N for i in 1:N + 1};
+    Modelica.Electrical.Analog.Basic.Resistor R[N + 1](R = rm, T_ref = fill(T_ref, N + 1), alpha = fill(alpha_R, N + 1), useHeatPort = fill(useHeatPort, N + 1), T = fill(T, N + 1));
+    parameter Modelica.SIunits.Inductance lm[N + 1] = {if i == 1 or i == N + 1 then l * length / (N * 2) else l * length / N for i in 1:N + 1};
+    Modelica.Electrical.Analog.Basic.Inductor L[N + 1](L = lm);
+    Modelica.Electrical.Analog.Basic.Capacitor C[N](C = fill(c * length / N, N));
+    Modelica.Electrical.Analog.Basic.Conductor G[N](G = fill(g * length / N, N), T_ref = fill(T_ref, N), alpha = fill(alpha_G, N), useHeatPort = fill(useHeatPort, N), T = fill(T, N));
   equation
     v13 = p1.v - p3.v;
     v23 = p2.v - p3.v;
@@ -93,8 +63,9 @@ package Lines
         connect(heatPort, G[i].heatPort);
       end for;
     end if;
-    annotation (defaultComponentName="line",
-      Documentation(info="<html>
+    annotation(
+      defaultComponentName = "line",
+      Documentation(info = "<html>
 <p>Like in the picture below, the lossy transmission line OLine is a single-conductor lossy transmission line which consists of segments of lumped resistors and inductors in series and conductor and capacitors that are connected with the reference pin p3. The precision of the model depends on the number N of lumped segments.</p>
 <p>To get a symmetric line model, the first resistor and inductor are cut into two parts (R1 and R_Nplus1, L1 and L_Nplus1). These two new resistors and inductors have the half of the resistance respectively inductance the original resistor respectively inductor.</p>
 
@@ -112,7 +83,7 @@ package Lines
 <p>Note, this is different to the lumped line model of SPICE.</p>
 
 <p><strong>References:</strong> [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Johnson1991</a>]</p>
-</html>",      revisions="<html>
+</html>", revisions = "<html>
 <ul>
 <li><em> 2016   </em>
        by Christoph Clauss<br> resistance and inductance calculation revised<br>
@@ -122,143 +93,70 @@ package Lines
        </li>
 </ul>
 </html>"),
-      Icon(coordinateSystem(
-          preserveAspectRatio=true,
-          extent={{-100,-100},{100,100}}), graphics={
-          Rectangle(
-            extent={{-80,80},{80,-80}},
-            fillColor={255,255,255},
-            fillPattern=FillPattern.Solid,
-            lineColor={0,0,255}),
-          Line(points={{0,-80},{0,-90}}, color={0,0,255}),
-          Line(points={{80,0},{90,0}}, color={0,0,255}),
-          Line(points={{-80,0},{-90,0}}, color={0,0,255}),
-          Text(
-            extent={{-150,130},{150,90}},
-            textString="%name",
-            textColor={0,0,255}),
-          Line(points={{40,30},{-40,30}}),
-          Line(points={{-40,40},{-40,20}}),
-          Line(points={{40,40},{40,20}})}));
+      Icon(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Rectangle(extent = {{-80, 80}, {80, -80}}, fillColor = {255, 255, 255}, fillPattern = FillPattern.Solid, lineColor = {0, 0, 255}), Line(points = {{0, -80}, {0, -90}}, color = {0, 0, 255}), Line(points = {{80, 0}, {90, 0}}, color = {0, 0, 255}), Line(points = {{-80, 0}, {-90, 0}}, color = {0, 0, 255}), Text(extent = {{-150, 130}, {150, 90}}, textString = "%name", textColor = {0, 0, 255}), Line(points = {{40, 30}, {-40, 30}}), Line(points = {{-40, 40}, {-40, 20}}), Line(points = {{40, 40}, {40, 20}})}));
   end OLine;
 
   model M_OLine "Multiple OLine"
+    parameter SI.Length length(final min = Modelica.Constants.small) = 0.1 "Length of line";
+    parameter Integer N(final min = 2) = 5 "Number of lumped segments";
+    parameter Integer lines(final min = 2) = 4 "Number of lines";
+    parameter Real r[lines](each final min = Modelica.Constants.small, each unit = "Ohm/m") = {4.76e5, 1.72e5, 1.72e5, 1.72e5} "Resistance per meter";
+    parameter Real l[dim_vector_lgc](each final min = Modelica.Constants.small, each unit = "H/m") = {5.98e-7, 4.44e-7, 4.39e-7, 3.99e-7, 5.81e-7, 4.09e-7, 4.23e-7, 5.96e-7, 4.71e-7, 6.06e-7} "Inductance per meter";
+    parameter Real g[dim_vector_lgc](each final min = Modelica.Constants.small, each unit = "S/m") = {8.05e-6, 3.42e-5, 2.91e-5, 1.76e-6, 9.16e-6, 7.12e-6, 2.43e-5, 5.93e-6, 4.19e-5, 6.64e-6} "Conductance per meter";
+    parameter Real c[dim_vector_lgc](each final min = Modelica.Constants.small, each unit = "F/m") = {2.38e-11, 1.01e-10, 8.56e-11, 5.09e-12, 2.71e-11, 2.09e-11, 7.16e-11, 1.83e-11, 1.23e-10, 2.07e-11} "Capacitance per meter";
+    parameter SI.LinearTemperatureCoefficient alpha_R = 0 "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
+    parameter SI.LinearTemperatureCoefficient alpha_G = 0 "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref))";
+    parameter Boolean useHeatPort = false "= true, if heatPort is enabled" annotation(
+      Evaluate = true,
+      HideResult = true,
+      choices(checkBox = true));
+    parameter SI.Temperature T = 293.15 "Fixed device temperature if useHeatPort = false" annotation(
+      Dialog(enable = not useHeatPort));
+    parameter SI.Temperature T_ref = 300.15 "Reference temperature";
+    Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort annotation(
+      Placement(transformation(extent = {{-110, -110}, {-90, -90}}), iconTransformation(extent = {{-110, -110}, {-90, -90}})));
 
-    parameter SI.Length length(final min=Modelica.Constants.small)=
-         0.1 "Length of line";
-    parameter Integer N(final min=2) = 5 "Number of lumped segments";
-    parameter Integer lines(final min=2) = 4 "Number of lines";
-  protected
-    parameter Integer dim_vector_lgc=div(lines*(lines + 1), 2);
-  public
-    parameter Real r[lines](
-      each final min=Modelica.Constants.small,
-      each unit="Ohm/m") = {4.76e5,1.72e5,1.72e5,1.72e5} "Resistance per meter";
-
-    parameter Real l[dim_vector_lgc](
-      each final min=Modelica.Constants.small,
-      each unit="H/m") = {5.98e-7,4.44e-7,4.39e-7,3.99e-7,5.81e-7,4.09e-7,
-      4.23e-7,5.96e-7,4.71e-7,6.06e-7} "Inductance per meter";
-
-    parameter Real g[dim_vector_lgc](
-      each final min=Modelica.Constants.small,
-      each unit="S/m") = {8.05e-6,3.42e-5,2.91e-5,1.76e-6,9.16e-6,7.12e-6,
-      2.43e-5,5.93e-6,4.19e-5,6.64e-6} "Conductance per meter";
-
-    parameter Real c[dim_vector_lgc](
-      each final min=Modelica.Constants.small,
-      each unit="F/m") = {2.38e-11,1.01e-10,8.56e-11,5.09e-12,2.71e-11,2.09e-11,
-      7.16e-11,1.83e-11,1.23e-10,2.07e-11} "Capacitance per meter";
-    parameter SI.LinearTemperatureCoefficient alpha_R=0
-      "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
-    parameter SI.LinearTemperatureCoefficient alpha_G=0
-      "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref))";
-    parameter Boolean useHeatPort=false "= true, if heatPort is enabled"
-      annotation (
-      Evaluate=true,
-      HideResult=true,
-      choices(checkBox=true));
-    parameter SI.Temperature T=293.15
-      "Fixed device temperature if useHeatPort = false"
-      annotation (Dialog(enable=not useHeatPort));
-    parameter SI.Temperature T_ref=300.15 "Reference temperature";
-    Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort
-      annotation (Placement(transformation(extent={{-110,-110},{-90,-90}}),
-          iconTransformation(extent={{-110,-110},{-90,-90}})));
     model segment "Multiple line segment model"
-
-      parameter Integer lines(final min=1) = 3 "Number of lines";
-      parameter Integer dim_vector_lgc=div(lines*(lines + 1), 2)
-        "Length of the vectors for l, g, c";
-      Modelica.Electrical.Analog.Interfaces.PositivePin p[lines] "Positive pin"
-        annotation (Placement(transformation(extent={{-110,-10},{-90,10}}), iconTransformation(extent={{-110,-10},{-90,10}})));
-      Modelica.Electrical.Analog.Interfaces.NegativePin n[lines] "Negative pin"
-        annotation (Placement(transformation(extent={{90,-10},{110,10}}), iconTransformation(extent={{90,-10},{110,10}})));
-
-      parameter Real Cl[dim_vector_lgc]=fill(1, dim_vector_lgc)
-        "Capacitance matrix";
-      parameter Real Rl[lines]=fill(7, lines) "Resistance matrix";
-      parameter Real Ll[dim_vector_lgc]=fill(2, dim_vector_lgc)
-        "Inductance matrix";
-      parameter Real Gl[dim_vector_lgc]=fill(1, dim_vector_lgc)
-        "Conductance matrix";
-      parameter SI.LinearTemperatureCoefficient alpha_R
-        "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
-      parameter SI.LinearTemperatureCoefficient alpha_G
-        "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref))";
-      parameter Boolean useHeatPort=false "= true, if heatPort is enabled"
-        annotation (
-        Evaluate=true,
-        HideResult=true,
-        choices(checkBox=true));
-      parameter SI.Temperature T=293.15
-        "Fixed device temperature if useHeatPort = false"
-        annotation (Dialog(enable=not useHeatPort));
+      parameter Integer lines(final min = 1) = 3 "Number of lines";
+      parameter Integer dim_vector_lgc = div(lines * (lines + 1), 2) "Length of the vectors for l, g, c";
+      Modelica.Electrical.Analog.Interfaces.PositivePin p[lines] "Positive pin" annotation(
+        Placement(transformation(extent = {{-110, -10}, {-90, 10}}), iconTransformation(extent = {{-110, -10}, {-90, 10}})));
+      Modelica.Electrical.Analog.Interfaces.NegativePin n[lines] "Negative pin" annotation(
+        Placement(transformation(extent = {{90, -10}, {110, 10}}), iconTransformation(extent = {{90, -10}, {110, 10}})));
+      parameter Real Cl[dim_vector_lgc] = fill(1, dim_vector_lgc) "Capacitance matrix";
+      parameter Real Rl[lines] = fill(7, lines) "Resistance matrix";
+      parameter Real Ll[dim_vector_lgc] = fill(2, dim_vector_lgc) "Inductance matrix";
+      parameter Real Gl[dim_vector_lgc] = fill(1, dim_vector_lgc) "Conductance matrix";
+      parameter SI.LinearTemperatureCoefficient alpha_R "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
+      parameter SI.LinearTemperatureCoefficient alpha_G "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref))";
+      parameter Boolean useHeatPort = false "= true, if heatPort is enabled" annotation(
+        Evaluate = true,
+        HideResult = true,
+        choices(checkBox = true));
+      parameter SI.Temperature T = 293.15 "Fixed device temperature if useHeatPort = false" annotation(
+        Dialog(enable = not useHeatPort));
       parameter SI.Temperature T_ref;
-
-      Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if
-        useHeatPort annotation (Placement(transformation(extent={{-10,-110},{10,
-                -90}}), iconTransformation(extent={{-110,-110},{-90,-90}})));
-
-      Modelica.Electrical.Analog.Basic.Capacitor C[dim_vector_lgc](C=Cl);
-      Modelica.Electrical.Analog.Basic.Resistor R[lines](
-        R=Rl,
-        T_ref=fill(T_ref, lines),
-        alpha=fill(alpha_R, lines),
-        useHeatPort=fill(useHeatPort, lines),
-        T=fill(T, lines));
-      Modelica.Electrical.Analog.Basic.Conductor G[dim_vector_lgc](
-        G=Gl,
-        T_ref=fill(T_ref, dim_vector_lgc),
-        alpha=fill(alpha_G, dim_vector_lgc),
-        useHeatPort=fill(useHeatPort, dim_vector_lgc),
-        T=fill(T, dim_vector_lgc));
-      Modelica.Electrical.Analog.Basic.M_Transformer inductance(N=lines, L=Ll);
+      Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort annotation(
+        Placement(transformation(extent = {{-10, -110}, {10, -90}}), iconTransformation(extent = {{-110, -110}, {-90, -90}})));
+      Modelica.Electrical.Analog.Basic.Capacitor C[dim_vector_lgc](C = Cl);
+      Modelica.Electrical.Analog.Basic.Resistor R[lines](R = Rl, T_ref = fill(T_ref, lines), alpha = fill(alpha_R, lines), useHeatPort = fill(useHeatPort, lines), T = fill(T, lines));
+      Modelica.Electrical.Analog.Basic.Conductor G[dim_vector_lgc](G = Gl, T_ref = fill(T_ref, dim_vector_lgc), alpha = fill(alpha_G, dim_vector_lgc), useHeatPort = fill(useHeatPort, dim_vector_lgc), T = fill(T, dim_vector_lgc));
+      Modelica.Electrical.Analog.Basic.M_Transformer inductance(N = lines, L = Ll);
       Modelica.Electrical.Analog.Basic.Ground M;
-
     equation
       for j in 1:lines - 1 loop
-
         connect(R[j].p, p[j]);
         connect(R[j].n, inductance.p[j]);
         connect(inductance.n[j], n[j]);
-        connect(inductance.n[j], C[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)),
-          2))].p);
-        connect(C[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)), 2))].n, M.p);
-        connect(inductance.n[j], G[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)),
-          2))].p);
-        connect(G[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)), 2))].n, M.p);
-
+        connect(inductance.n[j], C[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2)].p);
+        connect(C[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2)].n, M.p);
+        connect(inductance.n[j], G[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2)].p);
+        connect(G[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2)].n, M.p);
         for i in j + 1:lines loop
-          connect(inductance.n[j], C[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)),
-            2)) + 1 + i - (j + 1)].p);
-          connect(C[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)), 2)) + 1 + i
-             - (j + 1)].n, inductance.n[i]);
-          connect(inductance.n[j], G[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)),
-            2)) + 1 + i - (j + 1)].p);
-          connect(G[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)), 2)) + 1 + i
-             - (j + 1)].n, inductance.n[i]);
-
+          connect(inductance.n[j], C[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2) + 1 + i - (j + 1)].p);
+          connect(C[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2) + 1 + i - (j + 1)].n, inductance.n[i]);
+          connect(inductance.n[j], G[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2) + 1 + i - (j + 1)].p);
+          connect(G[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2) + 1 + i - (j + 1)].n, inductance.n[i]);
         end for;
       end for;
       connect(R[lines].p, p[lines]);
@@ -268,132 +166,79 @@ package Lines
       connect(C[dim_vector_lgc].n, M.p);
       connect(inductance.n[lines], G[dim_vector_lgc].p);
       connect(G[dim_vector_lgc].n, M.p);
-
       if useHeatPort then
-
         for j in 1:lines - 1 loop
           connect(heatPort, R[j].heatPort);
-          connect(heatPort, G[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)), 2))].heatPort);
+          connect(heatPort, G[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2)].heatPort);
           for i in j + 1:lines loop
-            connect(heatPort, G[((1 + (j - 1)*lines) - div(((j - 2)*(j - 1)), 2))
-               + 1 + i - (j + 1)].heatPort);
+            connect(heatPort, G[1 + (j - 1) * lines - div((j - 2) * (j - 1), 2) + 1 + i - (j + 1)].heatPort);
           end for;
         end for;
         connect(heatPort, R[lines].heatPort);
         connect(heatPort, G[dim_vector_lgc].heatPort);
       end if;
-
-      annotation (defaultComponentName="segment", Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics={Rectangle(extent={{40,-40},{-40,40}},
-              lineColor={0,0,255}),
-            Text(
-              extent={{-150,90},{150,50}},
-              textString="%name",
-              textColor={0,0,255})}), Documentation(info="<html>
+      annotation(
+        defaultComponentName = "segment",
+        Icon(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}}), graphics = {Rectangle(extent = {{40, -40}, {-40, 40}}, lineColor = {0, 0, 255}), Text(extent = {{-150, 90}, {150, 50}}, textString = "%name", textColor = {0, 0, 255})}),
+        Documentation(info = "<html>
 <p>The segment model is part of the multiple line model. It describes one line segment as outlined in the M_OLine description. Using the loop possibilities of Modelica it is formulated by connecting components the number of which depends on the number of lines.</p>
 </html>"));
     end segment;
 
     model segment_last "Multiple line last segment model"
-
-      Modelica.Electrical.Analog.Interfaces.PositivePin p[lines] "Positive pin"
-        annotation (Placement(transformation(extent={{-110,-10},{-90,10}}), iconTransformation(extent={{-110,-10},{-90,10}})));
-      Modelica.Electrical.Analog.Interfaces.NegativePin n[lines] "Negative pin"
-        annotation (Placement(transformation(extent={{90,-10},{110,10}}), iconTransformation(extent={{90,-10},{110,10}})));
-      parameter Integer lines(final min=1) = 3 "Number of lines";
-      parameter Integer dim_vector_lgc=div(lines*(lines + 1), 2)
-        "Length of the vectors for l, g, c";
-      parameter Real Rl[lines]=fill(1, lines) "Resistance matrix";
-      parameter Real Ll[dim_vector_lgc]=fill(1, dim_vector_lgc)
-        "Inductance matrix";
-      parameter SI.LinearTemperatureCoefficient alpha_R
-        "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
-      parameter Boolean useHeatPort=false "= true, if HeatPort is enabled"
-        annotation (
-        Evaluate=true,
-        HideResult=true,
-        choices(checkBox=true));
-      parameter SI.Temperature T=293.15
-        "Fixed device temperature if useHeatPort = false"
-        annotation (Dialog(enable=not useHeatPort));
+      Modelica.Electrical.Analog.Interfaces.PositivePin p[lines] "Positive pin" annotation(
+        Placement(transformation(extent = {{-110, -10}, {-90, 10}}), iconTransformation(extent = {{-110, -10}, {-90, 10}})));
+      Modelica.Electrical.Analog.Interfaces.NegativePin n[lines] "Negative pin" annotation(
+        Placement(transformation(extent = {{90, -10}, {110, 10}}), iconTransformation(extent = {{90, -10}, {110, 10}})));
+      parameter Integer lines(final min = 1) = 3 "Number of lines";
+      parameter Integer dim_vector_lgc = div(lines * (lines + 1), 2) "Length of the vectors for l, g, c";
+      parameter Real Rl[lines] = fill(1, lines) "Resistance matrix";
+      parameter Real Ll[dim_vector_lgc] = fill(1, dim_vector_lgc) "Inductance matrix";
+      parameter SI.LinearTemperatureCoefficient alpha_R "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
+      parameter Boolean useHeatPort = false "= true, if HeatPort is enabled" annotation(
+        Evaluate = true,
+        HideResult = true,
+        choices(checkBox = true));
+      parameter SI.Temperature T = 293.15 "Fixed device temperature if useHeatPort = false" annotation(
+        Dialog(enable = not useHeatPort));
       parameter SI.Temperature T_ref;
-      Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if
-        useHeatPort annotation (Placement(transformation(extent={{-10,-110},{10,
-                -90}}), iconTransformation(extent={{-110,-110},{-90,-90}})));
-      Modelica.Electrical.Analog.Basic.Resistor R[lines](
-        R=Rl,
-        T_ref=fill(T_ref, lines),
-        useHeatPort=fill(useHeatPort, lines),
-        T=fill(T, lines));
-      Modelica.Electrical.Analog.Basic.M_Transformer inductance(N=lines, L=Ll);
+      Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort annotation(
+        Placement(transformation(extent = {{-10, -110}, {10, -90}}), iconTransformation(extent = {{-110, -110}, {-90, -90}})));
+      Modelica.Electrical.Analog.Basic.Resistor R[lines](R = Rl, T_ref = fill(T_ref, lines), useHeatPort = fill(useHeatPort, lines), T = fill(T, lines));
+      Modelica.Electrical.Analog.Basic.M_Transformer inductance(N = lines, L = Ll);
       Modelica.Electrical.Analog.Basic.Ground M;
-
     equation
       for j in 1:lines - 1 loop
-
         connect(p[j], inductance.p[j]);
         connect(inductance.n[j], R[j].p);
         connect(R[j].n, n[j]);
-
       end for;
       connect(p[lines], inductance.p[lines]);
       connect(inductance.n[lines], R[lines].p);
       connect(R[lines].n, n[lines]);
-
       if useHeatPort then
         for j in 1:lines - 1 loop
           connect(heatPort, R[j].heatPort);
         end for;
         connect(heatPort, R[lines].heatPort);
       end if;
-      annotation (defaultComponentName="segment", Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics={Rectangle(extent={{20,-40},{-20,40}},
-              lineColor={0,0,255}),
-            Text(
-              extent={{-150,90},{150,50}},
-              textString="%name",
-              textColor={0,0,255})}), Documentation(info="<html>
+      annotation(
+        defaultComponentName = "segment",
+        Icon(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}}), graphics = {Rectangle(extent = {{20, -40}, {-20, 40}}, lineColor = {0, 0, 255}), Text(extent = {{-150, 90}, {150, 50}}, textString = "%name", textColor = {0, 0, 255})}),
+        Documentation(info = "<html>
 <p>The segment_last model is part of the multiple line model. It describes the special  line segment which is used to get the line symmetrical as outlined in the M_OLine description. Using the loop possibilities of Modelica it is formulated by connecting components the number of which depends on the number of lines.</p>
 </html>"));
     end segment_last;
 
-    segment s[N - 1](
-      lines=fill(lines, N - 1),
-      dim_vector_lgc=fill(dim_vector_lgc, N - 1),
-      Rl=fill(r*length/N, N - 1),
-      Ll=fill(l*length/N, N - 1),
-      Cl=fill(c*length/N, N - 1),
-      Gl=fill(g*length/N, N - 1),
-      alpha_R=fill(alpha_R, N - 1),
-      alpha_G=fill(alpha_G, N - 1),
-      T_ref=fill(T_ref, N - 1),
-      useHeatPort=fill(useHeatPort, N - 1),
-      T=fill(T, N - 1));
-    segment s_first(
-      lines=lines,
-      dim_vector_lgc=dim_vector_lgc,
-      Rl=r*length/(2*N),
-      Cl=c*length/(N),
-      Ll=l*length/(2*N),
-      Gl=g*length/(N),
-      alpha_R=alpha_R,
-      alpha_G=alpha_G,
-      T_ref=T_ref,
-      useHeatPort=useHeatPort,
-      T=T);
-    segment_last s_last(
-      lines=lines,
-      Rl=r*length/(2*N),
-      Ll=l*length/(2*N),
-      alpha_R=alpha_R,
-      T_ref=T_ref,
-      useHeatPort=useHeatPort,
-      T=T);
-    Modelica.Electrical.Analog.Interfaces.PositivePin p[lines] "Positive pin"
-      annotation (Placement(transformation(extent={{-110,-60},{-90,60}})));
-    Modelica.Electrical.Analog.Interfaces.NegativePin n[lines] "Negative pin"
-      annotation (Placement(transformation(extent={{90,-60},{110,60}})));
-
+    segment s[N - 1](lines = fill(lines, N - 1), dim_vector_lgc = fill(dim_vector_lgc, N - 1), Rl = fill(r * length / N, N - 1), Ll = fill(l * length / N, N - 1), Cl = fill(c * length / N, N - 1), Gl = fill(g * length / N, N - 1), alpha_R = fill(alpha_R, N - 1), alpha_G = fill(alpha_G, N - 1), T_ref = fill(T_ref, N - 1), useHeatPort = fill(useHeatPort, N - 1), T = fill(T, N - 1));
+    segment s_first(lines = lines, dim_vector_lgc = dim_vector_lgc, Rl = r * length / (2 * N), Cl = c * length / N, Ll = l * length / (2 * N), Gl = g * length / N, alpha_R = alpha_R, alpha_G = alpha_G, T_ref = T_ref, useHeatPort = useHeatPort, T = T);
+    segment_last s_last(lines = lines, Rl = r * length / (2 * N), Ll = l * length / (2 * N), alpha_R = alpha_R, T_ref = T_ref, useHeatPort = useHeatPort, T = T);
+    Modelica.Electrical.Analog.Interfaces.PositivePin p[lines] "Positive pin" annotation(
+      Placement(transformation(extent = {{-110, -60}, {-90, 60}})));
+    Modelica.Electrical.Analog.Interfaces.NegativePin n[lines] "Negative pin" annotation(
+      Placement(transformation(extent = {{90, -60}, {110, 60}})));
+  protected
+    parameter Integer dim_vector_lgc = div(lines * (lines + 1), 2);
   equation
     connect(p, s_first.p);
     connect(s_first.n, s[1].p);
@@ -409,31 +254,10 @@ package Lines
       end for;
       connect(heatPort, s_last.heatPort);
     end if;
-
-    annotation (defaultComponentName="line", Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-              -100},{100,100}}), graphics={
-          Rectangle(
-            extent={{80,80},{-80,-80}},
-            lineColor={0,0,255},
-            fillPattern=FillPattern.Solid,
-            fillColor={255,255,255}),
-          Line(points={{40,60},{40,40}}),
-          Line(points={{40,50},{-40,50}}),
-          Line(points={{-40,60},{-40,40}}),
-          Line(points={{40,-40},{40,-60}}),
-          Line(points={{40,-50},{-40,-50}}),
-          Line(points={{-40,-40},{-40,-60}}),
-          Line(points={{40,30},{40,10}}),
-          Line(points={{40,20},{-40,20}}),
-          Line(points={{-40,30},{-40,10}}),
-          Line(
-            points={{0,6},{0,-34}},
-            color={0,0,255},
-            pattern=LinePattern.Dot),
-          Text(
-            extent={{-150,130},{150,90}},
-            textString="%name",
-            textColor={0,0,255})}), Documentation(info="<html>
+    annotation(
+      defaultComponentName = "line",
+      Icon(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}}), graphics = {Rectangle(extent = {{80, 80}, {-80, -80}}, lineColor = {0, 0, 255}, fillPattern = FillPattern.Solid, fillColor = {255, 255, 255}), Line(points = {{40, 60}, {40, 40}}), Line(points = {{40, 50}, {-40, 50}}), Line(points = {{-40, 60}, {-40, 40}}), Line(points = {{40, -40}, {40, -60}}), Line(points = {{40, -50}, {-40, -50}}), Line(points = {{-40, -40}, {-40, -60}}), Line(points = {{40, 30}, {40, 10}}), Line(points = {{40, 20}, {-40, 20}}), Line(points = {{-40, 30}, {-40, 10}}), Line(points = {{0, 6}, {0, -34}}, color = {0, 0, 255}, pattern = LinePattern.Dot), Text(extent = {{-150, 130}, {150, 90}}, textString = "%name", textColor = {0, 0, 255})}),
+      Documentation(info = "<html>
 <p>The M_OLine is a multi line model which consists of several segments and several single lines. Each segment consists of resistors and inductors that are connected in series in each single line, and of capacitors and conductors both between the lines and to the ground. The inductors are coupled to each other like in the M_Transformer model. The following picture shows the schematic of a segment with four single lines (lines=4):</p>
 
 <blockquote>
@@ -479,7 +303,7 @@ package Lines
 </blockquote>
 
 <p>The user has the possibility to enable a conditional heatport. If so, the M_OLine can be connected to a thermal network. When the parameter alpha is set to a value greater than zero, the M_OLine becomes temperature sensitive due to their resistors which resistances are calculated by R_actual = R*(1 + alpha*(heatPort.T - T_ref)) and conductors calculated by (G_actual = G/(1 + alpha*(heatPort.T - T_ref)).</p>
-</html>", revisions="<html>
+</html>", revisions = "<html>
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
     <tr>
       <th>Version</th>
@@ -515,52 +339,34 @@ package Lines
 
   model ULine "Lossy RC Line"
     //extends Interfaces.ThreePol;
-    Modelica.Electrical.Analog.Interfaces.Pin p1 annotation (Placement(
-          transformation(extent={{-110,-10},{-90,10}})));
-    Modelica.Electrical.Analog.Interfaces.Pin p2 annotation (Placement(
-          transformation(extent={{90,-10},{110,10}})));
-    Modelica.Electrical.Analog.Interfaces.Pin p3 annotation (Placement(
-          transformation(extent={{-10,-110},{10,-90}}),
-          iconTransformation(extent={{-10,-110},{10,-90}})));
+    Modelica.Electrical.Analog.Interfaces.Pin p1 annotation(
+      Placement(transformation(extent = {{-110, -10}, {-90, 10}})));
+    Modelica.Electrical.Analog.Interfaces.Pin p2 annotation(
+      Placement(transformation(extent = {{90, -10}, {110, 10}})));
+    Modelica.Electrical.Analog.Interfaces.Pin p3 annotation(
+      Placement(transformation(extent = {{-10, -110}, {10, -90}}), iconTransformation(extent = {{-10, -110}, {10, -90}})));
     SI.Voltage v13;
     SI.Voltage v23;
     SI.Current i1;
     SI.Current i2;
-    parameter Real r(
-      final min=Modelica.Constants.small,
-      unit="Ohm/m",
-      start=1) "Resistance per meter";
-    parameter Real c(
-      final min=Modelica.Constants.small,
-      unit="F/m",
-      start=1) "Capacitance per meter";
-    parameter SI.Length length(final min=Modelica.Constants.small,
-        start=1) "Length of line";
-    parameter Integer N(final min=1, start=1) "Number of lumped segments";
-    parameter SI.LinearTemperatureCoefficient alpha=0
-      "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
-    parameter Boolean useHeatPort=false "= true, if heatPort is enabled"
-      annotation (
-      Evaluate=true,
-      HideResult=true,
-      choices(checkBox=true));
-    parameter SI.Temperature T=293.15
-      "Fixed device temperature if useHeatPort = false"
-      annotation (Dialog(enable=not useHeatPort));
-    parameter SI.Temperature T_ref=300.15 "Reference temperature";
-    Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort
-      annotation (Placement(transformation(extent={{-10,-110},{10,-90}}),
-          iconTransformation(extent={{-108,-110},{-88,-90}})));
+    parameter Real r(final min = Modelica.Constants.small, unit = "Ohm/m", start = 1) "Resistance per meter";
+    parameter Real c(final min = Modelica.Constants.small, unit = "F/m", start = 1) "Capacitance per meter";
+    parameter SI.Length length(final min = Modelica.Constants.small, start = 1) "Length of line";
+    parameter Integer N(final min = 1, start = 1) "Number of lumped segments";
+    parameter SI.LinearTemperatureCoefficient alpha = 0 "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
+    parameter Boolean useHeatPort = false "= true, if heatPort is enabled" annotation(
+      Evaluate = true,
+      HideResult = true,
+      choices(checkBox = true));
+    parameter SI.Temperature T = 293.15 "Fixed device temperature if useHeatPort = false" annotation(
+      Dialog(enable = not useHeatPort));
+    parameter SI.Temperature T_ref = 300.15 "Reference temperature";
+    Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort annotation(
+      Placement(transformation(extent = {{-10, -110}, {10, -90}}), iconTransformation(extent = {{-108, -110}, {-88, -90}})));
   protected
-     parameter Modelica.SIunits.Resistance rm[N + 1]=
-    {if i==1 or i==N + 1 then r*length/(N*2) else r*length/N for i in 1:N+1};
-    Modelica.Electrical.Analog.Basic.Resistor R[N + 1](
-      R=rm,
-      T_ref=fill(T_ref, N + 1),
-      alpha=fill(alpha, N + 1),
-      useHeatPort=fill(useHeatPort, N + 1),
-      T=fill(T, N + 1));
-    Modelica.Electrical.Analog.Basic.Capacitor C[N](C=fill(c*length/(N), N));
+    parameter Modelica.SIunits.Resistance rm[N + 1] = {if i == 1 or i == N + 1 then r * length / (N * 2) else r * length / N for i in 1:N + 1};
+    Modelica.Electrical.Analog.Basic.Resistor R[N + 1](R = rm, T_ref = fill(T_ref, N + 1), alpha = fill(alpha, N + 1), useHeatPort = fill(useHeatPort, N + 1), T = fill(T, N + 1));
+    Modelica.Electrical.Analog.Basic.Capacitor C[N](C = fill(c * length / N, N));
   equation
     v13 = p1.v - p3.v;
     v23 = p2.v - p3.v;
@@ -582,8 +388,9 @@ package Lines
         connect(heatPort, R[i].heatPort);
       end for;
     end if;
-    annotation (defaultComponentName="line",
-      Documentation(info="<html>
+    annotation(
+      defaultComponentName = "line",
+      Documentation(info = "<html>
 <p>As can be seen in the picture below, the lossy RC line ULine is a single conductor lossy transmission line which consists of segments of lumped series resistors and capacitors that are connected with the reference pin p3. The precision of the model depends on the number N of lumped segments.
 <br>To get a symmetric line model, the first resistor is cut into two parts (R1 and R_Nplus1). These two new resistors have the half of the resistance of the original resistor.
 </p>
@@ -598,7 +405,7 @@ The capacitances are calculated with: C=c*length/N.
 <p>due to their resistors which resistances are calculated by <code>R_actual= R*(1 + alpha*(heatPort.T - T_ref)).</code></p>
 <p>Note, this is different compared with the lumped line model of SPICE.</p>
 <p><strong>References:</strong> [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Johnson1991</a>]</p>
-</html>",      revisions="<html>
+</html>", revisions = "<html>
 <dl>
 <dt><em>2016</em></dt>
 <dd>by Christoph Clauss resistance calculation revised</dd>
@@ -606,228 +413,124 @@ The capacitances are calculated with: C=c*length/N.
 <dd>by Christoph Clauss initially implemented</dd>
 </dl>
 </html>"),
-      Icon(coordinateSystem(
-          preserveAspectRatio=true,
-          extent={{-100,-100},{100,100}}), graphics={
-          Text(
-            extent={{-150,130},{150,90}},
-            textString="%name",
-            textColor={0,0,255}),
-          Rectangle(
-            extent={{-80,80},{80,-80}},
-            lineColor={0,0,255},
-            fillPattern=FillPattern.Solid,
-            fillColor={255,255,255}),
-          Line(points={{80,0},{100,0}}, color={0,0,255}),
-          Line(points={{-80,0},{-100,0}}, color={0,0,255}),
-          Line(points={{-40,40},{-40,20}}),
-          Line(points={{40,30},{-40,30}}),
-          Line(points={{40,40},{40,20}}),
-          Line(points={{0,-80},{0,-100}}, color={0,0,255}),
-          Text(
-            extent={{-70,-10},{70,-50}},
-            textString="ULine")}));
+      Icon(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Text(extent = {{-150, 130}, {150, 90}}, textString = "%name", textColor = {0, 0, 255}), Rectangle(extent = {{-80, 80}, {80, -80}}, lineColor = {0, 0, 255}, fillPattern = FillPattern.Solid, fillColor = {255, 255, 255}), Line(points = {{80, 0}, {100, 0}}, color = {0, 0, 255}), Line(points = {{-80, 0}, {-100, 0}}, color = {0, 0, 255}), Line(points = {{-40, 40}, {-40, 20}}), Line(points = {{40, 30}, {-40, 30}}), Line(points = {{40, 40}, {40, 20}}), Line(points = {{0, -80}, {0, -100}}, color = {0, 0, 255}), Text(extent = {{-70, -10}, {70, -50}}, textString = "ULine")}));
   end ULine;
 
-  model TLine1
-    "Lossless transmission line with characteristic impedance Z0 and transmission delay TD"
-
+  model TLine1 "Lossless transmission line with characteristic impedance Z0 and transmission delay TD"
     extends Modelica.Electrical.Analog.Interfaces.TwoPort;
-    parameter SI.Resistance Z0(start=1)
-      "Characteristic impedance";
-    parameter SI.Time TD(start=1) "Transmission delay";
+    parameter SI.Resistance Z0(start = 1) "Characteristic impedance";
+    parameter SI.Time TD(start = 1) "Transmission delay";
   protected
     SI.Voltage er;
     SI.Voltage es;
-  equation
+  initial equation
     assert(Z0 > 0, "Z0 has to be positive");
     assert(TD > 0, "TD has to be positive");
-    i1 = (v1 - es)/Z0;
-    i2 = (v2 - er)/Z0;
-    es = 2*delay(v2, TD) - delay(er, TD);
-    er = 2*delay(v1, TD) - delay(es, TD);
-    annotation (defaultComponentName="line",
-      Documentation(info="<html>
+  equation
+    i1 = (v1 - es) / Z0;
+    i2 = (v2 - er) / Z0;
+    es = 2 * delay(v2, TD) - delay(er, TD);
+    er = 2 * delay(v1, TD) - delay(es, TD);
+    annotation(
+      defaultComponentName = "line",
+      Documentation(info = "<html>
 <p>Lossless transmission line with characteristic impedance Z0 and transmission delay TD The lossless transmission line TLine1 is a two Port. Both port branches consist of a resistor with characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay TD. For further details see [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>]. The model parameters can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;) and TD = sqrt(L&#39;*C&#39;)*length_of_line. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero.</p>
 
 <p><strong>References:</strong> 
    [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>],
    [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Hoefer1985</a>]</p>
-</html>",      revisions="<html>
-<ul>
+</html>", revisions = "<html><head></head><body><ul>
 <li><em> 1998   </em>
-       by Joachim Haase<br> initially implemented<br>
-       </li>
+       by Joachim Haase<br> initially implemented<br></li>
+  <li><em> November 12, 2019 </em> 
+       by Atiyah Elsheikh, Mathemodica.com<br> assert of parameter values being positive moved to an initial equation section<br> 
+  </li>
 </ul>
-</html>"),
-      Icon(coordinateSystem(
-          preserveAspectRatio=true,
-          extent={{-100,-100},{100,100}}), graphics={
-          Text(
-            extent={{-150,150},{150,110}},
-            textString="%name",
-            textColor={0,0,255}),
-          Rectangle(
-            extent={{-80,80},{80,-80}},
-            lineColor={0,0,255},
-            fillPattern=FillPattern.Solid,
-            fillColor={255,255,255}),
-          Line(points={{60,-100},{90,-100}}, color={0,0,255}),
-          Line(points={{60,100},{90,100}}, color={0,0,255}),
-          Line(points={{-60,100},{-90,100}}, color={0,0,255}),
-          Line(points={{-60,-100},{-90,-100}}, color={0,0,255}),
-          Text(
-            extent={{-70,-10},{70,-50}},
-            textString="TLine1"),
-          Line(points={{-40,40},{-40,20}}),
-          Line(points={{40,30},{-40,30}}),
-          Line(points={{40,40},{40,20}}),
-          Line(points={{-60,100},{-60,80}}, color={0,0,255}),
-          Line(points={{60,100},{60,80}}, color={0,0,255}),
-          Line(points={{60,-80},{60,-100}}, color={0,0,255}),
-          Line(points={{-60,-80},{-60,-100}}, color={0,0,255})}),
-      Diagram(coordinateSystem(
-          preserveAspectRatio=true,
-          extent={{-100,-100},{100,100}}),graphics={
-                                      Text(
-              extent={{-100,100},{100,70}},
-              textString="TLine1",
-              textColor={0,0,255})}));
+</body></html>"),
+      Icon(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Text(extent = {{-150, 150}, {150, 110}}, textString = "%name", textColor = {0, 0, 255}), Rectangle(extent = {{-80, 80}, {80, -80}}, lineColor = {0, 0, 255}, fillPattern = FillPattern.Solid, fillColor = {255, 255, 255}), Line(points = {{60, -100}, {90, -100}}, color = {0, 0, 255}), Line(points = {{60, 100}, {90, 100}}, color = {0, 0, 255}), Line(points = {{-60, 100}, {-90, 100}}, color = {0, 0, 255}), Line(points = {{-60, -100}, {-90, -100}}, color = {0, 0, 255}), Text(extent = {{-70, -10}, {70, -50}}, textString = "TLine1"), Line(points = {{-40, 40}, {-40, 20}}), Line(points = {{40, 30}, {-40, 30}}), Line(points = {{40, 40}, {40, 20}}), Line(points = {{-60, 100}, {-60, 80}}, color = {0, 0, 255}), Line(points = {{60, 100}, {60, 80}}, color = {0, 0, 255}), Line(points = {{60, -80}, {60, -100}}, color = {0, 0, 255}), Line(points = {{-60, -80}, {-60, -100}}, color = {0, 0, 255})}),
+      Diagram(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Text(extent = {{-100, 100}, {100, 70}}, textString = "TLine1", textColor = {0, 0, 255})}));
   end TLine1;
 
-  model TLine2
-    "Lossless transmission line with characteristic impedance Z0, frequency F and normalized length NL"
-
+  model TLine2 "Lossless transmission line with characteristic impedance Z0, frequency F and normalized length NL"
     extends Modelica.Electrical.Analog.Interfaces.TwoPort;
-    parameter SI.Resistance Z0(start=1)
-      "Characteristic impedance";
-    parameter SI.Frequency F(start=1) "Frequency";
-    parameter Real NL(start=1) "Normalized length";
+    parameter SI.Resistance Z0(start = 1) "Characteristic impedance";
+    parameter SI.Frequency F(start = 1) "Frequency";
+    parameter Real NL(start = 1) "Normalized length";
   protected
     SI.Voltage er;
     SI.Voltage es;
-    parameter SI.Time TD=NL/F;
-  equation
+    parameter SI.Time TD = NL / F;
+  initial equation
     assert(Z0 > 0, "Z0 has to be positive");
     assert(NL > 0, "NL has to be positive");
     assert(F > 0, "F has to be positive");
-    i1 = (v1 - es)/Z0;
-    i2 = (v2 - er)/Z0;
-    es = 2*delay(v2, TD) - delay(er, TD);
-    er = 2*delay(v1, TD) - delay(es, TD);
-    annotation (defaultComponentName="line",
-      Documentation(info="<html>
+  equation
+    i1 = (v1 - es) / Z0;
+    i2 = (v2 - er) / Z0;
+    es = 2 * delay(v2, TD) - delay(er, TD);
+    er = 2 * delay(v1, TD) - delay(es, TD);
+    annotation(
+      defaultComponentName = "line",
+      Documentation(info = "<html>
 <p>Lossless transmission line with characteristic impedance Z0, frequency F and normalized length NL The lossless transmission line TLine2 is a two Port. Both port branches consist of a resistor with the value of the characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay. For further details see [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>]. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero. The characteristic impedance Z0 can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;). The normalized length NL is equal to the length of the line divided by the wavelength corresponding to the frequency F, i. e. the transmission delay TD is the quotient of NL and F.</p>
 <p><strong>References:</strong> 
    [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>],
    [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Hoefer1985</a>]</p>
-</html>",      revisions="<html>
-<dl>
-<dt><em>1998</em></dt>
-<dd>by Joachim Haase initially implemented</dd>
-</dl>
+</html>", revisions = "<html>
+  <ul>
+<li>
+<em>1998</em>
+by Joachim Haase <br>initially implemented</br>
+</li>
+  <li><em> November 12, 2019 </em> 
+       by Atiyah Elsheikh, Mathemodica.com<br> assert of parameter values being positive moved to an initial equation section<br> 
+  </li>
+  </ul>
 </html>"),
-      Icon(coordinateSystem(
-          preserveAspectRatio=true,
-          extent={{-100,-100},{100,100}}), graphics={
-          Text(
-            extent={{-150,150},{150,110}},
-            textString="%name",
-            textColor={0,0,255}),
-          Rectangle(
-            extent={{-80,80},{80,-80}},
-            lineColor={0,0,255},
-            fillPattern=FillPattern.Solid,
-            fillColor={255,255,255}),
-          Line(points={{60,-100},{90,-100}}, color={0,0,255}),
-          Line(points={{60,100},{90,100}}, color={0,0,255}),
-          Line(points={{-60,100},{-90,100}}, color={0,0,255}),
-          Line(points={{-60,-100},{-90,-100}}, color={0,0,255}),
-          Text(
-            extent={{-70,-10},{70,-50}},
-            textString="TLine2"),
-          Line(points={{-40,40},{-40,20}}),
-          Line(points={{40,30},{-40,30}}),
-          Line(points={{40,40},{40,20}}),
-          Line(points={{-60,100},{-60,80}}, color={0,0,255}),
-          Line(points={{60,100},{60,80}}, color={0,0,255}),
-          Line(points={{60,-80},{60,-100}}, color={0,0,255}),
-          Line(points={{-60,-80},{-60,-100}}, color={0,0,255})}),
-      Diagram(coordinateSystem(
-          preserveAspectRatio=true,
-          extent={{-100,-100},{100,100}}), graphics={
-                                           Text(
-              extent={{-100,100},{100,70}},
-              textString="TLine2",
-              textColor={0,0,255})}));
+      Icon(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Text(extent = {{-150, 150}, {150, 110}}, textString = "%name", textColor = {0, 0, 255}), Rectangle(extent = {{-80, 80}, {80, -80}}, lineColor = {0, 0, 255}, fillPattern = FillPattern.Solid, fillColor = {255, 255, 255}), Line(points = {{60, -100}, {90, -100}}, color = {0, 0, 255}), Line(points = {{60, 100}, {90, 100}}, color = {0, 0, 255}), Line(points = {{-60, 100}, {-90, 100}}, color = {0, 0, 255}), Line(points = {{-60, -100}, {-90, -100}}, color = {0, 0, 255}), Text(extent = {{-70, -10}, {70, -50}}, textString = "TLine2"), Line(points = {{-40, 40}, {-40, 20}}), Line(points = {{40, 30}, {-40, 30}}), Line(points = {{40, 40}, {40, 20}}), Line(points = {{-60, 100}, {-60, 80}}, color = {0, 0, 255}), Line(points = {{60, 100}, {60, 80}}, color = {0, 0, 255}), Line(points = {{60, -80}, {60, -100}}, color = {0, 0, 255}), Line(points = {{-60, -80}, {-60, -100}}, color = {0, 0, 255})}),
+      Diagram(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Text(extent = {{-100, 100}, {100, 70}}, textString = "TLine2", textColor = {0, 0, 255})}));
   end TLine2;
 
-  model TLine3
-    "Lossless transmission line with characteristic impedance Z0 and frequency F"
+  model TLine3 "Lossless transmission line with characteristic impedance Z0 and frequency F"
     extends Modelica.Electrical.Analog.Interfaces.TwoPort;
-    parameter SI.Resistance Z0(start=1) "Natural impedance";
-    parameter SI.Frequency F(start=1) "Frequency";
+    parameter SI.Resistance Z0(start = 1) "Natural impedance";
+    parameter SI.Frequency F(start = 1) "Frequency";
   protected
     SI.Voltage er;
     SI.Voltage es;
-    parameter SI.Time TD=1/F/4;
-  equation
+    parameter SI.Time TD = 1 / F / 4;
+  initial equation
     assert(Z0 > 0, "Z0 has to be positive");
     assert(F > 0, "F has to be positive");
-    i1 = (v1 - es)/Z0;
-    i2 = (v2 - er)/Z0;
-    es = 2*delay(v2, TD) - delay(er, TD);
-    er = 2*delay(v1, TD) - delay(es, TD);
-    annotation (defaultComponentName="line",
-      Documentation(info="<html>
+  equation
+    i1 = (v1 - es) / Z0;
+    i2 = (v2 - er) / Z0;
+    es = 2 * delay(v2, TD) - delay(er, TD);
+    er = 2 * delay(v1, TD) - delay(es, TD);
+    annotation(
+      defaultComponentName = "line",
+      Documentation(info = "<html>
 <p>Lossless transmission line with characteristic impedance Z0 and frequency F The lossless transmission line TLine3 is a two Port. Both port branches consist of a resistor with value of the characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay. For further details see [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>]. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero. The characteristic impedance Z0 can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;). The length of the line is equal to a quarter of the wavelength corresponding to the frequency F, i. e. the transmission delay is the quotient of 4 and F. In this case, the characteristic impedance is called natural impedance.</p>
 <p><strong>References:</strong> 
    [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>],
    [<a href=\"Modelica.Electrical.Analog.UsersGuide.References\">Hoefer1985</a>]</p>
-</html>",      revisions="<html>
+</html>", revisions = "<html>
 <ul>
 <li><em> 1998   </em>
        by Joachim Haase<br> initially implemented<br>
-       </li>
+  </li>
+  <li><em> November 12, 2019 </em> 
+       by Atiyah Elsheikh, Mathemodica.com<br> assert of parameter values being positive moved to an initial equation section<br> 
+  </li>
 </ul>
 </html>"),
-      Icon(coordinateSystem(
-          preserveAspectRatio=true,
-          extent={{-100,-100},{100,100}}), graphics={
-          Rectangle(
-            extent={{-80,80},{80,-80}},
-            lineColor={0,0,255},
-            fillPattern=FillPattern.Solid,
-            fillColor={255,255,255}),
-          Line(points={{60,-100},{90,-100}}, color={0,0,255}),
-          Line(points={{60,100},{90,100}}, color={0,0,255}),
-          Line(points={{-60,100},{-90,100}}, color={0,0,255}),
-          Line(points={{-60,-100},{-90,-100}}, color={0,0,255}),
-          Text(
-            extent={{-70,-10},{70,-50}},
-            textString="TLine3"),
-          Text(
-            extent={{-150,150},{150,110}},
-            textString="%name",
-            textColor={0,0,255}),
-          Line(points={{-40,40},{-40,20}}),
-          Line(points={{40,30},{-40,30}}),
-          Line(points={{40,40},{40,20}}),
-          Line(points={{-60,100},{-60,80}}, color={0,0,255}),
-          Line(points={{60,100},{60,80}}, color={0,0,255}),
-          Line(points={{60,-80},{60,-100}}, color={0,0,255}),
-          Line(points={{-60,-80},{-60,-100}}, color={0,0,255})}),
-      Diagram(coordinateSystem(
-          preserveAspectRatio=true,
-          extent={{-100,-100},{100,100}}), graphics={
-                                           Text(
-              extent={{-100,100},{100,70}},
-              textString="TLine3",
-              textColor={0,0,255})}));
+      Icon(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Rectangle(extent = {{-80, 80}, {80, -80}}, lineColor = {0, 0, 255}, fillPattern = FillPattern.Solid, fillColor = {255, 255, 255}), Line(points = {{60, -100}, {90, -100}}, color = {0, 0, 255}), Line(points = {{60, 100}, {90, 100}}, color = {0, 0, 255}), Line(points = {{-60, 100}, {-90, 100}}, color = {0, 0, 255}), Line(points = {{-60, -100}, {-90, -100}}, color = {0, 0, 255}), Text(extent = {{-70, -10}, {70, -50}}, textString = "TLine3"), Text(extent = {{-150, 150}, {150, 110}}, textString = "%name", textColor = {0, 0, 255}), Line(points = {{-40, 40}, {-40, 20}}), Line(points = {{40, 30}, {-40, 30}}), Line(points = {{40, 40}, {40, 20}}), Line(points = {{-60, 100}, {-60, 80}}, color = {0, 0, 255}), Line(points = {{60, 100}, {60, 80}}, color = {0, 0, 255}), Line(points = {{60, -80}, {60, -100}}, color = {0, 0, 255}), Line(points = {{-60, -80}, {-60, -100}}, color = {0, 0, 255})}),
+      Diagram(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Text(extent = {{-100, 100}, {100, 70}}, textString = "TLine3", textColor = {0, 0, 255})}));
   end TLine3;
-  annotation (Documentation(info="<html>
+  annotation(
+    Documentation(info = "<html>
 <p>This package contains lossy and lossless segmented transmission lines, and LC distributed line models. The line models do not yet possess a conditional heating port.</p>
-</html>", revisions="<html>
+</html>", revisions = "<html>
 <dl>
 <dt>
 <strong>Main Authors:</strong>
@@ -849,14 +552,6 @@ Christoph Clau&szlig;
 <p>
 Copyright &copy; 1998-2019, Modelica Association and contributors
 </p>
-</html>"), Icon(graphics={
-        Line(points={{-60,50},{-90,50}}),
-        Rectangle(
-          extent={{-60,60},{60,-60}}),
-        Line(points={{-60,-50},{-90,-50}}),
-        Line(points={{36,20},{-36,20}}),
-        Line(points={{-36,40},{-36,0}}),
-        Line(points={{36,40},{36,0}}),
-        Line(points={{60,50},{90,50}}),
-        Line(points={{60,-50},{90,-50}})}));
+</html>"),
+    Icon(graphics = {Line(points = {{-60, 50}, {-90, 50}}), Rectangle(extent = {{-60, 60}, {60, -60}}), Line(points = {{-60, -50}, {-90, -50}}), Line(points = {{36, 20}, {-36, 20}}), Line(points = {{-36, 40}, {-36, 0}}), Line(points = {{36, 40}, {36, 0}}), Line(points = {{60, 50}, {90, 50}}), Line(points = {{60, -50}, {90, -50}})}));
 end Lines;


### PR DESCRIPTION
Asserting whether a parameter value is positive was done within equation section. I think it makes more sense to conduct this assertion within an initial equation section. In this way, the specification of the models declares that the assertion is conducted only once. 
 
I noticed also similar cases across the library. I can change them if this pull-request get accepted. 
