### PR TITLE
Fix missing import of constant eps

### DIFF
--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/LeakageWithCoefficient.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/LeakageWithCoefficient.mo
@@ -3,7 +3,7 @@ model LeakageWithCoefficient
 "Leakage reluctance with respect to the reluctance of a useful flux path (not for dynamic simulation of actuators)"
 
   extends BaseClasses.Leakage;
-
+  import Modelica.Constants.eps;
   parameter SI.CouplingCoefficient c_usefulFlux(final min=eps, final max=1-eps, start=0.7)
     "Ratio useful flux/(leakage flux + useful flux) = useful flux/total flux"
     annotation (Dialog(groupImage=


### PR DESCRIPTION
Forgot to include constant eps in #3307 somehow in the version I committed. 