### PR TITLE
Utilize absoluteValue=false annotation for relative sensors

### DIFF
--- a/Modelica/Thermal/FluidHeatFlow/Interfaces/RelativeSensor.mo
+++ b/Modelica/Thermal/FluidHeatFlow/Interfaces/RelativeSensor.mo
@@ -1,35 +1,13 @@
 within Modelica.Thermal.FluidHeatFlow.Interfaces;
 partial model RelativeSensor "Partial model of relative sensor"
-  extends Modelica.Icons.RoundSensor;
-  parameter FluidHeatFlow.Media.Medium medium=FluidHeatFlow.Media.Medium()
-    "Sensor's medium" annotation (choicesAllMatching=true);
-  FluidHeatFlow.Interfaces.FlowPort_a flowPort_a(final medium=medium)
-    annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
-  FluidHeatFlow.Interfaces.FlowPort_b flowPort_b(final medium=medium)
-    annotation (Placement(transformation(extent={{90,-10},{110,10}})));
+  extends RelativeSensorBase;
   Modelica.Blocks.Interfaces.RealOutput y
     annotation (Placement(transformation(
         origin={0,-110},
         extent={{10,-10},{-10,10}},
         rotation=90)));
-equation
-  // no mass exchange
-  flowPort_a.m_flow = 0;
-  flowPort_b.m_flow = 0;
-  // no energy exchange
-  flowPort_a.H_flow = 0;
-  flowPort_b.H_flow = 0;
 annotation (Documentation(info="<html>
 <p>Partial model for a relative sensor (pressure drop/temperature difference).</p>
 <p>Pressure, mass flow, temperature and enthalpy flow of medium are not affected.</p>
-</html>"),
-       Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-            -100},{100,100}}), graphics={
-        Line(points={{-70,0},{-90,0}}, color={255,0,0}),
-        Line(points={{70,0},{90,0}}, color={255,0,0}),
-        Line(points={{0,-100},{0,-70}}, color={0,0,127}),
-        Text(
-          extent={{-150,90},{150,130}},
-          textString="%name",
-          textColor={0,0,255})}));
+</html>"));
 end RelativeSensor;

--- a/Modelica/Thermal/FluidHeatFlow/Interfaces/RelativeSensorBase.mo
+++ b/Modelica/Thermal/FluidHeatFlow/Interfaces/RelativeSensorBase.mo
@@ -1,0 +1,30 @@
+within Modelica.Thermal.FluidHeatFlow.Interfaces;
+partial model RelativeSensorBase "Partial model of relative sensor without signal output"
+  extends Modelica.Icons.RoundSensor;
+  parameter FluidHeatFlow.Media.Medium medium=FluidHeatFlow.Media.Medium()
+    "Sensor's medium" annotation (choicesAllMatching=true);
+  FluidHeatFlow.Interfaces.FlowPort_a flowPort_a(final medium=medium)
+    annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
+  FluidHeatFlow.Interfaces.FlowPort_b flowPort_b(final medium=medium)
+    annotation (Placement(transformation(extent={{90,-10},{110,10}})));
+equation
+  // no mass exchange
+  flowPort_a.m_flow = 0;
+  flowPort_b.m_flow = 0;
+  // no energy exchange
+  flowPort_a.H_flow = 0;
+  flowPort_b.H_flow = 0;
+annotation (Documentation(info="<html>
+<p>Partial model for a relative sensor (pressure drop/temperature difference) without signal output.</p>
+<p>Pressure, mass flow, temperature and enthalpy flow of medium are not affected.</p>
+</html>"),
+       Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
+            -100},{100,100}}), graphics={
+        Line(points={{-70,0},{-90,0}}, color={255,0,0}),
+        Line(points={{70,0},{90,0}}, color={255,0,0}),
+        Line(points={{0,-100},{0,-70}}, color={0,0,127}),
+        Text(
+          extent={{-150,90},{150,130}},
+          textString="%name",
+          textColor={0,0,255})}));
+end RelativeSensorBase;

--- a/Modelica/Thermal/FluidHeatFlow/Interfaces/package.order
+++ b/Modelica/Thermal/FluidHeatFlow/Interfaces/package.order
@@ -2,5 +2,6 @@ FlowPort
 FlowPort_a
 FlowPort_b
 AbsoluteSensor
+RelativeSensorBase
 RelativeSensor
 FlowSensor

--- a/Modelica/Thermal/FluidHeatFlow/Sensors/RelPressureSensor.mo
+++ b/Modelica/Thermal/FluidHeatFlow/Sensors/RelPressureSensor.mo
@@ -1,14 +1,20 @@
 within Modelica.Thermal.FluidHeatFlow.Sensors;
 model RelPressureSensor "Pressure difference sensor"
 
