### PR TITLE
Fix misleading Greek symbols in documentation

### DIFF
--- a/Modelica/Fluid/Fittings.mo
+++ b/Modelica/Fluid/Fittings.mo
@@ -902,7 +902,7 @@ the approximation for Re &lt; 560/&Delta; is too bad.
 </p>
 
 <p>
-The absolute roughness <font face=\"Symbol\">d</font> has usually to
+The absolute roughness &delta; has usually to
 be estimated. In <em>[Idelchik 1994, pp. 105-109,
 Table 2-5; Miller 1990, p. 190, Table 8-1]</em> many examples are given.
 As a short summary:
@@ -910,27 +910,27 @@ As a short summary:
 <table border=1 cellspacing=0 cellpadding=2>
   <tr><td><strong>Smooth pipes</strong></td>
       <td>Drawn brass, copper, aluminium, glass, etc.</td>
-      <td><font face=\"Symbol\">d</font> = 0.0025 mm</td>
+      <td>&delta; = 0.0025 mm</td>
   </tr>
   <tr><td rowspan=\"3\"><strong>Steel pipes</strong></td>
       <td>New smooth pipes</td>
-      <td><font face=\"Symbol\">d</font> = 0.025 mm</td>
+      <td>&delta; = 0.025 mm</td>
   </tr>
   <tr><td>Mortar lined, average finish</td>
-      <td><font face=\"Symbol\">d</font> = 0.1 mm</td>
+      <td>&delta; = 0.1 mm</td>
   </tr>
   <tr><td>Heavy rust</td>
-      <td><font face=\"Symbol\">d</font> = 1 mm</td>
+      <td>&delta; = 1 mm</td>
   </tr>
   <tr><td rowspan=\"3\"><strong>Concrete pipes</strong></td>
       <td>Steel forms, first class workmanship</td>
-      <td><font face=\"Symbol\">d</font> = 0.025 mm</td>
+      <td>&delta; = 0.025 mm</td>
   </tr>
   <tr><td>Steel forms, average workmanship</td>
-      <td><font face=\"Symbol\">d</font> = 0.1 mm</td>
+      <td>&delta; = 0.1 mm</td>
   </tr>
   <tr><td>Block linings</td>
-      <td><font face=\"Symbol\">d</font> = 1 mm</td>
+      <td>&delta; = 1 mm</td>
   </tr>
 </table>
 </html>"));

--- a/Modelica/Fluid/Pipes.mo
+++ b/Modelica/Fluid/Pipes.mo
@@ -1278,7 +1278,7 @@ Basically, different variants of the equation
 </p>
 
 <pre>
