### PR TITLE
Add missing quasi-static FluxTubes models

### DIFF
--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/QuadraticCoreAirgap.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/QuadraticCoreAirgap.mo
@@ -138,7 +138,7 @@ The sum of all magnetic potential differences is covered by the mmf of the excit
 <p>
 Using the parameter values, the results can be validated by analytic calculations:
 </p>
-<table border="1" cellspacing="0" cellpadding="2">
+<table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
 <tr><th>element   </th><th>cross section</th><th>length       </th><th>rel. permeability </th><th>B                   </th><th>H                                    </th><th>mmf              </th></tr>
 <tr><td>left leg  </td><td>a*a          </td><td>l - a        </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
 <tr><td>upper yoke</td><td>a*a          </td><td>l - a        </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/QuadraticCoreAirgap.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/QuadraticCoreAirgap.mo
@@ -129,16 +129,16 @@ Educational example of a magnetic circuit containing an iron core and an airgap:
 <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Examples/MagneticCircuit.png\" alt=\"Magnetic circuit with iron core and airgap\">
 </p>
 <p>
-A current ramp is applied in positive electric direction through the exciting coil, causing a rising magnetomotive force (mmf) in positive magnetic direction of the electromagnetic converter.  
-The mmf in turn causes a magnetic flux through the circuit in the direction indicated by the flux sensor. 
+A current ramp is applied in positive electric direction through the exciting coil, causing a rising magnetomotive force (mmf) in positive magnetic direction of the electromagnetic converter.
+The mmf in turn causes a magnetic flux through the circuit in the direction indicated by the flux sensor.
 From that magnetic flux, flux density can be calculated in every element of the magnetic circuit. Flux density is used to derive magnetic field strength.
-Magnetic field strength times length of the flux line gives magnetic potential difference of each element. 
+Magnetic field strength times length of the flux line gives magnetic potential difference of each element.
 The sum of all magnetic potential differences is covered by the mmf of the exciting coil.
 </p>
 <p>
 Using the parameter values, the results can be validated by analytic calculations:
 </p>
-<table border=1 cellspacing=0 cellpadding=2>
+<table border="1" cellspacing="0" cellpadding="2">
 <tr><th>element   </th><th>cross section</th><th>length       </th><th>rel. permeability </th><th>B                   </th><th>H                                    </th><th>mmf              </th></tr>
 <tr><td>left leg  </td><td>a*a          </td><td>l - a        </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
 <tr><td>upper yoke</td><td>a*a          </td><td>l - a        </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
@@ -148,23 +148,22 @@ Using the parameter values, the results can be validated by analytic calculation
 <tr><td>total     </td><td>             </td><td>             </td><td>                  </td><td>                    </td><td>                                     </td><td>&Sigma; mmf = N*I</td></tr>
 </table>
 <p>
-Note that there is a leakage flux path present. Therefore the total magnetic flux of in core splits into 
+Note that there is a leakage flux path present. Therefore the total magnetic flux of in core splits into
 </p>
 <ul>
 <li>the useful flux through the airgap and</li>
 <li>the leakage flux through the leakage element.</li>
 </ul>
 <p>
-<p>
-However, the magnetic voltage across the airgap and the leakage model are equal. 
-The ratio of the useful flux over the flux in the core is equal to <code>1 - &sigma;</code>. 
-In the core the magnetic flux is the same in every element as they are connected in series. 
+However, the magnetic voltage across the airgap and the leakage model are equal.
+The ratio of the useful flux over the flux in the core is equal to <code>1 - &sigma;</code>.
+In the core the magnetic flux is the same in every element as they are connected in series.
 For the calculation of the length of flux lines inside the core, a medium flux line (dashed line) is used
 </p>
 <p>
-Additionally, a measuring coil is placed in the airgap. 
-Due to Faraday's law, the time derivative of flux causes an induced voltage both in the exciting coil (in positive direction) and in the measuring coil (in negative direction). 
-Since the quasi static current and therefore flux follow a time dependent ramp, the quasi static induced voltages follow a ramp as well. 
+Additionally, a measuring coil is placed in the airgap.
+Due to Faraday's law, the time derivative of flux causes an induced voltage both in the exciting coil (in positive direction) and in the measuring coil (in negative direction).
+Since the quasi static current and therefore flux follow a time dependent ramp, the quasi static induced voltages follow a ramp as well.
 </p>
 <p>
 Note the proper usage of electric and magnetic grounds to define zero potential.

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/QuadraticCoreAirgap.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/QuadraticCoreAirgap.mo
@@ -164,7 +164,7 @@ For the calculation of the length of flux lines inside the core, a medium flux l
 <p>
 Additionally, a measuring coil is placed in the airgap. 
 Due to Faraday's law, the time derivative of flux causes an induced voltage both in the exciting coil (in positive direction) and in the measuring coil (in negative direction). 
