### PR TITLE
Change alfa to alpha

### DIFF
--- a/Modelica/Magnetic/FluxTubes/Examples/BasicExamples/ToroidalCoreAirgap.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/BasicExamples/ToroidalCoreAirgap.mo
@@ -6,7 +6,7 @@ model ToroidalCoreAirgap "Educational example: iron core with airgap"
   parameter Modelica.SIunits.Length d=0.01 "Diameter of cylindrical cross section";
   parameter Modelica.SIunits.RelativePermeability mu_r=1000 "Relative permeability of core";
   parameter Modelica.SIunits.Length delta=0.001 "Length of airgap";
-  parameter Modelica.SIunits.Angle alfa=(1 - delta/(2*pi*r))*2*pi "Section angle of toroidal core";
+  parameter Modelica.SIunits.Angle alpha=(1 - delta/(2*pi*r))*2*pi "Section angle of toroidal core";
   parameter Integer N=500 "Number of exciting coil turns";
   parameter Modelica.SIunits.Current I=1.5 "Maximum exciting current";
   Modelica.Magnetic.FluxTubes.Basic.ElectroMagneticConverter excitingCoil(N=N)
@@ -16,7 +16,7 @@ model ToroidalCoreAirgap "Educational example: iron core with airgap"
     mu_rConst=mu_r,
     r=r,
     d=d,
-    alfa=alfa) annotation (Placement(transformation(
+    alpha=alpha) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=0,
         origin={0,30})));
@@ -25,7 +25,7 @@ model ToroidalCoreAirgap "Educational example: iron core with airgap"
     mu_rConst=1,
     r=r,
     d=d,
-    alfa=2*pi - alfa)
+    alpha=2*pi - alpha)
          annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,
@@ -97,8 +97,8 @@ Using the values shown in section Parameters, the results can be validated easil
 </p>
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
 <tr><th>element   </th><th>cross section     </th><th>length             </th><th>rel. permeability </th><th>B                   </th><th>H                                    </th><th>mmf              </th></tr>
-<tr><td>core      </td><td>d<sup>2</sup>*pi/4</td><td>r*alfa             </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
-<tr><td>airgap    </td><td>d<sup>2</sup>*pi/4</td><td>delta=r*(2*pi-alfa)</td><td>1</td><td>flux / cross section</td><td>B/(&mu;<sub>0</sub>)</td><td>H*delta         </td></tr>
+<tr><td>core      </td><td>d<sup>2</sup>*pi/4</td><td>r*alpha             </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
+<tr><td>airgap    </td><td>d<sup>2</sup>*pi/4</td><td>delta=r*(2*pi-alpha)</td><td>1</td><td>flux / cross section</td><td>B/(&mu;<sub>0</sub>)</td><td>H*delta         </td></tr>
 <tr><td>total     </td><td>                  </td><td>                   </td><td>                  </td><td>                    </td><td>                                     </td><td>&Sigma; mmf = N*I</td></tr>
 </table>
 <p>

--- a/Modelica/Magnetic/FluxTubes/Examples/BasicExamples/ToroidalCoreQuadraticCrossSection.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/BasicExamples/ToroidalCoreQuadraticCrossSection.mo
@@ -8,7 +8,7 @@ model ToroidalCoreQuadraticCrossSection
   parameter Modelica.SIunits.Length l=0.01 "Length of rectangular cross section";
   parameter Modelica.SIunits.RelativePermeability mu_r=1000 "Relative permeability of core";
   parameter Modelica.SIunits.Length delta=0.001 "Length of airgap";
-  parameter Modelica.SIunits.Angle alfa=(1 - delta/(2*pi*(r_o + r_i)/2))*2*pi "Section angle of toroidal core";
+  parameter Modelica.SIunits.Angle alpha=(1 - delta/(2*pi*(r_o + r_i)/2))*2*pi "Section angle of toroidal core";
   parameter Integer N=500 "Number of exciting coil turns";
   parameter Modelica.SIunits.Current I=1.5 "Maximum exciting current";
   Modelica.Magnetic.FluxTubes.Basic.ElectroMagneticConverter excitingCoil(N=N)
@@ -20,7 +20,7 @@ model ToroidalCoreQuadraticCrossSection
     l=l,
     r_i=r_i,
     r_o=r_o,
