### PR TITLE
Removing the non-linear case from doc strings

### DIFF
--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/Cuboid.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/Cuboid.mo
@@ -1,6 +1,6 @@
 within Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape;
 model Cuboid
-"Flux tube with rectangular cross-section; fixed shape; linear or non-linear material characteristics"
+"Flux tube with rectangular cross-section; fixed shape; linear material characteristics"
 
   extends BaseClasses.FixedShape;
   extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.Cuboid;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/Cuboid.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/Cuboid.mo
@@ -1,6 +1,6 @@
 within Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape;
 model Cuboid
-"Flux tube with rectangular cross-section; fixed shape; linear material characteristics"
+"Flux tube with rectangular cross-section of fixed shape and linear material characteristics"
 
   extends BaseClasses.FixedShape;
   extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.Cuboid;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/GenericFluxTube.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/GenericFluxTube.mo
@@ -1,6 +1,6 @@
 within Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape;
 model GenericFluxTube
-"Flux tube with fixed cross-section and length; linear material characteristics"
+"Flux tube with fixed cross-section, fixed length and linear material characteristics"
 
   extends BaseClasses.FixedShape;
   extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.Reluctance;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/GenericFluxTube.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/GenericFluxTube.mo
@@ -1,6 +1,6 @@
 within Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape;
 model GenericFluxTube
-"Flux tube with fixed cross-section and length; linear or non-linear material characteristics"
+"Flux tube with fixed cross-section and length; linear material characteristics"
 
   extends BaseClasses.FixedShape;
   extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.Reluctance;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderAxialFlux.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderAxialFlux.mo
@@ -1,6 +1,6 @@
 within Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape;
 model HollowCylinderAxialFlux
-"(Hollow) cylinder with axial flux; fixed shape; linear or non-linear material characteristics"
+"(Hollow) cylinder with axial flux; fixed shape; linear material characteristics"
 
   extends BaseClasses.FixedShape;
   extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.HollowCylinderAxialFlux;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderAxialFlux.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderAxialFlux.mo
@@ -1,6 +1,6 @@
 within Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape;
 model HollowCylinderAxialFlux
-"(Hollow) cylinder with axial flux; fixed shape; linear material characteristics"
+"(Hollow) cylinder with axial flux of fixed shape and linear material characteristics"
 
   extends BaseClasses.FixedShape;
   extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.HollowCylinderAxialFlux;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderRadialFlux.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderRadialFlux.mo
@@ -1,6 +1,6 @@
 within Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape;
 model HollowCylinderRadialFlux
-"Hollow cylinder with radial flux; fixed shape; linear material characteristics"
+"Hollow cylinder with radial flux of fixed shape and linear material characteristics"
 
   extends BaseClasses.FixedShape;
   extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.HollowCylinderRadialFlux;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderRadialFlux.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderRadialFlux.mo
@@ -1,6 +1,6 @@
 within Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape;
 model HollowCylinderRadialFlux
-"Hollow cylinder with radial flux; fixed shape; linear or non-linear material characteristics"
+"Hollow cylinder with radial flux; fixed shape; linear material characteristics"
 
   extends BaseClasses.FixedShape;
   extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.HollowCylinderRadialFlux;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/package.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/package.mo
@@ -1,5 +1,5 @@
 within Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes;
-package FixedShape "Flux tubes with fixed shape during simulation and linear or non-linear material characteristics"
+package FixedShape "Flux tubes with fixed shape during simulation and linear material characteristics"
   extends Modelica.Icons.VariantsPackage;
   annotation (Documentation(info="<html>
 <p>


### PR DESCRIPTION
This PR fixes some wrong documentation of the `QuasiStatic.FluxTubes` library, which was introduced by copy + paste errors when creating this library.  