### PR TITLE
Add variable reluctance and permeance to FluxTubes

### DIFF
--- a/Modelica/Magnetic/FluxTubes/Basic/VariablePermeance.mo
+++ b/Modelica/Magnetic/FluxTubes/Basic/VariablePermeance.mo
@@ -1,0 +1,24 @@
+within Modelica.Magnetic.FluxTubes.Basic;
+model VariablePermeance "Variable permeance"
+
+  extends Interfaces.TwoPorts;
+  extends Modelica.Magnetic.FluxTubes.Icons.Reluctance;
+  Modelica.Blocks.Interfaces.RealInput G_m(quantity="Permeance", unit="H") "Magnetic permeance"
+    annotation (Placement(transformation(
+        extent={{-20,-20},{20,20}},
+        rotation=270,
+        origin={0,120})));
+
+equation
+  G_m * V_m = Phi;
+
+  annotation (defaultComponentName="permeance", Icon(coordinateSystem(
+      preserveAspectRatio=false,
+      extent={{-100,-100},{100,100}})),
+                                Documentation(info="<html>
+<p>
+The permeance of this model is controlled by a real signal input. 
+</p>
+</html>",
+      revisions=""));
+end VariablePermeance;

--- a/Modelica/Magnetic/FluxTubes/Basic/VariablePermeance.mo
+++ b/Modelica/Magnetic/FluxTubes/Basic/VariablePermeance.mo
@@ -15,10 +15,9 @@ equation
   annotation (defaultComponentName="permeance", Icon(coordinateSystem(
       preserveAspectRatio=false,
       extent={{-100,-100},{100,100}})),
-                                Documentation(info="<html>
+      Documentation(info="<html>
 <p>
 The permeance of this model is controlled by a real signal input. 
 </p>
-</html>",
-      revisions=""));
+</html>"));
 end VariablePermeance;

--- a/Modelica/Magnetic/FluxTubes/Basic/VariableReluctance.mo
+++ b/Modelica/Magnetic/FluxTubes/Basic/VariableReluctance.mo
@@ -1,0 +1,23 @@
+within Modelica.Magnetic.FluxTubes.Basic;
+model VariableReluctance "Variable reluctance"
+
+  extends Interfaces.TwoPorts;
+  extends Modelica.Magnetic.FluxTubes.Icons.Reluctance;
+  Modelica.Blocks.Interfaces.RealInput R_m(quantity="Reluctance", unit="H-1") "Magnetic reluctance"
+    annotation (Placement(transformation(
+        extent={{-20,-20},{20,20}},
+        rotation=270,
+        origin={0,120})));
+
+equation
+  V_m = Phi*R_m;
+
+  annotation (defaultComponentName="reluctance", Icon(coordinateSystem(
+      preserveAspectRatio=false,
+      extent={{-100,-100},{100,100}})),
+      Documentation(info="<html>
+<p>
+This constant reluctance is provided for test purposes and simple magnetic network models. The reluctance is not calculated from geometry and permeability of a flux tube, but is provided as parameter.
+</p>
+</html>", revisions=""));
+end VariableReluctance;

--- a/Modelica/Magnetic/FluxTubes/Basic/VariableReluctance.mo
+++ b/Modelica/Magnetic/FluxTubes/Basic/VariableReluctance.mo
@@ -17,7 +17,7 @@ equation
       extent={{-100,-100},{100,100}})),
       Documentation(info="<html>
 <p>
-This constant reluctance is provided for test purposes and simple magnetic network models. The reluctance is not calculated from geometry and permeability of a flux tube, but is provided as parameter.
+The reluctance of this model is controlled by a real signal input. 
 </p>
-</html>", revisions=""));
+</html>"));
 end VariableReluctance;

--- a/Modelica/Magnetic/FluxTubes/Basic/package.order
+++ b/Modelica/Magnetic/FluxTubes/Basic/package.order
@@ -3,6 +3,8 @@ ElectroMagneticConverter
 ElectroMagneticConverterWithLeakageInductance
 ConstantReluctance
 ConstantPermeance
+VariableReluctance
+VariablePermeance
 LeakageWithCoefficient
 EddyCurrent
 Idle

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/VariablePermeance.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/VariablePermeance.mo
@@ -1,0 +1,29 @@
+within Modelica.Magnetic.QuasiStatic.FluxTubes.Basic;
+model VariablePermeance "Variable permeance"
+
+  extends Interfaces.TwoPorts;
+  extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.Reluctance;
+
+  Blocks.Interfaces.RealInput G_m(quantity="Permeance", unit="H") "Magnetic permeance"
+    annotation (Placement(transformation(
+        extent={{-20,-20},{20,20}},
+        rotation=270,
+        origin={0,120})));
+equation
+  G_m * V_m = Phi;
+
+  annotation (Icon(coordinateSystem(
+      preserveAspectRatio=false,
+      extent={{-100,-100},{100,100}}), graphics={
+      Line(points={{70,0},{90,0}}, color={255,170,85}),
+      Text(
+        extent={{-150,50},{150,90}},
+        textString="%name",
+        textColor={0,0,255})}), Documentation(info="<html>
+<p>
+This constant permeance is provided for test purposes and simple magnetic network models. The permeance is not calculated from geometry and permeability of a flux tube, but is provided as parameter.
+</p>
+</html>",
+      revisions="<html>
+</html>"));
+end VariablePermeance;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/VariableReluctance.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/VariableReluctance.mo
@@ -1,0 +1,27 @@
+within Modelica.Magnetic.QuasiStatic.FluxTubes.Basic;
+model VariableReluctance "Variable reluctance"
+
+  extends Interfaces.TwoPorts;
+  extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.Reluctance;
+
+  Blocks.Interfaces.RealInput          R_m(quantity="Reluctance", unit="H-1") "Magnetic reluctance"
+    annotation (Placement(transformation(
+        extent={{-20,-20},{20,20}},
+        rotation=270,
+        origin={0,120})));
+equation
+  V_m = Phi*R_m;
+
+  annotation (Icon(coordinateSystem(
+      preserveAspectRatio=false,
+      extent={{-100,-100},{100,100}}), graphics={
+      Line(points={{70,0},{90,0}}, color={255,170,85}),
+      Text(
+        extent={{-150,50},{150,90}},
+        textString="%name",
+        textColor={0,0,255})}), Documentation(info="<html>
+<p>
+The reluctance of this model is controlled by a real signal input. 
+</p>
+</html>"));
+end VariableReluctance;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/VariableReluctance.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/VariableReluctance.mo
@@ -4,7 +4,7 @@ model VariableReluctance "Variable reluctance"
   extends Interfaces.TwoPorts;
   extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.Reluctance;
 
-  Blocks.Interfaces.RealInput          R_m(quantity="Reluctance", unit="H-1") "Magnetic reluctance"
+  Blocks.Interfaces.RealInput R_m(quantity="Reluctance", unit="H-1") "Magnetic reluctance"
     annotation (Placement(transformation(
         extent={{-20,-20},{20,20}},
         rotation=270,

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/package.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/package.mo
@@ -1,7 +1,6 @@
 within Modelica.Magnetic.QuasiStatic.FluxTubes;
 package Basic "Basic elements of magnetic network models"
   extends Modelica.Icons.Package;
-
   annotation (Documentation(info="<html>
 <p>This package contains the basic components of quasi-static flux tubes package.</p>
 </html>"));

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/package.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/package.mo
@@ -1,6 +1,7 @@
 within Modelica.Magnetic.QuasiStatic.FluxTubes;
 package Basic "Basic elements of magnetic network models"
   extends Modelica.Icons.Package;
+
   annotation (Documentation(info="<html>
 <p>This package contains the basic components of quasi-static flux tubes package.</p>
 </html>"));

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/package.order
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/package.order
@@ -2,6 +2,8 @@ Ground
 ElectroMagneticConverter
 ConstantReluctance
 ConstantPermeance
+VariableReluctance
+VariablePermeance
 LeakageWithCoefficient
 EddyCurrent
 Idle

--- a/ModelicaTest/FluxTubes.mo
+++ b/ModelicaTest/FluxTubes.mo
@@ -69,11 +69,11 @@ package FluxTubes "Test library for Modelica.Magnetic.FluxTubes"
     connect(stepVoltage.p, conductor.p) annotation (Line(
         points={{-80,80},{-70,80}}, color={0,0,255}));
     connect(conductor.n, converter.p) annotation (Line(
-        points={{-50,80},{-40,80},{-40,76}}, color={0,0,255}));
+        points={{-50,80},{-40,80},{-40,80}}, color={0,0,255}));
     connect(converter.n, stepVoltage.n) annotation (Line(
-        points={{-40,64},{-40,60},{-80,60}}, color={0,0,255}));
+        points={{-40,60},{-40,60},{-80,60}}, color={0,0,255}));
     connect(converter.port_p, leakageWithCoefficient.port_p) annotation (Line(
-        points={{-20,76},{-20,80},{0,80}}, color={255,127,0}));
+        points={{-20,80},{-20,80},{0,80}}, color={255,127,0}));
     connect(leakageWithCoefficient.port_p, constantReluctance.port_p) annotation (
        Line(
         points={{0,80},{20,80}}, color={255,127,0}));
@@ -81,7 +81,7 @@ package FluxTubes "Test library for Modelica.Magnetic.FluxTubes"
        Line(
         points={{20,60},{0,60}}, color={255,127,0}));
     connect(leakageWithCoefficient.port_n, converter.port_n) annotation (Line(
-        points={{0,60},{-20,60},{-20,64}}, color={255,127,0}));
+        points={{0,60},{-20,60},{-20,60}}, color={255,127,0}));
     connect(ground3.p, stepVoltage1.n) annotation (Line(
         points={{-80,-10},{-80,0}}, color={0,0,255}));
     connect(stepVoltage1.p, conductor1.p) annotation (Line(
@@ -89,19 +89,20 @@ package FluxTubes "Test library for Modelica.Magnetic.FluxTubes"
     connect(ground2.port, constantReluctance.port_n) annotation (Line(
         points={{20,50},{20,60}}, color={255,127,0}));
     connect(converter1.port_p, eddyCurrent.port_p) annotation (Line(
-        points={{-20,16},{-20,20},{-10,20}}, color={255,127,0}));
+        points={{-20,20},{-20,20},{-10,20}}, color={255,127,0}));
     connect(conductor1.n, converter1.p) annotation (Line(
-        points={{-50,20},{-40,20},{-40,16}}, color={0,0,255}));
+        points={{-50,20},{-40,20},{-40,20}}, color={0,0,255}));
     connect(converter1.n, stepVoltage1.n) annotation (Line(
-        points={{-40,4},{-40,0},{-80,0}}, color={0,0,255}));
+        points={{-40,0.2},{-40,0},{-80,0}},
+                                          color={0,0,255}));
     connect(ground.port, converter1.port_n) annotation (Line(
-        points={{-20,-10},{-20,4}}, color={255,127,0}));
+        points={{-20,-10},{-20,0}}, color={255,127,0}));
     connect(eddyCurrent.port_n, crossing.port_n2) annotation (Line(
         points={{10,20},{20,20}}, color={255,127,0}));
     connect(crossing.port_p2, short.port_p) annotation (Line(
         points={{40,20},{50,20}}, color={255,127,0}));
     connect(crossing.port_p1, converter1.port_n) annotation (Line(
-        points={{20,0},{-20,0},{-20,4}}, color={255,127,0}));
+        points={{20,0},{-20,0},{-20,0}}, color={255,127,0}));
     connect(constantPermeance.port_p, short.port_n) annotation (Line(
         points={{80,20},{70,20}}, color={255,127,0}));
     connect(constantPermeance.port_n, crossing.port_n1) annotation (Line(
@@ -684,4 +685,39 @@ package FluxTubes "Test library for Modelica.Magnetic.FluxTubes"
             0}));
     annotation (experiment(StartTime=0, StopTime=1, Interval=1e-3, Tolerance=1e-005));
   end Sensors;
