### PR TITLE
Minor epsilon_0/mu_0 change

### DIFF
--- a/Modelica/Constants.mo
+++ b/Modelica/Constants.mo
@@ -29,7 +29,7 @@ package Constants
   // (name, value, description from https://www.bipm.org/en/CGPM/db/26/1/, effective from May 20, 2019)
   // The values for c, q, h, k, N_A are exact and part of the basis of the SI-system
   // Note that the elementary charge uses the common alternate name q since e was taken.
-  // The values for F, R, sigma, T_zero, epsilon_0 are also exact.
+  // The values for F, R, sigma, T_zero are also exact.
   // The value for mu_0 can now be expressed as 2*alpha*h/(q^2*c), 
   // where alpha is the experimental fine-structure constant,
   // and the value is from https://physics.nist.gov/cuu/pdf/wall_2018.pdf
@@ -51,7 +51,7 @@ package Constants
     "Stefan-Boltzmann constant ";
   final constant Real N_A(final unit="1/mol") = 6.02214076e23
     "Avogadro constant";
-  final constant Real mu_0(final unit="N/A2") = 4*pi*1.00000000055e-7 "Magnetic constant";
+  final constant Real mu_0(final unit="N/A2") = 1.25663706212e-6 "Magnetic constant";
   final constant Real epsilon_0(final unit="F/m") = 1/(mu_0*c*c)
     "Electric constant";
   final constant NonSI.Temperature_degC T_zero=-273.15


### PR DESCRIPTION
Three comments here:
1) Fixed the comment regarding epsilon_0 being exact
2) I would argue there is no advantage in expressing mu_0 = 4*pi*1.00000000055e-7 instead of the recommended value directly. The only insight it gives (as far as I can tell) is how big the change is compared to the previous definition (as exactly 1e-7).
3) Technically using 4*pi*1.00000000055e-7 instead of just 1.25663706212e-6 (recommended value) causes the last digit for mu_0 to be off by 1 (3 instead of 2) from the recommended value. Of course this is well within the error values so it's minor.