### PR TITLE
Update issue links or revision links

### DIFF
--- a/Modelica/Electrical/QuasiStatic/UsersGuide/ReleaseNotes.mo
+++ b/Modelica/Electrical/QuasiStatic/UsersGuide/ReleaseNotes.mo
@@ -40,7 +40,7 @@ class ReleaseNotes "Release notes"
     <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/1367\">#1367</a>)</li>
 <li>Updated documentation on temperature dependency of resistance and conductance models</li>
 <li>Rewrote source models to simplify initialization (
-    <a href=\"https://trac.modelica.org/Modelica/changeset/7031\">r7031</a>)</li>
+    <a href=\"https://github.com/modelica/ModelicaStandardLibrary/commit/861851e3b9628fa483e958a943ab015c15fcb821\">r7031</a>)</li>
 <li>Implementation of ideal transformer model</li>
 </ul>
 

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -4319,9 +4319,7 @@ units are wrong or errors in documentation):
 </table>
 
 <p><br>
-The following
-<a href=\"http://trac.modelica.org/Modelica\">trac tickets</a>
-have been fixed:
+The following trac tickets have been fixed:
 </p>
 
 <table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -7201,65 +7201,65 @@ Copyright &copy; 2003-2019, Modelica Association and contributors
       <td>
 <ul>
 <li> Update of grammar from Maplesoft which reflects changes from
-     <a href=\"http://trac.modelica.org/Modelica/ticket/1140\">#1140</a></li>
+     <a href=\"https://github.com/modelica/ModelicaSpecification/issues/1140\">#1140</a></li>
 <li> Introduced the same new icons as in Modelica 3.2.1</li>
 <li> Fixing incorrect links and HTML errors in documentation.</li>
 <li> Fixing trivial typos.</li>
 <li> Moves operators from the top level (array, cat, ..) to subpackage Operators</li>
 <li> Adding homotopy() operator.</li>
-<li> <a href=\"http://trac.modelica.org/Modelica/ticket/1007\">#1007</a>: png figures are compressed.</li>
-<li> <a href=\"http://trac.modelica.org/Modelica/ticket/670\">#670</a>: Adds more function and operator descriptions</li>
-<li> <a href=\"http://trac.modelica.org/Modelica/ticket/644\">#644</a>: Improved description of operator delay</li>
+<li> <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/1007\">#1007</a>: png figures are compressed.</li>
+<li> <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/670\">#670</a>: Adds more function and operator descriptions</li>
+<li> <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/644\">#644</a>: Improved description of operator delay</li>
 <li> Updated the documentation to reflect Modelica Specification 3.2 Rev2:
      <ul>
      <li> Update of reinit(), Integer(), DocumentationClass</li>
-     <li> <a href=\"http://trac.modelica.org/Modelica/ticket/988\">#988</a>: Adding the annotations:<br>
+     <li> <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/988\">#988</a>: Adding the annotations:<br>
           checkBox<br>
           choicesAllMatching<br>
           colorSelector<br>
           loadSelector<br>
           saveSelector<br>
           normallyConstant</li>
-     <li> <a href=\"http://trac.modelica.org/Modelica/ticket/802\">#802</a>: Adding the additional connection operators<br>
+     <li> <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/802\">#802</a>: Adding the additional connection operators<br>
           Connections.branch()<br>
           Connections.root()<br>
           Connections.potentialRoot()<br>
           Connections.isRoot()<br>
           Connections.rooted()<br>
           rooted() with deprecation notice</li>
-     <li> <a href=\"http://trac.modelica.org/Modelica/ticket/1048\">#1048</a>: GenerateEvents annotation removed in Modelica 3.2 rev2</li>
+     <li> <a href=\"https://github.com/modelica/ModelicaSpecification/issues/1048\">#1048</a>: GenerateEvents annotation removed in Modelica 3.2 rev2</li>
      </ul>
 </ul>
      </td>
      </tr>
 
      <tr>
-      <td><a href=\"http://trac.modelica.org/Modelica/changeset/4781/Modelica\">r4781</a></td>
+      <td><a href=\"https://github.com/modelica/ModelicaStandardLibrary/commit/e46b941f168f0cb5fb1a9e10d31a247e08ea4dec\">r4781</a></td>
       <td>2011-12-15</td>
       <td><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a></td>