-Since the quasi static current and therefore flux follow a time dependent ramp, the quasi static induced voltages follows a ramp as well. 
+Since the quasi static current and therefore flux follow a time dependent ramp, the quasi static induced voltages follow a ramp as well. 
 </p>
 <p>
 Note the proper usage of electric and magnetic grounds to define zero potential.

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/QuadraticCoreAirgap.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/QuadraticCoreAirgap.mo
@@ -1,0 +1,173 @@
+within Modelica.Magnetic.QuasiStatic.FluxTubes.Examples.BasicExamples;
+model QuadraticCoreAirgap "Educational example: iron core with airgap"
+  extends Modelica.Icons.Example;
+
+  parameter Modelica.SIunits.Length l=0.1 "Outer length of iron core";
+  parameter Modelica.SIunits.Length a=0.01 "Side length of square cross section";
+  parameter Real mu_r=1000 "Relative permeability of core";
+  parameter Modelica.SIunits.Length delta=0.001 "Length of airgap";
+  parameter Real sigma=0.1 "Leakage coefficient";
+  parameter Integer N=500 "Number of turns of exciting coil";
+  parameter Modelica.SIunits.Current I=1.5 "Maximum exciting current";
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Basic.ElectroMagneticConverter excitingCoil(N=N) annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape.Cuboid leftLeg(
+    mu_rConst=mu_r,
+    l=l - a,
+    a=a,
+    b=a) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={-20,30})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape.Cuboid upperYoke(
+    mu_rConst=mu_r,
+    l=l - a,
+    a=a,
+    b=a) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=0,
+        origin={10,50})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape.Cuboid rightLeg(
+    mu_rConst=mu_r,
+    l=l - a - delta,
+    a=a,
+    b=a) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={40,30})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape.Cuboid airGap(
+    mu_rConst=1,
+    l=delta,
+    a=a,
+    b=a) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={40,-30})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Basic.ElectroMagneticConverter measuringCoil(N=1) annotation (Placement(transformation(extent={{60,-10},{40,10}})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape.Cuboid lowerYoke(
+    mu_rConst=mu_r,
+    l=l - a,
+    a=a,
+    b=a) annotation (Placement(transformation(
+        extent={{10,-10},{-10,10}},
+        rotation=0,
+        origin={10,-50})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Basic.Ground magneticGround annotation (Placement(transformation(extent={{-30,-70},{-10,-50}})));
+  Modelica.Electrical.QuasiStatic.SinglePhase.Basic.Ground electricGround1 annotation (Placement(transformation(extent={{-60,-30},{-40,-10}})));
+  Modelica.Electrical.QuasiStatic.SinglePhase.Sources.VariableCurrentSource currentSource(gamma(fixed=true, start=0))
+                                                                                          annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={-60,0})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Sensors.MagneticFluxSensor magFluxSensor annotation (Placement(transformation(
+        extent={{10,-10},{-10,10}},
+        rotation=270,
+        origin={-20,-30})));
+  Modelica.Electrical.QuasiStatic.SinglePhase.Basic.Ground electricGround2 annotation (Placement(transformation(extent={{60,-30},{80,-10}})));
+  Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageSensor voltageSensor annotation (Placement(transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=270,
+        origin={80,0})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Basic.LeakageWithCoefficient leakage(c_usefulFlux=1 - sigma) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={10,0})));
+  Modelica.Blocks.Sources.RealExpression usefulReluctance(y=1/airGap.G_m) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={30,-20})));
+  Modelica.Blocks.Sources.Constant const(k=10.6103) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-80,30})));
+  Modelica.ComplexBlocks.Sources.ComplexRampPhasor complexRamp(
+    magnitude1=0,
+    magnitude2=I,
+    phi=0,
+    startTime=0.01,
+    duration=0.015) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={-80,-30})));
+equation
+  connect(excitingCoil.port_p, leftLeg.port_p)
+    annotation (Line(points={{-20,10},{-20,20}}, color={255,127,0}));
+  connect(leftLeg.port_n, upperYoke.port_p)
+    annotation (Line(points={{-20,40},{-20,50},{0,50}},   color={255,127,0}));
+  connect(upperYoke.port_n, rightLeg.port_p)
+    annotation (Line(points={{20,50},{40,50},{40,40}}, color={255,127,0}));
+  connect(rightLeg.port_n, measuringCoil.port_p)
+    annotation (Line(points={{40,20},{40,10}}, color={255,127,0}));
+  connect(measuringCoil.port_n, airGap.port_p)
+    annotation (Line(points={{40,-10},{40,-20}}, color={255,127,0}));
+  connect(lowerYoke.port_p, airGap.port_n)
+    annotation (Line(points={{20,-50},{40,-50},{40,-40}}, color={255,127,0}));
+  connect(lowerYoke.port_n, magneticGround.port)
+    annotation (Line(points={{0,-50},{-20,-50}},   color={255,127,0}));
+  connect(excitingCoil.port_n, magFluxSensor.port_n)
+    annotation (Line(points={{-20,-10},{-20,-20}}, color={255,127,0}));
+  connect(magFluxSensor.port_p, magneticGround.port)
+    annotation (Line(points={{-20,-40},{-20,-50}}, color={255,127,0}));
+  connect(leakage.port_n, airGap.port_n) annotation (Line(points={{10,-10},{10,-40},{40,-40}},
+                                          color={255,127,0}));
+  connect(measuringCoil.port_p, leakage.port_p)
+    annotation (Line(points={{40,10},{10,10}},color={255,127,0}));
+  connect(leakage.R_mUsefulTot, usefulReluctance.y)
+    annotation (Line(points={{22,0},{30,0},{30,-9}}, color={0,0,127}));
+  connect(currentSource.pin_n, excitingCoil.pin_p) annotation (Line(points={{-60,10},{-40,10}}, color={85,170,255}));
+  connect(currentSource.pin_p, electricGround1.pin) annotation (Line(points={{-60,-10},{-50,-10}}, color={85,170,255}));
+  connect(electricGround1.pin, excitingCoil.pin_n) annotation (Line(points={{-50,-10},{-40,-10}}, color={85,170,255}));
+  connect(measuringCoil.pin_p, voltageSensor.pin_p) annotation (Line(points={{60,10},{80,10}}, color={85,170,255}));
+  connect(measuringCoil.pin_n, electricGround2.pin) annotation (Line(points={{60,-10},{70,-10}}, color={85,170,255}));
+  connect(electricGround2.pin, voltageSensor.pin_n) annotation (Line(points={{70,-10},{80,-10}}, color={85,170,255}));
+  connect(const.y, currentSource.f) annotation (Line(points={{-80,19},{-80,6},{-72,6}}, color={0,0,127}));
+  connect(complexRamp.y, currentSource.I) annotation (Line(points={{-80,-19},{-80,-6},{-72,-6}}, color={85,170,255}));
+  annotation (Documentation(info="<html>
+<p>
+Educational example of a magnetic circuit containing an iron core and an airgap:
+</p>
+<p>
+<img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Examples/MagneticCircuit.png\" alt=\"Magnetic circuit with iron core and airgap\">
+</p>
+<p>
+A current ramp is applied in positive electric direction through the exciting coil, causing a rising magnetomotive force (mmf) in positive magnetic direction of the electromagnetic converter.  
+The mmf in turn causes a magnetic flux through the circuit in the direction indicated by the flux sensor. 
+From that magnetic flux, flux density can be calculated in every element of the magnetic circuit. Flux density is used to derive magnetic field strength.
+Magnetic field strength times length of the flux line gives magnetic potential difference of each element. 
+The sum of all magnetic potential differences is covered by the mmf of the exciting coil.
+</p>
+<p>
+Using the parameter values, the results can be validated by analytic calculations:
+</p>
+<table border=1 cellspacing=0 cellpadding=2>
+<tr><th>element   </th><th>cross section</th><th>length       </th><th>rel. permeability </th><th>B                   </th><th>H                                    </th><th>mmf              </th></tr>
+<tr><td>left leg  </td><td>a*a          </td><td>l - a        </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
+<tr><td>upper yoke</td><td>a*a          </td><td>l - a        </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
+<tr><td>right leg </td><td>a*a          </td><td>l - a - delta</td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
+<tr><td>airgap    </td><td>a*a          </td><td>delta        </td><td>1                 </td><td>useful flux / cross section</td><td>B/&mu;<sub>0</sub>            </td><td>H*length         </td></tr>
+<tr><td>lower yoke</td><td>a*a          </td><td>l - a        </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
+<tr><td>total     </td><td>             </td><td>             </td><td>                  </td><td>                    </td><td>                                     </td><td>&Sigma; mmf = N*I</td></tr>
+</table>
+<p>
+Note that there is a leakage flux path present. Therefore the total magnetic flux of in core splits into 
+</p>
+<ul>
+<li>the useful flux through the airgap and</li>
+<li>the leakage flux through the leakage element.</li>
+</ul>
+<p>
+<p>
+However, the magnetic voltage across the airgap and the leakage model are equal. 
+The ratio of the useful flux over the flux in the core is equal to <code>1 - &sigma;</code>. 
+In the core the magnetic flux is the same in every element as they are connected in series. 
+For the calculation of the length of flux lines inside the core, a medium flux line (dashed line) is used
+</p>
+<p>
+Additionally, a measuring coil is placed in the airgap. 
+Due to Faraday's law, the time derivative of flux causes an induced voltage both in the exciting coil (in positive direction) and in the measuring coil (in negative direction). 
+Since the quasi static current and therefore flux follow a time dependent ramp, the quasi static induced voltages follows a ramp as well. 
+</p>
+<p>
+Note the proper usage of electric and magnetic grounds to define zero potential.
+</p>
+</html>"), experiment(StopTime=0.05, Interval=0.0001));
+end QuadraticCoreAirgap;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreAirgap.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreAirgap.mo
@@ -99,7 +99,7 @@ The sum of all magnetic potential differences is covered by the mmf of the excit
 <p>
 Using the values shown in section Parameters, the results can be validated easily by analytic calculations:
 </p>
-<table border="1" cellspacing="0" cellpadding="2">
+<table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
 <tr><th>element   </th><th>cross section     </th><th>length             </th><th>rel. permeability </th><th>B                   </th><th>H                                    </th><th>mmf              </th></tr>
 <tr><td>core      </td><td>d<sup>2</sup>*pi/4</td><td>r*alfa             </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
 <tr><td>airgap    </td><td>d<sup>2</sup>*pi/4</td><td>delta=r*(2*pi-alfa)</td><td>1</td><td>flux / cross section</td><td>B/(&mu;<sub>0</sub>)</td><td>H*delta         </td></tr>

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreAirgap.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreAirgap.mo
@@ -90,28 +90,28 @@ equation
 Educational example of a magnetic circuit containing a toroidal iron core with circular cross section and an airgap:
 </p>
 <p>
-A current ramp is applied in positive electric direction through the exciting coil, causing a rising magnetomotive force (mmf) in positive magnetic direction of the electromagnetic converter.  
-The mmf in turn causes a magnetic flux through the circuit in the direction indicated by the flux sensor. 
+A current ramp is applied in positive electric direction through the exciting coil, causing a rising magnetomotive force (mmf) in positive magnetic direction of the electromagnetic converter.
+The mmf in turn causes a magnetic flux through the circuit in the direction indicated by the flux sensor.
 From that magnetic flux, flux density can be calculated in every element of the magnetic circuit. Flux density is used to derive magnetic field strength.
-Magnetic field strength times length of the flux line gives magnetic potential difference of each element. 
+Magnetic field strength times length of the flux line gives magnetic potential difference of each element.
 The sum of all magnetic potential differences is covered by the mmf of the exciting coil.
 </p>
 <p>
 Using the values shown in section Parameters, the results can be validated easily by analytic calculations:
 </p>
-<table border=1 cellspacing=0 cellpadding=2>
+<table border="1" cellspacing="0" cellpadding="2">
 <tr><th>element   </th><th>cross section     </th><th>length             </th><th>rel. permeability </th><th>B                   </th><th>H                                    </th><th>mmf              </th></tr>
 <tr><td>core      </td><td>d<sup>2</sup>*pi/4</td><td>r*alfa             </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
 <tr><td>airgap    </td><td>d<sup>2</sup>*pi/4</td><td>delta=r*(2*pi-alfa)</td><td>1</td><td>flux / cross section</td><td>B/(&mu;<sub>0</sub>)</td><td>H*delta         </td></tr>
 <tr><td>total     </td><td>                  </td><td>                   </td><td>                  </td><td>                    </td><td>                                     </td><td>&Sigma; mmf = N*I</td></tr>
 </table>
 <p>
-Note that since no leakage is present, the magnetic flux is the same in every element - they are connected in series. 
+Note that since no leakage is present, the magnetic flux is the same in every element - they are connected in series.
 For calculation of the length of flux lines, a flux line in the middle of the toroid is used.
 </p>
 <p>
-Additionally, a measuring coil is placed in the airgap. 
-Due to Faraday's law, the time derivative of flux causes an induced voltage both in the exciting coil (in positive direction) and in the measuring coil (in negative direction). 
+Additionally, a measuring coil is placed in the airgap.
+Due to Faraday's law, the time derivative of flux causes an induced voltage both in the exciting coil (in positive direction) and in the measuring coil (in negative direction).
 Since the quasi static current and therefore flux follow a time dependent ramp, the quasi static induced voltages follow a ramp as well. </p>
 <p>
 Note the proper usage of electric and magnetic grounds to define zero potential.

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreAirgap.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreAirgap.mo
@@ -101,8 +101,8 @@ Using the values shown in section Parameters, the results can be validated easil
 </p>
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
 <tr><th>element   </th><th>cross section     </th><th>length             </th><th>rel. permeability </th><th>B                   </th><th>H                                    </th><th>mmf              </th></tr>
-<tr><td>core      </td><td>d<sup>2</sup>*pi/4</td><td>r*alfa             </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
-<tr><td>airgap    </td><td>d<sup>2</sup>*pi/4</td><td>delta=r*(2*pi-alfa)</td><td>1</td><td>flux / cross section</td><td>B/(&mu;<sub>0</sub>)</td><td>H*delta         </td></tr>
+<tr><td>core      </td><td>d<sup>2</sup>*pi/4</td><td>r*alpha             </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
+<tr><td>airgap    </td><td>d<sup>2</sup>*pi/4</td><td>delta=r*(2*pi-alpha)</td><td>1</td><td>flux / cross section</td><td>B/(&mu;<sub>0</sub>)</td><td>H*delta         </td></tr>
 <tr><td>total     </td><td>                  </td><td>                   </td><td>                  </td><td>                    </td><td>                                     </td><td>&Sigma; mmf = N*I</td></tr>
 </table>
 <p>

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreAirgap.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreAirgap.mo
@@ -112,9 +112,7 @@ For calculation of the length of flux lines, a flux line in the middle of the to
 <p>
 Additionally, a measuring coil is placed in the airgap. 
 Due to Faraday's law, the time derivative of flux causes an induced voltage both in the exciting coil (in positive direction) and in the measuring coil (in negative direction). 
-Since current is given as a linear-time dependent ramp, the induced voltages during that ramp are constant and otherwise zero. 
-Note that usage of nonlinear magnetic material would change that result due the nonlinear relationship between magnetic field strength and flux density.
-</p>
+Since the quasi static current and therefore flux follow a time dependent ramp, the quasi static induced voltages follow a ramp as well. </p>
 <p>
 Note the proper usage of electric and magnetic grounds to define zero potential.
 </p>

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreAirgap.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreAirgap.mo
@@ -1,0 +1,122 @@
+within Modelica.Magnetic.QuasiStatic.FluxTubes.Examples.BasicExamples;
+model ToroidalCoreAirgap "Educational example: iron core with airgap"
+  extends Modelica.Icons.Example;
+  import Modelica.Constants.pi;
+  parameter Modelica.SIunits.Length r=0.05 "Middle radius of iron core";
+  parameter Modelica.SIunits.Length d=0.01 "Diameter of cylindrical cross section";
+  parameter Modelica.SIunits.RelativePermeability mu_r=1000 "Relative permeability of core";
+  parameter Modelica.SIunits.Length delta=0.001 "Length of airgap";
+  parameter Modelica.SIunits.Angle alpha=(1 - delta/(2*pi*r))*2*pi "Section angle of toroidal core";
+  parameter Integer N=500 "Number of exciting coil turns";
+  parameter Modelica.SIunits.Current I=1.5 "Maximum exciting current";
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Basic.ElectroMagneticConverter excitingCoil(N=N)
+    annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape.Toroid core(
+    mu_rConst=mu_r,
+    r=r,
+    d=d,
+    alpha=alpha) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=0,
+        origin={0,30})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape.Toroid airGap(
+    mu_rConst=1,
+    r=r,
+    d=d,
+    alpha=2*pi - alpha) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=180,
+        origin={0,-50})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Basic.ElectroMagneticConverter measuringCoil(N=1)
+    annotation (Placement(transformation(extent={{40,-10},{20,10}})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Basic.Ground magneticGround
+    annotation (Placement(transformation(extent={{-30,-70},{-10,-50}})));
+  Modelica.Electrical.QuasiStatic.SinglePhase.Basic.Ground electricGround1
+    annotation (Placement(transformation(extent={{-60,-30},{-40,-10}})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Sensors.MagneticFluxSensor magFluxSensor
+    annotation (Placement(transformation(
+        extent={{10,-10},{-10,10}},
+        rotation=270,
+        origin={-20,-30})));
+  Modelica.Electrical.QuasiStatic.SinglePhase.Basic.Ground electricGround2
+    annotation (Placement(transformation(extent={{40,-30},{60,-10}})));
+  Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageSensor voltageSensor annotation (
+      Placement(transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=270,
+        origin={60,0})));
+  Modelica.Electrical.QuasiStatic.SinglePhase.Sources.VariableCurrentSource currentSource(gamma(fixed=true, start=0))
+                                                                                          annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={-60,0})));
+  Modelica.Blocks.Sources.Constant const(k=50) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-80,30})));
+  Modelica.ComplexBlocks.Sources.ComplexRampPhasor complexRamp(
+    magnitude1=0,
+    magnitude2=I,
+    phi=0,
+    startTime=0.01,
+    duration=0.015) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={-80,-30})));
+equation
+  connect(core.port_n, measuringCoil.port_p)
+    annotation (Line(points={{10,30},{20,30},{20,10}}, color={255,127,0}));
+  connect(measuringCoil.port_n, airGap.port_p)
+    annotation (Line(points={{20,-10},{20,-50},{10,-50}},
+                                                 color={255,127,0}));
+  connect(excitingCoil.port_n, magFluxSensor.port_n)
+    annotation (Line(points={{-20,-10},{-20,-20}}, color={255,127,0}));
+  connect(magFluxSensor.port_p, magneticGround.port)
+    annotation (Line(points={{-20,-40},{-20,-50}}, color={255,127,0}));
+  connect(magneticGround.port, airGap.port_n)
+    annotation (Line(points={{-20,-50},{-10,-50}}, color={255,127,0}));
+  connect(excitingCoil.port_p, core.port_p)
+    annotation (Line(points={{-20,10},{-20,30},{-10,30}}, color={255,127,0}));
+  connect(electricGround1.pin, excitingCoil.pin_n) annotation (Line(points={{-50,-10},{-40,-10}}, color={85,170,255}));
+  connect(measuringCoil.pin_p, voltageSensor.pin_p) annotation (Line(points={{40,10},{60,10}}, color={85,170,255}));
+  connect(measuringCoil.pin_n, electricGround2.pin) annotation (Line(points={{40,-10},{50,-10}}, color={85,170,255}));
+  connect(electricGround2.pin, voltageSensor.pin_n) annotation (Line(points={{50,-10},{60,-10}}, color={85,170,255}));
+  connect(const.y, currentSource.f) annotation (Line(points={{-80,19},{-80,6},{-72,6}}, color={0,0,127}));
+  connect(complexRamp.y, currentSource.I) annotation (Line(points={{-80,-19},{-80,-6},{-72,-6}}, color={85,170,255}));
+  connect(currentSource.pin_p, electricGround1.pin) annotation (Line(points={{-60,-10},{-50,-10}}, color={85,170,255}));
+  connect(currentSource.pin_n, excitingCoil.pin_p) annotation (Line(points={{-60,10},{-40,10}}, color={85,170,255}));
+  annotation (Documentation(info="<html>
+<p>
+Educational example of a magnetic circuit containing a toroidal iron core with circular cross section and an airgap:
+</p>
+<p>
+A current ramp is applied in positive electric direction through the exciting coil, causing a rising magnetomotive force (mmf) in positive magnetic direction of the electromagnetic converter.  
+The mmf in turn causes a magnetic flux through the circuit in the direction indicated by the flux sensor. 
+From that magnetic flux, flux density can be calculated in every element of the magnetic circuit. Flux density is used to derive magnetic field strength.
+Magnetic field strength times length of the flux line gives magnetic potential difference of each element. 
+The sum of all magnetic potential differences is covered by the mmf of the exciting coil.
+</p>
+<p>
+Using the values shown in section Parameters, the results can be validated easily by analytic calculations:
+</p>
+<table border=1 cellspacing=0 cellpadding=2>
+<tr><th>element   </th><th>cross section     </th><th>length             </th><th>rel. permeability </th><th>B                   </th><th>H                                    </th><th>mmf              </th></tr>
+<tr><td>core      </td><td>d<sup>2</sup>*pi/4</td><td>r*alfa             </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
+<tr><td>airgap    </td><td>d<sup>2</sup>*pi/4</td><td>delta=r*(2*pi-alfa)</td><td>1</td><td>flux / cross section</td><td>B/(&mu;<sub>0</sub>)</td><td>H*delta         </td></tr>
+<tr><td>total     </td><td>                  </td><td>                   </td><td>                  </td><td>                    </td><td>                                     </td><td>&Sigma; mmf = N*I</td></tr>
+</table>
+<p>
+Note that since no leakage is present, the magnetic flux is the same in every element - they are connected in series. 
+For calculation of the length of flux lines, a flux line in the middle of the toroid is used.
+</p>
+<p>
+Additionally, a measuring coil is placed in the airgap. 
+Due to Faraday's law, the time derivative of flux causes an induced voltage both in the exciting coil (in positive direction) and in the measuring coil (in negative direction). 
+Since current is given as a linear-time dependent ramp, the induced voltages during that ramp are constant and otherwise zero. 
+Note that usage of nonlinear magnetic material would change that result due the nonlinear relationship between magnetic field strength and flux density.
+</p>
+<p>
+Note the proper usage of electric and magnetic grounds to define zero potential.
+</p>
+</html>"), experiment(StopTime=0.05, Interval=0.0001));
+end ToroidalCoreAirgap;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreQuadraticCrossSection.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreQuadraticCrossSection.mo
@@ -111,8 +111,7 @@ For calculation of the length of flux lines, a medium flux line is used.
 <p>
 Additionally, a measuring coil is placed in the airgap. 
 Due to Faraday's law, the time derivative of flux causes an induced voltage both in the exciting coil (in positive direction) and in the measuring coil (in negative direction). 
-Since current and therefore flux are a linear time dependent ramp, induced voltages are constant during that ramp and zero otherwise. 
-Note that usage of nonlinear magnetic material would change that result due the nonlinear relationship between magnetic field strength and flux density.
+Since the quasi static current and therefore flux follow a time dependent ramp, the quasi static induced voltages follow a ramp as well. 
 </p>
 <p>
 Note the proper usage of electric and magnetic grounds to define zero potential.

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreQuadraticCrossSection.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreQuadraticCrossSection.mo
@@ -1,0 +1,121 @@
+within Modelica.Magnetic.QuasiStatic.FluxTubes.Examples.BasicExamples;
+model ToroidalCoreQuadraticCrossSection "Educational example: iron core with airgap"
+  extends Modelica.Icons.Example;
+  import Modelica.Constants.pi;
+  parameter Modelica.SIunits.Length r_o=0.055 "Outer radius of iron core";
+  parameter Modelica.SIunits.Length r_i=0.045 "Inner radius of iron core";
+  parameter Modelica.SIunits.Length l=0.01 "Length of rectangular cross section";
+  parameter Modelica.SIunits.RelativePermeability mu_r=1000 "Relative permeability of core";
+  parameter Modelica.SIunits.Length delta=0.001 "Length of airgap";
+  parameter Modelica.SIunits.Angle alpha=(1 - delta/(2*pi*(r_o + r_i)/2))*2*pi "Section angle of toroidal core";
+  parameter Integer N=500 "Number of exciting coil turns";
+  parameter Modelica.SIunits.Current I=1.5 "Maximum exciting current";
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Basic.ElectroMagneticConverter excitingCoil(N=N)
+    annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape.HollowCylinderCircumferentialFlux core(
+    mu_rConst=mu_r,
+    l=l,
+    r_i=r_i,
+    r_o=r_o,
+    alpha=alpha) annotation (Placement(transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=0,
+        origin={0,30})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape.HollowCylinderCircumferentialFlux airGap(
+    mu_rConst=1,
+    l=l,
+    r_i=r_i,
+    r_o=r_o,
+    alpha=2*pi - alpha) annotation (Placement(transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=180,
+        origin={0,-50})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Basic.ElectroMagneticConverter measuringCoil(N=1)
+    annotation (Placement(transformation(extent={{40,-10},{20,10}})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Basic.Ground magneticGround
+    annotation (Placement(transformation(extent={{-30,-70},{-10,-50}})));
+  Modelica.Electrical.QuasiStatic.SinglePhase.Basic.Ground electricGround1
+    annotation (Placement(transformation(extent={{-60,-30},{-40,-10}})));
+  Modelica.Electrical.QuasiStatic.SinglePhase.Sources.VariableCurrentSource currentSource(gamma(fixed=true, start=0)) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={-60,0})));
+  Modelica.Magnetic.QuasiStatic.FluxTubes.Sensors.MagneticFluxSensor magFluxSensor
+    annotation (Placement(transformation(
+        extent={{10,-10},{-10,10}},
+        rotation=270,
+        origin={-20,-30})));
+  Modelica.Electrical.QuasiStatic.SinglePhase.Basic.Ground electricGround2
+    annotation (Placement(transformation(extent={{40,-30},{60,-10}})));
+  Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageSensor voltageSensor annotation (
+      Placement(transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=270,
+        origin={60,0})));
+  Blocks.Sources.Constant const(k=50) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-80,30})));
+  ComplexBlocks.Sources.ComplexRampPhasor complexRamp(
+    magnitude1=0,
+    magnitude2=I,
+    phi=0,
+    startTime=0.01,
+    duration=0.015) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={-80,-30})));
+equation
+  connect(excitingCoil.port_n, magFluxSensor.port_n)
+    annotation (Line(points={{-20,-10},{-20,-20}}, color={255,127,0}));
+  connect(magFluxSensor.port_p, magneticGround.port)
+    annotation (Line(points={{-20,-40},{-20,-50}}, color={255,127,0}));
+  connect(magneticGround.port, airGap.port_n)
+    annotation (Line(points={{-20,-50},{-10,-50}}, color={255,127,0}));
+  connect(excitingCoil.port_p, core.port_p)
+    annotation (Line(points={{-20,10},{-20,30},{-10,30}}, color={255,127,0}));
+  connect(currentSource.pin_n, excitingCoil.pin_p) annotation (Line(points={{-60,10},{-40,10}}, color={85,170,255}));
+  connect(currentSource.pin_p, electricGround1.pin) annotation (Line(points={{-60,-10},{-50,-10}}, color={85,170,255}));
+  connect(electricGround1.pin, excitingCoil.pin_n) annotation (Line(points={{-50,-10},{-40,-10}}, color={85,170,255}));
+  connect(electricGround2.pin, voltageSensor.pin_n) annotation (Line(points={{50,-10},{60,-10}}, color={85,170,255}));
+  connect(const.y, currentSource.f) annotation (Line(points={{-80,19},{-80,6},{-72,6}}, color={0,0,127}));
+  connect(complexRamp.y, currentSource.I) annotation (Line(points={{-80,-19},{-80,-6},{-72,-6}}, color={85,170,255}));
+  connect(measuringCoil.pin_n, electricGround2.pin) annotation (Line(points={{40,-10},{50,-10}}, color={85,170,255}));
+  connect(measuringCoil.pin_p, voltageSensor.pin_p) annotation (Line(points={{40,10},{50,10},{50,10},{60,10}}, color={85,170,255}));
+  connect(core.port_n, measuringCoil.port_p) annotation (Line(points={{10,30},{20,30},{20,10}}, color={255,170,85}));
+  connect(airGap.port_p, measuringCoil.port_n) annotation (Line(points={{10,-50},{20,-50},{20,-10}}, color={255,170,85}));
+  annotation (Documentation(info="<html>
+<p>
+Educational example of a magnetic circuit containing a toroidal iron core with rectangular cross section and an airgap:
+</p>
+<p>
+A current ramp is applied in positive electric direction through the exciting coil, causing a rising magnetomotive force (mmf) in positive magnetic direction of the electromagnetic converter.  
+The mmf in turn causes a magnetic flux through the circuit in the direction indicated by the flux sensor. 
+From that magnetic flux, flux density can be calculated in every element of the magnetic circuit. Flux density is used to derive magnetic field strength.
+Magnetic field strength times length of the flux line gives magnetic potential difference of each element. 
+The sum of all magnetic potential differences is covered by the mmf of the exciting coil.
+</p>
+<p>
+Using the values shown in section Parameters, the results can be validated easily by analytic calculations:
+</p>
+<table border=1 cellspacing=0 cellpadding=2>
+<tr><th>element   </th><th>cross section</th><th>length                         </th><th>rel. permeability </th><th>B                   </th><th>H                                    </th><th>mmf              </th></tr>
+<tr><td>core      </td><td>(r_o - r_i)*l</td><td>(r_o + r_i)/2*alfa             </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
+<tr><td>airgap    </td><td>(r_o - r_i)*l</td><td>delta=(r_o + r_i)/2*(2*pi-alfa)</td><td>1</td><td>flux / cross section</td><td>B/(&mu;<sub>0</sub>)</td><td>H*delta         </td></tr>
+<tr><td>total     </td><td>             </td><td>                               </td><td>                  </td><td>                    </td><td>                                     </td><td>&Sigma; mmf = N*I</td></tr>
+</table>
+<p>
+Note that since no leakage is present, the magnetic flux is the same in every element - they are connected in series. 
+For calculation of the length of flux lines, a medium flux line is used.
+</p>
+<p>
+Additionally, a measuring coil is placed in the airgap. 
+Due to Faraday's law, the time derivative of flux causes an induced voltage both in the exciting coil (in positive direction) and in the measuring coil (in negative direction). 
+Since current and therefore flux are a linear time dependent ramp, induced voltages are constant during that ramp and zero otherwise. 
+Note that usage of nonlinear magnetic material would change that result due the nonlinear relationship between magnetic field strength and flux density.
+</p>
+<p>
+Note the proper usage of electric and magnetic grounds to define zero potential.
+</p>
+</html>"), experiment(StopTime=0.05, Interval=0.0001));
+end ToroidalCoreQuadraticCrossSection;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreQuadraticCrossSection.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreQuadraticCrossSection.mo
@@ -89,29 +89,29 @@ equation
 Educational example of a magnetic circuit containing a toroidal iron core with rectangular cross section and an airgap:
 </p>
 <p>
-A current ramp is applied in positive electric direction through the exciting coil, causing a rising magnetomotive force (mmf) in positive magnetic direction of the electromagnetic converter.  
-The mmf in turn causes a magnetic flux through the circuit in the direction indicated by the flux sensor. 
+A current ramp is applied in positive electric direction through the exciting coil, causing a rising magnetomotive force (mmf) in positive magnetic direction of the electromagnetic converter.
+The mmf in turn causes a magnetic flux through the circuit in the direction indicated by the flux sensor.
 From that magnetic flux, flux density can be calculated in every element of the magnetic circuit. Flux density is used to derive magnetic field strength.
-Magnetic field strength times length of the flux line gives magnetic potential difference of each element. 
+Magnetic field strength times length of the flux line gives magnetic potential difference of each element.
 The sum of all magnetic potential differences is covered by the mmf of the exciting coil.
 </p>
 <p>
 Using the values shown in section Parameters, the results can be validated easily by analytic calculations:
 </p>
-<table border=1 cellspacing=0 cellpadding=2>
+<table border="1" cellspacing="0" cellpadding="2">
 <tr><th>element   </th><th>cross section</th><th>length                         </th><th>rel. permeability </th><th>B                   </th><th>H                                    </th><th>mmf              </th></tr>
 <tr><td>core      </td><td>(r_o - r_i)*l</td><td>(r_o + r_i)/2*alfa             </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
 <tr><td>airgap    </td><td>(r_o - r_i)*l</td><td>delta=(r_o + r_i)/2*(2*pi-alfa)</td><td>1</td><td>flux / cross section</td><td>B/(&mu;<sub>0</sub>)</td><td>H*delta         </td></tr>
 <tr><td>total     </td><td>             </td><td>                               </td><td>                  </td><td>                    </td><td>                                     </td><td>&Sigma; mmf = N*I</td></tr>
 </table>
 <p>
-Note that since no leakage is present, the magnetic flux is the same in every element - they are connected in series. 
+Note that since no leakage is present, the magnetic flux is the same in every element - they are connected in series.
 For calculation of the length of flux lines, a medium flux line is used.
 </p>
 <p>
-Additionally, a measuring coil is placed in the airgap. 
-Due to Faraday's law, the time derivative of flux causes an induced voltage both in the exciting coil (in positive direction) and in the measuring coil (in negative direction). 
-Since the quasi static current and therefore flux follow a time dependent ramp, the quasi static induced voltages follow a ramp as well. 
+Additionally, a measuring coil is placed in the airgap.
+Due to Faraday's law, the time derivative of flux causes an induced voltage both in the exciting coil (in positive direction) and in the measuring coil (in negative direction).
+Since the quasi static current and therefore flux follow a time dependent ramp, the quasi static induced voltages follow a ramp as well.
 </p>
 <p>
 Note the proper usage of electric and magnetic grounds to define zero potential.

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreQuadraticCrossSection.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreQuadraticCrossSection.mo
@@ -98,7 +98,7 @@ The sum of all magnetic potential differences is covered by the mmf of the excit
 <p>
 Using the values shown in section Parameters, the results can be validated easily by analytic calculations:
 </p>
-<table border="1" cellspacing="0" cellpadding="2">
+<table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
 <tr><th>element   </th><th>cross section</th><th>length                         </th><th>rel. permeability </th><th>B                   </th><th>H                                    </th><th>mmf              </th></tr>
 <tr><td>core      </td><td>(r_o - r_i)*l</td><td>(r_o + r_i)/2*alfa             </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
 <tr><td>airgap    </td><td>(r_o - r_i)*l</td><td>delta=(r_o + r_i)/2*(2*pi-alfa)</td><td>1</td><td>flux / cross section</td><td>B/(&mu;<sub>0</sub>)</td><td>H*delta         </td></tr>

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreQuadraticCrossSection.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/ToroidalCoreQuadraticCrossSection.mo
@@ -100,8 +100,8 @@ Using the values shown in section Parameters, the results can be validated easil
 </p>
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
 <tr><th>element   </th><th>cross section</th><th>length                         </th><th>rel. permeability </th><th>B                   </th><th>H                                    </th><th>mmf              </th></tr>
-<tr><td>core      </td><td>(r_o - r_i)*l</td><td>(r_o + r_i)/2*alfa             </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
-<tr><td>airgap    </td><td>(r_o - r_i)*l</td><td>delta=(r_o + r_i)/2*(2*pi-alfa)</td><td>1</td><td>flux / cross section</td><td>B/(&mu;<sub>0</sub>)</td><td>H*delta         </td></tr>
+<tr><td>core      </td><td>(r_o - r_i)*l</td><td>(r_o + r_i)/2*alpha             </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
+<tr><td>airgap    </td><td>(r_o - r_i)*l</td><td>delta=(r_o + r_i)/2*(2*pi-alpha)</td><td>1</td><td>flux / cross section</td><td>B/(&mu;<sub>0</sub>)</td><td>H*delta         </td></tr>
 <tr><td>total     </td><td>             </td><td>                               </td><td>                  </td><td>                    </td><td>                                     </td><td>&Sigma; mmf = N*I</td></tr>
 </table>
 <p>

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/package.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/package.mo
@@ -2,5 +2,4 @@ within Modelica.Magnetic.QuasiStatic.FluxTubes.Examples;
 package BasicExamples "Educational examples"
 extends Modelica.Icons.ExamplesPackage;
 
-annotation ();
 end BasicExamples;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/package.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/package.mo
@@ -1,0 +1,6 @@
+within Modelica.Magnetic.QuasiStatic.FluxTubes.Examples;
+package BasicExamples "Educational examples"
+extends Modelica.Icons.ExamplesPackage;
+
+annotation ();
+end BasicExamples;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/package.order
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/package.order
@@ -1,0 +1,1 @@
+QuadraticCoreAirgap

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/package.order
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/BasicExamples/package.order
@@ -1,1 +1,3 @@
 QuadraticCoreAirgap
+ToroidalCoreAirgap
+ToroidalCoreQuadraticCrossSection

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/Leakage/GeneralLeakage.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/Leakage/GeneralLeakage.mo
@@ -3,7 +3,8 @@ model GeneralLeakage "Magnetic circuit with generic leakage mode"
   extends Modelica.Icons.Example;
   Basic.ConstantReluctance constantReluctance(R_m=1E-5)
     annotation (Placement(transformation(extent={{0,50},{20,70}})));
-  Basic.LeakageWithCoefficient leakageWithCoefficient(R_mUsefulTot=1E-5)
+  Basic.LeakageWithCoefficient leakageWithCoefficient(c_usefulFlux=0.7,
+                                                      R_mUsefulTot=1E-5)
     annotation (Placement(transformation(extent={{20,10},{0,30}})));
   Basic.EddyCurrent eddyCurrent(useConductance=true, G=10000) annotation (
       Placement(transformation(

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/package.order
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/package.order
@@ -1,4 +1,5 @@
 LinearInductor
 NonLinearInductor
+BasicExamples
 FixedShapes
 Leakage

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/HollowCylinderCircumferentialFlux.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/HollowCylinderCircumferentialFlux.mo
@@ -1,0 +1,43 @@
+within Modelica.Magnetic.QuasiStatic.FluxTubes.Icons;
+partial model HollowCylinderCircumferentialFlux "Icon for cylinder with circumferential flux"
+  annotation (Icon(graphics={
+        Text(
+          extent={{-150,50},{150,90}},
+          textString="%name",
+          textColor={0,0,255}),
+        Line(points={{-60,0},{-100,0}}, color={255,170,85}),
+        Line(points={{100,0},{60,0}},   color={255,170,85}),
+        Polygon(
+          points={{-40,20},{-80,-20},{-60,-20},{-20,20},{-40,20}},
+          lineColor={255,170,85},
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-60,0},{20,-40}},
+          lineColor={255,170,85},
+          startAngle=0,
+          endAngle=180,
+          closure=EllipseClosure.None),
+        Ellipse(
+          extent={{-80,14},{40,-54}},
+          lineColor={255,170,85},
+          startAngle=0,
+          endAngle=180,
+          closure=EllipseClosure.None),
+        Polygon(
+          points={{60,20},{20,-20},{40,-20},{80,20},{60,20}},
+          lineColor={255,170,85},
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-20,40},{60,0}},
+          lineColor={255,170,85},
+          startAngle=52,
+          endAngle=180,
+          closure=EllipseClosure.None),
+        Line(points={{40,-40},{2.22045e-16,1.35963e-32}},
+                                        color={255,170,85},
+          origin={36,-32},
+          rotation=90),
+        Line(points={{76,8},{78,12},{80,20}},  color={255,170,85})}));
+end HollowCylinderCircumferentialFlux;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/Toroid.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/Toroid.mo
@@ -1,0 +1,36 @@
+within Modelica.Magnetic.QuasiStatic.FluxTubes.Icons;
+partial model Toroid "Icon for toroid"
+  annotation (Icon(graphics={
+        Text(
+          extent={{-150,50},{150,90}},
+          textString="%name",
+          textColor={0,0,255}),
+        Ellipse(
+          extent={{-70,10},{-50,-10}},
+          lineColor={255,170,85},
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{50,10},{70,-10}},
+          lineColor={255,170,85},
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid),
+        Line(points={{100,0},{60,0}},   color={255,170,85}),
+        Line(points={{-60,0},{-100,0}}, color={255,170,85}),
+        Ellipse(
+          extent={{-70,36},{70,-44}},
+          lineColor={255,170,85},
+          fillColor={215,215,215},
+          fillPattern=FillPattern.None,
+          startAngle=195,
+          endAngle=345,
+          closure=EllipseClosure.None),
+        Ellipse(
+          extent={{-60,14},{60,-68}},
+          lineColor={255,170,85},
+          fillColor={215,215,215},
+          fillPattern=FillPattern.None,
+          startAngle=210,
+          endAngle=330,
+          closure=EllipseClosure.None)}));
+end Toroid;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/package.order
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/package.order
@@ -1,4 +1,6 @@
 Reluctance
 Cuboid
