### PR TITLE
Fix simplified homotopy models

### DIFF
--- a/Modelica/Electrical/Analog/Examples/OpAmps.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps.mo
@@ -941,7 +941,8 @@ In case this resistance is high, the amplifier's common is floating with respect
     parameter SI.Capacitance C=1/f/(2*R*log(1 + 2*R1/R2)) "Calculated capacitance to reach the desired frequency f";
     Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimited opAmp(
       Vps=Vps,
-      Vns=Vns) annotation (Placement(transformation(extent={{0,-10},{20,10}})));
+      Vns=Vns,
+      homotopyType = Modelica.Blocks.Types.LimiterHomotopy.LowerLimit, strict = true) annotation (Placement(transformation(extent={{0,-10},{20,10}})));
     Modelica.Electrical.Analog.Basic.Ground ground
       annotation (Placement(transformation(extent={{-20,-80},{0,-60}})));
     Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(

--- a/Modelica/Electrical/Analog/Examples/OpAmps.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps.mo
@@ -989,6 +989,7 @@ In case this resistance is high, the amplifier's common is floating with respect
     annotation (Documentation(info="<html>
 <p>This is a Multivibrator with Schmitt trigger according to:</p>
 <p>U. Tietze and C. Schenk, Halbleiter-Schaltungstechnik (German), 11th edition, Springer 1999, Chapter 6.5.3</p>
+<p>As the initialization system has two solutions, one with the op amp output at the lower saturation limit, and the other one with the two voltage inputs very close to each other, the <code>homotopyType</code> parameter is set to get the solver to converge to the former one, which is the required solution.</p>
 </html>"),
       experiment(
         StartTime=0,

--- a/Modelica/Electrical/Analog/Examples/OpAmps.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps.mo
@@ -798,8 +798,7 @@ In case this resistance is high, the amplifier's common is floating with respect
     Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimited opAmp(
       Vps=Vps,
       Vns=Vns,
-      out(i(start=0)),
-      homotopyType=Modelica.Blocks.Types.LimiterHomotopy.LowerLimit)
+      out(i(start=0)))
       annotation (Placement(transformation(extent={{0,-10},{20,10}})));
     Modelica.Electrical.Analog.Basic.Ground ground
       annotation (Placement(transformation(extent={{-20,-100},{0,-80}})));
@@ -871,8 +870,7 @@ In case this resistance is high, the amplifier's common is floating with respect
     Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimited opAmp(
       Vps=Vps,
       Vns=Vns,
-      out(i(start=0)),
-      homotopyType=Modelica.Blocks.Types.LimiterHomotopy.UpperLimit)
+      out(i(start=0)))
       annotation (Placement(transformation(extent={{0,10},{20,-10}})));
     Modelica.Electrical.Analog.Basic.Ground ground
       annotation (Placement(transformation(extent={{-20,-100},{0,-80}})));
@@ -942,7 +940,7 @@ In case this resistance is high, the amplifier's common is floating with respect
     Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimited opAmp(
       Vps=Vps,
       Vns=Vns,
-      homotopyType = Modelica.Blocks.Types.LimiterHomotopy.LowerLimit, strict = true) annotation (Placement(transformation(extent={{0,-10},{20,10}})));
+      strict = true) annotation (Placement(transformation(extent={{0,-10},{20,10}})));
     Modelica.Electrical.Analog.Basic.Ground ground
       annotation (Placement(transformation(extent={{-20,-80},{0,-60}})));
     Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(

--- a/Modelica/Electrical/Analog/Examples/OpAmps.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps.mo
@@ -940,6 +940,7 @@ In case this resistance is high, the amplifier's common is floating with respect
     Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimited opAmp(
       Vps=Vps,
       Vns=Vns,
+      homotopyType = Modelica.Blocks.Types.LimiterHomotopy.LowerLimit,
       strict = true) annotation (Placement(transformation(extent={{0,-10},{20,10}})));
     Modelica.Electrical.Analog.Basic.Ground ground
       annotation (Placement(transformation(extent={{-20,-80},{0,-60}})));

--- a/Modelica/Electrical/Analog/Ideal.mo
+++ b/Modelica/Electrical/Analog/Ideal.mo
@@ -687,7 +687,7 @@ If the input voltage is vin larger than 0, the output voltage is out.v = VMax.
       annotation (Dialog(enable=not useSupply));
     parameter Boolean strict=true "= true, if strict limits with noEvent(..)"
       annotation (Evaluate=true, choices(checkBox=true), Dialog(tab="Advanced"));
-    parameter Modelica.Blocks.Types.LimiterHomotopy homotopyType = Modelica.Blocks.Types.LimiterHomotopy.Linear "Simplified model for homotopy-based initialization"
+    parameter Modelica.Blocks.Types.LimiterHomotopy homotopyType = Modelica.Blocks.Types.LimiterHomotopy.NoHomotopy "Simplified model for homotopy-based initialization"
       annotation (Evaluate=true, Dialog(group="Initialization"));
     SI.Voltage vps "Positive supply voltage";
     SI.Voltage vns "Negative supply voltage";
@@ -772,6 +772,12 @@ If the input voltage is vin larger than 0, the output voltage is out.v = VMax.
 </ul>
 <p>Supply voltage is either defined by parameter Vps and Vns or by (optional) pins s_p and s_n.</p>
 <p>In the first case the necessary power is drawn from an implicit internal supply, in the second case from the external supply.</p>
+<p>If initializion is problematic for a model containing this as a component you can set the <strong>homotopyType</strong> parameter.
+Using <strong>Linear</strong> ignores the saturation initially which simplifies the initialization, and may help if the component 
+is connected with negative feedback; but generally fails if the feedback is positive.
+Using <strong>LowerLimit</strong> (or <strong>UpperLimit</strong>) gives a fixed value within the saturation bounds, which works with positive feedback.
+However, it does not work if the intent is to initialize the input to give a specific output.
+</p>
 </html>"));
   end IdealizedOpAmpLimited;
 

--- a/Modelica/Fluid/Examples/HeatExchanger.mo
+++ b/Modelica/Fluid/Examples/HeatExchanger.mo
@@ -169,7 +169,7 @@ package HeatExchanger "Demo of a heat exchanger model"
       //Initialization pipe 1
       parameter SI.Temperature Twall_start "Start value of wall temperature"
                                                                             annotation(Dialog(tab="Initialization", group="Wall"));
-      parameter SI.Temperature dT "Start value for pipe_1.T - pipe_2.T"
+      parameter SI.TemperatureDifference dT "Start value for pipe_1.T - pipe_2.T"
         annotation (Dialog(tab="Initialization", group="Wall"));
       parameter Boolean use_T_start=true
         "Use T_start if true, otherwise h_start"

--- a/Modelica/Fluid/Examples/PumpingSystem.mo
+++ b/Modelica/Fluid/Examples/PumpingSystem.mo
@@ -28,7 +28,6 @@ model PumpingSystem "Model of a pumping system for drinking water"
 
   Machines.PrescribedPump pumps(
     checkValve=true,
-    checkValveClosedInit=true,
     N_nominal=1200,
     redeclare function flowCharacteristic =
         Modelica.Fluid.Machines.BaseClasses.PumpCharacteristics.quadraticFlow (

--- a/Modelica/Fluid/Examples/PumpingSystem.mo
+++ b/Modelica/Fluid/Examples/PumpingSystem.mo
@@ -28,6 +28,7 @@ model PumpingSystem "Model of a pumping system for drinking water"
 
   Machines.PrescribedPump pumps(
     checkValve=true,
+    checkValveClosedInit=true,
     N_nominal=1200,
     redeclare function flowCharacteristic =
         Modelica.Fluid.Machines.BaseClasses.PumpCharacteristics.quadraticFlow (

--- a/Modelica/Fluid/Examples/PumpingSystem.mo
+++ b/Modelica/Fluid/Examples/PumpingSystem.mo
@@ -133,6 +133,8 @@ Water is pumped from a source by a pump (fitted with check valves), through a pi
 <p>
 The water controller is a simple on-off controller, regulating on the gauge pressure measured at the base of the tower; the output of the controller is the rotational speed of the pump, which is represented by the output of a first-order system. A small but nonzero rotational speed is used to represent the standby state of the pumps, in order to avoid singularities in the flow characteristic.
 </p>
+<p>When the simulation starts, the level is above the set point, so the initial state of the pump controller is off. Hence, the check valve of the pump is engaged. In order to facilitate the solution of the initialiation problem, the <code>homotopyType</code> parameter is set accordingly.
+</p>
 <p>
 Simulate for 2000 s. When the valve is opened at time t=200, the pump starts turning on and off to keep the reservoir level around 2 meters, which roughly corresponds to a gauge pressure of 200 mbar.
 </p>

--- a/Modelica/Fluid/Examples/PumpingSystem.mo
+++ b/Modelica/Fluid/Examples/PumpingSystem.mo
@@ -28,6 +28,7 @@ model PumpingSystem "Model of a pumping system for drinking water"
 
   Machines.PrescribedPump pumps(
     checkValve=true,
+    checkValveHomotopy = Modelica.Fluid.Types.CheckValveHomotopyType.Closed,
     N_nominal=1200,
     redeclare function flowCharacteristic =
         Modelica.Fluid.Machines.BaseClasses.PumpCharacteristics.quadraticFlow (

--- a/Modelica/Fluid/Machines.mo
+++ b/Modelica/Fluid/Machines.mo
@@ -311,7 +311,7 @@ Then the model can be replaced with a Pump with rotational shaft or with a Presc
     parameter Medium.MassFlowRate m_flow_start = system.m_flow_start
         "Guess value of m_flow = port_a.m_flow"
       annotation(Dialog(tab = "Initialization"));
-    parameter Boolean checkValveClosedInit = false "= true if the check valve is closed at initialization"
+    parameter Types.CheckValveHomotopyType checkValveHomotopy = Types.CheckValveHomotopyType.NoHomotopy "= whether the valve is Closed, Open, or unknown at initialization"
       annotation(Dialog(tab = "Initialization"));
     final parameter SI.VolumeFlowRate V_flow_single_init = m_flow_start/rho_nominal/nParallel
         "Used for simplified initialization model";
@@ -434,14 +434,20 @@ Then the model can be replaced with a Pump with rotational shaft or with a Presc
       // Flow characteristics when check valve is open
       // The simplified model uses an approximation of the tangent to the head curve in the initialization point
       // or the zero-flow vertical axis in case the system is initialized with the check valve closed
-      head = homotopy(if s > 0 then (N/N_nominal)^2*flowCharacteristic(V_flow_single*N_nominal/N)
+      if checkValveHomotopy == Types.CheckValveHomotopyType.NoHomotopy then
+        head = if s > 0 then (N/N_nominal)^2*flowCharacteristic(V_flow_single*N_nominal/N)
+                               else (N/N_nominal)^2*flowCharacteristic(0) - s*unitHead;
+        V_flow_single = if s > 0 then s*unitMassFlowRate/rho else 0;
+      else
+        head = homotopy(if s > 0 then (N/N_nominal)^2*flowCharacteristic(V_flow_single*N_nominal/N)
                                else (N/N_nominal)^2*flowCharacteristic(0) - s*unitHead,
-                      if not checkValveClosedInit then 
+                      if checkValveHomotopy == Types.CheckValveHomotopyType.Open then 
                         N/N_nominal*(flowCharacteristic(V_flow_single_init)+(V_flow_single-V_flow_single_init)*noEvent(if abs(V_flow_single_init)>0 then delta_head_init/(0.1*V_flow_single_init) else 0))
                       else
                         N/N_nominal*flowCharacteristic(0) - s*unitHead);
-      V_flow_single = homotopy(if s > 0 then s*unitMassFlowRate/rho else 0,
-                               if not checkValveClosedInit then s*unitMassFlowRate/rho_nominal else 0);
+        V_flow_single = homotopy(if s > 0 then s*unitMassFlowRate/rho else 0,
+                               if checkValveHomotopy == Types.CheckValveHomotopyType.Open then s*unitMassFlowRate/rho_nominal else 0);
+      end if;
     end if;
     // Power consumption
     if use_powerCharacteristic then

--- a/Modelica/Fluid/Types.mo
+++ b/Modelica/Fluid/Types.mo
@@ -317,6 +317,12 @@ ModelStructure.a_vb).
 </p>
 
 </html>"));
+  type CheckValveHomotopyType = enumeration(Open, Closed, NoHomotopy)
+   "Enumeration with choices for check valve homotopy"
+    annotation (Documentation(info="<html>
+    <p>If it is know whether the check valve will start open or closed this can simplify the initialization.</p>
+    <p>The choice <strong>NoHomotopy</strong> is useful if nothing is known for the check valve.</p>
+    </html>"));
 
   annotation (preferredView="info",
               Documentation(info="<html>

--- a/Modelica/Fluid/Vessels.mo
+++ b/Modelica/Fluid/Vessels.mo
@@ -354,10 +354,9 @@ of the modeller. Increase nPorts to add an additional port.
                               * noEvent(if ports[i].m_flow>0 then zeta_in[i]/portInDensities[i] else -zeta_out[i]/medium.d);
               */
 
-              ports[i].p = homotopy(vessel_ps_static[i] + (0.5/portAreas[i]^2*Utilities.regSquare2(ports[i].m_flow, m_flow_turbulent[i],
-                                           (portsData_zeta_in[i] - 1 + portAreas[i]^2/vesselArea^2)/portInDensities[i]*ports_penetration[i],
-                                           (portsData_zeta_out[i] + 1 - portAreas[i]^2/vesselArea^2)/medium.d/ports_penetration[i])),
-                                    vessel_ps_static[i]);
+              ports[i].p = vessel_ps_static[i] + (0.5/portAreas[i]^2*Utilities.regSquare2(ports[i].m_flow, m_flow_turbulent[i],
+                                (portsData_zeta_in[i] - 1 + portAreas[i]^2/vesselArea^2)/portInDensities[i]*ports_penetration[i],
+                                (portsData_zeta_out[i] + 1 - portAreas[i]^2/vesselArea^2)/medium.d/ports_penetration[i]));
               /*
                 // alternative formulation m_flow=f(dp); not allowing the ideal portsData_zeta_in[i]=1 though
                 ports[i].m_flow = smooth(2, portAreas[i]*Utilities.regRoot2(ports[i].p - vessel_ps_static[i], dp_small,


### PR DESCRIPTION
Some models in the MSL worked in Dymola because it first tried without homotopy by default, so the simplified model was never tested. OpenModelica tries first with homotopy (which I think in general is a better idea, since homotopy can also be used to steer the solution towards the required one in case multiple ones are possible, so trying without it first can get you on the wrong solution). This caused the simulation to fail.

This PR fixes `Modelica.Electrical.Analog.Examples.OpAmps.Multivibrator` by setting the correct homotopy initialization parameter value, `Modelica.Fluid.Examples.Explanatory.MeasuringTemperature` by removing a wrong simplified equation in the `PartialVessel` model, and `Modelica.Fluid.Examples.PumpingSystem` by adding an option to initialize the pump with the check valve closed.

The test cases passed successfully in Dymola (with Advanced.OnlyUseHomotopyMethod = true and = false) and with OpenModelica 1.16.0-dev

If accepted, this PR should also be back-ported to 3.2.3 maintenance