-      <td>Use quoted class names for function descriptions (closes ticket <a href=\"http://trac.modelica.org/Modelica/ticket/565\">#565</a>)</td>
+      <td>Use quoted class names for function descriptions (closes ticket <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/565\">#565</a>)</td>
     </tr>
     <tr>
-      <td><a href=\"http://trac.modelica.org/Modelica/changeset/4256/Modelica\">r4256</a></td>
+      <td><a href=\"https://github.com/modelica/ModelicaStandardLibrary/commit/13f826a01b70f8d7b7616b4bfe00413563ed6c40\">r4256</a></td>
       <td>2010-10-06</td>
       <td><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a></td>
-      <td>Removed 'uses' annotation and added icons so it can be used with multiple versions of the MSL (closes ticket <a href=\"http://trac.modelica.org/Modelica/ticket/425\">#425</a>)</td>
+      <td>Removed 'uses' annotation and added icons so it can be used with multiple versions of the MSL (closes ticket <a href=\https://github.com/modelica/ModelicaStandardLibrary/issues/425\">#425</a>)</td>
     </tr>
     <tr>
-      <td><a href=\"http://trac.modelica.org/Modelica/changeset/4218/Modelica\">r4218</a></td>
+      <td><a href=\"https://github.com/modelica/ModelicaStandardLibrary/commit/da0b65b3f79cf097ab5314904158006c9b02d0b0\">r4218</a></td>
       <td>2010-09-25</td>
       <td><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a></td>
-      <td>Major clean up of the documentation by use of <a href=\"http://linkchecker.sourceforge.net\"> LinkChecker</a> (closes ticket <a href=\"http://trac.modelica.org/Modelica/ticket/228\">#228</a>)</td>
+      <td>Major clean up of the documentation by use of <a href=\"http://linkchecker.sourceforge.net\">LinkChecker</a> (closes ticket <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/228\">#228</a>)</td>
     </tr>
     <tr>
-      <td><a href=\"http://trac.modelica.org/Modelica/changeset/4145/Modelica\">r4145</a></td>
+      <td><a href=\"https://github.com/modelica/ModelicaStandardLibrary/commit/ba34d1a53de471a689e0582b766ace2ac462edd9\">r4145</a></td>
       <td>2010-09-07</td>
       <td><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a></td>
       <td>Added an update of the <a href=\"modelica://ModelicaReference.ModelicaGrammar\">Modelica 3.2 grammar</a>
                        from Stefan Vorkoetter (Maplesoft).</td>
     </tr>
     <tr>
-      <td><a href=\"http://trac.modelica.org/Modelica/changeset/3742/Modelica\">r3742</a></td>
+      <td><a href=\"https://github.com/modelica/ModelicaStandardLibrary/commit/1d033f42c988e62f418dd2cc817a9f4055569941\">r3742</a></td>
       <td>2010-04-13</td>
       <td><a href=\"http://www.robotic.dlr.de/Martin.Otter/\">Martin Otter</a></td>
       <td>Added the <a href=\"modelica://ModelicaReference.ModelicaGrammar\">Modelica 3.2 grammar</a>
@@ -7268,13 +7268,13 @@ Copyright &copy; 2003-2019, Modelica Association and contributors
                        acknowledgment information.</td>
     </tr>
     <tr>
-      <td><a href=\"http://trac.modelica.org/Modelica/changeset/3598/Modelica\">r3598</a></td>
+      <td><a href=\"https://github.com/modelica/ModelicaStandardLibrary/commit/5500dfde969ec28db5dca88afb771ea308100160\">r3598</a></td>
       <td>2010-03-10</td>
       <td><a href=\"https://github.com/dietmarw\">Dietmar Winkler</a></td>
-      <td>Added some annotations from Modelica language version 3.1 and 3.2 (see ticket <a href=\"http://trac.modelica.org/Modelica/ticket/228\">#228</a>)</td>
+      <td>Added some annotations from Modelica language version 3.1 and 3.2 (see ticket <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/228\">#228</a>)</td>
     </tr>
     <tr>
-      <td><a href=\"http://trac.modelica.org/Modelica/changeset/948/Modelica\">r948</a></td>
+      <td><a href=\"https://github.com/modelica/ModelicaStandardLibrary/commit/a792223829c266d80d648ecd3a912062b0cdb67d\">r948</a></td>
       <td>2008-01-02</td>
       <td><a href=\"http://www.robotic.dlr.de/Martin.Otter/\">Martin Otter</a></td>
       <td>Adapted to Modelica language version 3.0</td>


### PR DESCRIPTION
Completely remove all links to trac.modelica.org.

This addresses the remaining ones from #2821.