### PR TITLE
Follow heading convention

### DIFF
--- a/Modelica/Blocks/Nonlinear.mo
+++ b/Modelica/Blocks/Nonlinear.mo
@@ -642,7 +642,7 @@ As a result, both the simulation of the PadeDelay block, and especially
 its linearization becomes more reliable.
 </p>
 
-<h5>Literature:</h5>
+<h5>Literature</h5>
 <p>Otto Foellinger: Regelungstechnik, 8. Auflage,
 chapter 11.9, page 412-414, Huethig Verlag Heidelberg, 1994
 </p>

--- a/Modelica/Clocked/RealSignals.mo
+++ b/Modelica/Clocked/RealSignals.mo
@@ -2612,7 +2612,7 @@ distributions on the real line:
 ------------------------------
     normal (Gaussian) 2 versions
 </pre></blockquote>
-<h4>Reference Literature:</h4>
+<h4>Reference Literature</h4>
 <ul>
 <li>function random: Wichmann, B. A. & Hill, I. D. (1982), Algorithm AS 183:
   <br>

--- a/Modelica/Electrical/Analog/Examples/HeatingPNP_NORGate.mo
+++ b/Modelica/Electrical/Analog/Examples/HeatingPNP_NORGate.mo
@@ -187,7 +187,7 @@ annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
 <p>They are different from zero if the transistor is conducting.</p>
 </html>",
    revisions="<html>
-<h4>Release Notes:</h4>
+<h4>Release Notes</h4>
 <ul>
 <li><em>May 02, 2018</em> by Kristin Majetta and Christoph Clauss<br>realized<br></li>
 </ul>

--- a/Modelica/Electrical/Batteries/BaseClasses/BaseCellStack.mo
+++ b/Modelica/Electrical/Batteries/BaseClasses/BaseCellStack.mo
@@ -89,7 +89,7 @@ All losses are dissipated to the optional <code>heatPort</code>.
 <p>
 For details, see <a href=\"modelica://Modelica.Electrical.Batteries.UsersGuide.Concept\">concept</a> and <a href=\"modelica://Modelica.Electrical.Batteries.UsersGuide.Parameterization\">parameterization</a>.
 </p>
-<h4>Note:</h4>
+<h4>Note</h4>
 <p>
 SOC &gt; SOCmax and SOC &lt; SOCmin triggers an error.
 </p>

--- a/Modelica/Electrical/Batteries/BatteryStacks/CellRCStack.mo
+++ b/Modelica/Electrical/Batteries/BatteryStacks/CellRCStack.mo
@@ -43,7 +43,7 @@ This model can be used for a single cell <code>Ns = Np = 1</code> as well as a s
 <p>
 For details, see <a href=\"modelica://Modelica.Electrical.Batteries.UsersGuide.Concept\">concept</a> and <a href=\"modelica://Modelica.Electrical.Batteries.UsersGuide.Parameterization\">parameterization</a>.
 </p>
-<h4>Note:</h4>
+<h4>Note</h4>
 <p>
 Parameter record array <a href=\"modelica://Modelica.Electrical.Batteries.ParameterRecords.TransientData.RCData\">rcData</a> contained in
 parameter record <a href=\"modelica://Modelica.Electrical.Batteries.ParameterRecords.TransientData.CellData\">cellData</a> has to be specified.

--- a/Modelica/Electrical/Batteries/BatteryStacks/CellStack.mo
+++ b/Modelica/Electrical/Batteries/BatteryStacks/CellStack.mo
@@ -16,7 +16,7 @@ This model can be used for a single cell <code>Ns = Np = 1</code> as well as a s
 <p>
 For details, see <a href=\"modelica://Modelica.Electrical.Batteries.UsersGuide.Concept\">concept</a> and <a href=\"modelica://Modelica.Electrical.Batteries.UsersGuide.Parameterization\">parameterization</a>.
 </p>
-<h4>Note:</h4>
+<h4>Note</h4>
 <p>
 Parameter record array <a href=\"modelica://Modelica.Electrical.Batteries.ParameterRecords.RCData\">rcData</a> contained in
 parameter record <a href=\"modelica://Modelica.Electrical.Batteries.ParameterRecords.CellData\">cellData</a> is neglected.

