### PR TITLE
maint/3.2.3: Do not mark Modelica.Utilities.Files.splitPathName as impure

### DIFF
--- a/Modelica/Utilities/Files.mo
+++ b/Modelica/Utilities/Files.mo
@@ -659,8 +659,7 @@ algorithm
        name :=pathName;
      end if;
    end if;
-  annotation (__ModelicaAssociation_Impure=true,
-Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
 (directory, name, extension) = Files.<strong>splitPathName</strong>(pathName);


### PR DESCRIPTION
Back-port from @HansOlsson's review during https://github.com/modelica/ModelicaStandardLibrary/pull/2858#pullrequestreview-242552186.