+
+  model VariableComponents "Test of reluctance and permeance model with signal inputs"
+    extends Modelica.Icons.Example;
+    Modelica.Magnetic.FluxTubes.Basic.VariableReluctance reluctance annotation (Placement(transformation(
+          extent={{-10,-10},{10,10}},
+          rotation=270,
+          origin={40,0})));
+    Modelica.Magnetic.FluxTubes.Basic.VariablePermeance permeance annotation (Placement(transformation(
+          extent={{-10,10},{10,-10}},
+          rotation=270,
+          origin={20,0})));
+    Modelica.Magnetic.FluxTubes.Basic.Ground ground annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
+    Modelica.Magnetic.FluxTubes.Sources.ConstantMagneticFlux magFluxSource(Phi=1) annotation (Placement(transformation(
+          extent={{10,-10},{-10,10}},
+          rotation=270,
+          origin={-40,0})));
+    Modelica.Blocks.Sources.Ramp rampPermeance(
+      height=1,
+      duration=0.3,
+      offset=0,
+      startTime=0.6) annotation (Placement(transformation(extent={{-20,-10},{0,10}})));
+    Modelica.Blocks.Sources.Ramp rampReluctance(
+      height=1,
+      duration=0.3,
+      offset=0,
+      startTime=0.1) annotation (Placement(transformation(extent={{80,-10},{60,10}})));
+  equation
+    connect(ground.port, permeance.port_n) annotation (Line(points={{0,-30},{20,-30},{20,-10}}, color={255,127,0}));
+    connect(reluctance.port_n, permeance.port_n) annotation (Line(points={{40,-10},{40,-30},{20,-30},{20,-10}}, color={255,127,0}));
+    connect(rampPermeance.y, permeance.G_m) annotation (Line(points={{1,0},{8,0}}, color={0,0,127}));
+    connect(reluctance.R_m, rampReluctance.y) annotation (Line(points={{52,-2.22045e-15},{56,-2.22045e-15},{56,0},{59,0}}, color={0,0,127}));
+    connect(magFluxSource.port_n, permeance.port_p) annotation (Line(points={{-40,10},{-40,30},{20,30},{20,10}}, color={255,127,0}));
+    connect(reluctance.port_p, permeance.port_p) annotation (Line(points={{40,10},{40,30},{20,30},{20,10}}, color={255,127,0}));
+    connect(ground.port, magFluxSource.port_p) annotation (Line(points={{0,-30},{-40,-30},{-40,-10}}, color={255,127,0}));
+  end VariableComponents;
 end FluxTubes;

