### PR TITLE
Relocate ParameterDefaults

### DIFF
--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -1,6 +1,8 @@
 // Convert from Modelica 3.2.3 to Modelica 4.0.0
 
 // Change references to classes that are removed from Modelica Standard Library
+convertClass("Modelica.UsersGuide.ParameterDefaults",
+              "Modelica.UsersGuide.Conventions.ModelicaCode.ParameterDefaults")
 convertClass("Modelica.Fluid.Dissipation.Utilities.Functions.General.CubicInterpolation_DP",
               "Modelica.Fluid.Dissipation.Utilities.Functions.General.CubicInterpolation_Re")
 convertClass("Modelica.Fluid.Dissipation.Utilities.Functions.General.CubicInterpolation_MFLOW",

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -1421,16 +1421,14 @@ constants of a model that might be changed before simulation starts.
 Example:
 </p>
 
-<blockquote>
-<pre>
+<blockquote><pre>
 <strong>model</strong> SpringDamper
 <strong>parameter</strong> Real c(final unit=\"N.m/rad\")    = 1e5 \"Spring constant\";
 <strong>parameter</strong> Real d(final unit=\"N.m.s/rad\")  = 0   \"Damping constant\";
 <strong>parameter</strong> Modelica.SIunits.Angle phi_rel0 = 0   \"Unstretched spring angle\";
 ...
 <strong>end</strong> SpringDamper;
-</pre>
-</blockquote>
+</pre></blockquote>
 
 <p>
 In Modelica it is possible to define a default value of a parameter in
@@ -1474,8 +1472,7 @@ uses two approaches to define default parameters, as demonstrated with the
 following example:
 </p>
 
-<blockquote>
-<pre>
+<blockquote><pre>
 <strong>model</strong> SpringDamper
 <strong>parameter</strong> Real c(final unit=\"N.m/rad\"  , start=1e5) \"Spring constant\";
 <strong>parameter</strong> Real d(final unit=\"N.m.s/rad\", start=  0) \"Damping constant\";
@@ -1485,8 +1482,7 @@ following example:
 
 SpringDamper sp1;              // warning for \"c\" and \"d\"
 SpringDamper sp2(c=1e4, d=0);  // fine, no warning
-</pre>
-</blockquote>
+</pre></blockquote>
 
 <p>
 Both definition forms, using a \"start\" value (for \"c\" and \"d\") and providing

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -1405,12 +1405,105 @@ For Boolean parameters, the description string should start with &quot;= true, &
 </html>"));
       end Naming;
 
+    class ParameterDefaults "Parameter defaults"
+      extends Modelica.Icons.Information;
+
+     annotation (Documentation(info="<html>
+
+<p>
+In this section the convention is summarized how default parameters are
+handled in the Modelica Standard Library (since version 3.0).
+</p>
+
+<p>
+Many models in this library have parameter declarations to define
+constants of a model that might be changed before simulation starts.
+Example:
+</p>
+
+<blockquote>
+<pre>
+<strong>model</strong> SpringDamper
+<strong>parameter</strong> Real c(final unit=\"N.m/rad\")    = 1e5 \"Spring constant\";
+<strong>parameter</strong> Real d(final unit=\"N.m.s/rad\")  = 0   \"Damping constant\";
+<strong>parameter</strong> Modelica.SIunits.Angle phi_rel0 = 0   \"Unstretched spring angle\";
+...
+<strong>end</strong> SpringDamper;
+</pre>
+</blockquote>
+
+<p>
+In Modelica it is possible to define a default value of a parameter in
+the parameter declaration. In the example above, this is performed for
+all parameters. Providing default values for all parameters can lead to
+errors that are difficult to detect, since a modeler may have forgotten
+to provide a meaningful value (the model simulates but gives wrong
+results due to wrong parameter values). In general the following basic
+situations are present:
+</p>
+
+<ol>
+<li> The parameter value could be anything (e.g., a spring constant or
+  a resistance value) and therefore the user should provide a value in
+  all cases. A Modelica translator should warn, if no value is provided.
+</li>
+
+<li> The parameter value is not changed in &gt; 95 % of the cases
+  (e.g., initialization or visualization parameters, or parameter phi_rel0
+  in the example above). In this case a default parameter value should be
+  provided, in order that the model or function can be conveniently
+  used by a modeler.
+</li>
+
+<li> A modeler would like to quickly utilize a model, e.g.,
+  <ul>
+  <li> to automatically check that the model still translates and/or simulates
+    (after some changes in the library),</li>
+  <li> to make a quick demo of a library by drag-and-drop of components,</li>
+  <li> to implement a simple test model in order to get a better understanding
+    of the desired component.</li>
+  </ul>
+  In all these cases, it would be not practical, if the modeler would
+  have to provide explicit values for all parameters first.
+  </li>
+</ol>
+
+<p>
+To handle the conflicting goals of (1) and (3), the Modelica Standard Library
+uses two approaches to define default parameters, as demonstrated with the
+following example:
+</p>
+
+<blockquote>
+<pre>
+<strong>model</strong> SpringDamper
+<strong>parameter</strong> Real c(final unit=\"N.m/rad\"  , start=1e5) \"Spring constant\";
+<strong>parameter</strong> Real d(final unit=\"N.m.s/rad\", start=  0) \"Damping constant\";
+<strong>parameter</strong> Modelica.SIunits.Angle phi_rel0 = 0       \"Unstretched spring angle\";
+...
+<strong>end</strong> SpringDamper;
+
+SpringDamper sp1;              // warning for \"c\" and \"d\"
+SpringDamper sp2(c=1e4, d=0);  // fine, no warning
+</pre>
+</blockquote>
+
+<p>
+Both definition forms, using a \"start\" value (for \"c\" and \"d\") and providing
+a declaration equation (for \"phi_rel0\"), are valid Modelica and define the value
+of the parameter. By convention, it is expected that Modelica translators will
+trigger a warning message for parameters that are <strong>not</strong> defined by a declaration
+equation, by a modifier equation or in an initial equation/algorithm section.
+A Modelica translator might have options to change this behavior, especially,
+that no messages are printed in such cases and/or that an error is triggered
+instead of a warning.
+</p>
+
+</html>"));
+    end ParameterDefaults;
       annotation (Documentation(info="<html>
 
-<p>In this section the
-<a href=\"modelica://Modelica.UsersGuide.Conventions.ModelicaCode.Naming\">naming conventions</a> of class and instance names, parameters and variables are specified.
-Additional
-<a href=\"modelica://Modelica.UsersGuide.Conventions.ModelicaCode.Format\">format</a> guidelines are provided.</p>
+<p>In this section guidelines on creating Modelica code are provided.</p>
 
 </html>"));
     end ModelicaCode;
@@ -2121,99 +2214,6 @@ Graphical illustrations shall not be added in the diagram layer, but can be adde
 </ol>
 </html>"));
   end Conventions;
-
-class ParameterDefaults "Parameter defaults"
-  extends Modelica.Icons.Information;
-
- annotation (Documentation(info="<html>
-
-<p>
-In this section the convention is summarized how default parameters are
-handled in the Modelica Standard Library (since version 3.0).
-</p>
-
-<p>
-Many models in this library have parameter declarations to define
-constants of a model that might be changed before simulation starts.
-Example:
-</p>
-
-<blockquote><pre>
-<strong>model</strong> SpringDamper
-<strong>parameter</strong> Real c(final unit=\"N.m/rad\")    = 1e5 \"Spring constant\";
-<strong>parameter</strong> Real d(final unit=\"N.m.s/rad\")  = 0   \"Damping constant\";
-<strong>parameter</strong> Modelica.SIunits.Angle phi_rel0 = 0   \"Unstretched spring angle\";
-...
-<strong>end</strong> SpringDamper;
-</pre></blockquote>
-
-<p>
-In Modelica it is possible to define a default value of a parameter in
-the parameter declaration. In the example above, this is performed for
-all parameters. Providing default values for all parameters can lead to
-errors that are difficult to detect, since a modeler may have forgotten
-to provide a meaningful value (the model simulates but gives wrong
-results due to wrong parameter values). In general the following basic
-situations are present:
-</p>
-
-<ol>
-<li> The parameter value could be anything (e.g., a spring constant or
-  a resistance value) and therefore the user should provide a value in
-  all cases. A Modelica translator should warn, if no value is provided.
-</li>
-
-<li> The parameter value is not changed in &gt; 95 % of the cases
-  (e.g., initialization or visualization parameters, or parameter phi_rel0
-  in the example above). In this case a default parameter value should be
-  provided, in order that the model or function can be conveniently
-  used by a modeler.
-</li>
-
-<li> A modeler would like to quickly utilize a model, e.g.,
-  <ul>
-  <li> to automatically check that the model still translates and/or simulates
-    (after some changes in the library),</li>
-  <li> to make a quick demo of a library by drag-and-drop of components,</li>
-  <li> to implement a simple test model in order to get a better understanding
-    of the desired component.</li>
-  </ul>
-  In all these cases, it would be not practical, if the modeler would
-  have to provide explicit values for all parameters first.
-  </li>
-</ol>
-
-<p>
-To handle the conflicting goals of (1) and (3), the Modelica Standard Library
-uses two approaches to define default parameters, as demonstrated with the
-following example:
-</p>
-
-<blockquote><pre>
-<strong>model</strong> SpringDamper
-<strong>parameter</strong> Real c(final unit=\"N.m/rad\"  , start=1e5) \"Spring constant\";
-<strong>parameter</strong> Real d(final unit=\"N.m.s/rad\", start=  0) \"Damping constant\";
-<strong>parameter</strong> Modelica.SIunits.Angle phi_rel0 = 0       \"Unstretched spring angle\";
-...
-<strong>end</strong> SpringDamper;
-
-SpringDamper sp1;              // warning for \"c\" and \"d\"
-SpringDamper sp2(c=1e4, d=0);  // fine, no warning
-</pre></blockquote>
-
-<p>
-Both definition forms, using a \"start\" value (for \"c\" and \"d\") and providing
-a declaration equation (for \"phi_rel0\"), are valid Modelica and define the value
-of the parameter. By convention, it is expected that Modelica translators will
-trigger a warning message for parameters that are <strong>not</strong> defined by a declaration
-equation, by a modifier equation or in an initial equation/algorithm section.
-A Modelica translator might have options to change this behavior, especially,
-that no messages are printed in such cases and/or that an error is triggered
-instead of a warning.
-</p>
-
-</html>"));
-end ParameterDefaults;
 
 package ReleaseNotes "Release notes"
   extends Modelica.Icons.ReleaseNotes;


### PR DESCRIPTION
Move `UsersGuide.ParameterDefaults` to `Modelica.UsersGuide.Conventions.ModelicaCode`; fix #3248