+Toroid
 HollowCylinderAxialFlux
 HollowCylinderRadialFlux
+HollowCylinderCircumferentialFlux

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderCircumferentialFlux.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderCircumferentialFlux.mo
@@ -1,0 +1,35 @@
+within Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape;
+model HollowCylinderCircumferentialFlux "Hollow cylinder with circumferential flux; fixed shape"
+
+  extends Modelica.Magnetic.QuasiStatic.FluxTubes.BaseClasses.FixedShape;
+  extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.HollowCylinderCircumferentialFlux;
+  import Modelica.Constants.pi;
+  parameter SI.Length l=0.02 "Width (orthogonal to flux direction)"
+    annotation (Dialog(group=
+          "Fixed geometry", groupImage=
+          "modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Shapes/Circumferential.png"));
+  parameter SI.Radius r_i=0.01 "Inner radius of hollow cylinder"
+    annotation (Dialog(group="Fixed geometry"));
+  parameter SI.Radius r_o=0.02 "Outer radius of hollow cylinder"
+    annotation (Dialog(group="Fixed geometry"));
+  parameter SI.Angle alpha=pi/2 "Angle of cylinder section"
+    annotation (Dialog(group="Fixed geometry"));
+equation
+  A = l*(r_o - r_i) "Area at arithmetic mean radius for calculation of average flux density";
+  G_m = mu_0*mu_r*A/((r_o + r_i)/2*alpha);
+
+  annotation (defaultComponentName="cylinder", Documentation(info="<html>
+<p>
+Please refer to the enclosing sub-package <a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.FixedShape\">FixedShape</a> for a description of all elements of this package and to <a href=\"modelica://Modelica.Magnetic.FluxTubes.UsersGuide.Literature\">[Ro41]</a> for derivation and/or coefficients of the equation for permeance <code>G_m</code>.
+</p>
+
+<p>
+For hollow cylindrical flux tubes with a circumferential magnetic flux, the flux density is a function of the radius. 
+For that reason, the characteristic <code>mu_r(B)</code> is evaluated for the flux density at the flux tube's mean radius.
+</p>
+
+<p>
+For those flux tube sections of a magnetic device that have a nonlinear material characteristic <code>mu_r(B)</code> and a large aspect ratio of outer to inner radius <code>r_o/r_i</code>, the section can be split up in a series connection of several hollow cylindrical flux tubes with radial flux. This allows for more realistic modelling of the dependence of flux density on the radius compared to modelling with just one flux tube element.
+</p>
+</html>"));
+end HollowCylinderCircumferentialFlux;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/Toroid.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/Toroid.mo
@@ -1,0 +1,32 @@
+within Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape;
+model Toroid "Toroid with circular cross section; fixed shape"
+
+  extends Modelica.Magnetic.QuasiStatic.FluxTubes.BaseClasses.FixedShape;
+  extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.Toroid;
+  import Modelica.Constants.pi;
+  parameter SI.Radius r=0.1 "Radius of toroid (middle)"
+    annotation (Dialog(group="Fixed geometry", groupImage=
+          "modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Shapes/Toroid.png"));
+  parameter SI.Radius d=0.01 "Diameter of cylindrical core"
+    annotation (Dialog(group="Fixed geometry"));
+  parameter SI.Angle alpha=pi/2 "Angle of toroid section"
+    annotation (Dialog(group="Fixed geometry"));
+equation
+  A = d^2*pi/4 "Area at arithmetic mean radius for calculation of average flux density";
+  G_m = mu_0*mu_r*A/(r*alpha);
+
+  annotation (defaultComponentName="cylinder", Documentation(info="<html>
+<p>
+Please refer to the enclosing sub-package <a href=\"modelica://Modelica.Magnetic.FluxTubes.Shapes.FixedShape\">FixedShape</a> for a description of all elements of this package and to <a href=\"modelica://Modelica.Magnetic.FluxTubes.UsersGuide.Literature\">[Ro41]</a> for derivation and/or coefficients of the equation for permeance G_m.
+</p>
+
+<p>
+For toroidal flux tubes with a circumferental magnetic flux, the flux density is a function of the radius. 
+For that reason, the characteristic <code>mu_r(B)</code> is evaluated for the flux density at the flux tube's mean radius.
+</p>
+
+<p>
+For those flux tube sections of a magnetic device that have a nonlinear material characteristic <code>mu_r(B)</code> and a large aspect ratio of outer to inner radius <code>r_o/r_i</code>, the section can be split up in a series connection of several hollow cylindrical flux tubes with radial flux. This allows for more realistic modelling of the dependence of flux density on the radius compared to modelling with just one flux tube element.
+</p>
+</html>"));
+end Toroid;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/package.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/package.mo
@@ -1,6 +1,7 @@
 within Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes;
 package FixedShape "Flux tubes with fixed shape during simulation and linear or non-linear material characteristics"
   extends Modelica.Icons.VariantsPackage;
+
   annotation (Documentation(info="<html>
 <p>
 This package provides different reluctance models, based on different geometric data.

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/package.order
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/package.order
@@ -2,3 +2,5 @@ GenericFluxTube
 Cuboid
 HollowCylinderAxialFlux
 HollowCylinderRadialFlux
+HollowCylinderCircumferentialFlux
+Toroid


### PR DESCRIPTION
The Magnetic.FluxTubes library contains some fixed shape models which have been forgotten to be implemented in the quasi static FluxTubes library. This PR provides the missing models and the "same" examples implemented in Magnetic.FluxTubes.Examples.