### PR TITLE
Fix issue #3236 by using a simpler medium model for the HeatingSystem example and by improving state selection in PartialLumpedVolume

### DIFF
--- a/Modelica/Fluid/Examples/HeatingSystem.mo
+++ b/Modelica/Fluid/Examples/HeatingSystem.mo
@@ -2,7 +2,7 @@ within Modelica.Fluid.Examples;
 model HeatingSystem "Simple model of a heating system"
   extends Modelica.Icons.Example;
    replaceable package Medium =
-      Modelica.Media.Water.StandardWater
+      Modelica.Media.CompressibleLiquids.LinearWater_pT_Ambient
      constrainedby Modelica.Media.Interfaces.PartialMedium;
 
   Modelica.Fluid.Vessels.OpenTank tank(

--- a/Modelica/Fluid/Interfaces.mo
+++ b/Modelica/Fluid/Interfaces.mo
@@ -550,7 +550,8 @@ the boundary temperatures <code>heatPorts[n].T</code>, and the heat flow rates <
         annotation (Dialog(tab="Initialization", enable=Medium.nC > 0));
 
       Medium.BaseProperties medium(
-        preferredMediumStates=true,
+        preferredMediumStates = (if energyDynamics == Dynamics.SteadyState and
+                                    massDynamics   == Dynamics.SteadyState then false else true),
         p(start=p_start),
         h(start=h_start),
         T(start=T_start),


### PR DESCRIPTION
Fixes #3236 by
- using a simpler medium model for the example
- making sure that all models using `PartialLumpedVolume` with static mass and energy balances do not have StateSelect.prefer on the medium preferred states, which can fool state selection algorithms badly.

I tested `HeatingSystem` on both Dymola and OpenModelica and it works as expected. The changes should be fairly safe also for other Modelica.Fluid models. However, I would suggest that we wait to see if there are regressions on the OpenModelica CI system when the library is updated. If not, we can backport this to MSL 3.2.3