--- a/Modelica/Electrical/Batteries/BatteryStacks/SuperCap.mo
+++ b/Modelica/Electrical/Batteries/BatteryStacks/SuperCap.mo
@@ -69,7 +69,7 @@ This is a simple model of a supercapacitor, comprising:
 <li>a series resistance</li>
 <li>a self-discharge conductor</li>
 </ul>
-<h4>Note:</h4>
+<h4>Note</h4>
 <p>
 There is no limit included against too high charging and too low discharging or even charging in the opposite direction.
 </p>

--- a/Modelica/Electrical/Batteries/ParameterRecords/CellData.mo
+++ b/Modelica/Electrical/Batteries/ParameterRecords/CellData.mo
@@ -37,7 +37,7 @@ record CellData "Parameters of a battery cell"
 <li>OCV versus SOC characteristic</li>
 <li>Inner resistance; can be calculated from OCVmax / short-circuit current (at OCVmax)</li>
 </ul>
-<h4>Note:</h4>
+<h4>Note</h4>
 <p>
 If <code>useLinearSOCDependency=true</code>, the OCV versus SOC table is built up internally from <code>OCVmax, OCVmin, SOCmax, SOCmin</code>.<br>
 Otherwise, the OCV versus SOC table has to be specified: 1st column = SOC values in ascending order, 2nd column = corresponding OCV values with respect to OCVmax.

--- a/Modelica/Electrical/Batteries/ParameterRecords/TransientData/CellData.mo
+++ b/Modelica/Electrical/Batteries/ParameterRecords/TransientData/CellData.mo
@@ -17,7 +17,7 @@ record CellData "Parameters of a transient battery cell"
 <li>Inner resistance; can be calculated from OCVmax / short-circuit current (at OCVmax)</li>
 <li>Array of records <code>rcData</code> for battery models comprising RC-elements</li>
 </ul>
-<h4>Note:</h4>
+<h4>Note</h4>
 <p>
 If <code>useLinearSOCDependency=true</code>, the OCV versus SOC table is built up internally from <code>OCVmax, OCVmin, SOCmax, SOCmin</code>.<br>
 Otherwise, the OCV versus SOC table has to be specified: 1st column = SOC values in ascending order, 2nd column = corresponding OCV values with respect to OCVmax.

--- a/Modelica/Electrical/Batteries/ParameterRecords/TransientData/package.mo
+++ b/Modelica/Electrical/Batteries/ParameterRecords/TransientData/package.mo
@@ -6,7 +6,7 @@ package TransientData "Parameter records for transient battery models"
 <p>
 Parameter records for transient battery models
 </p>
