### PR TITLE
maint/3.2.3: Fix two-phase calculation of setState_dTX for R134a

### DIFF
--- a/Modelica/Media/package.mo
+++ b/Modelica/Media/package.mo
@@ -6462,7 +6462,7 @@ to the above list of assumptions</li>
       output Temperature T "Saturation temperature";
     end saturationTemperature;
 
-    replaceable function saturationPressure_sat "Return saturation temperature"
+    replaceable function saturationPressure_sat "Return saturation pressure"
       extends Modelica.Icons.Function;
       input SaturationProperties sat "Saturation property record";
       output AbsolutePressure p "Saturation pressure";


### PR DESCRIPTION
Back-port of #3275 to fix #3163 in maint/3.2.3.