### PR TITLE
Fix Modelica.Media.R134a.R134a_ph.setState_pTX (only applicable for one-phase)

### DIFF
--- a/Modelica/Media/R134a.mo
+++ b/Modelica/Media/R134a.mo
@@ -361,7 +361,7 @@ Example:
 parameter Medium.Density d = 4;
 parameter Medium.Temperature T = 298;
 
-Medium.SpecficEntropy s;
+Medium.SpecificEntropy s;
 
 <strong>equation</strong>
 
@@ -408,9 +408,9 @@ Example:
 </p>
 <blockquote><pre>
 parameter Medium.AbsolutePressure p = 3e5;
-parameter Medium.SpecficEntropy s = 1.7e3;
+parameter Medium.SpecificEntropy s = 1.7e3;
 
-Medium.SpecficEnthalpy h;
+Medium.SpecificEnthalpy h;
 
 <strong>equation</strong>
 
@@ -423,16 +423,15 @@ h = Medium.specificEnthalpy(setState_psX(p, s, fill(0, Medium.nX)));
       "Set state for pressure and temperature (X not used since single substance)"
 
     protected
-        Modelica.SIunits.Pressure delp=1.0e-2
-        "Relative error in p in iteration";
+      SpecificEnthalpy h = hofpT(p, T) "Specific enthalpy";
 
     algorithm
       Modelica.Media.R134a.R134a_ph.phaseBoundaryAssert(p, T);
 
       state := ThermodynamicState(
-              d=dofpT(p, T, delp),
+              d=density_ph(p, h),
               T=T,
-              h=hofpT(p, T, delp),
+              h=h,
               p=p,
               phase=1);
       annotation (Inline=true, Documentation(info="<html>
@@ -542,7 +541,7 @@ eta_vap = Medium.DynamicViscosity(Medium.setBubbleState(Medium.setSat_p(p)));
               getPhase_ph(p, h)));
 
       annotation (Inline=true, Documentation(info="<html>
-<p> This function calculates the density of R134a from the state variables p (absolute pressure) and h (specific enthalpy). The density is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
+<p>This function calculates the density of R134a from the state variables p (absolute pressure) and h (specific enthalpy). The density is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
 
 <p><img src=\"modelica://Modelica/Resources/Images/Media/R134a/log(p)d-Diagram-R134a.png\"/></p>
 
@@ -584,7 +583,7 @@ by the fundamental equation of state of Tillner-Roth and Baehr (1994).
               getPhase_ph(p, h)));
 
       annotation (Inline=true, Documentation(info="<html>
-<p> This function calculates the Kelvin temperature of R134a from the state variables p (absolute pressure) and h (specific enthalpy). The temperature is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
+<p>This function calculates the Kelvin temperature of R134a from the state variables p (absolute pressure) and h (specific enthalpy). The temperature is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
 
 <p><img src=\"modelica://Modelica/Resources/Images/Media/R134a/log(p)h-Diagram-R134a.png\"/></p>
 
@@ -599,7 +598,7 @@ by the fundamental equation of state of Tillner-Roth and Baehr (1994).
       T := state.T;
 
       annotation (Inline=true, Documentation(info="<html>
-<p> This function calculates the Kelvin temperature of R134a from the state record (e.g., use setState_phX function for input). The temperature is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
+<p>This function calculates the Kelvin temperature of R134a from the state record (e.g., use setState_phX function for input). The temperature is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
 <p><img src=\"modelica://Modelica/Resources/Images/Media/R134a/log(p)h-Diagram-R134a.png\"/></p>
 </html>"));
     end temperature;
@@ -619,7 +618,7 @@ by the fundamental equation of state of Tillner-Roth and Baehr (1994).
       u := specificEnthalpy(state) - pressure(state)/density(state);
 
       annotation (Inline=true, Documentation(info="<html>
-<p> This function calculates the specific internal energy of R134a from the state record (e.g., use setState_phX function for input). The specific internal energy is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
+<p>This function calculates the specific internal energy of R134a from the state record (e.g., use setState_phX function for input). The specific internal energy is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
 <p><img src=\"modelica://Modelica/Resources/Images/Media/R134a/log(p)u-Diagram-R134a.png\"/></p>
 
 </html>"));
@@ -663,7 +662,7 @@ by the fundamental equation of state of Tillner-Roth and Baehr (1994).
       end if;
 
       annotation (Documentation(info="<html>
-<p> This function calculates the specific entropy of R134a from the state record (e.g., use setState_phX function for input). The specific entropy is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
+<p>This function calculates the specific entropy of R134a from the state record (e.g., use setState_phX function for input). The specific entropy is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
 <p><img src=\"modelica://Modelica/Resources/Images/Media/R134a/log(p)s-Diagram-R134a.png\"/></p>
 </html>"));
     end specificEntropy;
@@ -1362,7 +1361,7 @@ the fundamental equation of state of Tillner-Roth and Baehr (1994) and the Maxwe
         f.delta*f.fdelta + f.delta*f.delta*f.fdeltadelta));
 
       annotation (Documentation(info="<html>
-<p> This function calculates the specific heat capacity of R134a at <strong>constant pressure</strong> from the state record (e.g., use setState_phX function for input). The specific heat capacity is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
+<p>This function calculates the specific heat capacity of R134a at <strong>constant pressure</strong> from the state record (e.g., use setState_phX function for input). The specific heat capacity is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
 <h4> Restrictions</h4>
 <p>This property is only defined in one-phase region.
 </p>
@@ -1401,7 +1400,7 @@ the fundamental equation of state of Tillner-Roth and Baehr (1994) and the Maxwe
       end if;
 
       annotation (Documentation(info="<html>
-<p> This function calculates the specific heat capacity of R134a at <strong>constant volume</strong> from the state record (e.g., use setState_phX function for input). The specific heat capacity is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
+<p>This function calculates the specific heat capacity of R134a at <strong>constant volume</strong> from the state record (e.g., use setState_phX function for input). The specific heat capacity is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
 <p>
 Please note, that the function can also be called in the two-phase region, but the output is not continuous for a phase transition (see Tillner-Roth and Baehr, 1994). Values in two-phase region are considerably higher than in one-phase domain. The following figure just shows one-phase properties.
 </p>
@@ -1459,7 +1458,7 @@ Please note, that the function can also be called in the two-phase region, but t
       eta := (eta_star + eta_res*1e3)*1e-06;
 
       annotation (Documentation(info="<html>
-<p> This function calculates the dynamic viscosity of R134a from the state record (e.g., use setState_phX function for input). The dynamic viscosity is modelled by the corresponding states method of Klein, McLinden and Laesecke (1997).</p>
+<p>This function calculates the dynamic viscosity of R134a from the state record (e.g., use setState_phX function for input). The dynamic viscosity is modelled by the corresponding states method of Klein, McLinden and Laesecke (1997).</p>
 <h4> Restrictions</h4>
 <p>This property is only defined in one-phase region.
 </p>
@@ -1544,7 +1543,7 @@ Int. J. Refrig., Vol. 20, No.3, pp. 208-217, 1997.</dd>
       lambda := max(lambda_dg + lambda_reduced + lambda_crit, 1e-8);
 
       annotation (Documentation(info="<html>
-<p> This function calculates the thermal conductivity of R134a from the state record (e.g., use setState_phX function for input). The thermal conductivity is modelled by the corresponding states model of McLinden, Klein. and Perkins (2000).</p>
+<p>This function calculates the thermal conductivity of R134a from the state record (e.g., use setState_phX function for input). The thermal conductivity is modelled by the corresponding states model of McLinden, Klein. and Perkins (2000).</p>
 <h4> Restrictions</h4>
 <p>This property is only defined in one-phase region.
 </p>
@@ -1579,7 +1578,7 @@ Int. J. Refrig., 23 (2000) 43-63.</dd>
       end if;
 
       annotation (Documentation(info="<html>
-<p> This function calculates the surface tension of R134a from the saturation record (e.g., use setSat_T function for input). The property is modelled by an approach of Okada and Higashi (1994).</p>
+<p>This function calculates the surface tension of R134a from the saturation record (e.g., use setSat_T function for input). The property is modelled by an approach of Okada and Higashi (1994).</p>
 <h4> Restrictions</h4>
 <p>This property is only defined in two-phase region.
 </p>
@@ -1608,7 +1607,7 @@ Proceedings of the Joint Meeting of IIR Commissions B1, B2, E1, and E2, Padua, I
           *f.fdelta - f.delta*f.tau*f.fdeltatau))/(f.tau*f.tau*f.ftautau)))^0.5;
       end if;
       annotation (Documentation(info="<html>
-<p> This function calculates the velocity of sound of R134a from the state record (e.g., use setState_phX function for input). The velocity of sound is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
+<p>This function calculates the velocity of sound of R134a from the state record (e.g., use setState_phX function for input). The velocity of sound is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
 <h4> Restrictions</h4>
 <p>This property is only defined in one-phase region.
 </p>
@@ -1630,7 +1629,7 @@ Proceedings of the Joint Meeting of IIR Commissions B1, B2, E1, and E2, Padua, I
           *f.fdeltadelta));
       end if;
       annotation (Documentation(info="<html>
-<p> This function calculates the isothermal compressibility of R134a from the state record (e.g., use setState_phX function for input). The isothermal compressibility is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
+<p>This function calculates the isothermal compressibility of R134a from the state record (e.g., use setState_phX function for input). The isothermal compressibility is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
 <h4> Restrictions</h4>
 <p>This property is only defined in one-phase region.
 </p>
@@ -1651,7 +1650,7 @@ Proceedings of the Joint Meeting of IIR Commissions B1, B2, E1, and E2, Padua, I
           *isothermalCompressibility(state);
       end if;
       annotation (Documentation(info="<html>
-<p> This function calculates the isobaric expansion coefficient of R134a from the state record (e.g., use setState_phX function for input). The isobaric expansion coefficient is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
+<p>This function calculates the isobaric expansion coefficient of R134a from the state record (e.g., use setState_phX function for input). The isobaric expansion coefficient is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
 <h4> Restrictions</h4>
 <p>This property is only defined in one-phase region.
 </p>
@@ -1666,7 +1665,7 @@ Proceedings of the Joint Meeting of IIR Commissions B1, B2, E1, and E2, Padua, I
          else 1e-6)*velocityOfSound(state)^2;
 
       annotation (Inline=true, Documentation(info="<html>
-<p> This function calculates the isentropic exponent of R134a from the state record (e.g., use setState_phX function for input). The isentropic exponent is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
+<p>This function calculates the isentropic exponent of R134a from the state record (e.g., use setState_phX function for input). The isentropic exponent is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).</p>
 <h4> Restrictions</h4>
 <p>This property is only defined in one-phase region.
 </p>
@@ -1678,7 +1677,7 @@ Proceedings of the Joint Meeting of IIR Commissions B1, B2, E1, and E2, Padua, I
     algorithm
       g := state.h - state.T*specificEntropy(state);
       annotation (Documentation(info="<html>
-<p> This function calculates the specific Gibbs energy of R134a from the state record (e.g., use setState_phX function for input). The isentropic exponent is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).
+<p>This function calculates the specific Gibbs energy of R134a from the state record (e.g., use setState_phX function for input). The isentropic exponent is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).
 </p>
 </html>"));
     end specificGibbsEnergy;
@@ -1688,7 +1687,7 @@ Proceedings of the Joint Meeting of IIR Commissions B1, B2, E1, and E2, Padua, I
     algorithm
       f := state.h - state.p/state.d - state.T*specificEntropy(state);
       annotation (Documentation(info="<html>
-<p> This function calculates the specific Helmholtz energy of R134a from the state record (e.g., use setState_phX function for input). The Helmholtz energy is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).
+<p>This function calculates the specific Helmholtz energy of R134a from the state record (e.g., use setState_phX function for input). The Helmholtz energy is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994).
 </p>
 </html>"));
     end specificHelmholtzEnergy;
@@ -1710,7 +1709,7 @@ Proceedings of the Joint Meeting of IIR Commissions B1, B2, E1, and E2, Padua, I
         derivs.pd*derivs.cv + state.T*derivs.pt^2);
 
       annotation (Documentation(info="<html>
-<p> This function calculates the density derivative w.r.t. specific enthalpy at constant pressure of R134a (e.g., use setState_phX function for input). The derivative is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994). It can be used for manual state transformations (e.g. from density to specific enthalpy).
+<p>This function calculates the density derivative w.r.t. specific enthalpy at constant pressure of R134a (e.g., use setState_phX function for input). The derivative is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994). It can be used for manual state transformations (e.g. from density to specific enthalpy).
 </p>
 </html>"));
     end density_derh_p;
@@ -1733,7 +1732,7 @@ Proceedings of the Joint Meeting of IIR Commissions B1, B2, E1, and E2, Padua, I
         derivs.pt^2);
 
       annotation (Documentation(info="<html>
-<p> This function calculates the density derivative w.r.t. absolute pressure at constant specific enthalpy of R134a (e.g., use setState_phX function for input). The derivative is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994). It can be used for manual state transformations (e.g. from density to pressure).
+<p>This function calculates the density derivative w.r.t. absolute pressure at constant specific enthalpy of R134a (e.g., use setState_phX function for input). The derivative is modelled by the fundamental equation of state of Tillner-Roth and Baehr (1994). It can be used for manual state transformations (e.g. from density to pressure).
 </p>
 </html>"));
     end density_derp_h;
@@ -1838,7 +1837,7 @@ The isentropic efficiency function should not be applied in liquid region.
       end if;
 
       annotation (Documentation(info="<html>
-<p> This function calculates the derivatives required for an inversion of temperature and density function.
+<p>This function calculates the derivatives required for an inversion of temperature and density function.
 </p>
 </html>"));
     end derivsOf_ph;
@@ -1883,7 +1882,7 @@ The isentropic efficiency function should not be applied in liquid region.
       end if;
 
       annotation (Documentation(info="<html>
-<p> This function calculates the density and temperature of R134a from absolute pressure and specific enthalpy. In one-phase region the function calls the fundamental Helmholtz equation of Tillner-Roth (1994). In two-phase the density and temperature is computed from cubic splines for saturated pressure, liquid and vapor density.
+<p>This function calculates the density and temperature of R134a from absolute pressure and specific enthalpy. In one-phase region the function calls the fundamental Helmholtz equation of Tillner-Roth (1994). In two-phase the density and temperature is computed from cubic splines for saturated pressure, liquid and vapor density.
 </p>
 <h4>Restrictions</h4>
 The function cannot be inverted in a numerical way. Please use functions <a href=\"modelica://Modelica.Media.R134a.R134a_ph.rho_props_ph\">rho_props_ph</a> and <a href=\"modelica://Modelica.Media.R134a.R134a_ph.T_props_ph\">T_props_ph</a> for this purpose.
@@ -1998,7 +1997,7 @@ The function cannot be inverted in a numerical way. Please use functions <a href
       end while;
 
       annotation (Documentation(info="<html>
-<p> This function calculates the density and temperature of R134a from absolute pressure and specific enthalpy in one-phase region. The function calls the fundamental Helmholtz equation of Tillner-Roth (1994) which is requiring density and temperature for input. Thus, a newton iteration is performed to determine density and temperature. The newton iteration stops if the inputs for pressure difference delp and specific enthalpy difference delh are larger than the actual differences derived from the newton iteration.
+<p>This function calculates the density and temperature of R134a from absolute pressure and specific enthalpy in one-phase region. The function calls the fundamental Helmholtz equation of Tillner-Roth (1994) which is requiring density and temperature for input. Thus, a newton iteration is performed to determine density and temperature. The newton iteration stops if the inputs for pressure difference delp and specific enthalpy difference delh are larger than the actual differences derived from the newton iteration.
 </p>
 <h4>Restrictions</h4>
 The function shall only be used for one-phase inputs since the fundamental equation is not valid for two-phase states.
@@ -2099,7 +2098,7 @@ The function shall only be used for one-phase inputs since the fundamental equat
       end if;
 
       annotation (Documentation(info="<html>
-<p> This function calculates the density and temperature of R134a from absolute pressure and specific entropy in one-phase region. The function calls the fundamental helmholtz equation of Tillner-Roth (1994) which is requiring density and temperature for input. Thus, a newton iteration is performed to determine density and temperature. The newton iteration stops if the inputs for pressure difference delp and specific entropy difference dels are larger than the actual differences derived from the newton iteration.
+<p>This function calculates the density and temperature of R134a from absolute pressure and specific entropy in one-phase region. The function calls the fundamental helmholtz equation of Tillner-Roth (1994) which is requiring density and temperature for input. Thus, a newton iteration is performed to determine density and temperature. The newton iteration stops if the inputs for pressure difference delp and specific entropy difference dels are larger than the actual differences derived from the newton iteration.
 </p>
 <h4>Restrictions</h4>
 The function shall only be used for one-phase inputs since the fundamental equation is not valid for two-phase states. The iteration could fail for liquid states with high pressures.
@@ -2484,70 +2483,14 @@ This function integrates the derivative of temperature w.r.t. time in order to a
       input SI.Pressure delp "Iteration converged if (p-pre(p) < delp)";
       output SI.Density d "Density";
 
-    protected
-      constant Real p_breaks[:]=R134aData.pbreaks
-        "Grid points of reduced pressure";
-      constant Real dl_coef[:, 4]=R134aData.dlcoef
-        "Coefficients of cubic spline for rho_liq(p)";
-      constant Real dv_coef[:, 4]=R134aData.dvcoef
-        "Coefficients of cubic spline for rho_vap(p)";
-
-      Boolean liquid "Is liquid";
-      Boolean supercritical "Is supercritcal";
-      Integer int "Interval number";
-      Real pred "Reduced pressure";
-      Real localx "Oordinate of local spline";
-      Integer i "Newton iteration number";
-      Real dp "Pressure difference";
-      SI.Density deld "Density step";
-      Modelica.Media.Common.HelmholtzDerivs f
-        "Dimensionless Helmholtz function and derivatives w.r.t. delta and tau";
-      Modelica.Media.Common.NewtonDerivatives_pT nDerivs
-        "Derivatives needed in Newton iteration";
-      Boolean found "Flag for iteration success";
-      Integer error "1 if did not converged";
-
     algorithm
-      Modelica.Media.R134a.R134a_ph.phaseBoundaryAssert(p, T);
-      i := 0;
-      error := 0;
-      found := false;
-      pred := p/R134aData.data.FPCRIT;
-      (int,error) := Common.FindInterval(pred, p_breaks);
-      localx := pred - p_breaks[int];
-      // set decent initial guesses for d and T
-      supercritical := p > R134aData.data.FPCRIT;
-      if supercritical then
-        // iteration seems to work better if coming from high densities
-        d := R134aData.data.FDCRIT*3.0;
-      else
-        liquid := T <= Modelica.Media.R134a.R134a_ph.saturationTemperature(p);
-        if liquid then
-          d := R134aData.data.FDCRIT*Common.CubicSplineEval(localx, dl_coef[int,
-            1:4])*1.02;
-        else
-          d := R134aData.data.FDCRIT*Common.CubicSplineEval(localx, dv_coef[int,
-            1:4])*0.95;
-        end if;
-      end if;
-
-      while ((i < 100) and not found) loop
-        f := Modelica.Media.R134a.R134a_ph.f_R134a(d, T);
-        nDerivs := Modelica.Media.Common.Helmholtz_pT(f);
-        dp := nDerivs.p - p;
-        if (abs(dp) <= delp) then
-          found := true;
-        end if;
-        deld := dp/nDerivs.pd;
-        d := d - deld;
-        i := i + 1;
-      end while;
+      d := density_ph(p, hofpT(p, T, delp));
 
       annotation (Documentation(info="<html>
-<p> This function calculates the density of R134a from absolute pressure and temperature. The function can only be executed in one-phase region. The safety margin to the phase boundary is 1[K] and 1000[Pa].
+<p>This function calculates the density of R134a from absolute pressure and temperature. The function can only be executed in one-phase region.
 </p>
 <h4>Restrictions</h4>
-The function cannot be inverted in a numerical way. Please use functions <a href=\"modelica://Modelica.Media.R134a.R134a_ph.rho_props_ph\">rho_props_ph</a> and <a href=\"modelica://Modelica.Media.R134a.R134a_ph.T_props_ph\">T_props_ph</a> for this purpose.
+<p>The function cannot be inverted in a numerical way. Please use functions <a href=\"modelica://Modelica.Media.R134a.R134a_ph.rho_props_ph\">rho_props_ph</a> and <a href=\"modelica://Modelica.Media.R134a.R134a_ph.T_props_ph\">T_props_ph</a> for this purpose.</p>
 </html>"));
     end dofpT;
 
@@ -2555,23 +2498,24 @@ The function cannot be inverted in a numerical way. Please use functions <a href
       extends Modelica.Icons.Function;
       input SI.Pressure p "Pressure";
       input SI.Temperature T "Temperature";
-      input Modelica.SIunits.Pressure delp
-        "Iteration converged if (p-pre(p) < delp)";
+      input Modelica.SIunits.Pressure delp=0
+        "Iteration converged if (p-pre(p) < delp) (unused)";
       output SI.SpecificEnthalpy h "Specific Enthalpy";
 
     protected
-      SI.Density d "Density";
-      Modelica.Media.Common.HelmholtzDerivs f "Helmholtz derivatives";
+      function f_nonlinear "Solve temperature_ph(p,h) for h with given T"
+        extends Modelica.Math.Nonlinear.Interfaces.partialScalarFunction;
+        input AbsolutePressure p "Pressure";
+        input Temperature T "Temperature";
+      algorithm
+        y := temperature_ph(p=p, h=u) - T;
+      end f_nonlinear;
 
     algorithm
-      Modelica.Media.R134a.R134a_ph.phaseBoundaryAssert(p, T);
-      d := dofpT(p, T, delp);
-      f := f_R134a(d, T);
-      h := R134aData.data.R_s*T*(f.tau*f.ftau + f.delta*f.fdelta);
-
-      annotation (Documentation(info="<html>
-<p> This function calculates the specific enthalpy of R134a from absolute pressure and temperature. The function can only be executed in one-phase region. The safety margin to the phase boundary is 1[K] and 1000[Pa].
-</p>
+      h := Modelica.Math.Nonlinear.solveOneNonlinearEquation(
+        function f_nonlinear(p=p, T=T), 71455.2, 400000);
+    annotation (Documentation(info="<html>
+<p>This function calculates the specific enthalpy of R134a from absolute pressure and temperature via numerical inversion of function <a href=\"modelica://Modelica.Media.R134a.R134a_ph.temperature_ph\">temperature_ph</a>.</p>.
 </html>"));
     end hofpT;
 
@@ -2584,10 +2528,12 @@ The function cannot be inverted in a numerical way. Please use functions <a href
     protected
       Modelica.SIunits.Temperature T_lim_gas "Upper temperature limit";
       Modelica.SIunits.Temperature T_lim_liq "Lower temperature limit";
+      Modelica.SIunits.Temperature T_sat "Saturation temperature";
 
     algorithm
-      T_lim_gas := Modelica.Media.R134a.R134a_ph.saturationTemperature(p) + 1;
-      T_lim_liq := Modelica.Media.R134a.R134a_ph.saturationTemperature(p) - 1;
+      T_sat := Modelica.Media.R134a.R134a_ph.saturationTemperature(p);
+      T_lim_gas := T_sat + 1;
+      T_lim_liq := T_sat - 1;
 
       assert(p>R134aData.data.PCRIT+1000 or not
                                           (T<T_lim_gas and T>T_lim_liq), "Fluid state is too close to the two-phase region (p="+String(p)+"[Pa], T="+String(T)+"[K]. Pressure and temperature can not be used to determine properties in two-phase region.");


### PR DESCRIPTION
The property tables, especially for setState_pTX, created by [T3276.mo](https://gist.github.com/beutlich/ccd3505920466e99d0446b1f6d6f2b78) at least look as expected now (compared to https://github.com/modelica/ModelicaStandardLibrary/issues/3276#issuecomment-574316755):

**setState_phX()** (ref props in parentheses)

| row | T | p | d | h |
|---|---|---|---|---|
| 1 | 374.21 | 4.05911e+06 | 511.899<br>(511.9) | 389639<br>(389639) |
| 2 | 169.85 | 389.563 | 1517.14<br>(1591.11) | 71455.2<br>(71455.2) |
| 3 | 298.15 | 3e+06 | 1220.13<br>(1220.13) | 234687<br>(234687) |
| 4 | 305.987 | 3e+06 | 1190.76<br>(1190.76) | 245776<br>(245776) |
| 5 | 273.15 | 292803 | 1294.76<br>(1294.78) | 200000<br>(200000) |
| 6 | 298.15 | 665380 | 969.978<br>(969.916) | 235741<br>(235741) |

**setState_pTX()** (ref props in parentheses)

| row | T | p | d | h |
|---|---|---|---|---|
| 1 | 374.21 | 4.05911e+06 | 501.2<br>(511.9) | 390934<br>(389639) |
| 2 | 169.85 | 389.563 | n.a.<br>(1591.11) | n.a.<br>(71455.2) |
| 3 | 298.15 | 3e+06 | :heavy_check_mark: 1220.13<br>(1220.13) | :heavy_check_mark: 234687<br>(234687) |
| 4 | 305.987 | 3e+06 | :heavy_check_mark: 1190.76<br>(1190.76) | :heavy_check_mark: 245776<br>(245776) |
| 5 | 273.15 | 292803 | n.a.<br>(1294.78) | n.a.<br>(200000) |
| 6 | 298.15 | 665380 | n.a.<br>(969.916) | n.a.<br>(235741) |

Except when looking at the results, I am not sure if this derivative-free appoach is appropriate at all or if the limits used for the specific enthalpy 71455.2, 400000 are valid choices.

This issue with isentropic exponent was not addressed, currently.