-    alfa=alfa) annotation (Placement(transformation(
+    alpha=alpha) annotation (Placement(transformation(
         extent={{-10,10},{10,-10}},
         rotation=0,
         origin={0,30})));
@@ -30,7 +30,7 @@ model ToroidalCoreQuadraticCrossSection
     l=l,
     r_i=r_i,
     r_o=r_o,
-    alfa=2*pi - alfa)
+    alpha=2*pi - alpha)
          annotation (Placement(transformation(
         extent={{-10,10},{10,-10}},
         rotation=180,
@@ -102,8 +102,8 @@ Using the values shown in section Parameters, the results can be validated easil
 </p>
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
 <tr><th>element   </th><th>cross section</th><th>length                         </th><th>rel. permeability </th><th>B                   </th><th>H                                    </th><th>mmf              </th></tr>
-<tr><td>core      </td><td>(r_o - r_i)*l</td><td>(r_o + r_i)/2*alfa             </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
-<tr><td>airgap    </td><td>(r_o - r_i)*l</td><td>delta=(r_o + r_i)/2*(2*pi-alfa)</td><td>1</td><td>flux / cross section</td><td>B/(&mu;<sub>0</sub>)</td><td>H*delta         </td></tr>
+<tr><td>core      </td><td>(r_o - r_i)*l</td><td>(r_o + r_i)/2*alpha             </td><td>&mu;<sub>r</sub>  </td><td>flux / cross section</td><td>B/(&mu;<sub>r</sub>*&mu;<sub>0</sub>)</td><td>H*length         </td></tr>
+<tr><td>airgap    </td><td>(r_o - r_i)*l</td><td>delta=(r_o + r_i)/2*(2*pi-alpha)</td><td>1</td><td>flux / cross section</td><td>B/(&mu;<sub>0</sub>)</td><td>H*delta         </td></tr>
 <tr><td>total     </td><td>             </td><td>                               </td><td>                  </td><td>                    </td><td>                                     </td><td>&Sigma; mmf = N*I</td></tr>
 </table>
 <p>

--- a/Modelica/Magnetic/FluxTubes/Shapes/FixedShape/HollowCylinderCircumferentialFlux.mo
+++ b/Modelica/Magnetic/FluxTubes/Shapes/FixedShape/HollowCylinderCircumferentialFlux.mo
@@ -13,11 +13,11 @@ model HollowCylinderCircumferentialFlux
     annotation (Dialog(group="Fixed geometry"));
   parameter SI.Radius r_o=0.02 "Outer radius of hollow cylinder"
     annotation (Dialog(group="Fixed geometry"));
-  parameter SI.Angle alfa=pi/2 "Angle of cylinder section"
+  parameter SI.Angle alpha=pi/2 "Angle of cylinder section"
     annotation (Dialog(group="Fixed geometry"));
 equation
   A = l*(r_o - r_i) "Area at arithmetic mean radius for calculation of average flux density";
-  G_m = mu_0*mu_r*A/((r_o + r_i)/2*alfa);
+  G_m = mu_0*mu_r*A/((r_o + r_i)/2*alpha);
 
   annotation (defaultComponentName="cylinder", Documentation(info="<html>
 <p>

--- a/Modelica/Magnetic/FluxTubes/Shapes/FixedShape/Toroid.mo
+++ b/Modelica/Magnetic/FluxTubes/Shapes/FixedShape/Toroid.mo
@@ -10,11 +10,11 @@ model Toroid
           "modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Shapes/Toroid.png"));
   parameter SI.Radius d=0.01 "Diameter of cylindrical core"
     annotation (Dialog(group="Fixed geometry"));
-  parameter SI.Angle alfa=pi/2 "Angle of toroid section"
+  parameter SI.Angle alpha=pi/2 "Angle of toroid section"
     annotation (Dialog(group="Fixed geometry"));
 equation
   A = d^2*pi/4 "Area at arithmetic mean radius for calculation of average flux density";
-  G_m = mu_0*mu_r*A/(r*alfa);
+  G_m = mu_0*mu_r*A/(r*alpha);
 
   annotation (defaultComponentName="cylinder", Documentation(info="<html>
 <p>


### PR DESCRIPTION
When introducing the models

- `HollowCylinderCircumferentialFlux`
- `Toroid`

the angle name `alfa` was used. I propose to change it to `alpha` which follows the usual spelling (of the MSL). This is a backwards compatible change, as the new models are not included in the MSL 3.2.3. 

**Note.** The new name `alpha` is already incorporated in  #3326

@AHaumer could you please update the files:

- `Modelica/Resources/Images/Magnetic/FluxTubes/Shapes/Circumferential.png`
- `Modelica/Resources/Images/Magnetic/FluxTubes/Shapes/Toroid.png`