### PR TITLE
Move signal output of sensors to standard locations

### DIFF
--- a/Modelica/Thermal/HeatTransfer/Sensors/ConditionalFixedHeatFlowSensor.mo
+++ b/Modelica/Thermal/HeatTransfer/Sensors/ConditionalFixedHeatFlowSensor.mo
@@ -21,7 +21,7 @@ model ConditionalFixedHeatFlowSensor
     "Heat flow from port_a to port_b as output signal" annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={0,-100})));
+        origin={0,-110})));
 equation
   connect(heatFlowSensor.port_b, port_b) annotation (Line(
       points={{10,0},{100,0}}, color={191,0,0}));
@@ -30,10 +30,10 @@ equation
   connect(fixedTemperature.port, heatFlowSensor.port_a) annotation (Line(
       points={{-50,-20},{-50,0},{-10,0}}, color={191,0,0}));
   connect(heatFlowSensor.Q_flow, Q_flow) annotation (Line(
-      points={{0,-10},{0,-100}},color={0,0,127}));
+      points={{0,-11},{0,-110}},color={0,0,127}));
   annotation (defaultComponentName="heatFlowSensor",
     Icon(graphics={
-      Line(points = {{0,-70},{0,-90}}, color = {0,0,127}),
+      Line(points={{0,-70},{0,-100}},  color = {0,0,127}),
         Text(
           extent={{-150,120},{150,80}},
           textString="%name",

--- a/Modelica/Thermal/HeatTransfer/Sensors/HeatFlowSensor.mo
+++ b/Modelica/Thermal/HeatTransfer/Sensors/HeatFlowSensor.mo
@@ -4,9 +4,12 @@ model HeatFlowSensor "Heat flow rate sensor"
   Modelica.Blocks.Interfaces.RealOutput Q_flow(unit="W")
     "Heat flow from port_a to port_b as output signal" annotation (Placement(
         transformation(
-        origin={0,-100},
+        origin={0,-110},
         extent={{-10,-10},{10,10}},
-        rotation=270)));
+        rotation=270), iconTransformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={0,-110})));
   Interfaces.HeatPort_a port_a annotation (Placement(transformation(extent={{
             -110,-10},{-90,10}})));
   Interfaces.HeatPort_b port_b annotation (Placement(transformation(extent={{
@@ -22,7 +25,7 @@ equation
             100,100}}), graphics={
         Line(points={{-70,0},{-90,0}}, color={191,0,0}),
         Line(points={{70,0},{90,0}}, color={191,0,0}),
-        Line(points={{0,-70},{0,-90}}, color={0,0,127}),
+        Line(points={{0,-70},{0,-100}},color={0,0,127}),
         Text(
           extent={{-150,120},{150,80}},
           textString="%name",

--- a/Modelica/Thermal/HeatTransfer/Sensors/RelTemperatureSensor.mo
+++ b/Modelica/Thermal/HeatTransfer/Sensors/RelTemperatureSensor.mo
@@ -8,9 +8,12 @@ model RelTemperatureSensor "Relative Temperature sensor"
   Modelica.Blocks.Interfaces.RealOutput T_rel(unit="K", displayUnit="K")
     "Relative temperature as output signal"
     annotation (Placement(transformation(
-        origin={0,-90},
+        origin={0,-110},
         extent={{10,-10},{-10,10}},
-        rotation=90)));
+        rotation=90), iconTransformation(
+        extent={{10,-10},{-10,10}},
+        rotation=90,
+        origin={0,-110})));
 equation
   T_rel = port_a.T - port_b.T;
   0 = port_a.Q_flow;
@@ -21,7 +24,7 @@ equation
         Line(points={{-90,0},{-70,0},{-70,0}}, color={191,0,0}),
         Line(points={{-90,0},{-70,0},{-70,0}}, color={191,0,0}),
         Line(points={{70,0},{90,0},{90,0}}, color={191,0,0}),
-        Line(points={{0,-38},{0,-80}}, color={0,0,127}),
+        Line(points={{0,-38},{0,-100}},color={0,0,127}),
         Text(
           extent={{-150,80},{150,40}},
           textString="%name",

--- a/Modelica/Thermal/HeatTransfer/Sensors/TemperatureSensor.mo
+++ b/Modelica/Thermal/HeatTransfer/Sensors/TemperatureSensor.mo
@@ -3,7 +3,7 @@ model TemperatureSensor "Absolute temperature sensor in Kelvin"
 
   Modelica.Blocks.Interfaces.RealOutput T(unit="K")
     "Absolute temperature as output signal"
-    annotation (Placement(transformation(extent={{90,-10},{110,10}})));
+    annotation (Placement(transformation(extent={{100,-10},{120,10}}), iconTransformation(extent={{100,-10},{120,10}})));
   Interfaces.HeatPort_a port annotation (Placement(transformation(extent={{
             -110,-10},{-90,10}})));
 equation
@@ -24,7 +24,7 @@ equation
           lineColor={191,0,0},
           fillColor={191,0,0},
           fillPattern=FillPattern.Solid),
-        Line(points={{12,0},{90,0}}, color={0,0,127}),
+        Line(points={{12,0},{100,0}},color={0,0,127}),
         Line(points={{-90,0},{-12,0}}, color={191,0,0}),
         Polygon(
           points={{-12,40},{-12,80},{-10,86},{-6,88},{0,90},{6,88},{10,86},

--- a/Modelica/Thermal/HeatTransfer/Sensors/package.mo
+++ b/Modelica/Thermal/HeatTransfer/Sensors/package.mo
@@ -1,6 +1,7 @@
 within Modelica.Thermal.HeatTransfer;
 package Sensors "Thermal sensors"
   extends Modelica.Icons.SensorsPackage;
+
   annotation (Documentation(info="<html>
 
 </html>"));


### PR DESCRIPTION
The locations of the signal outputs of the `HeatTransfer` sensors

![image](https://user-images.githubusercontent.com/4184218/70380123-952e7680-1936-11ea-89c9-062d53641e39.png)

are moved to their standard locations outside the icon boundaries:

![image](https://user-images.githubusercontent.com/4184218/70380095-3e28a180-1936-11ea-9ce4-4f20a7c9c299.png)
 