### PR TITLE
Utilize blockwise I/O in ModelicaInternal_copyFile

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaInternal.c
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.c
@@ -30,6 +30,10 @@
 */
 
 /* Release Notes:
+      Nov. 13, 2019: by Thomas Beutlich
+                     Utilized blockwise I/O in ModelicaInternal_copyFile
+                     (ticket #3229)
+
       Oct. 10, 2019: by Thomas Beutlich
                      Fixed month and year correction in ModelicaInternal_getTime
                      (ticket #3143)
@@ -407,17 +411,11 @@ void ModelicaInternal_removeFile(_In_z_ const char* file) {
 void ModelicaInternal_copyFile(_In_z_ const char* oldFile,
                                _In_z_ const char* newFile) {
     /* Copy file */
-#ifdef _WIN32
     const char* modeOld = "rb";
     const char* modeNew = "wb";
-#else
-    const char* modeOld = "r";
-    const char* modeNew = "w";
-#endif
     FILE* fpOld;
     FILE* fpNew;
     ModelicaFileType type;
-    int c;
 
     /* Check file existence */
     type = Internal_stat(oldFile);
@@ -454,8 +452,18 @@ void ModelicaInternal_copyFile(_In_z_ const char* oldFile,
             oldFile, newFile, strerror(errno));
         return;
     }
-    while ( (c = getc(fpOld)) != EOF ) {
-        putc(c, fpNew);
+    {
+        size_t len;
+        char buf[BUFSIZ] = {'\0'};
+
+        while ( (len = fread(buf, sizeof(char), BUFSIZ, fpOld)) > 0 ) {
+            if ( len != fwrite(buf, sizeof(char), len, fpNew) ) {
+                fclose(fpOld);
+                fclose(fpNew);
+                ModelicaFormatError("Error writing to file \"%s\".", newFile);
+                return;
+            }
+        }
     }
     fclose(fpOld);
     fclose(fpNew);

--- a/Modelica/Utilities/Internal.mo
+++ b/Modelica/Utilities/Internal.mo
@@ -180,7 +180,7 @@ package FileSystem
   end removeFile;
 
   function copyFile
-      "Copy existing file (C functions 'fopen', 'getc', 'putc', 'fclose')"
+      "Copy existing file (C functions 'fopen', 'fread', 'fwrite', 'fclose')"
     extends Modelica.Icons.Function;
     input String fromName "Name of file to be copied";
     input String toName "Name of copy of file";


### PR DESCRIPTION
Blockwise I/O usually is faster then byte-wise I/O.