--- a/ModelicaTest/Magnetic/QuasiStatic/FluxTubes.mo
+++ b/ModelicaTest/Magnetic/QuasiStatic/FluxTubes.mo
@@ -77,4 +77,42 @@ package FluxTubes "Test examples of Modelica.Magnetic.QuasiStatic.FluxTubes"
               -100},{100,100}})),
       experiment(Interval=0.001, StartTime=0, StopTime=1, Tolerance=1e-06));
   end NoPhysicalTestLeakage;
+
+  model VariableComponents "Test of reluctance and permeance model with signal inputs"
+    extends Modelica.Icons.Example;
+    Modelica.Magnetic.QuasiStatic.FluxTubes.Basic.VariableReluctance reluctance annotation (Placement(transformation(
+          extent={{-10,-10},{10,10}},
+          rotation=270,
+          origin={40,0})));
+    Modelica.Magnetic.QuasiStatic.FluxTubes.Basic.VariablePermeance permeance annotation (Placement(transformation(
+          extent={{-10,10},{10,-10}},
+          rotation=270,
+          origin={20,0})));
+    Modelica.Magnetic.QuasiStatic.FluxTubes.Basic.Ground ground annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
+    Modelica.Magnetic.QuasiStatic.FluxTubes.Sources.ConstantMagneticFlux magFluxSource(
+      gamma(fixed=true),
+      f=50,
+      Phi=Complex(1, 0))                                                               annotation (Placement(transformation(
+          extent={{10,-10},{-10,10}},
+          rotation=270,
+          origin={-40,0})));
+    Modelica.Blocks.Sources.Ramp rampPermeance(
+      height=1,
+      duration=0.3,
+      offset=0,
+      startTime=0.6) annotation (Placement(transformation(extent={{-20,-10},{0,10}})));
+    Modelica.Blocks.Sources.Ramp rampReluctance(
+      height=1,
+      duration=0.3,
+      offset=0,
+      startTime=0.1) annotation (Placement(transformation(extent={{80,-10},{60,10}})));
+  equation
+    connect(rampPermeance.y, permeance.G_m) annotation (Line(points={{1,0},{8,0}}, color={0,0,127}));
+    connect(reluctance.R_m, rampReluctance.y) annotation (Line(points={{52,-2.22045e-15},{56,-2.22045e-15},{56,0},{59,0}}, color={0,0,127}));
+    connect(magFluxSource.port_p, ground.port) annotation (Line(points={{-40,-10},{-40,-30},{0,-30}}, color={255,170,85}));
+    connect(ground.port, permeance.port_n) annotation (Line(points={{0,-30},{20,-30},{20,-10}}, color={255,170,85}));
+    connect(ground.port, reluctance.port_n) annotation (Line(points={{0,-30},{40,-30},{40,-10}}, color={255,170,85}));
+    connect(magFluxSource.port_n, permeance.port_p) annotation (Line(points={{-40,10},{-40,30},{20,30},{20,10}}, color={255,170,85}));
+    connect(reluctance.port_p, permeance.port_p) annotation (Line(points={{40,10},{40,30},{20,30},{20,10}}, color={255,170,85}));
+  end VariableComponents;
 end FluxTubes;


### PR DESCRIPTION
As there is a signal connector provided for `LeakageWithCoefficient` in #3300 it makes a lot of sense to have pure reluctance and permeance models with signal inputs as well:

- `VariableReluctance`
- `VariablePermeance`

This PR provides these models for 

- `Modelica.Magnetic.FluxTubes.Basic`
- `Modelica.Magnetic.QuasiStatic.FluxTubes.Basic`