### PR TITLE
Further improve example documentation of Modelica.Math.Nonlinear.Examples.QuadratureLobatto3

### DIFF
--- a/Modelica/Math/Nonlinear.mo
+++ b/Modelica/Math/Nonlinear.mo
@@ -315,17 +315,27 @@ The following nonlinear equations are solved:
     model QuadratureLobatto3 "Integrate function in a model"
       extends Modelica.Icons.Example;
       parameter Real A=1 "Amplitude of integrand of s";
-      parameter Real w=2 "Angular frequency of integrand of s";
-      Real x "Integral value";
+      parameter Real ws=2 "Angular frequency of integrand of s";
+      parameter Real wq=3 "Squared angular frequency of q";
+      Real q(start=1, fixed=true) "First-order state variable";
+      Real qd(start=0, fixed=true) "Second-order state variable";
+      Real x "Overall value as product of s and q";
       final parameter Real s = Modelica.Math.Nonlinear.quadratureLobatto(
-                                  function UtilityFunctions.fun7(A=A, w=w),
-                                  0,1) "Integral value used as parameter";
+                                  function UtilityFunctions.fun7(A=A, w=ws),
+                                  0,1) "Time-invariant integral value";
     equation
-      x = s;
+      qd = der(q);
+      der(qd) + wq*q = 0 "Equation of motion for the free, undamped harmonic oscillator";
+      x = s*q;
       annotation (Documentation(info="<html>
 <p>
-This example demonstrates how to utilize a function as input argument
+Technically, this example demonstrates how to utilize a function as input argument
 to a function in a model.
+</p>
+
+<p>
+From a modeling point of view, the example demonstrates in very simplified way the basic approach to model distributed systems with the Ritz method.
+The displacement field <code>u(c,t)</code> of a particle (where <code>c</code> is the undeformed position and <code>t</code> is time) is hereby approximated by space-dependent mode shapes <code>&Phi;(c)</code> and time-dependent modal amplitudes <code>q(t)</code>, that is <code>u</code> = <code>&Phi;(c)*q(t)</code>. When inserting this decomposition in the equations of motion and then integrating over all particles, terms such as <code>&int;(&Phi;(c) dc)*q(t)</code> appear, where the time-invariant integral term can be computed beforehand once with the <a href=\"modelica://Modelica.Math.Nonlinear.quadratureLobatto\">Lobatto method</a>. By this approach the partial differential equations are transformed to a system of ordinary differential equations.
 </p>
 </html>"),
         experiment(StopTime=5));


### PR DESCRIPTION
As proposed and discussed in https://github.com/modelica/ModelicaStandardLibrary/pull/3193#issuecomment-553762667, give background information on example purpose.

Note, that `wq` is not the resonance frequency of the harmonic oscillator, but its squared value.

![grafik](https://user-images.githubusercontent.com/14896695/68999006-27080e00-08ba-11ea-8a9c-5b45694ba4c4.png)