-   dp = &lambda;(Re,<font face=\"Symbol\">D</font>)*(L/D)*&rho;*v*|v|/2.
+   dp = &lambda;(Re,&Delta;)*(L/D)*&rho;*v*|v|/2.
 </pre>
 
 <p>
@@ -3474,7 +3474,7 @@ Basically, different variants of the equation
 </p>
 
 <pre>
-   dp = &lambda;(Re,<font face=\"Symbol\">D</font>)*(L/D)*&rho;*v*|v|/2
+   dp = &lambda;(Re,&Delta;)*(L/D)*&rho;*v*|v|/2
 </pre>
 
 <p>
@@ -3536,7 +3536,7 @@ Basically, different variants of the equation
 </p>
 
 <pre>
-   dp = &lambda;(Re,<font face=\"Symbol\">D</font>)*(L/D)*&rho;*v*|v|/2
+   dp = &lambda;(Re,&Delta;)*(L/D)*&rho;*v*|v|/2
 </pre>
 
 <p>

--- a/Modelica/Fluid/package.mo
+++ b/Modelica/Fluid/package.mo
@@ -640,9 +640,9 @@ For pipes with circular cross section the pressure drop is computed as:
 </p>
 
 <pre>
-   dp = &lambda;(Re,<font face=\"Symbol\">D</font>)*(L/D)*&rho;*v*|v|/2
-      = &lambda;(Re,<font face=\"Symbol\">D</font>)*8*L/(&pi;^2*D^5*&rho;)*m_flow*|m_flow|
-      = &lambda;2(Re,<font face=\"Symbol\">D</font>)*k2*sign(m_flow);
+   dp = &lambda;(Re,&Delta;)*(L/D)*&rho;*v*|v|/2
+      = &lambda;(Re,&Delta;)*8*L/(&pi;^2*D^5*&rho;)*m_flow*|m_flow|
+      = &lambda;2(Re,&Delta;)*k2*sign(m_flow);
 
 with
    Re     = |v|*D*&rho;/&mu;
@@ -661,14 +661,14 @@ where
 <li> D is the diameter of the pipe. If the pipe has not a
      circular cross section, D = 4*A/P, where A is the cross section
      area and P is the wetted perimeter.</li>
-<li> &lambda; = &lambda;(Re,<font face=\"Symbol\">D</font>) is the \"usual\" wall friction coefficient.</li>
+<li> &lambda; = &lambda;(Re,&Delta;) is the \"usual\" wall friction coefficient.</li>
 <li> &lambda;2 = &lambda;*Re^2 is the used friction coefficient to get a numerically
      well-posed formulation.</li>
 <li> Re = |v|*D*&rho;/&mu; is the Reynolds number.</li>
-<li> <font face=\"Symbol\">D</font> = <font face=\"Symbol\">d</font>/D is the relative roughness where
-     \"<font face=\"Symbol\">d</font>\" is
+<li> &Delta; = &delta;/D is the relative roughness where
+     \"&delta;\" is
      the absolute \"roughness\", i.e., the averaged height of asperities in the pipe
-     (<font face=\"Symbol\">d</font> may change over time due to growth of surface asperities during
+     (&delta; may change over time due to growth of surface asperities during
       service, see <em>[Idelchik 1994, p. 85, Tables 2-1, 2-2])</em>.</li>
 <li> &rho; is the upstream density.</li>
 <li> &mu; is the upstream dynamic viscosity.</li>
@@ -719,10 +719,10 @@ The pressure loss characteristic is divided into three regions:
      is assumed to be known, &lambda;2 = |dp|/k2. The
      Colebrook-White equation
      <em>[Colebrook 1939; Idelchik 1994, p. 83, eq. (2-9)]</em>:
-     <pre>1/sqrt(&lambda;) = -2*lg( 2.51/(Re*sqrt(&lambda;)) + 0.27*<font face=\"Symbol\">D</font>) </pre>
+     <pre>1/sqrt(&lambda;) = -2*lg( 2.51/(Re*sqrt(&lambda;)) + 0.27*&Delta;) </pre>
      gives an implicit relationship between Re and &lambda;.
      Inserting &lambda;2 = &lambda;*Re^2 allows to solve this equation analytically
-     for Re: <pre>Re = -2*sqrt(&lambda;2)*lg(2.51/sqrt(&lambda;2) + 0.27*<font face=\"Symbol\">D</font>)</pre>
+     for Re: <pre>Re = -2*sqrt(&lambda;2)*lg(2.51/sqrt(&lambda;2) + 0.27*&Delta;)</pre>
      Finally, the mass flow rate m_flow is computed from Re via
      m_flow = Re*&pi;*D*&mu;/4*sign(dp).
      These are the <strong>red</strong> curves in the diagrams above.<br>
@@ -731,7 +731,7 @@ The pressure loss characteristic is divided into three regions:
      approximation of the inverse of the Colebrook-White equation
      <em>[Swamee and Jain 1976;
      Miller 1990, p. 191, eq.(8.4)]</em> adapted to &lambda;2:
-     <pre> &lambda;2 = 0.25*(Re/lg(<font face=\"Symbol\">D</font>/3.7 + 5.74/Re^0.9))^2 </pre>
+     <pre> &lambda;2 = 0.25*(Re/lg(&Delta;/3.7 + 5.74/Re^0.9))^2 </pre>
      The pressure drop is then computed as dp = k2*&lambda;2*sign(m_flow).
      These are the <strong>blue</strong> curves in the diagrams above.<br>&nbsp;</li>
 
@@ -744,9 +744,9 @@ The pressure loss characteristic is divided into three regions:
      relative roughness. A laminar flow at Re=2000 is only reached for smooth pipes.
      The deviation Reynolds number Re1 is computed according to
      <em>[Samoilenko 1968; Idelchik 1994, p. 81, sect. 2.1.21]</em> as:
-     <pre>Re1 = 745*e^(if <font face=\"Symbol\">D</font> &le; 0.0065 then 1 else 0.0065/<font face=\"Symbol\">D</font>)</pre>
+     <pre>Re1 = 745*e^(if &Delta; &le; 0.0065 then 1 else 0.0065/&Delta;)</pre>
      These are the <strong>blue</strong> curves in the diagrams above.<br>
-     Between Re1=Re1(<font face=\"Symbol\">d</font>/D) and Re2=4000,
+     Between Re1=Re1(&delta;/D) and Re2=4000,
      &lambda;2 is approximated by a cubic
      polynomial in the \"lg(&lambda;2) - lg(Re)\" chart (see figures above) such that the
      first derivative is continuous at these two points. In order to avoid
@@ -759,7 +759,7 @@ The pressure loss characteristic is divided into three regions:
      not in this region.</li>
 </ul>
 <p>
-The absolute roughness <font face=\"Symbol\">d</font> has usually to
+The absolute roughness &delta; has usually to
 be estimated. In <em>[Idelchik 1994, pp. 105-109,
 Table 2-5; Miller 1990, p. 190, Table 8-1]</em> many examples are given.
 As a short summary:
@@ -767,27 +767,27 @@ As a short summary:
 <table border=1 cellspacing=0 cellpadding=2>
   <tr><td><strong>Smooth pipes</strong></td>
       <td>Drawn brass, copper, aluminium, glass, etc.</td>
-      <td><font face=\"Symbol\">d</font> = 0.0025 mm</td>
+      <td>&delta; = 0.0025 mm</td>
   </tr>
   <tr><td rowspan=\"3\"><strong>Steel pipes</strong></td>
       <td>New smooth pipes</td>
-      <td><font face=\"Symbol\">d</font> = 0.025 mm</td>
+      <td>&delta; = 0.025 mm</td>
   </tr>
   <tr><td>Mortar lined, average finish</td>
-      <td><font face=\"Symbol\">d</font> = 0.1 mm</td>
+      <td>&delta; = 0.1 mm</td>
   </tr>
   <tr><td>Heavy rust</td>
-      <td><font face=\"Symbol\">d</font> = 1 mm</td>
+      <td>&delta; = 1 mm</td>
   </tr>
   <tr><td rowspan=\"3\"><strong>Concrete pipes</strong></td>
       <td>Steel forms, first class workmanship</td>
-      <td><font face=\"Symbol\">d</font> = 0.025 mm</td>
+      <td>&delta; = 0.025 mm</td>
   </tr>
   <tr><td>Steel forms, average workmanship</td>
-      <td><font face=\"Symbol\">d</font> = 0.1 mm</td>
+      <td>&delta; = 0.1 mm</td>
   </tr>
   <tr><td>Block linings</td>
-      <td><font face=\"Symbol\">d</font> = 1 mm</td>
+      <td>&delta; = 1 mm</td>
   </tr>
 </table>
 <p>
@@ -834,8 +834,8 @@ in cases where the inverse pressure loss function is needed.
 
 <p>
 A detailed pressure drop model for pipe wall friction is
-provided in the form m_flow = f1(dp, <font face=\"Symbol\">D</font>) or
-dp = f2(m_flow, <font face=\"Symbol\">D</font>).
+provided in the form m_flow = f1(dp, &Delta;) or
+dp = f2(m_flow, &Delta;).
 These functions are continuous and differentiable,
 are provided in an explicit form without solving non-linear equations,
 and do behave well also at small mass flow rates. This pressure drop

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -1833,18 +1833,18 @@ singular vectors of matrix A. Basically the singular
 value decomposition of A is computed, i.e.,
 </p>
 <blockquote><pre>
-<strong>A</strong> = <strong>U</strong> <strong><font face=\"Symbol\">S</font></strong> <strong>V</strong><sup>T</sup>
+<strong>A</strong> = <strong>U</strong> <strong>&Sigma;</strong> <strong>V</strong><sup>T</sup>
   = U*Sigma*VT
 </pre></blockquote>
 <p>
 where <strong>U</strong> and <strong>V</strong> are orthogonal matrices (<strong>UU</strong><sup>T</sup>=<strong>I,
-</strong><strong>VV</strong><sup>T</sup>=<strong>I</strong>). <strong><font face=\"Symbol\">S
-</font></strong> = [diagonal(<font face=\"Symbol\">s</font><sub>i</sub>), zeros(n,m-n)], if n=size(A,1) &le;
-m=size(A,2)) or [diagonal(<font face=\"Symbol\">s</font><sub>i</sub>); zeros(n-m,m)], if n &gt;
-m=size(A,2)). <strong><font face=\"Symbol\">S</font></strong> has the same size as matrix A with
+</strong><strong>VV</strong><sup>T</sup>=<strong>I</strong>).
+<strong>&Sigma;</strong> = [diagonal(&sigma;<sub>i</sub>), zeros(n,m-n)], if n=size(A,1) &le;
+m=size(A,2)) or [diagonal(&sigma;<sub>i</sub>); zeros(n-m,m)], if n &gt;
+m=size(A,2)). <strong>&Sigma;</strong> has the same size as matrix A with
 nonnegative diagonal elements in decreasing order and with all other elements zero
-(<font face=\"Symbol\">s</font><sub>1</sub> is the largest element). The function
-returns the singular values <font face=\"Symbol\">s</font><sub>i</sub>
+(&sigma;<sub>1</sub> is the largest element). The function
+returns the singular values &sigma;<sub>i</sub>
 in vector <code>sigma</code> and the orthogonal matrices in
 matrices <code>U</code> and <code>VT</code>.
 </p>

--- a/Modelica/Mechanics/MultiBody/Frames.mo
+++ b/Modelica/Mechanics/MultiBody/Frames.mo
@@ -563,7 +563,7 @@ fulfills the following equation:
 The rotation angle is returned in the range
 </p>
 <pre>
-    -<font face=\"Symbol\">p</font> &lt;= angle &lt;= <font face=\"Symbol\">p</font>
+    -&pi; &lt;= angle &lt;= &pi;
 </pre>
 <p>
 This function makes the following assumptions on the input arguments
@@ -805,7 +805,7 @@ R = <strong>axesRotation</strong>(sequence, angles)
 The rotation angles are returned in the range
 </p>
 <blockquote><pre>
--<font face=\"Symbol\">p</font> &lt;= angles[i] &lt;= <font face=\"Symbol\">p</font>
+-&pi; &lt;= angles[i] &lt;= &pi;
 </pre></blockquote>
 <p>
 There are <strong>two solutions</strong> for \"angles[1]\" in this range.
@@ -2761,7 +2761,7 @@ v2 = <strong>resolve2</strong>(<strong>planarRotation</strong>(e,angle), v1)
 The rotation angle is returned in the range
 </p>
 <blockquote><pre>
--<font face=\"Symbol\">p</font> &lt;= angle &lt;= <font face=\"Symbol\">p</font>
+-&pi; &lt;= angle &lt;= &pi;
 </pre></blockquote>
 <p>
 This function makes the following assumptions on the input arguments
@@ -2991,7 +2991,7 @@ T = <strong>axesRotation</strong>(sequence, angles)
 The rotation angles are returned in the range
 </p>
 <blockquote><pre>
--<font face=\"Symbol\">p</font> &lt;= angles[i] &lt;= <font face=\"Symbol\">p</font>
+-&pi; &lt;= angles[i] &lt;= &pi;
 </pre></blockquote>
 <p>
 There are <strong>two solutions</strong> for \"angles[1]\" in this range.

--- a/Modelica/Mechanics/MultiBody/Sensors.mo
+++ b/Modelica/Mechanics/MultiBody/Sensors.mo
@@ -421,7 +421,7 @@ angles[3] along the y-axis and is then identical to frame_a.
 The 3 angles are returned in the range
 </p>
 <pre>
-    -<font face=\"Symbol\">p</font> &lt;= angles[i] &lt;= <font face=\"Symbol\">p</font>
+    -&pi; &lt;= angles[i] &lt;= &pi;
 </pre>
 <p>
 There are <strong>two solutions</strong> for \"angles[1]\" in this range.
@@ -897,7 +897,7 @@ angles[3] along the y-axis and is then identical to frame_b.
 The 3 angles are returned in the range
 </p>
 <pre>
-    -<font face=\"Symbol\">p</font> &lt;= angles[i] &lt;= <font face=\"Symbol\">p</font>
+    -&pi; &lt;= angles[i] &lt;= &pi;
 </pre>
 <p>
 There are <strong>two solutions</strong> for \"angles[1]\" in this range.
@@ -1215,7 +1215,7 @@ angles[3] along the y-axis and is then identical to frame_a.
 The 3 angles are returned in the range
 </p>
 <pre>
-    -<font face=\"Symbol\">p</font> &lt;= angles[i] &lt;= <font face=\"Symbol\">p</font>
+    -&pi; &lt;= angles[i] &lt;= &pi;
 </pre>
 <p>
 There are <strong>two solutions</strong> for \"angles[1]\" in this range.
@@ -1662,7 +1662,7 @@ angles[3] along the y-axis and is then identical to frame_b.
 The 3 angles are returned in the range
 </p>
 <pre>
-    -<font face=\"Symbol\">p</font> &lt;= angles[i] &lt;= <font face=\"Symbol\">p</font>
+    -&pi; &lt;= angles[i] &lt;= &pi;
 </pre>
 <p>
 There are <strong>two solutions</strong> for \"angles[1]\" in this range.

--- a/Modelica/Media/Water/IF97_Utilities.mo
+++ b/Modelica/Media/Water/IF97_Utilities.mo
@@ -6136,9 +6136,8 @@ of Water and Steam. ASME Journal of Engineering for Gas Turbines and Power 122 (
        <tr>
        <td>10<br>
       </td>
-      <td>Isentropic exponent, kappa<span class=\"nobr\">=<font face=\"Symbol\">-</font>(v/p)
-(dp/dv)<sub>s</sub></span></td>
-     <td>kappa (<font face=\"Symbol\">k</font>)<br>
+      <td>Isentropic exponent, kappa = -(v/p) (dp/dv)<sub>s</sub></td>
+     <td>kappa (&kappa;)<br>
      </td>
      <td>1<br>
      </td>
@@ -6166,7 +6165,7 @@ of Water and Steam. ASME Journal of Engineering for Gas Turbines and Power 122 (
      <tr>
      <td>13<br>
       </td>
-      <td>Specific Helmholtz free energy,     f = u - Ts</td>
+      <td>Specific Helmholtz free energy, f = u - Ts</td>
      <td>f<br>
      </td>
      <td>J/kg<br>
@@ -6175,7 +6174,7 @@ of Water and Steam. ASME Journal of Engineering for Gas Turbines and Power 122 (
      <tr>
      <td>14<br>
       </td>
-      <td>Specific Gibbs free energy,     g = h - Ts</td>
+      <td>Specific Gibbs free energy, g = h - Ts</td>
      <td>g<br>
      </td>
      <td>J/kg<br>
@@ -6184,8 +6183,8 @@ of Water and Steam. ASME Journal of Engineering for Gas Turbines and Power 122 (
      <tr>
      <td>15<br>
       </td>
-      <td>Isenthalpic exponent, <span class=\"nobr\"> theta = -(v/p)(dp/dv)<sub>h</sub></span></td>
-     <td>theta (<font face=\"Symbol\">q</font>)<br>
+      <td>Isenthalpic exponent, theta = -(v/p) (dp/dv)<sub>h</sub></td>
+     <td>theta (&theta;)<br>
      </td>
      <td>1<br>
      </td>
@@ -6193,8 +6192,8 @@ of Water and Steam. ASME Journal of Engineering for Gas Turbines and Power 122 (
      <tr>
      <td>16<br>
       </td>
-      <td>Isobaric volume expansion coefficient, alpha = v<sup>-1</sup>       (dv/dT)<sub>p</sub></td>
-     <td>alpha  (<font face=\"Symbol\">a</font>)<br>
+      <td>Isobaric volume expansion coefficient, alpha = v<sup>-1</sup> (dv/dT)<sub>p</sub></td>
+     <td>alpha (&alpha;)<br>
      </td>
        <td>1/K<br>
      </td>
@@ -6202,8 +6201,8 @@ of Water and Steam. ASME Journal of Engineering for Gas Turbines and Power 122 (
      <tr>
      <td>17<br>
       </td>
-      <td>Isochoric pressure coefficient,     <span class=\"nobr\">beta = p<sup><font face=\"Symbol\">-</font>1</sup>(dp/dT)<sub>v</sub></span></td>
-     <td>beta (<font face=\"Symbol\">b</font>)<br>
+      <td>Isochoric pressure coefficient, beta = p<sup>-1</sup>(dp/dT)<sub>v</sub></td>
+     <td>beta (&beta;)<br>
      </td>
      <td>1/K<br>
      </td>
@@ -6211,9 +6210,8 @@ of Water and Steam. ASME Journal of Engineering for Gas Turbines and Power 122 (
      <tr>
      <td>18<br>
      </td>
-     <td>Isothermal compressibility, <span class=\"nobr\">gamma = <font
- face=\"Symbol\">-</font>v<sup><font face=\"Symbol\">-</font>1</sup>(dv/dp)<sub>T</sub></span></td>
-     <td>gamma (<font face=\"Symbol\">g</font>)<br>
+     <td>Isothermal compressibility, gamma = -v<sup>-1</sup>(dv/dp)<sub>T</sub></td>
+     <td>gamma (&gamma;)<br>
      </td>
      <td>1/Pa<br>
      </td>
@@ -6222,7 +6220,7 @@ of Water and Steam. ASME Journal of Engineering for Gas Turbines and Power 122 (
      <td>19<br>
       </td>
       <td>Dynamic viscosity</td>
-     <td>eta (<font face=\"Symbol\">h</font>)<br>
+     <td>eta (&eta;)<br>
      </td>
      <td>Pa s<br>
      </td>
@@ -6231,7 +6229,7 @@ of Water and Steam. ASME Journal of Engineering for Gas Turbines and Power 122 (
      <td>20<br>
       </td>
       <td>Kinematic viscosity</td>
-     <td>nu (<font face=\"Symbol\">n</font>)<br>
+     <td>nu (&nu;)<br>
      </td>
      <td>m<sup>2</sup>/s<br>
      </td>
@@ -6240,7 +6238,7 @@ of Water and Steam. ASME Journal of Engineering for Gas Turbines and Power 122 (
      <td>21<br>
       </td>
       <td>Thermal conductivity</td>
-     <td>lambda (<font face=\"Symbol\">l</font>)<br>
+     <td>lambda (&lambda;)<br>
      </td>
      <td>W/(m K)<br>
      </td>
@@ -6249,7 +6247,7 @@ of Water and Steam. ASME Journal of Engineering for Gas Turbines and Power 122 (
      <td>22<br>
       </td>
       <td>Surface tension</td>
-     <td>sigma (<font face=\"Symbol\">s</font>)<br>
+     <td>sigma (&sigma;)<br>
      </td>
      <td>N/m<br>
      </td>


### PR DESCRIPTION
The Greek symbols are not correctly rendered in all cases, for example

![grafik](https://user-images.githubusercontent.com/14896695/68710974-ee55f500-0598-11ea-82b6-16a2138519b3.png)
