### PR TITLE
maint/3.2.3: Bump library version of libmodelicastandardtables

### DIFF
--- a/Modelica/Blocks/Tables.mo
+++ b/Modelica/Blocks/Tables.mo
@@ -1337,7 +1337,7 @@ double mydummyfunc(double* dummy_in) {
 equation
   connect(clock.y,t_new. u[1]) annotation (Line(
       points={{-59,10},{-42,10}}, color={0,0,127}));
-  annotation (experiment(StartTime=0, StopTime=5), uses(Modelica(version=\"3.2.2\")));
+  annotation (experiment(StartTime=0, StopTime=5), uses(Modelica(version=\"3.2.3\")));
 end Test25_usertab;
 </pre>
 </html>"), Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},

--- a/Modelica/Resources/BuildProjects/autotools/configure.ac
+++ b/Modelica/Resources/BuildProjects/autotools/configure.ac
@@ -1,6 +1,6 @@
 dnl Init
 AC_PREREQ([2.63])
-AC_INIT([Modelica Standard Library Tables],[3.2.2],[https://trac.modelica.org/Modelica],[libmodelicastandardtables],[https://modelica.org])
+AC_INIT([Modelica Standard Library Tables],[3.2.3],[https://trac.modelica.org/Modelica],[libmodelicastandardtables],[https://modelica.org])
 
 AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
This was forgotten to update when releasing MSL v3.2.3.