-  extends FluidHeatFlow.Interfaces.RelativeSensor(y(unit="Pa", displayUnit=
-          "bar") "Pressure difference as output signal");
+  extends FluidHeatFlow.Interfaces.RelativeSensorBase;
+  Modelica.Blocks.Interfaces.RealOutput y(unit="Pa", displayUnit="bar")
+    "Pressure difference as output signal"
+	annotation (absoluteValue = false, Placement(transformation(
+        origin={0,-110},
+        extent={{10,-10},{-10,10}},
+        rotation=90)));
 equation
   y = flowPort_a.p - flowPort_b.p;
 annotation (
     Documentation(info="<html>
 <p>The RelPressureSensor measures the pressure drop between flowPort_a and flowPort_b.</p>
-<p>Thermodynamic equations are defined by Interfaces.RelativeSensor.</p>
+<p>Thermodynamic equations are defined by <a href=\"modelica://Modelica.Thermal.FluidHeatFlow.Interfaces.RelativeSensorBase\">Interfaces.RelativeSensorBase</a>.</p>
+<p>
 </html>"),
   Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,100}}), graphics={
         Text(

--- a/Modelica/Thermal/FluidHeatFlow/Sensors/RelTemperatureSensor.mo
+++ b/Modelica/Thermal/FluidHeatFlow/Sensors/RelTemperatureSensor.mo
@@ -1,14 +1,19 @@
 within Modelica.Thermal.FluidHeatFlow.Sensors;
 model RelTemperatureSensor "Temperature difference sensor"
 
-  extends FluidHeatFlow.Interfaces.RelativeSensor(y(unit="K")
-      "Temperature difference as output signal");
+  extends FluidHeatFlow.Interfaces.RelativeSensorBase;
+  Modelica.Blocks.Interfaces.RealOutput y(unit="K")
+    "Temperature difference as output signal"
+	annotation (absoluteValue = false, Placement(transformation(
+        origin={0,-110},
+        extent={{10,-10},{-10,10}},
+        rotation=90)));
 equation
   medium.cp*y = flowPort_a.h - flowPort_b.h;
   annotation (
     Documentation(info="<html>
 <p>The RelTemperatureSensor measures the temperature difference between flowPort_a and flowPort_b.</p>
-<p>Thermodynamic equations are defined by Interfaces.RelativeSensor.</p>
+<p>Thermodynamic equations are defined by <a href=\"modelica://Modelica.Thermal.FluidHeatFlow.Interfaces.RelativeSensorBase\">Interfaces.RelativeSensorBase</a>.</p>
 <p>
 <strong>Note:</strong> Connected flowPorts have the same temperature (mixing temperature)!
 Since mixing my occur, the outlet temperature of a component may be different from the connector's temperature.

--- a/Modelica/Thermal/HeatTransfer/Celsius/FixedTemperature.mo
+++ b/Modelica/Thermal/HeatTransfer/Celsius/FixedTemperature.mo
@@ -3,7 +3,7 @@ model FixedTemperature
   "Fixed temperature boundary condition in degree Celsius"
   extends HeatTransfer.Icons.FixedTemperature;
   parameter Modelica.SIunits.Conversions.NonSIunits.Temperature_degC T
-    "Fixed Temperature at the port";
+    "Fixed temperature at the port";
   Interfaces.HeatPort_b port annotation (Placement(transformation(extent={{
             90,-10},{110,10}})));
 equation

--- a/Modelica/Thermal/HeatTransfer/Fahrenheit/FixedTemperature.mo
+++ b/Modelica/Thermal/HeatTransfer/Fahrenheit/FixedTemperature.mo
@@ -3,7 +3,7 @@ model FixedTemperature
   "Fixed temperature boundary condition in degFahrenheit"
   extends HeatTransfer.Icons.FixedTemperature;
   parameter Modelica.SIunits.Conversions.NonSIunits.Temperature_degF T
-    "Fixed Temperature at the port";
+    "Fixed temperature at the port";
   Interfaces.HeatPort_b port annotation (Placement(transformation(extent={{
             90,-10},{110,10}})));
 equation

--- a/Modelica/Thermal/HeatTransfer/Sensors/ConditionalFixedHeatFlowSensor.mo
+++ b/Modelica/Thermal/HeatTransfer/Sensors/ConditionalFixedHeatFlowSensor.mo
@@ -1,9 +1,9 @@
 within Modelica.Thermal.HeatTransfer.Sensors;
 model ConditionalFixedHeatFlowSensor
-  "HeatFlowSensor, conditional fixed Temperature"
+  "HeatFlowSensor, conditional fixed temperature"
   extends Modelica.Icons.RoundSensor;
   parameter Boolean useFixedTemperature(start=false)
-    "Fixed Temperature if true"
+    "Fixed temperature if true"
     annotation(Evaluate=true);
   HeatTransfer.Interfaces.HeatPort_a port_a
     annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));

--- a/Modelica/Thermal/HeatTransfer/Sensors/RelTemperatureSensor.mo
+++ b/Modelica/Thermal/HeatTransfer/Sensors/RelTemperatureSensor.mo
@@ -1,5 +1,5 @@
 within Modelica.Thermal.HeatTransfer.Sensors;
-model RelTemperatureSensor "Relative Temperature sensor"
+model RelTemperatureSensor "Relative temperature sensor"
   extends Modelica.Icons.RectangularSensor;
   Interfaces.HeatPort_a port_a annotation (Placement(transformation(extent={{
             -110,-10},{-90,10}})));
@@ -7,7 +7,7 @@ model RelTemperatureSensor "Relative Temperature sensor"
             90,-10},{110,10}})));
   Modelica.Blocks.Interfaces.RealOutput T_rel(unit="K", displayUnit="K")
     "Relative temperature as output signal"
-    annotation (Placement(transformation(
+    annotation (absoluteValue=false, Placement(transformation(
         origin={0,-110},
         extent={{10,-10},{-10,10}},
         rotation=90), iconTransformation(


### PR DESCRIPTION
Resolves #3254.

As confirmed in https://github.com/modelica/ModelicaStandardLibrary/issues/3254#issuecomment-571530727 this is not yet supported by Dymola 2020(x).