### PR TITLE
Fix issue #3236 by using a simpler medium model for the HeatingSystem example and by improving state selection in PartialLumpedVolume

### DIFF
--- a/Modelica/Fluid/Examples/HeatingSystem.mo
+++ b/Modelica/Fluid/Examples/HeatingSystem.mo
@@ -2,7 +2,7 @@ within Modelica.Fluid.Examples;
 model HeatingSystem "Simple model of a heating system"
   extends Modelica.Icons.Example;
    replaceable package Medium =
-      Modelica.Media.Water.StandardWater
+      Modelica.Media.CompressibleLiquids.LinearWater_pT_Ambient
      constrainedby Modelica.Media.Interfaces.PartialMedium;
 
   Modelica.Fluid.Vessels.OpenTank tank(

--- a/Modelica/Fluid/Interfaces.mo
+++ b/Modelica/Fluid/Interfaces.mo
@@ -550,7 +550,8 @@ the boundary temperatures <code>heatPorts[n].T</code>, and the heat flow rates <
         annotation (Dialog(tab="Initialization", enable=Medium.nC > 0));
 
       Medium.BaseProperties medium(
-        preferredMediumStates=true,
+        preferredMediumStates = (if energyDynamics == Dynamics.SteadyState and
+                                    massDynamics   == Dynamics.SteadyState then false else true),
         p(start=p_start),
         h(start=h_start),
         T(start=T_start),


### PR DESCRIPTION
Back-port #3249 to fix #3236 in maint/3.2.3.