### PR TITLE
Fix some improper uses of `each` in Electrical

### DIFF
--- a/Modelica/Electrical/Polyphase/Sensors/PotentialSensor.mo
+++ b/Modelica/Electrical/Polyphase/Sensors/PotentialSensor.mo
@@ -4,7 +4,7 @@ model PotentialSensor "Polyphase potential sensor"
   parameter Integer m(final min=1) = 3 "Number of phases";
   Interfaces.PositivePlug plug_p(final m=m) annotation (Placement(
         transformation(extent={{-110,-10},{-90,10}})));
-  Modelica.Blocks.Interfaces.RealOutput phi[m](unit="V")
+  Modelica.Blocks.Interfaces.RealOutput phi[m](each unit="V")
     "Absolute voltage potential as output signal" annotation (Placement(
         transformation(extent={{100,-10},{120,10}})));
   Modelica.Electrical.Analog.Sensors.PotentialSensor potentialSensor[m]

--- a/Modelica/Electrical/PowerConverters/ACDC/DiodeBridge2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/DiodeBridge2mPulse.mo
@@ -18,7 +18,7 @@ model DiodeBridge2mPulse "2*m pulse diode rectifier bridge"
     final Ron=fill(RonDiode, m),
     final Goff=fill(GoffDiode, m),
     final Vknee=fill(VkneeDiode, m),
