### PR TITLE
Add units to real I/O signals

### DIFF
--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -844,9 +844,9 @@ Example:
 
   block Feedback "Output difference between commanded and feedback input"
 
-    Interfaces.RealInput u1 annotation (Placement(transformation(extent={{-100,
+    Interfaces.RealInput u1 "Commanded input" annotation (Placement(transformation(extent={{-100,
               -20},{-60,20}})));
-    Interfaces.RealInput u2 annotation (Placement(transformation(
+    Interfaces.RealInput u2 "Feedback input" annotation (Placement(transformation(
           origin={0,-80},
           extent={{-20,-20},{20,20}},
           rotation=90)));
@@ -3207,9 +3207,9 @@ This block is demonstrated in the examples
     extends Modelica.Blocks.Icons.Block;
     parameter Modelica.SIunits.Frequency f(start=50) "Base frequency";
     parameter Integer k(start=1) "Order of harmonic";
-        parameter Boolean useConjugateComplex=false
+    parameter Boolean useConjugateComplex=false
       "Gives conjugate complex result if true"
-          annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
+      annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
     parameter Real x0Cos=0 "Start value of cos integrator state";
     parameter Real x0Sin=0 "Start value of sin integrator state";
     Sources.Cosine      sin1(

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -739,7 +739,7 @@ The Real output y is a cosine signal:
           extent={{-2,-2},{2,2}},
           rotation=0,
           origin={-80,60})));
-    Blocks.Interfaces.RealInput f_internal "Frequency" annotation (Placement(
+    Blocks.Interfaces.RealInput f_internal(unit="Hz") "Frequency" annotation (Placement(
           transformation(
           extent={{-2,-2},{2,2}},
           rotation=0,
@@ -849,7 +849,7 @@ and that the parameter <code>startTime</code> is omitted since the voltage can b
           extent={{-2,-2},{2,2}},
           rotation=0,
           origin={-80,60})));
-    Blocks.Interfaces.RealInput f_internal "Frequency" annotation (Placement(
+    Blocks.Interfaces.RealInput f_internal(unit="Hz") "Frequency" annotation (Placement(
           transformation(
           extent={{-2,-2},{2,2}},
           rotation=0,

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -2568,7 +2568,7 @@ random number generator. This block is used in the example
           Modelica.Mechanics.Rotational.Interfaces.Flange_b flange
             "Right flange of shaft"
             annotation (Placement(transformation(extent={{90,-10},{110,10}})));
-          Modelica.Blocks.Interfaces.RealOutput phi
+          Modelica.Blocks.Interfaces.RealOutput phi(unit="rad")
             "Absolute angle of flange as output signal" annotation (Placement(
                 transformation(
                 extent={{-10,-10},{10,10}},

--- a/Modelica/ComplexBlocks.mo
+++ b/Modelica/ComplexBlocks.mo
@@ -1577,7 +1577,7 @@ Otherwise the output <code>y = u</code>.</p>
         "Numerator coefficients of transfer function (e.g., 2*s+3 is specified as {2,3})";
       parameter Real a[:]={1}
         "Denominator coefficients of transfer function (e.g., 5*s+6 is specified as {5,6})";
-      Modelica.Blocks.Interfaces.RealInput w "Frequency input" annotation (Placement(transformation(
+      Modelica.Blocks.Interfaces.RealInput w(unit="Hz") "Frequency input" annotation (Placement(transformation(
             extent={{-20,-20},{20,20}},
             rotation=90,
             origin={0,-120})));

--- a/Modelica/ComplexBlocks.mo
+++ b/Modelica/ComplexBlocks.mo
@@ -1577,7 +1577,7 @@ Otherwise the output <code>y = u</code>.</p>
         "Numerator coefficients of transfer function (e.g., 2*s+3 is specified as {2,3})";
       parameter Real a[:]={1}
         "Denominator coefficients of transfer function (e.g., 5*s+6 is specified as {5,6})";
-      Modelica.Blocks.Interfaces.RealInput w(unit="Hz") "Frequency input" annotation (Placement(transformation(
+      Modelica.Blocks.Interfaces.RealInput w(unit="rad/s") "Angular frequency input" annotation (Placement(transformation(
             extent={{-20,-20},{20,20}},
             rotation=90,
             origin={0,-120})));
@@ -1604,7 +1604,7 @@ Otherwise the output <code>y = u</code>.</p>
             extent={{-90,-90},{90,-10}},
               textString="a(jw)")}), Documentation(info="<html>
 <p>
-The complex input u is multiplied by the complex transfer function (depending on frequency input w) to obtain the complex output y (nb = dimension of b, na = dimension of a):
+The complex input u is multiplied by the complex transfer function (depending on the angular frequency input w) to obtain the complex output y (nb = dimension of b, na = dimension of a):
 </p>
 <pre>
            b[1]*(jw)^[nb-1] + b[2]*(jw)^[nb-2] + ... + b[nb]

--- a/Modelica/Electrical/Analog/Sources.mo
+++ b/Modelica/Electrical/Analog/Sources.mo
@@ -436,12 +436,12 @@ package Sources "Time-dependent and controlled voltage and current sources"
           rotation=270,
           origin={-60,120})));
   protected
-    Blocks.Interfaces.RealInput V_internal "Amplitude" annotation (Placement(
+    Blocks.Interfaces.RealInput V_internal(unit="V") "Amplitude" annotation (Placement(
           transformation(
           extent={{-2,-2},{2,2}},
           rotation=270,
           origin={60,80})));
-    Blocks.Interfaces.RealInput f_internal "Frequency" annotation (Placement(
+    Blocks.Interfaces.RealInput f_internal(unit="Hz") "Frequency" annotation (Placement(
           transformation(
           extent={{-2,-2},{2,2}},
           rotation=270,
@@ -532,12 +532,12 @@ and that the parameter <code>startTime</code> is omitted since the voltage can b
           rotation=270,
           origin={-60,120})));
   protected
-    Blocks.Interfaces.RealInput V_internal "Amplitude" annotation (Placement(
+    Blocks.Interfaces.RealInput V_internal(unit="V") "Amplitude" annotation (Placement(
           transformation(
           extent={{-2,-2},{2,2}},
           rotation=270,
           origin={60,80})));
-    Blocks.Interfaces.RealInput f_internal "Frequency" annotation (Placement(
+    Blocks.Interfaces.RealInput f_internal(unit="Hz") "Frequency" annotation (Placement(
           transformation(
           extent={{-2,-2},{2,2}},
           rotation=270,
@@ -1681,12 +1681,12 @@ If, e.g., time = 1.0, the voltage v =  0.0 (before event), 1.0 (after event)
       annotation (Placement(transformation(extent={{20,70},{40,90}})));
     Blocks.Sources.Constant f_constant(final k=constantFrequency) if useConstantFrequency
       annotation (Placement(transformation(extent={{-20,70},{-40,90}})));
-    Blocks.Interfaces.RealInput I_internal "Amplitude" annotation (Placement(
+    Blocks.Interfaces.RealInput I_internal(unit="A") "Amplitude" annotation (Placement(
           transformation(
           extent={{-2,-2},{2,2}},
           rotation=270,
           origin={60,80})));
-    Blocks.Interfaces.RealInput f_internal "Frequency" annotation (Placement(
+    Blocks.Interfaces.RealInput f_internal(unit="Hz") "Frequency" annotation (Placement(
           transformation(
           extent={{-2,-2},{2,2}},
           rotation=270,
@@ -1777,12 +1777,12 @@ and that the parameter <code>startTime</code> is omitted since the current can b
       annotation (Placement(transformation(extent={{20,70},{40,90}})));
     Blocks.Sources.Constant f_constant(final k=constantFrequency) if useConstantFrequency
       annotation (Placement(transformation(extent={{-20,70},{-40,90}})));
-    Blocks.Interfaces.RealInput I_internal "Amplitude" annotation (Placement(
+    Blocks.Interfaces.RealInput I_internal(unit="A") "Amplitude" annotation (Placement(
           transformation(
           extent={{-2,-2},{2,2}},
           rotation=270,
           origin={60,80})));
-    Blocks.Interfaces.RealInput f_internal "Frequency" annotation (Placement(
+    Blocks.Interfaces.RealInput f_internal(unit="Hz") "Frequency" annotation (Placement(
           transformation(
           extent={{-2,-2},{2,2}},
           rotation=270,

--- a/Modelica/Electrical/Machines.mo
+++ b/Modelica/Electrical/Machines.mo
@@ -12686,7 +12686,7 @@ Zero-sequence voltage and current are present at pin zero. An additional zero-se
               transformation(extent={{-110,90},{-90,110}})));
         Machines.Interfaces.SpacePhasor spacePhasor_b annotation (Placement(
               transformation(extent={{90,90},{110,110}})));
-        Modelica.Blocks.Interfaces.RealInput angle annotation (Placement(
+        Modelica.Blocks.Interfaces.RealInput angle(unit="rad") annotation (Placement(
               transformation(
               origin={0,-120},
               extent={{-20,-20},{20,20}},
@@ -14159,7 +14159,7 @@ where <code>RRef</code> is the value (e.g. resistance) at the reference temperat
               extent={{-10,-10},{10,10}},
               rotation=90,
               origin={-50,30})));
-        Modelica.Blocks.Interfaces.RealInput TRotorWinding if
+        Modelica.Blocks.Interfaces.RealInput TRotorWinding(unit="K") if
           useTemperatureInputs "Temperature of squirrel cage" annotation (
             Placement(transformation(
               extent={{-20,-20},{20,20}},
@@ -14210,7 +14210,7 @@ Additionally, all losses = heat flows are recorded.
               extent={{-10,-10},{10,10}},
               rotation=90,
               origin={-50,30})));
-        Modelica.Blocks.Interfaces.RealInput TRotorWinding if
+        Modelica.Blocks.Interfaces.RealInput TRotorWinding(unit="K") if
           useTemperatureInputs "Temperature of rotor windings" annotation (
             Placement(transformation(
               extent={{-20,-20},{20,20}},
@@ -14287,7 +14287,7 @@ Thermal parts for induction machines
               extent={{-10,-10},{10,10}},
               rotation=90,
               origin={-20,30})));
-        Modelica.Blocks.Interfaces.RealInput TRotorWinding if (
+        Modelica.Blocks.Interfaces.RealInput TRotorWinding(unit="K") if (
           useTemperatureInputs and useDamperCage)
           "Temperature of damper cage (optional)" annotation (Placement(
               transformation(
@@ -14313,7 +14313,7 @@ Thermal parts for induction machines
               extent={{-10,-10},{10,10}},
               rotation=90,
               origin={-50,-10})));
-        Modelica.Blocks.Interfaces.RealInput TPermanentMagnet if
+        Modelica.Blocks.Interfaces.RealInput TPermanentMagnet(unit="K") if
           useTemperatureInputs "Temperature of permanent magnet" annotation (
             Placement(transformation(
               extent={{-20,-20},{20,20}},
@@ -14374,7 +14374,7 @@ Additionally, all losses = heat flows are recorded.
               extent={{-10,-10},{10,10}},
               rotation=90,
               origin={-20,30})));
-        Modelica.Blocks.Interfaces.RealInput TRotorWinding if (
+        Modelica.Blocks.Interfaces.RealInput TRotorWinding(unit="K") if (
           useTemperatureInputs and useDamperCage)
           "Temperature of damper cage (optional)" annotation (Placement(
               transformation(
@@ -14392,7 +14392,7 @@ Additionally, all losses = heat flows are recorded.
               extent={{-10,-10},{10,10}},
               rotation=90,
               origin={-50,30})));
-        Modelica.Blocks.Interfaces.RealInput TExcitation if
+        Modelica.Blocks.Interfaces.RealInput TExcitation(unit="K") if
           useTemperatureInputs "Temperature of excitation" annotation (
             Placement(transformation(
               extent={{-20,-20},{20,20}},
@@ -14457,7 +14457,7 @@ Additionally, all losses = heat flows are recorded.
               extent={{-10,-10},{10,10}},
               rotation=90,
               origin={-20,30})));
-        Modelica.Blocks.Interfaces.RealInput TRotorWinding if (
+        Modelica.Blocks.Interfaces.RealInput TRotorWinding(unit="K") if (
           useTemperatureInputs and useDamperCage)
           "Temperature of damper cage (optional)" annotation (Placement(
               transformation(
@@ -14516,7 +14516,7 @@ Thermal parts for synchronous machines
               extent={{-10,-10},{10,10}},
               rotation=90,
               origin={-20,-10})));
-        Modelica.Blocks.Interfaces.RealInput TPermanentMagnet if
+        Modelica.Blocks.Interfaces.RealInput TPermanentMagnet(unit="K") if
           useTemperatureInputs "Temperature of permanent magnet" annotation (
             Placement(transformation(
               extent={{-20,-20},{20,20}},
@@ -14563,7 +14563,7 @@ Additionally, all losses = heat flows are recorded.
               extent={{-10,-10},{10,10}},
               rotation=90,
               origin={-20,-10})));
-        Modelica.Blocks.Interfaces.RealInput TExcitation if
+        Modelica.Blocks.Interfaces.RealInput TExcitation(unit="K") if
           useTemperatureInputs "Temperature of (shunt) excitation" annotation (
             Placement(transformation(
               extent={{-20,-20},{20,20}},
@@ -14609,7 +14609,7 @@ Additionally, all losses = heat flows are recorded.
               extent={{-10,-10},{10,10}},
               rotation=90,
               origin={-50,-10})));
-        Modelica.Blocks.Interfaces.RealInput T_se if useTemperatureInputs
+        Modelica.Blocks.Interfaces.RealInput T_se(unit="K") if useTemperatureInputs
           "Temperature of series excitation" annotation (Placement(
               transformation(
               extent={{-20,-20},{20,20}},
@@ -14664,7 +14664,7 @@ Additionally, all losses = heat flows are recorded.
               extent={{-10,-10},{10,10}},
               rotation=90,
               origin={-20,-10})));
-        Modelica.Blocks.Interfaces.RealInput T_e if useTemperatureInputs
+        Modelica.Blocks.Interfaces.RealInput T_e(unit="K") if useTemperatureInputs
           "Temperature of (shunt) excitation" annotation (Placement(
               transformation(
               extent={{-20,-20},{20,20}},
@@ -14683,7 +14683,7 @@ Additionally, all losses = heat flows are recorded.
               extent={{-10,-10},{10,10}},
               rotation=90,
               origin={-50,-10})));
-        Modelica.Blocks.Interfaces.RealInput T_se if useTemperatureInputs
+        Modelica.Blocks.Interfaces.RealInput T_se(unit="K") if useTemperatureInputs
           "Temperature of series excitation" annotation (Placement(
               transformation(
               extent={{-20,-20},{20,20}},
@@ -14752,7 +14752,7 @@ Thermal parts for DC machines
             extent={{-10,-10},{10,10}},
             rotation=90,
             origin={-80,-10})));
-      Modelica.Blocks.Interfaces.RealInput TPrimary if useTemperatureInputs
+      Modelica.Blocks.Interfaces.RealInput TPrimary(unit="K") if useTemperatureInputs
         "Temperature of primary windings" annotation (Placement(transformation(
             extent={{-20,-20},{20,20}},
             rotation=90,
@@ -14770,7 +14770,7 @@ Thermal parts for DC machines
             extent={{-10,10},{10,-10}},
             rotation=90,
             origin={80,-10})));
-      Modelica.Blocks.Interfaces.RealInput TSecondary if useTemperatureInputs
+      Modelica.Blocks.Interfaces.RealInput TSecondary(unit="K") if useTemperatureInputs
         "Temperature of secondary windings" annotation (Placement(
             transformation(
             extent={{-20,20},{20,-20}},
@@ -15388,7 +15388,7 @@ Partial thermal port for induction machines
               extent={{-10,-10},{10,10}},
               rotation=90,
               origin={80,30})));
-        Modelica.Blocks.Interfaces.RealInput TStatorWinding if
+        Modelica.Blocks.Interfaces.RealInput TStatorWinding(unit="K") if
           useTemperatureInputs "Temperature of stator windings" annotation (
             Placement(transformation(
               extent={{-20,-20},{20,20}},
@@ -15866,7 +15866,7 @@ Partial thermal port for DC machines
               extent={{-10,-10},{10,10}},
               rotation=90,
               origin={80,30})));
-        Modelica.Blocks.Interfaces.RealInput TArmature if useTemperatureInputs
+        Modelica.Blocks.Interfaces.RealInput TArmature(unit="K") if useTemperatureInputs
           "Temperature of armature" annotation (Placement(transformation(
               extent={{-20,-20},{20,20}},
               rotation=90,
@@ -17318,13 +17318,13 @@ The correction by factor &radic;2 is done automatically.
       Modelica.Blocks.Interfaces.RealInput iq "Reference of q-current"
         annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
       Modelica.Blocks.Interfaces.RealInput phi(unit="rad") "Rotor angle"
-                                                           annotation (Placement(
+        annotation (Placement(
             transformation(
             origin={60,-120},
             extent={{20,-20},{-20,20}},
             rotation=270)));
-      Modelica.Blocks.Interfaces.RealInput iActual[m]
-        "Measured three-phase currents"               annotation (Placement(
+      Modelica.Blocks.Interfaces.RealInput iActual[m](each unit="A")
+        "Measured three-phase currents" annotation (Placement(
             transformation(
             origin={-60,-120},
             extent={{20,-20},{-20,20}},

--- a/Modelica/Electrical/Polyphase/Examples/Utilities/AnalysatorAC.mo
+++ b/Modelica/Electrical/Polyphase/Examples/Utilities/AnalysatorAC.mo
@@ -13,23 +13,23 @@ model AnalysatorAC "Analyze AC voltage, current and power"
   Interfaces.NegativePlug plug_nv(final m=m)
     "Negative polyphase electrical plug with m pins" annotation (Placement(transformation(
           extent={{-10,-110},{10,-90}})));
-  Modelica.Blocks.Interfaces.RealOutput pTotal "Total power, mean"  annotation (
+  Modelica.Blocks.Interfaces.RealOutput pTotal(unit="W") "Total power, mean"  annotation (
      Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=0,
         origin={110,-60})));
-  Modelica.Blocks.Interfaces.RealOutput iFeed[m]
+  Modelica.Blocks.Interfaces.RealOutput iFeed[m](each unit="A")
     "RMS feed currents, first harmonic" annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-60,-110})));
-  Modelica.Blocks.Interfaces.RealOutput vLL1[m]
+  Modelica.Blocks.Interfaces.RealOutput vLL1[m](each unit="V")
     "RMS voltages line-to-line, first harmonic" annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,
         origin={-110,-60})));
-  Modelica.Blocks.Interfaces.RealOutput vLN[m]
+  Modelica.Blocks.Interfaces.RealOutput vLN[m](each unit="V")
     "RMS voltages line-to-neutral, first harmonic" annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
@@ -88,7 +88,7 @@ equation
           -60},{-110,-60}}, color={0,0,127}));
   connect(voltageSensor.v, voltageLine2Line.u)
     annotation (Line(points={{-59,30},{-50,30},{-50,-18}}, color={0,0,127}));
-  connect(multiSensorAC.powerTotal,powerTotal. u)
+  connect(multiSensorAC.powerTotal,powerTotal.u)
     annotation (Line(points={{11,-6},{50,-6},{50,-18}}, color={0,0,127}));
   connect(powerTotal.y, pTotal)
     annotation (Line(points={{50,-41},{50,-60},{110,-60}}, color={0,0,127}));

--- a/Modelica/Electrical/Polyphase/Examples/Utilities/AnalysatorDC.mo
+++ b/Modelica/Electrical/Polyphase/Examples/Utilities/AnalysatorDC.mo
@@ -6,17 +6,17 @@ model AnalysatorDC "Analyze DC voltage, current and power"
   parameter Modelica.SIunits.Frequency f=50 "Mains frequency";
   Analog.Interfaces.NegativePin nv "Negative electrical pin"
     annotation (Placement(transformation(extent={{-10,-110},{10,-90}})));
-  Modelica.Blocks.Interfaces.RealOutput pDC "Mean power" annotation (
+  Modelica.Blocks.Interfaces.RealOutput pDC(unit="W") "Mean power" annotation (
       Placement(transformation(
         extent={{10,-10},{-10,10}},
         rotation=0,
         origin={-110,-60})));
-  Modelica.Blocks.Interfaces.RealOutput iMean "Mean current" annotation (
+  Modelica.Blocks.Interfaces.RealOutput iMean(unit="A") "Mean current" annotation (
       Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-60,-110})));
-  Modelica.Blocks.Interfaces.RealOutput vMean "Mean voltage" annotation (
+  Modelica.Blocks.Interfaces.RealOutput vMean(unit="V") "Mean voltage" annotation (
       Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,

--- a/Modelica/Electrical/Polyphase/Sensors/AronSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/AronSensor.mo
@@ -7,7 +7,7 @@ model AronSensor "Three-phase Aron sensor for active power"
         transformation(extent={{-110,-10},{-90,10}})));
   Interfaces.NegativePlug plug_n(final m=m) annotation (Placement(
         transformation(extent={{90,-10},{110,10}})));
-  Modelica.Blocks.Interfaces.RealOutput power "Active power" annotation (
+  Modelica.Blocks.Interfaces.RealOutput power(unit="W") "Active power" annotation (
       Placement(transformation(
         origin={0,-110},
         extent={{10,-10},{-10,10}},

--- a/Modelica/Electrical/Polyphase/Sensors/CurrentQuasiRMSSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/CurrentQuasiRMSSensor.mo
@@ -4,7 +4,7 @@ model CurrentQuasiRMSSensor
   extends Modelica.Icons.RoundSensor;
   extends Polyphase.Interfaces.TwoPlug;
   parameter Integer m(min=1) = 3 "Number of phases";
-  Modelica.Blocks.Interfaces.RealOutput I
+  Modelica.Blocks.Interfaces.RealOutput I(unit="A")
     "Continuous quasi average RMS of current" annotation (Placement(
         transformation(
         origin={0,-100},

--- a/Modelica/Electrical/Polyphase/Sensors/CurrentSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/CurrentSensor.mo
@@ -6,8 +6,8 @@ model CurrentSensor "Polyphase current sensor"
         transformation(extent={{-110,-10},{-90,10}})));
   Interfaces.NegativePlug plug_n(final m=m) annotation (Placement(
         transformation(extent={{90,-10},{110,10}})));
-  Modelica.Blocks.Interfaces.RealOutput i[m]
-    "current in the branch from p to n as output signal" annotation (
+  Modelica.Blocks.Interfaces.RealOutput i[m](each unit="A")
+    "Current in the branch from p to n as output signal" annotation (
       Placement(transformation(
         origin={0,-110},
         extent={{10,-10},{-10,10}},

--- a/Modelica/Electrical/Polyphase/Sensors/PotentialSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/PotentialSensor.mo
@@ -4,7 +4,7 @@ model PotentialSensor "Polyphase potential sensor"
   parameter Integer m(final min=1) = 3 "Number of phases";
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(
         transformation(extent={{-110,-10},{-90,10}})));
-  Modelica.Blocks.Interfaces.RealOutput phi[m]
+  Modelica.Blocks.Interfaces.RealOutput phi[m](unit="V")
     "Absolute voltage potential as output signal" annotation (Placement(
         transformation(extent={{100,-10},{120,10}})));
   Modelica.Electrical.Analog.Sensors.PotentialSensor potentialSensor[m]

--- a/Modelica/Electrical/Polyphase/Sensors/PowerSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/PowerSensor.mo
@@ -10,7 +10,7 @@ model PowerSensor "Polyphase instantaneous power sensor"
     annotation (Placement(transformation(extent={{-10,90},{10,110}})));
   Polyphase.Interfaces.NegativePlug nv(final m=m) "Negative plug, voltage path"
     annotation (Placement(transformation(extent={{-10,-90},{10,-110}})));
-  Modelica.Blocks.Interfaces.RealOutput power annotation (Placement(
+  Modelica.Blocks.Interfaces.RealOutput power(unit="W") annotation (Placement(
         transformation(
         origin={-100,-110},
         extent={{10,-10},{-10,10}},

--- a/Modelica/Electrical/Polyphase/Sensors/ReactivePowerSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/ReactivePowerSensor.mo
@@ -7,7 +7,7 @@ model ReactivePowerSensor "Three-phase sensor for reactive power"
         transformation(extent={{-110,-10},{-90,10}})));
   Interfaces.NegativePlug plug_n(final m=m) annotation (Placement(
         transformation(extent={{90,-10},{110,10}})));
-  Modelica.Blocks.Interfaces.RealOutput reactivePower "reactive power"
+  Modelica.Blocks.Interfaces.RealOutput reactivePower(unit="var") "Reactive power"
     annotation (Placement(transformation(
         origin={0,-110},
         extent={{10,-10},{-10,10}},

--- a/Modelica/Electrical/Polyphase/Sensors/VoltageQuasiRMSSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/VoltageQuasiRMSSensor.mo
@@ -5,7 +5,7 @@ model VoltageQuasiRMSSensor
   extends Polyphase.Interfaces.TwoPlug;
   parameter Integer m(min=1) = 3 "Number of phases";
 
-  Modelica.Blocks.Interfaces.RealOutput V "Continuous quasi RMS of voltage"
+  Modelica.Blocks.Interfaces.RealOutput V(unit="V") "Continuous quasi RMS of voltage"
     annotation (Placement(transformation(
         origin={-2,-110},
         extent={{-10,-10},{10,10}},

--- a/Modelica/Electrical/Polyphase/Sensors/VoltageSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/VoltageSensor.mo
@@ -6,7 +6,7 @@ model VoltageSensor "Polyphase voltage sensor"
         transformation(extent={{-110,-10},{-90,10}})));
   Interfaces.NegativePlug plug_n(final m=m) annotation (Placement(
         transformation(extent={{90,-10},{110,10}})));
-  Modelica.Blocks.Interfaces.RealOutput v[m]
+  Modelica.Blocks.Interfaces.RealOutput v[m](each unit="V")
     "Voltage between pin p and n (= p.v - n.v) as output signal"
     annotation (Placement(transformation(
         origin={0,-110},

--- a/Modelica/Electrical/PowerConverters/ACAC/Control/SoftStartControl.mo
+++ b/Modelica/Electrical/PowerConverters/ACAC/Control/SoftStartControl.mo
@@ -5,7 +5,7 @@ block SoftStartControl
     Modelica.Electrical.PowerConverters.Types.SoftStarterModeOfOperation;
   parameter Modelica.SIunits.Time tRampUp "Start ramp duration";
   parameter Real vStart=0 "Start voltage / nominal voltage";
-  parameter Real iMax "Maximum current / Nominal current";
+  parameter Real iMax "Maximum current / nominal current";
   parameter Real iMin=0.9*iMax "Lower threshold of current control";
   parameter Modelica.SIunits.Current INominal "Nominal current";
 parameter Modelica.SIunits.Time tRampDown "Stop ramp duration";

--- a/Modelica/Electrical/PowerConverters/ACAC/Control/VoltageToAngle.mo
+++ b/Modelica/Electrical/PowerConverters/ACAC/Control/VoltageToAngle.mo
@@ -19,8 +19,8 @@ block VoltageToAngle "Reference voltage to firing angle converter"
   Modelica.Blocks.Nonlinear.Limiter limiter(final uMax=1, final uMin=0)
     annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
   Modelica.Blocks.Tables.CombiTable1Ds combiTable1Ds(final table=
-    if voltage2Angle ==PowerConverters.Types.Voltage2AngleType.Lin                      then Lin
-    elseif voltage2Angle ==PowerConverters.Types.Voltage2AngleType.H01                      then H01
+    if voltage2Angle ==PowerConverters.Types.Voltage2AngleType.Lin then Lin
+    elseif voltage2Angle ==PowerConverters.Types.Voltage2AngleType.H01 then H01
     else RMS, final extrapolation=Modelica.Blocks.Types.Extrapolation.HoldLastPoint)
     annotation (Placement(transformation(extent={{0,-10},{20,10}})));
   Modelica.Blocks.Math.Gain gain_alpha(final k=pi)

--- a/Modelica/Electrical/PowerConverters/ACDC/Control/Signal2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/Control/Signal2mPulse.mo
@@ -16,7 +16,7 @@ block Signal2mPulse "Generic control of 2*m pulse rectifiers"
   parameter Modelica.SIunits.Voltage vStart[m]=zeros(m)
     "Start voltage of filter output"
     annotation (Dialog(tab="Filter", enable=useFilter));
-  Modelica.Blocks.Interfaces.RealInput firingAngle if not
+  Modelica.Blocks.Interfaces.RealInput firingAngle(unit="rad") if not
     useConstantFiringAngle "Firing angle (rad)" annotation (Placement(
         transformation(
         extent={{20,-20},{-20,20}},
@@ -91,7 +91,7 @@ block Signal2mPulse "Generic control of 2*m pulse rectifiers"
         extent={{10,-10},{-10,10}},
         rotation=270,
         origin={0,-20})));
-  Modelica.Blocks.Interfaces.RealInput v[m] "Voltages" annotation (
+  Modelica.Blocks.Interfaces.RealInput v[m](each unit="V") "Voltages" annotation (
       Placement(transformation(
         extent={{-20,-20},{20,20}},
         origin={-120,0})));

--- a/Modelica/Electrical/PowerConverters/ACDC/Control/Signal2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/Control/Signal2mPulse.mo
@@ -17,7 +17,7 @@ block Signal2mPulse "Generic control of 2*m pulse rectifiers"
     "Start voltage of filter output"
     annotation (Dialog(tab="Filter", enable=useFilter));
   Modelica.Blocks.Interfaces.RealInput firingAngle(unit="rad") if not
-    useConstantFiringAngle "Firing angle (rad)" annotation (Placement(
+    useConstantFiringAngle "Firing angle" annotation (Placement(
         transformation(
         extent={{20,-20},{-20,20}},
         rotation=270,

--- a/Modelica/Electrical/PowerConverters/ACDC/Control/VoltageBridge2Pulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/Control/VoltageBridge2Pulse.mo
@@ -19,7 +19,7 @@ model VoltageBridge2Pulse "Control of 2 pulse bridge rectifier"
   parameter Modelica.SIunits.Voltage vStart=0
     "Start voltage of filter output"
     annotation (Dialog(tab="Filter", enable=useFilter));
-  Modelica.Blocks.Interfaces.RealInput firingAngle if not
+  Modelica.Blocks.Interfaces.RealInput firingAngle(unit="rad") if not
     useConstantFiringAngle "Firing angle (rad)" annotation (Placement(
         transformation(
         extent={{-20,-20},{20,20}},

--- a/Modelica/Electrical/PowerConverters/ACDC/Control/VoltageBridge2Pulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/Control/VoltageBridge2Pulse.mo
@@ -20,7 +20,7 @@ model VoltageBridge2Pulse "Control of 2 pulse bridge rectifier"
     "Start voltage of filter output"
     annotation (Dialog(tab="Filter", enable=useFilter));
   Modelica.Blocks.Interfaces.RealInput firingAngle(unit="rad") if not
-    useConstantFiringAngle "Firing angle (rad)" annotation (Placement(
+    useConstantFiringAngle "Firing angle" annotation (Placement(
         transformation(
         extent={{-20,-20},{20,20}},
         rotation=90,

--- a/Modelica/Electrical/PowerConverters/ACDC/Control/VoltageBridge2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/Control/VoltageBridge2mPulse.mo
@@ -21,7 +21,7 @@ model VoltageBridge2mPulse "Control of 2*m pulse bridge rectifier"
     "Start voltage of filter output"
     annotation (Dialog(tab="Filter", enable=useFilter));
   Modelica.Blocks.Interfaces.RealInput firingAngle(unit="rad") if not
-    useConstantFiringAngle "Firing angle (rad)" annotation (Placement(
+    useConstantFiringAngle "Firing angle" annotation (Placement(
         transformation(
         extent={{-20,-20},{20,20}},
         rotation=90,

--- a/Modelica/Electrical/PowerConverters/ACDC/Control/VoltageBridge2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/Control/VoltageBridge2mPulse.mo
@@ -20,7 +20,7 @@ model VoltageBridge2mPulse "Control of 2*m pulse bridge rectifier"
   parameter Modelica.SIunits.Voltage vStart[m]=zeros(m)
     "Start voltage of filter output"
     annotation (Dialog(tab="Filter", enable=useFilter));
-  Modelica.Blocks.Interfaces.RealInput firingAngle if not
+  Modelica.Blocks.Interfaces.RealInput firingAngle(unit="rad") if not
     useConstantFiringAngle "Firing angle (rad)" annotation (Placement(
         transformation(
         extent={{-20,-20},{20,20}},

--- a/Modelica/Electrical/PowerConverters/ACDC/Control/VoltageCenterTap2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/Control/VoltageCenterTap2mPulse.mo
@@ -21,7 +21,7 @@ model VoltageCenterTap2mPulse "Control of 2*m pulse center tap rectifier"
     "Start voltage of filter output"
     annotation (Dialog(tab="Filter", enable=useFilter));
   Modelica.Blocks.Interfaces.RealInput firingAngle(unit="rad") if not
-    useConstantFiringAngle "Firing angle (rad)" annotation (Placement(
+    useConstantFiringAngle "Firing angle" annotation (Placement(
         transformation(
         extent={{-20,-20},{20,20}},
         rotation=90,

--- a/Modelica/Electrical/PowerConverters/ACDC/Control/VoltageCenterTap2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/Control/VoltageCenterTap2mPulse.mo
@@ -20,7 +20,7 @@ model VoltageCenterTap2mPulse "Control of 2*m pulse center tap rectifier"
   parameter Modelica.SIunits.Voltage vStart[m]=zeros(m)
     "Start voltage of filter output"
     annotation (Dialog(tab="Filter", enable=useFilter));
-  Modelica.Blocks.Interfaces.RealInput firingAngle if not
+  Modelica.Blocks.Interfaces.RealInput firingAngle(unit="rad") if not
     useConstantFiringAngle "Firing angle (rad)" annotation (Placement(
         transformation(
         extent={{-20,-20},{20,20}},

--- a/Modelica/Electrical/PowerConverters/DCDC/Control/Voltage2DutyCycle.mo
+++ b/Modelica/Electrical/PowerConverters/DCDC/Control/Voltage2DutyCycle.mo
@@ -28,7 +28,7 @@ block Voltage2DutyCycle "Linearly transforms voltage to duty cycle"
     "Constant voltage limit"
     annotation (Placement(transformation(extent={{40,70},{20,90}})));
 protected
-  Modelica.Blocks.Interfaces.RealInput vLimInt "Internal voltage limit"
+  Modelica.Blocks.Interfaces.RealInput vLimInt(unit="V") "Internal voltage limit"
     annotation (Placement(transformation(
         extent={{-4,-4},{4,4}},
         rotation=180,

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/AronSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/AronSensor.mo
@@ -7,7 +7,7 @@ model AronSensor "Three-phase Aron sensor for active power"
     annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
   Modelica.Electrical.QuasiStatic.Polyphase.Interfaces.NegativePlug plug_n(final m=m)
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
-  Modelica.Blocks.Interfaces.RealOutput power "Active power" annotation (
+  Modelica.Blocks.Interfaces.RealOutput power(unit="W") "Active power" annotation (
       Placement(transformation(
         origin={0,-110},
         extent={{10,-10},{-10,10}},

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/CurrentQuasiRMSSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/CurrentQuasiRMSSensor.mo
@@ -4,7 +4,7 @@ model CurrentQuasiRMSSensor
   extends Modelica.Icons.RoundSensor;
   extends QuasiStatic.Polyphase.Interfaces.TwoPlug;
   parameter Integer m(min=1) = 3 "Number of phases";
-  Modelica.Blocks.Interfaces.RealOutput I
+  Modelica.Blocks.Interfaces.RealOutput I(unit="A")
     "Continuous quasi average RMS of current" annotation (Placement(
         transformation(
         origin={0,-100},

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/FrequencySensor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/FrequencySensor.mo
@@ -5,7 +5,7 @@ model FrequencySensor "Frequency sensor"
         transformation(extent={{-10,-10},{10,10}})));
   Basic.PlugToPin_p plugToPin_p(final m=m, final k=1) annotation (Placement(
         transformation(extent={{-80,-10},{-60,10}})));
-  Modelica.Blocks.Interfaces.RealOutput y annotation (Placement(
+  Modelica.Blocks.Interfaces.RealOutput y(unit="Hz") annotation (Placement(
         transformation(extent={{100,-10},{120,10}})));
 equation
 

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sources/VariableCurrentSource.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sources/VariableCurrentSource.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Sources;
 model VariableCurrentSource "Variable polyphase AC current"
   extends Interfaces.Source;
-  Modelica.Blocks.Interfaces.RealInput f annotation (Placement(
+  Modelica.Blocks.Interfaces.RealInput f(unit="Hz") annotation (Placement(
         transformation(
         origin={40,100},
         extent={{-20,-20},{20,20}},

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sources/VariableVoltageSource.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sources/VariableVoltageSource.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.QuasiStatic.Polyphase.Sources;
 model VariableVoltageSource "Variable polyphase AC voltage"
   extends Interfaces.Source;
-  Modelica.Blocks.Interfaces.RealInput f annotation (Placement(
+  Modelica.Blocks.Interfaces.RealInput f(unit="Hz") annotation (Placement(
         transformation(
         origin={60,120},
         extent={{-20,-20},{20,20}},

--- a/Modelica/Fluid/Examples/DrumBoiler.mo
+++ b/Modelica/Fluid/Examples/DrumBoiler.mo
@@ -8,7 +8,7 @@ package DrumBoiler
     extends Modelica.Icons.Example;
 
     parameter Boolean use_inputs = false
-      "use external inputs instead of test data contained internally";
+      "= true, if external inputs shall be used, otherwise use test data contained internally";
 
     Modelica.Fluid.Examples.DrumBoiler.BaseClasses.EquilibriumDrumBoiler
       evaporator(
@@ -61,13 +61,13 @@ package DrumBoiler
       annotation (Placement(transformation(extent={{-22,20},{-42,40}})));
     Modelica.Blocks.Sources.Constant levelSetPoint(k=67)
       annotation (Placement(transformation(extent={{-38,48},{-24,62}})));
-    Modelica.Blocks.Interfaces.RealOutput T_S(final unit="degC") "steam temperature"
+    Modelica.Blocks.Interfaces.RealOutput T_S(final unit="degC") "Steam temperature"
       annotation (Placement(transformation(extent={{100,48},{112,60}})));
-    Modelica.Blocks.Interfaces.RealOutput p_S(final unit="bar") "steam pressure"
+    Modelica.Blocks.Interfaces.RealOutput p_S(final unit="bar") "Steam pressure"
       annotation (Placement(transformation(extent={{100,22},{112,34}})));
-    Modelica.Blocks.Interfaces.RealOutput qm_S(unit="kg/s") "steam flow rate"
+    Modelica.Blocks.Interfaces.RealOutput qm_S(unit="kg/s") "Steam flow rate"
       annotation (Placement(transformation(extent={{100,-2},{112,10}})));
-    Modelica.Blocks.Interfaces.RealOutput V_l(unit="m3") "liquid volume inside drum"
+    Modelica.Blocks.Interfaces.RealOutput V_l(unit="m3") "Liquid volume inside drum"
       annotation (Placement(transformation(extent={{100,74},{112,86}})));
   public
     Modelica.Blocks.Math.Gain MW2W(k=1e6)
@@ -95,9 +95,9 @@ package DrumBoiler
     Modelica.Blocks.Sources.TimeTable Y_Valve_Tab(table=[0,0; 900,1; 7210,1]) if not use_inputs
                annotation (Placement(transformation(extent={{30,-80},{50,-60}})));
     Blocks.Interfaces.RealInput q_F(unit="MW") if
-                                       use_inputs "fuel flow rate"
+                                       use_inputs "Fuel flow rate"
       annotation (Placement(transformation(extent={{-112,-56},{-100,-44}})));
-    Blocks.Interfaces.RealInput Y_Valve if use_inputs "valve opening"
+    Blocks.Interfaces.RealInput Y_Valve if use_inputs "Valve opening"
       annotation (Placement(transformation(extent={{-112,-96},{-100,-84}})));
   equation
     connect(furnace.port, evaporator.heatPort)

--- a/Modelica/Fluid/Examples/HeatingSystem.mo
+++ b/Modelica/Fluid/Examples/HeatingSystem.mo
@@ -45,7 +45,7 @@ model HeatingSystem "Simple model of a heating system"
     dp_nominal=10000)
     annotation (Placement(transformation(extent={{60,-80},{40,-60}})));
 protected
-  Modelica.Blocks.Interfaces.RealOutput m_flow
+  Modelica.Blocks.Interfaces.RealOutput m_flow(unit="kg/s")
     annotation (Placement(transformation(extent={{-6,34},{6,46}})));
 public
   Sensors.MassFlowRate sensor_m_flow(redeclare package Medium = Medium)
@@ -101,9 +101,9 @@ public
     annotation (Placement(transformation(extent={{20,-80},{0,-60}})));
 
 protected
-  Modelica.Blocks.Interfaces.RealOutput T_forward
+  Modelica.Blocks.Interfaces.RealOutput T_forward(unit="K")
     annotation (Placement(transformation(extent={{74,34},{86,46}})));
-  Modelica.Blocks.Interfaces.RealOutput T_return
+  Modelica.Blocks.Interfaces.RealOutput T_return(unit="K")
     annotation (Placement(transformation(extent={{-46,-56},{-58,-44}})));
 public
   Modelica.Fluid.Sensors.Temperature sensor_T_forward(redeclare package Medium
@@ -113,7 +113,7 @@ public
       = Medium)
     annotation (Placement(transformation(extent={{-20,-60},{-40,-40}})));
 protected
-  Modelica.Blocks.Interfaces.RealOutput tankLevel
+  Modelica.Blocks.Interfaces.RealOutput tankLevel(unit="m")
                                  annotation (Placement(transformation(extent={{-56,34},
             {-44,46}})));
 public

--- a/Modelica/Fluid/Machines.mo
+++ b/Modelica/Fluid/Machines.mo
@@ -163,13 +163,13 @@ package Machines
     final parameter SI.Position head_op = (p_b_nominal-p_a_nominal)/(rho_nominal*g)
       "operational pump head according to nominal values";
 
-    Modelica.Blocks.Interfaces.RealInput m_flow_set if use_m_flow_set
+    Modelica.Blocks.Interfaces.RealInput m_flow_set(unit="kg/s") if use_m_flow_set
       "Prescribed mass flow rate"
       annotation (Placement(transformation(
           extent={{-20,-20},{20,20}},
           rotation=-90,
           origin={-50,82})));
-    Modelica.Blocks.Interfaces.RealInput p_set if use_p_set
+    Modelica.Blocks.Interfaces.RealInput p_set(unit="Pa") if use_p_set
       "Prescribed outlet pressure"
       annotation (Placement(transformation(
           extent={{-20,-20},{20,20}},
@@ -177,9 +177,9 @@ package Machines
           origin={50,82})));
 
   protected
-    Modelica.Blocks.Interfaces.RealInput m_flow_set_internal
+    Modelica.Blocks.Interfaces.RealInput m_flow_set_internal(unit="kg/s")
       "Needed to connect to conditional connector";
-    Modelica.Blocks.Interfaces.RealInput p_set_internal
+    Modelica.Blocks.Interfaces.RealInput p_set_internal(unit="Pa")
       "Needed to connect to conditional connector";
   equation
     // Ideal control

--- a/Modelica/Fluid/Sources.mo
+++ b/Modelica/Fluid/Sources.mo
@@ -154,24 +154,24 @@ with exception of boundary pressure, do not have an effect.
          quantity=Medium.extraPropertiesNames) = Medium.C_default
       "Fixed values of trace substances"
       annotation (Dialog(enable = (not use_C_in) and Medium.nC > 0));
-    Modelica.Blocks.Interfaces.RealInput p_in if use_p_in
+    Modelica.Blocks.Interfaces.RealInput p_in(unit="Pa") if use_p_in
       "Prescribed boundary pressure"
       annotation (Placement(transformation(extent={{-140,60},{-100,100}})));
-    Modelica.Blocks.Interfaces.RealInput T_in if use_T_in
+    Modelica.Blocks.Interfaces.RealInput T_in(unit="K") if use_T_in
       "Prescribed boundary temperature"
       annotation (Placement(transformation(extent={{-140,20},{-100,60}})));
-    Modelica.Blocks.Interfaces.RealInput X_in[Medium.nX] if use_X_in
+    Modelica.Blocks.Interfaces.RealInput X_in[Medium.nX](each unit="1") if use_X_in
       "Prescribed boundary composition"
       annotation (Placement(transformation(extent={{-140,-60},{-100,-20}})));
     Modelica.Blocks.Interfaces.RealInput C_in[Medium.nC] if use_C_in
       "Prescribed boundary trace substances"
       annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   protected
-    Modelica.Blocks.Interfaces.RealInput p_in_internal
+    Modelica.Blocks.Interfaces.RealInput p_in_internal(unit="Pa")
       "Needed to connect to conditional connector";
-    Modelica.Blocks.Interfaces.RealInput T_in_internal
+    Modelica.Blocks.Interfaces.RealInput T_in_internal(unit="K")
       "Needed to connect to conditional connector";
-    Modelica.Blocks.Interfaces.RealInput X_in_internal[Medium.nX]
+    Modelica.Blocks.Interfaces.RealInput X_in_internal[Medium.nX](each unit="1")
       "Needed to connect to conditional connector";
     Modelica.Blocks.Interfaces.RealInput C_in_internal[Medium.nC]
       "Needed to connect to conditional connector";
@@ -298,24 +298,24 @@ with exception of boundary pressure, do not have an effect.
          quantity=Medium.extraPropertiesNames) = Medium.C_default
       "Fixed values of trace substances"
       annotation (Dialog(enable = (not use_C_in) and Medium.nC > 0));
-    Modelica.Blocks.Interfaces.RealInput p_in if use_p_in
+    Modelica.Blocks.Interfaces.RealInput p_in(unit="Pa") if use_p_in
       "Prescribed boundary pressure"
       annotation (Placement(transformation(extent={{-140,60},{-100,100}})));
-    Modelica.Blocks.Interfaces.RealInput h_in if use_h_in
+    Modelica.Blocks.Interfaces.RealInput h_in(unit="J/kg") if use_h_in
       "Prescribed boundary specific enthalpy"
       annotation (Placement(transformation(extent={{-140,20},{-100,60}})));
-    Modelica.Blocks.Interfaces.RealInput X_in[Medium.nX] if use_X_in
+    Modelica.Blocks.Interfaces.RealInput X_in[Medium.nX](each unit="1") if use_X_in
       "Prescribed boundary composition"
       annotation (Placement(transformation(extent={{-140,-60},{-100,-20}})));
     Modelica.Blocks.Interfaces.RealInput C_in[Medium.nC] if use_C_in
       "Prescribed boundary trace substances"
       annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   protected
-    Modelica.Blocks.Interfaces.RealInput p_in_internal
+    Modelica.Blocks.Interfaces.RealInput p_in_internal(unit="Pa")
       "Needed to connect to conditional connector";
-    Modelica.Blocks.Interfaces.RealInput h_in_internal
+    Modelica.Blocks.Interfaces.RealInput h_in_internal(unit="J/kg")
       "Needed to connect to conditional connector";
-    Modelica.Blocks.Interfaces.RealInput X_in_internal[Medium.nX]
+    Modelica.Blocks.Interfaces.RealInput X_in_internal[Medium.nX](each unit="1")
       "Needed to connect to conditional connector";
     Modelica.Blocks.Interfaces.RealInput C_in_internal[Medium.nC]
       "Needed to connect to conditional connector";
@@ -442,26 +442,24 @@ with exception of boundary pressure, do not have an effect.
          quantity=Medium.extraPropertiesNames) = Medium.C_default
       "Fixed values of trace substances"
       annotation (Dialog(enable = (not use_C_in) and Medium.nC > 0));
-    Modelica.Blocks.Interfaces.RealInput m_flow_in if     use_m_flow_in
+    Modelica.Blocks.Interfaces.RealInput m_flow_in(unit="kg/s") if use_m_flow_in
       "Prescribed mass flow rate"
       annotation (Placement(transformation(extent={{-120,60},{-80,100}}), iconTransformation(extent={{-120,60},{-80,100}})));
-    Modelica.Blocks.Interfaces.RealInput T_in if         use_T_in
+    Modelica.Blocks.Interfaces.RealInput T_in(unit="K") if use_T_in
       "Prescribed fluid temperature"
       annotation (Placement(transformation(extent={{-140,20},{-100,60}}), iconTransformation(extent={{-140,20},{-100,60}})));
-    Modelica.Blocks.Interfaces.RealInput X_in[Medium.nX] if
-                                                          use_X_in
+    Modelica.Blocks.Interfaces.RealInput X_in[Medium.nX](each unit="1") if use_X_in
       "Prescribed fluid composition"
       annotation (Placement(transformation(extent={{-140,-60},{-100,-20}})));
-    Modelica.Blocks.Interfaces.RealInput C_in[Medium.nC] if
-                                                          use_C_in
+    Modelica.Blocks.Interfaces.RealInput C_in[Medium.nC] if use_C_in
       "Prescribed boundary trace substances"
       annotation (Placement(transformation(extent={{-120,-100},{-80,-60}})));
   protected
-    Modelica.Blocks.Interfaces.RealInput m_flow_in_internal
+    Modelica.Blocks.Interfaces.RealInput m_flow_in_internal(unit="kg/s")
       "Needed to connect to conditional connector";
-    Modelica.Blocks.Interfaces.RealInput T_in_internal
+    Modelica.Blocks.Interfaces.RealInput T_in_internal(unit="K")
       "Needed to connect to conditional connector";
-    Modelica.Blocks.Interfaces.RealInput X_in_internal[Medium.nX]
+    Modelica.Blocks.Interfaces.RealInput X_in_internal[Medium.nX](each unit="1")
       "Needed to connect to conditional connector";
     Modelica.Blocks.Interfaces.RealInput C_in_internal[Medium.nC]
       "Needed to connect to conditional connector";
@@ -591,26 +589,24 @@ with exception of boundary flow rate, do not have an effect.
          quantity=Medium.extraPropertiesNames) = Medium.C_default
       "Fixed values of trace substances"
       annotation (Dialog(enable = (not use_C_in) and Medium.nC > 0));
-    Modelica.Blocks.Interfaces.RealInput m_flow_in if     use_m_flow_in
+    Modelica.Blocks.Interfaces.RealInput m_flow_in(unit="kg/s") if use_m_flow_in
       "Prescribed mass flow rate"
       annotation (Placement(transformation(extent={{-120,60},{-80,100}})));
-    Modelica.Blocks.Interfaces.RealInput h_in if              use_h_in
+    Modelica.Blocks.Interfaces.RealInput h_in(unit="J/kg") if use_h_in
       "Prescribed fluid specific enthalpy"
       annotation (Placement(transformation(extent={{-140,20},{-100,60}}), iconTransformation(extent={{-140,20},{-100,60}})));
-    Modelica.Blocks.Interfaces.RealInput X_in[Medium.nX] if
-                                                          use_X_in
+    Modelica.Blocks.Interfaces.RealInput X_in[Medium.nX](each unit="1") if use_X_in
       "Prescribed fluid composition"
       annotation (Placement(transformation(extent={{-140,-60},{-100,-20}})));
-    Modelica.Blocks.Interfaces.RealInput C_in[Medium.nC] if
-                                                          use_C_in
+    Modelica.Blocks.Interfaces.RealInput C_in[Medium.nC] if use_C_in
       "Prescribed boundary trace substances"
       annotation (Placement(transformation(extent={{-120,-100},{-80,-60}}), iconTransformation(extent={{-120,-100},{-80,-60}})));
   protected
-    Modelica.Blocks.Interfaces.RealInput m_flow_in_internal
+    Modelica.Blocks.Interfaces.RealInput m_flow_in_internal(unit="kg/s")
       "Needed to connect to conditional connector";
-    Modelica.Blocks.Interfaces.RealInput h_in_internal
+    Modelica.Blocks.Interfaces.RealInput h_in_internal(unit="J/kg")
       "Needed to connect to conditional connector";
-    Modelica.Blocks.Interfaces.RealInput X_in_internal[Medium.nX]
+    Modelica.Blocks.Interfaces.RealInput X_in_internal[Medium.nX](each unit="1")
       "Needed to connect to conditional connector";
     Modelica.Blocks.Interfaces.RealInput C_in_internal[Medium.nC]
       "Needed to connect to conditional connector";

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Sensors/FrequencySensor.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Sensors/FrequencySensor.mo
@@ -2,11 +2,11 @@ within Modelica.Magnetic.QuasiStatic.FluxTubes.Sensors;
 model FrequencySensor "Frequency sensor"
   extends FluxTubes.Interfaces.AbsoluteSensor;
   import Modelica.Constants.pi;
-  Modelica.Blocks.Interfaces.RealOutput y annotation (Placement(transformation(
+  Modelica.Blocks.Interfaces.RealOutput y(unit="Hz") annotation (Placement(transformation(
           extent={{100,-10},{120,10}})));
 equation
   2*pi*y = omega;
-  annotation (               Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <p>
 This sensor can be used to measure the frequency of the reference system.
 The integral of the angular frequency of the quasi-static magnetic system is equal to the reference angle.

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Sensors/ReferenceSensor.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Sensors/ReferenceSensor.mo
@@ -1,11 +1,11 @@
 within Modelica.Magnetic.QuasiStatic.FluxTubes.Sensors;
 model ReferenceSensor "Sensor of reference angle gamma"
   extends FluxTubes.Interfaces.AbsoluteSensor;
-  Modelica.Blocks.Interfaces.RealOutput y "Reference angle" annotation (
+  Modelica.Blocks.Interfaces.RealOutput y(unit="rad") "Reference angle" annotation (
       Placement(transformation(extent={{100,-10},{120,10}})));
 equation
   y = port.reference.gamma;
-  annotation (                 Diagram(coordinateSystem(preserveAspectRatio=false)),
+  annotation (Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
 <p>This sensor determines the reference angle of the connected quasi-static magnetic system.
 The integral of the angular frequency of the quasi-static magnetic system is equal to the reference angle.

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Sensors/Transient/FundamentalWavePermabilitySensor.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Sensors/Transient/FundamentalWavePermabilitySensor.mo
@@ -43,13 +43,13 @@ model FundamentalWavePermabilitySensor
         transformation(
         extent={{10,-10},{-10,10}},
         origin={30,-10})));
-  Modelica.Blocks.Interfaces.RealOutput mu "Absolute permeability"
+  Modelica.Blocks.Interfaces.RealOutput mu(unit="H/m") "Absolute permeability"
                    annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-40,-110})));
-  Modelica.Blocks.Interfaces.RealOutput mur "Relative permeability"
+  Modelica.Blocks.Interfaces.RealOutput mur(unit="1") "Relative permeability"
                             annotation (
       Placement(transformation(
         extent={{-10,-10},{10,10}},

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Sensors/Transient/Permeability.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Sensors/Transient/Permeability.mo
@@ -7,17 +7,17 @@ model Permeability
   parameter Modelica.SIunits.Length l
   "Length associated with magnetic potential difference";
 
-  Modelica.Blocks.Interfaces.RealInput Phi "Magnetic flux"
+  Modelica.Blocks.Interfaces.RealInput Phi(unit="Wb") "Magnetic flux"
                     annotation (Placement(
         transformation(extent={{-140,40},{-100,80}})));
-  Modelica.Blocks.Interfaces.RealInput V_m
-  "Magnetic potential difference"   annotation (
+  Modelica.Blocks.Interfaces.RealInput V_m(unit="A")
+  "Magnetic potential difference" annotation (
       Placement(transformation(extent={{-140,-80},
             {-100,-40}})));
-  Modelica.Blocks.Interfaces.RealOutput mu "Absolute permeability"
+  Modelica.Blocks.Interfaces.RealOutput mu(unit="H/m") "Absolute permeability"
                    annotation (Placement(
         transformation(extent={{100,50},{120,70}})));
-  Modelica.Blocks.Interfaces.RealOutput mur "Relative Permeability"
+  Modelica.Blocks.Interfaces.RealOutput mur(unit="1") "Relative permeability"
                             annotation (Placement(
         transformation(extent={{100,-70},{120,-50}})));
 

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Sources/SignalMagneticFlux.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Sources/SignalMagneticFlux.mo
@@ -2,7 +2,7 @@ within Modelica.Magnetic.QuasiStatic.FluxTubes.Sources;
 model SignalMagneticFlux "Signal-controlled magnetic flux source"
 
   extends FluxTubes.Interfaces.Source;
-  Modelica.Blocks.Interfaces.RealInput f annotation (Placement(
+  Modelica.Blocks.Interfaces.RealInput f(unit="Hz") annotation (Placement(
         transformation(
         origin={60,120},
         extent={{-20,-20},{20,20}},

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Sources/SignalMagneticPotentialDifference.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Sources/SignalMagneticPotentialDifference.mo
@@ -3,7 +3,7 @@ model SignalMagneticPotentialDifference
 "Signal-controlled magnetomotive force"
 
   extends FluxTubes.Interfaces.Source;
-  Modelica.Blocks.Interfaces.RealInput f annotation (Placement(
+  Modelica.Blocks.Interfaces.RealInput f(unit="Hz") annotation (Placement(
         transformation(
         origin={60,120},
         extent={{-20,-20},{20,20}},

--- a/Modelica/Mechanics/Rotational.mo
+++ b/Modelica/Mechanics/Rotational.mo
@@ -5655,9 +5655,9 @@ torque as output signal. Note, the input signals must be consistent to each othe
         "Torque to drive the flange"
         annotation (Placement(transformation(extent={{60,-110},{20,-70}}), iconTransformation(extent={{40,-90},{20,-70}})));
     protected
-      Modelica.Blocks.Interfaces.RealInput w_internal
+      Modelica.Blocks.Interfaces.RealInput w_internal(unit="rad/s")
         "Needed to connect to conditional connector w";
-      Modelica.Blocks.Interfaces.RealInput a_internal
+      Modelica.Blocks.Interfaces.RealInput a_internal(unit="rad/s2")
         "Needed to connect to conditional connector a";
     equation
       connect(w, w_internal);

--- a/Modelica/Thermal/FluidHeatFlow/Sources/PressureIncrease.mo
+++ b/Modelica/Thermal/FluidHeatFlow/Sources/PressureIncrease.mo
@@ -8,7 +8,7 @@ model PressureIncrease "Enforces constant pressure increase"
   parameter Modelica.SIunits.Pressure constantPressureIncrease(start=1)
     "Pressure increase"
     annotation(Dialog(enable=not usePressureIncreaseInput));
-  Modelica.Blocks.Interfaces.RealInput pressureIncrease=internalPressureIncrease if usePressureIncreaseInput
+  Modelica.Blocks.Interfaces.RealInput pressureIncrease(unit="Pa")=internalPressureIncrease if usePressureIncreaseInput
     annotation (Placement(
         transformation(
         extent={{-20,-20},{20,20}},

--- a/Modelica/Thermal/FluidHeatFlow/Sources/VolumeFlow.mo
+++ b/Modelica/Thermal/FluidHeatFlow/Sources/VolumeFlow.mo
@@ -8,7 +8,7 @@ model VolumeFlow "Enforces constant volume flow"
   parameter Modelica.SIunits.VolumeFlowRate constantVolumeFlow(start=1)
     "Volume flow rate"
     annotation(Dialog(enable=not useVolumeFlowInput));
-  Modelica.Blocks.Interfaces.RealInput volumeFlow=internalVolumeFlow if useVolumeFlowInput
+  Modelica.Blocks.Interfaces.RealInput volumeFlow(unit="m3/s")=internalVolumeFlow if useVolumeFlowInput
     annotation (Placement(transformation(
         extent={{-20,-20},{20,20}},
         rotation=270,


### PR DESCRIPTION
Though decided in #2492 to utilize `final unit="X"`, I discared the `final`. For me, the unit of real I/O signals currently seems arbitrary and uncontrolled in MSL. Some use, `unit="X"`, some `final unit="X"`, some with `displayUnit` and some even with `quantity`. There could be anther issue to harmonize these kind of unit modifications.

@christiankral @HansOlsson @AHaumer Please check carefully when reviewing. Thanks.

Closes #2488, closes #2492.