-<h4>Note:</h4>
+<h4>Note</h4>
 <p>
 The user can easily build up a collection of different battery types by creating individual parameter records extending from the base record <code>CellData</code>.
 Do not forget to add the <code>annotation(defaultComponentPrefixes=\"parameter\");</code> in each individual parameter record.

--- a/Modelica/Electrical/Batteries/ParameterRecords/package.mo
+++ b/Modelica/Electrical/Batteries/ParameterRecords/package.mo
@@ -7,7 +7,7 @@ package ParameterRecords "Parameter records for batteries"
 <p>
 Parameter records for batteries
 </p>
-<h4>Note:</h4>
+<h4>Note</h4>
 <p>
 The user can easily build up a collection of different battery types by creating individual parameter records extending from the base record <code>CellData</code>.
 Do not forget to add the <code>annotation(defaultComponentPrefixes=\"parameter\");</code> in each individual parameter record.

--- a/Modelica/Electrical/Machines/BasicMachines/QuasiStaticDCMachines/package.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/QuasiStaticDCMachines/package.mo
@@ -9,7 +9,7 @@ these models are fully compatible with the
 <a href=\"modelica://Modelica.Electrical.Machines.BasicMachines.DCMachines\">transient machine models of DC machines</a>;
 the only difference is that electrical transients are neglected.
 </p>
-<h4>Please note</h4>
+<h4>Note</h4>
 <p>
 Quasi-static DC machine models are basically different from quasi-static induction machine models:
 Quasi-static DC machine models neglect electrical transients, i.e., setting <code>der(i) = 0</code>,

--- a/Modelica/Electrical/Machines/BasicMachines/QuasiStaticDCMachines/package.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/QuasiStaticDCMachines/package.mo
@@ -9,7 +9,7 @@ these models are fully compatible with the
 <a href=\"modelica://Modelica.Electrical.Machines.BasicMachines.DCMachines\">transient machine models of DC machines</a>;
 the only difference is that electrical transients are neglected.
 </p>
-<h4>Please note:</h4>
+<h4>Please note</h4>
 <p>
 Quasi-static DC machine models are basically different from quasi-static induction machine models:
 Quasi-static DC machine models neglect electrical transients, i.e., setting <code>der(i) = 0</code>,

--- a/Modelica/Electrical/Machines/Examples/Transformers/AsymmetricalLoad.mo
+++ b/Modelica/Electrical/Machines/Examples/Transformers/AsymmetricalLoad.mo
@@ -83,7 +83,7 @@ equation
   connect(earth.n, groundT.p) annotation (Line(points={{-10,-50},{-10,-50},
           {-10,-60}}, color={0,0,255}));
   annotation (Documentation(info="<html>
-<h4>Asymmetrical (single-phase) load:</h4>
+<h4>Asymmetrical (single-phase) load</h4>
 <p>
 You may choose different connections.
 </p>

--- a/Modelica/Electrical/Machines/Examples/Transformers/TransformerTestbench.mo
+++ b/Modelica/Electrical/Machines/Examples/Transformers/TransformerTestbench.mo
@@ -133,7 +133,7 @@ equation
   connect(deltaL.plug_p, voltageRMSSensorL.plug_n) annotation (Line(
       points={{60,-10},{60,-30}}, color={0,0,255}));
   annotation (Documentation(info="<html>
-<h4>Transformer test bench:</h4>
+<h4>Transformer test bench</h4>
 <p>
 You may choose different connections as well as vary the load (even not symmetrical).
 </p>

--- a/Modelica/Electrical/Machines/Losses/DCMachines/Brush.mo
+++ b/Modelica/Electrical/Machines/Losses/DCMachines/Brush.mo
@@ -43,7 +43,7 @@ Model of voltage drop and losses of carbon brushes. For currents between <code>-
                 alt=\"brush.png\"> </td> </tr>
   <tr><td> <strong> Fig. 1: </strong>Model of voltage drop of carbon brushes</td> </tr>
 </table>
-<h4>Note:</h4>
+<h4>Note</h4>
 <p>
 The voltage drop <code>v</code> is the total voltage drop of all series connected brushes.
 </p>

--- a/Modelica/Electrical/Machines/Thermal/package.mo
+++ b/Modelica/Electrical/Machines/Thermal/package.mo
@@ -30,7 +30,7 @@ They are modeled as <a href=\"modelica://Modelica.Electrical.Analog.Basic.Resist
 <blockquote><pre>
 ROperational = RRef * (1 + alphaRef * (TOperational - TRef))
 </pre></blockquote>
-<h5>Parameters:</h5>
+<h5>Parameters</h5>
 <ul>
 <li>Resistance <code>RRef</code> at reference temperature</li>
 <li>Reference temperature <code>TRef</code></li>

--- a/Modelica/Electrical/Machines/UsersGuide/Discrimination.mo
+++ b/Modelica/Electrical/Machines/UsersGuide/Discrimination.mo
@@ -44,7 +44,7 @@ class Discrimination "Discrimination of Machine models"
    </tbody>
   </table>
 
-  <h4>Note:</h4>
+  <h4>Note</h4>
   <ul>
   <li>Transient and quasiStatic models are parameter compatible.</li>
   <li>Induction machine models limited to three phases and with arbitrary number of phases are parameter compatible.</li>

--- a/Modelica/Electrical/Polyphase/Basic/MultiDelta.mo
+++ b/Modelica/Electrical/Polyphase/Basic/MultiDelta.mo
@@ -45,7 +45,7 @@ equation
 Delta (polygon) connection of a polyphase circuit consisting of multiple base systems (see
 <a href=\"modelica://Modelica.Magnetic.FundamentalWave.UsersGuide.Polyphase\">polyphase guidelines</a>).
 </p>
-<h4>Note:</h4>
+<h4>Note</h4>
 <p>
 If kPolygon&lt;1 or kPolygon&gt;(mBasic - 1)/2, kPolygon is replaced by the value 1 without further warning.<br>
 In case of m=2, kPolygon=1 is the only valid choice.

--- a/Modelica/Electrical/Polyphase/Functions/factorY2D.mo
+++ b/Modelica/Electrical/Polyphase/Functions/factorY2D.mo
@@ -22,7 +22,7 @@ algorithm
 <p>
 Calculates line-to-line voltage from line-to-neutral voltage.
 </p>
-<h4>Note:</h4>
+<h4>Note</h4>
 <p>
 For m&gt;3 phases, more than one variant exists for the choice of the line-to-line voltage. 
 If input kPolygon is not in the range of 1 &le; kPolygon &le; (mBasic - 1)/2, the function is evaluated for kPolygon = 1.

--- a/Modelica/Electrical/QuasiStatic/Machines/package.mo
+++ b/Modelica/Electrical/QuasiStatic/Machines/package.mo
@@ -34,7 +34,7 @@ Copyright &copy; 1998-2019, Modelica Association and contributors
 </p>
 <p>This package hosts models for quasi-static induction machines and transformers.
 </p>
-<h4>Please note</h4>
+<h4>Note</h4>
 <p>
 Quasi-static DC machines are still operated with Dc voltage and current, whereas the quasi-static induction machines and transformers
 are operated with sinusoidal voltages and currents represented by time phasors. Quasi-static theory can be found in the

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Utilities/IdealACDCConverter.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Utilities/IdealACDCConverter.mo
@@ -68,7 +68,7 @@ This is an ideal AC DC converter, based on a power balance between QS circuit an
 The parameter <em>conversionFactor</em> defines the ratio between averaged DC voltage and QS rms voltage.
 Furthermore, reactive power at the QS side is set to 0.
 </p>
-<h4>Note:</h4>
+<h4>Note</h4>
 <p>
 Of course no voltage or current ripple is present, neither at the QS side nor at the DC side.
 At the QS side, only base harmonics of voltage and current are taken into account.

--- a/Modelica/Electrical/Spice3.mo
+++ b/Modelica/Electrical/Spice3.mo
@@ -3057,7 +3057,7 @@ Christoph Clau&szlig;
               textColor={0,0,255},
               textString="%name")}),  Documentation(info="<html>
 <p>Damped sinusoidal source</p>
-<h4>Note:</h4>
+<h4>Note</h4>
 <ul>
 <li>All parameters of sources should be set explicitly.</li>
 <li>since TSTEP and TSTOP are not available for modeling in Modelica, differences to SPICE may occur if not all parameters are set.<br></li>
@@ -3113,7 +3113,7 @@ Christoph Clau&szlig;
               textString="%name")}),
         Documentation(info="<html>
 <p>Rising and falling exponential source.</p>
-<h4>Note:</h4>
+<h4>Note</h4>
 <ul>
 <li>All parameters of sources should be set explicitly.</li>
 <li>since TSTEP and TSTOP are not available for modeling in Modelica, differences to SPICE may occur if not all parameters are set.- it should be set all the parameters definitely<br>- normally, there exist differences between Dymola and Spice, because TSTEP and TSTOP are not available.<br></li>
@@ -3245,7 +3245,7 @@ Christoph Clau&szlig;
 <td><p>1</p></td>
 </tr>
 </table>
-<h4>Note:</h4>
+<h4>Note</h4>
 <ul>
 <li>All parameters of sources should be set explicitly.</li>
 <li>since TSTEP and TSTOP are not available for modeling in Modelica, differences to SPICE may occur if not all parameters are set.</li>
@@ -3357,7 +3357,7 @@ If, e.g., time = 1.0, the voltage v =  0.0 (before event), 1.0 (after event)
               textString="%name")}),
         Documentation(info="<html>
 <p>The single-frequency frequency modulation source generates a carrier signal of the frequency FC. This signal is modulated by the signal frequency FS. See the formula in the Modelica text.</p>
-<h4>Attention:</h4>
+<h4>Attention</h4>
 <ul>
 <li>All parameters of sources should be set explicitly.</li>
 <li>since TSTEP and TSTOP are not available for modeling in Modelica, differences to SPICE may occur if not all parameters are set.</li>
@@ -3440,7 +3440,7 @@ If, e.g., time = 1.0, the voltage v =  0.0 (before event), 1.0 (after event)
               textString="%name")}),
         Documentation(info="<html>
 <p>Damped sinusoidal source</p>
-<h4>Note:</h4>
+<h4>Note</h4>
 <ul>
 <li>All parameters of sources should be set explicitly.</li>
 <li>since TSTEP and TSTOP are not available for modeling in Modelica, differences to SPICE may occur if not all parameters are set.</li>
@@ -3491,7 +3491,7 @@ If, e.g., time = 1.0, the voltage v =  0.0 (before event), 1.0 (after event)
               textString="%name")}),
         Documentation(info="<html>
 <p>Rising and falling exponential source.</p>
-<h4>Note:</h4>
+<h4>Note</h4>
 <ul>
 <li>All parameters of sources should be set explicitly.</li>
 <li>since TSTEP and TSTOP are not available for modeling in Modelica, differences to SPICE may occur if not all parameters are set.</li>
@@ -3620,7 +3620,7 @@ If, e.g., time = 1.0, the voltage v =  0.0 (before event), 1.0 (after event)
 <td><p>1</p></td>
 </tr>
 </table>
-<h4>Note:</h4>
+<h4>Note</h4>
 <ul>
 <li>All parameters of sources should be set explicitly.</li>
 <li>since TSTEP and TSTOP are not available for modeling in Modelica, differences to SPICE may occur if not all parameters are set.</li>
@@ -3730,7 +3730,7 @@ If, e.g., time = 1.0, the current i =  0.0 (before event), 1.0 (after event)
               textString="%name")}),
         Documentation(info="<html>
 <p>The single-frequency frequency modulation source generates a carrier signal of the frequency FC. This signal is modulated by the signal frequency FS. See the formula in the Modelica text.</p>
-<h4>Note:</h4>
+<h4>Note</h4>
 <ul>
 <li>All parameters of sources should be set explicitly.</li>
 <li>since TSTEP and TSTOP are not available for modeling in Modelica, differences to SPICE may occur if not all parameters are set.</li>

--- a/Modelica/Icons.mo
+++ b/Modelica/Icons.mo
@@ -793,7 +793,7 @@ corresponding library in a future release.
             extent={{-12.5,-12.5},{12.5,12.5}})}), Documentation(info="<html>
 <p>This package contains definitions for the graphical layout of components which may be used in different libraries. The icons can be utilized by inheriting them in the desired class using &quot;extends&quot; or by directly copying the &quot;icon&quot; layer.</p>
 
-<h4>Main Authors:</h4>
+<h4>Main Authors</h4>
 
 <dl>
 <dt><a href=\"http://www.robotic.dlr.de/Martin.Otter/\">Martin Otter</a></dt>

--- a/Modelica/Magnetic/FluxTubes/Basic/LeakageWithCoefficient.mo
+++ b/Modelica/Magnetic/FluxTubes/Basic/LeakageWithCoefficient.mo
@@ -22,7 +22,7 @@ Differently from the flux tube elements of package <a href=\"modelica://Modelica
 that are calculated from their geometry, this leakage reluctance is calculated with reference to the total reluctance of a useful flux path. Please refer to the <strong>Parameters</strong> section for an illustration of the resulting magnetic network. Exploiting <em>Kirchhoff</em>'s generalized current law, the leakage reluctance is calculated by means of a coupling coefficient c_usefulFlux.
 </p>
 
-<h4>Attention:</h4>
+<h4>Attention</h4>
 
 <p>
 This element must <strong>not</strong> be used <strong>for dynamic simulation of</strong> electro-magneto-mechanical <strong>actuators</strong>, where the shape of at least one flux tube element with reluctance force generation in the useful flux path changes with armature motion (e.g., air gap). This change results in a non-zero derivative dG_m/dx of those elements permeance G_m with respect to armature position x, which in turn will lead to a non-zero derivative of the leakage permeance with respect to armature position. This would generate a reluctance force in the leakage element that is not accounted for properly. <a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.Force.LeakageAroundPoles\">Shapes.Force.LeakageAroundPoles</a> provides a simple leakage reluctance with force generation.

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -2346,7 +2346,7 @@ which based on the <code>balance</code> function from EISPACK.
 </p>
 
 </html>", revisions="<html>
-<h4>Release Notes:</h4>
+<h4>Release Notes</h4>
 <ul>
 <li><em>July 5, 2002</em>
        by H. D. Joos and Nico Walther<br>
@@ -3151,7 +3151,7 @@ to compute the solution of a linear system of differential equations</p>
 der(<strong>x</strong>) = <strong>A</strong>*<strong>x</strong>   ->   <strong>x</strong>(t0 + T) = e^(<strong>A</strong>T)*x(t0)
 </pre></blockquote>
 
-<h4>Algorithmic details:</h4>
+<h4>Algorithmic details</h4>
 
 <p>The algorithm is taken from</p>
 <dl>

--- a/Modelica/Mechanics/Rotational.mo
+++ b/Modelica/Mechanics/Rotational.mo
@@ -4521,7 +4521,7 @@ e.g., chattering occurs when using the
 Modelica.Mechanics.Rotational.GearEfficiency model.
 </p>
 
-<h4>Acknowledgement:</h4>
+<h4>Acknowledgement</h4>
 <ul>
 <li> The essential idea to model efficiency
      in this way is from Christoph Pelchen, ZF Friedrichshafen.</li>

--- a/Modelica/Mechanics/Translational.mo
+++ b/Modelica/Mechanics/Translational.mo
@@ -3698,7 +3698,7 @@ in the lossPower due to the discontinuously changing kinetic energy of the mass
 </p>
 
 </html>", revisions="<html>
-<h4>Release Notes:</h4>
+<h4>Release Notes</h4>
 <ul>
 <li><em>First Version from December 7, 1999 by P. Beater (based on Rotational.BearingFriction)</em></li>
 <li><em>July 14, 2001 by P. Beater, assert on initialization added, diagram modified</em></li>

--- a/Modelica/Media/IdealGases/Common/Functions.mo
+++ b/Modelica/Media/IdealGases/Common/Functions.mo
@@ -236,7 +236,7 @@ transform the formula to SI units:
       1e-3 is due to conversion from cm^3/mol->m^3/mol</li>
 </ul>
 
-<h4>References:</h4>
+<h4>References</h4>
 <p>
 [1] Bruce E. Poling, John E. Prausnitz, John P. O'Connell, \"The Properties of Gases and Liquids\" 5th Ed. Mc Graw Hill.
 </p>

--- a/Modelica/Media/IdealGases/Common/package.mo
+++ b/Modelica/Media/IdealGases/Common/package.mo
@@ -434,7 +434,7 @@ transform the formula to SI units:
       1e-3 is due to conversion from cm^3/mol->m^3/mol</li>
 </ul>
 
-<h4>References:</h4>
+<h4>References</h4>
 <p>
 [1] Bruce E. Poling, John E. Prausnitz, John P. O'Connell, \"The Properties of Gases and Liquids\" 5th Ed. Mc Graw Hill.
 </p>

--- a/Modelica/Media/Water/IF97_Utilities.mo
+++ b/Modelica/Media/Water/IF97_Utilities.mo
@@ -8324,7 +8324,7 @@ public
   end dynamicIsentropicEnthalpy;
 
   annotation (Documentation(info="<html>
-      <h4>Package description:</h4>
+      <h4>Package description</h4>
       <p>This package provides high accuracy physical properties for water according
       to the IAPWS/IF97 standard. It has been part of the ThermoFluid Modelica library and been extended,
       reorganized and documented to become part of the Modelica Standard library.</p>

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -472,7 +472,7 @@ This can be recommended by having  <code><strong>annotation</strong> choicesAllM
   ...
   <strong>end</strong> Modelica;
 </pre></blockquote>
-<h5>Related annotations:</h5>
+<h5>Related annotations</h5>
 <ul>
   <li><a href=\"modelica://ModelicaReference.Annotations.revisionId\">revisionId</a></li>
   <li><a href=\"modelica://ModelicaReference.Annotations.uses\">uses</a></li>
@@ -1266,7 +1266,7 @@ The preferredView annotation defines the default view when selecting the class. 
              <em>revisionId   = &quot;c04e23a0d 2018-08-01 12:00:00 +0200&quot;</em>);
   ...
   <strong>end</strong> Modelica;</pre></blockquote>
-<h5>Related annotations:</h5>
+<h5>Related annotations</h5>
 <ul>
   <li><a href=\"modelica://ModelicaReference.Annotations.version\">version</a></li>
   <li><a href=\"modelica://ModelicaReference.Annotations.versionDate\">versionDate</a></li>
@@ -1399,7 +1399,7 @@ Defines that classes within this top-level class uses a specific version of anot
      The annotations uses and conversion may contain several different sub-entries.</li>
 </ul>
 
-<h5>Related annotations:</h5>
+<h5>Related annotations</h5>
 <ul>
   <li><a href=\"modelica://ModelicaReference.Annotations.dateModified\">dateModified</a></li>
   <li><a href=\"modelica://ModelicaReference.Annotations.revisionId\">revisionId</a></li>
@@ -1510,7 +1510,7 @@ of the following ways in a directory given in the MODELICAPATH:
 <p>
 This allows a tool to access multiple versions of the same package.
 </p>
-<h5>Related annotations:</h5>
+<h5>Related annotations</h5>
 <ul>
   <li><a href=\"modelica://ModelicaReference.Annotations.dateModified\">dateModified</a></li>
   <li><a href=\"modelica://ModelicaReference.Annotations.revisionId\">revisionId</a></li>
@@ -1553,7 +1553,7 @@ A &ldquo;<code>versionBuild</code>&rdquo; number A that is higher as &ldquo;<cod
   ...
   <strong>end</strong> Modelica;
 </pre></blockquote>
-<h5>Related annotations:</h5>
+<h5>Related annotations</h5>
 <ul>
   <li><a href=\"modelica://ModelicaReference.Annotations.dateModified\">dateModified</a></li>
   <li><a href=\"modelica://ModelicaReference.Annotations.revisionId\">revisionId</a></li>
@@ -1584,7 +1584,7 @@ A &ldquo;<code>versionBuild</code>&rdquo; number A that is higher as &ldquo;<cod
              revisionId   = &quot;c04e23a0d 2018-08-01 12:00:00 +0200&quot;);
   ...
   <strong>end</strong> Modelica;</pre></blockquote>
-<h5>Related annotations:</h5>
+<h5>Related annotations</h5>
 <ul>
   <li><a href=\"modelica://ModelicaReference.Annotations.uses\">uses</a></li>
   <li><a href=\"modelica://ModelicaReference.Annotations.version\">version</a></li>

--- a/ModelicaServices/package.mo
+++ b/ModelicaServices/package.mo
@@ -74,7 +74,7 @@ First version of the ModelicaServices library.
     class Contact "Contact"
       extends Modelica.Icons.Contact;
       annotation (Documentation(info="<html>
-<h5>Main Author:</h5>
+<h5>Main Author</h5>
 
 <table border=0 cellspacing=0 cellpadding=2>
 <tr>

--- a/ModelicaTest/Blocks.mo
+++ b/ModelicaTest/Blocks.mo
@@ -1428,7 +1428,7 @@ The standard text book version uses order \"m=n\", which is
 also the default setting of this block. The setting
 \"m=n-1\" may yield a better approximation in certain cases.
 </p>
-<h5>Literature:</h5>
+<h5>Literature</h5>
 <p>Otto Foellinger: Regelungstechnik, 8. Auflage,
 chapter 11.9, page 412-414, Huethig Verlag Heidelberg, 1994
 </p>

--- a/ModelicaTest/Fluid/TestComponents/Vessels/TestInitialization.mo
+++ b/ModelicaTest/Fluid/TestComponents/Vessels/TestInitialization.mo
@@ -52,9 +52,9 @@ equation
           textString="See Documentation view for more info.")}),
                        experiment(StopTime=1, Tolerance=1e-6),
     Documentation(info="<html>
-<h4>Original intention:</h4>
+<h4>Original intention</h4>
 <p><br>Ticket #63: Medium SimpleAir was missing stateSelect.prefer on pressure p. This led to the bad state m without start value and resulted in a division by zero. Work-around: Use Medium MoistAir.</p>
-<h4>New intention:</h4>
+<h4>New intention</h4>
 <p>Ticket #1222 (TestInitialization does not initialize): The model uses StaticPipe models connected to a ClosedVolume with port models. This results in algebraic loops for the pressures between the pipes and the volume. The use of homotopy in its current form results in additional nonlinear equation systems.</p>
 <p>Ticket #736 (Use of m_flow_small, m_flow_turbulent and dp_small): The model is motivated by air conditioning that is characterized by relatively small mass flow rates and very small pressure drops. The overall pressure drop is 10 Pa from source to sink. This pressure drop is almost completely taken by the tank outlet towards pipe2 under steady conditions. The pipes have a pressure drop between about 5 Pa and 1e-2 Pa each during the transient simulation. The mass flow rate starts at about 0.2 kg/s and reaches a steady value at about 6e-3 kg/s.</p>
 <p>The classic setting in the Advanced tab of the system model introduce m_flow_small=1e-2 kg/s and dp_small=1 Pa per default. In particular dp_small is too large for the pipe models and can hardly be used for regularization of zero flow -- note that it may be appropriate for other component models, like the tank outlet. dp_small largely depends on the flow characteristics of individual component models.</p>

--- a/ModelicaTest/Fluid/TestComponents/Vessels/TestInitialization.mo
+++ b/ModelicaTest/Fluid/TestComponents/Vessels/TestInitialization.mo
@@ -53,7 +53,7 @@ equation
                        experiment(StopTime=1, Tolerance=1e-6),
     Documentation(info="<html>
 <h4>Original intention</h4>
-<p><br>Ticket #63: Medium SimpleAir was missing stateSelect.prefer on pressure p. This led to the bad state m without start value and resulted in a division by zero. Work-around: Use Medium MoistAir.</p>
+<p>Ticket #63: Medium SimpleAir was missing stateSelect.prefer on pressure p. This led to the bad state m without start value and resulted in a division by zero. Work-around: Use Medium MoistAir.</p>
 <h4>New intention</h4>
 <p>Ticket #1222 (TestInitialization does not initialize): The model uses StaticPipe models connected to a ClosedVolume with port models. This results in algebraic loops for the pressures between the pipes and the volume. The use of homotopy in its current form results in additional nonlinear equation systems.</p>
 <p>Ticket #736 (Use of m_flow_small, m_flow_turbulent and dp_small): The model is motivated by air conditioning that is characterized by relatively small mass flow rates and very small pressure drops. The overall pressure drop is 10 Pa from source to sink. This pressure drop is almost completely taken by the tank outlet towards pipe2 under steady conditions. The pipes have a pressure drop between about 5 Pa and 1e-2 Pa each during the transient simulation. The mass flow rate starts at about 0.2 kg/s and reaches a steady value at about 6e-3 kg/s.</p>


### PR DESCRIPTION
```
The <h4> and <h5> headings must not be terminated by a colon (:).
```