-    each final useHeatPort=useHeatPort)
+    final useHeatPort=useHeatPort)
     "Diodes connected to positive DC potential" annotation (Placement(
         transformation(
         origin={0,40},
@@ -29,7 +29,7 @@ model DiodeBridge2mPulse "2*m pulse diode rectifier bridge"
     final Ron=fill(RonDiode, m),
     final Goff=fill(GoffDiode, m),
     final Vknee=fill(VkneeDiode, m),
-    each final useHeatPort=useHeatPort)
+    final useHeatPort=useHeatPort)
     "Diodes connected to negative DC potential" annotation (Placement(
         transformation(
         origin={0,-40},

--- a/Modelica/Electrical/PowerConverters/ACDC/DiodeCenterTap2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/DiodeCenterTap2mPulse.mo
@@ -18,7 +18,7 @@ model DiodeCenterTap2mPulse "2*m pulse diode rectifier with center tap"
     final Ron=fill(RonDiode, m),
     final Goff=fill(GoffDiode, m),
     final Vknee=fill(VkneeDiode, m),
-    each final useHeatPort=useHeatPort)
+    final useHeatPort=useHeatPort)
     "Diodes connected to positive DC potential" annotation (Placement(
         transformation(
         origin={-10,60},
@@ -29,7 +29,7 @@ model DiodeCenterTap2mPulse "2*m pulse diode rectifier with center tap"
     final Ron=fill(RonDiode, m),
     final Goff=fill(GoffDiode, m),
     final Vknee=fill(VkneeDiode, m),
-    each final useHeatPort=useHeatPort)
+    final useHeatPort=useHeatPort)
     "Diodes connected to negative DC potential" annotation (Placement(
         transformation(
         origin={-10,-60},

--- a/Modelica/Electrical/PowerConverters/ACDC/DiodeCenterTapmPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/DiodeCenterTapmPulse.mo
@@ -18,7 +18,7 @@ model DiodeCenterTapmPulse "m pulse diode rectifier with center tap"
     final Ron=fill(RonDiode, m),
     final Goff=fill(GoffDiode, m),
     final Vknee=fill(VkneeDiode, m),
-    each final useHeatPort=useHeatPort)
+    final useHeatPort=useHeatPort)
     "Diodes connected to positive DC potential" annotation (Placement(
         transformation(
         origin={-10,0},

--- a/Modelica/Electrical/PowerConverters/ACDC/HalfControlledBridge2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/HalfControlledBridge2mPulse.mo
@@ -33,7 +33,7 @@ model HalfControlledBridge2mPulse
     final Ron=fill(RonThyristor, m),
     final Goff=fill(GoffThyristor, m),
     final Vknee=fill(VkneeThyristor, m),
-    each final useHeatPort=useHeatPort,
+    final useHeatPort=useHeatPort,
     final idealThyristor(off(start=offStart_p, fixed=fill(true, m))))
     "Thyristors connected to positive DC potential" annotation (Placement(
         transformation(
@@ -45,7 +45,7 @@ model HalfControlledBridge2mPulse
     final Ron=fill(RonDiode, m),
     final Goff=fill(GoffDiode, m),
     final Vknee=fill(VkneeDiode, m),
-    each final useHeatPort=useHeatPort)
+    final useHeatPort=useHeatPort)
     "Diodes connected to negative DC potential" annotation (Placement(
         transformation(
         origin={0,-40},

--- a/Modelica/Electrical/PowerConverters/ACDC/ThyristorBridge2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/ThyristorBridge2mPulse.mo
@@ -24,7 +24,7 @@ model ThyristorBridge2mPulse "2*m pulse thyristor rectifier bridge"
     final Ron=fill(RonThyristor, m),
     final Goff=fill(GoffThyristor, m),
     final Vknee=fill(VkneeThyristor, m),
-    each final useHeatPort=useHeatPort,
+    final useHeatPort=useHeatPort,
     final idealThyristor(off(start=offStart_p, fixed=fill(true, m))))
     "Thyristors connected to positive DC potential" annotation (Placement(
         transformation(
@@ -36,7 +36,7 @@ model ThyristorBridge2mPulse "2*m pulse thyristor rectifier bridge"
     final Ron=fill(RonThyristor, m),
     final Goff=fill(GoffThyristor, m),
     final Vknee=fill(VkneeThyristor, m),
-    each final useHeatPort=useHeatPort,
+    final useHeatPort=useHeatPort,
     final idealThyristor(off(start=offStart_n, fixed=fill(true, m))))
     "Thyristors connected to negative DC potential" annotation (Placement(
         transformation(

--- a/Modelica/Electrical/PowerConverters/ACDC/ThyristorCenterTap2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/ThyristorCenterTap2mPulse.mo
@@ -26,7 +26,7 @@ model ThyristorCenterTap2mPulse
     final Ron=fill(RonThyristor, m),
     final Goff=fill(GoffThyristor, m),
     final Vknee=fill(VkneeThyristor, m),
-    each final useHeatPort=useHeatPort,
+    final useHeatPort=useHeatPort,
     final idealThyristor(off(start=offStart_p, fixed=fill(true, m))))
     "Thyristors conducting positive plug AC potentials" annotation (
       Placement(transformation(
@@ -38,7 +38,7 @@ model ThyristorCenterTap2mPulse
     final Ron=fill(RonThyristor, m),
     final Goff=fill(GoffThyristor, m),
     final Vknee=fill(VkneeThyristor, m),
-    each final useHeatPort=useHeatPort,
+    final useHeatPort=useHeatPort,
     final idealThyristor(off(start=offStart_n, fixed=fill(true, m))))
     "Thyristors conducting negative plug AC potentials" annotation (
       Placement(transformation(

--- a/Modelica/Electrical/PowerConverters/ACDC/ThyristorCenterTapmPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/ThyristorCenterTapmPulse.mo
@@ -23,7 +23,7 @@ model ThyristorCenterTapmPulse
     final Ron=fill(RonThyristor, m),
     final Goff=fill(GoffThyristor, m),
     final Vknee=fill(VkneeThyristor, m),
-    each final useHeatPort=useHeatPort,
+    final useHeatPort=useHeatPort,
     final idealThyristor(off(start=offStart, fixed=fill(true, m))))
     "Thyristors conducting AC potentials" annotation (Placement(transformation(
         origin={-10,0},

--- a/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierBridge2mPulse/ThyristorBridge2mPulse_DC_Drive.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierBridge2mPulse/ThyristorBridge2mPulse_DC_Drive.mo
@@ -26,8 +26,8 @@ model ThyristorBridge2mPulse_DC_Drive
   output Modelica.SIunits.Torque tau=dcpm.tauShaft;
   Modelica.Electrical.Polyphase.Sources.SineVoltage sinevoltage(
     m=m,
-    each final V=fill(sqrt(2)*Vrms, m),
-    each f=fill(f, m)) annotation (Placement(transformation(
+    final V=fill(sqrt(2)*Vrms, m),
+    f=fill(f, m)) annotation (Placement(transformation(
         origin={-80,0},
         extent={{-10,-10},{10,10}},
         rotation=-90)));


### PR DESCRIPTION
Fixes one missing `each` in Electrical.Polyphase.Sensors.PotentialSensor introduced in 86c4774e, as well as some older unnecessary uses of `each` in Electrical.PowerConverters.ACDC. 