### PR TITLE
Reduce result file size of FFT examples (#3349)

### DIFF
--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1139,9 +1139,10 @@ calculating the harmonics with the <a href=\"modelica://Modelica.Blocks.Math.Rea
 </p>
 <p>
 Sampling starts after the initial transients are settled - waiting for
-<code>2&nbsp;periods&nbsp;=&nbsp;0.04&nbsp;s</code>.
+<code>2&nbsp;periods&nbsp;= 2/f&nbsp;= 0.04&nbsp;s&nbsp;= realFFT.startTime</code>.
 Choosing a&nbsp;maximum frequency <code>f_max&nbsp;=&nbsp;2000&nbsp;Hz</code>,
-a&nbsp;frequency resolution <code>f_res&nbsp;=&nbsp;5&nbsp;Hz</code> and
+a&nbsp;frequency resolution <code>f_res&nbsp;=&nbsp;5&nbsp;Hz</code>
+(both given in the block <code>realFFT</code>) and
 the default oversampling factor <code>f_max_factor&nbsp;=&nbsp;5</code>,
 we have to acquire <code>n&nbsp;= 2*f_max/f_res*f_max_factor&nbsp;=&nbsp;4000</code>
 sampling intervals.
@@ -1184,9 +1185,10 @@ calculating the harmonics with the <a href=\"modelica://Modelica.Blocks.Math.Rea
 </p>
 <p>
 Sampling starts after the initial transients are settled - waiting for
-<code>2&nbsp;periods&nbsp;=&nbsp;0.04&nbsp;s</code>. 
+<code>2&nbsp;periods&nbsp;= 2/f&nbsp;= 0.04&nbsp;s&nbsp;= realFFT.startTime</code>.
 Choosing a&nbsp;maximum frequency <code>f_max&nbsp;=&nbsp;2000&nbsp;Hz</code>,
-a&nbsp;frequency resolution <code>f_res&nbsp;=&nbsp;5&nbsp;Hz</code> and
+a&nbsp;frequency resolution <code>f_res&nbsp;=&nbsp;5&nbsp;Hz</code>
+(both given in the block <code>realFFT</code>) and
 the default oversampling factor <code>f_max_factor&nbsp;=&nbsp;5</code>, 
 we have to acquire <code>n&nbsp;= 2*f_max/f_res*f_max_factor&nbsp;=&nbsp;4000</code>
 sampling intervals. 

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1122,7 +1122,7 @@ just potential signals. The user might still add different signal names.
       f_max=2000,
       f_res=5,
       resultFileName="rectifier6pulseFFTresult.mat")
-                                               annotation (Placement(
+    annotation (Placement(
           transformation(
           extent={{-10,-10},{10,10}},
           rotation=270,
@@ -1130,13 +1130,23 @@ just potential signals. The user might still add different signal names.
   equation
     connect(currentSensor.i[1], realFFT.u)
       annotation (Line(points={{-70,-11},{-70,-18}}, color={0,0,127}));
-    annotation (experiment(StopTime=2.5, Interval=0.0001),
+    annotation (experiment(StopTime=0.25, Interval=0.0001),
       Documentation(info="<html>
 <p>
 This example is based on a <a href=\"modelica://Modelica.Electrical.Machines.Examples.Transformers.Rectifier6pulse\">6-pulse rectifier example</a>,
 calculating the harmonics with the <a href=\"modelica://Modelica.Blocks.Math.RealFFT\">FFT block</a>.
 </p>
 <p>
+Sampling starts after the initial transients are settled - waiting for <code>2 periods = 0.04 s</code>. 
+Choosing a maximum frequency <code>f_max=2000 Hz</code>, a frequency resolution <code>f_res=5 Hz</code> and the default oversampling factor <code>f_max_factor=5</code>, 
+we have to acquire <code>n = 2*f_max/f_res*f_max_factor = 4000</code> sampling intervals. 
+The resulting sampling interval is <code>samplePeriod = 1/(n*f_res) = 0.05 ms</code>. 
+Thus, we have to sample for a period of <code>n*samplePeriod = 1/f_res = 0.2 s</code>.
+</p>
+<p>
+The resultfile rectifier6pulseFFTresult.mat can be used to plot amplitudes versus frequencies. 
+Note that for each frequency 3 rows exits: one with amplitude zero, one with the calculated amplitude, one with apmplitude zero. 
+Thus, easily the second column (amplitude) can be plotted versus the first column (frequency). 
 As expected, one can see the 5<sup>th</sup>, 7<sup>th</sup>, 11<sup>th</sup>, 13<sup>th</sup>, 17<sup>th</sup>, 19<sup>th</sup>, 23<sup>th</sup>, 25<sup>th</sup>, ... harmonic in the result.
 </p>
 </html>"));
@@ -1157,13 +1167,23 @@ As expected, one can see the 5<sup>th</sup>, 7<sup>th</sup>, 11<sup>th</sup>, 13
   equation
     connect(currentSensor.i[1], realFFT.u) annotation (Line(points={{-70,-11},{
             -70,-14.5},{-70,-18}}, color={0,0,127}));
-    annotation (experiment(StopTime=2.5, Interval=0.0001),
+    annotation (experiment(StopTime=0.25, Interval=0.0001),
       Documentation(info="<html>
 <p>
 This example is based on a <a href=\"modelica://Modelica.Electrical.Machines.Examples.Transformers.Rectifier12pulse\">12-pulse rectifier example</a>,
 calculating the harmonics with the <a href=\"modelica://Modelica.Blocks.Math.RealFFT\">FFT block</a>.
 </p>
 <p>
+Sampling starts after the initial transients are settled - waiting for <code>2 periods = 0.04 s</code>. 
+Choosing a maximum frequency <code>f_max=2000 Hz</code>, a frequency resolution <code>f_res=5 Hz</code> and the default oversampling factor <code>f_max_factor=5</code>, 
+we have to acquire <code>n = 2*f_max/f_res*f_max_factor = 4000</code> sampling intervals. 
+The resulting sampling interval is <code>samplePeriod = 1/(n*f_res) = 0.05 ms</code>. 
+Thus, we have to sample for a period of <code>n*samplePeriod = 1/f_res = 0.2 s</code>.
+</p>
+<p>
+The resultfile rectifier6pulseFFTresult.mat can be used to plot amplitudes versus frequencies. 
+Note that for each frequency 3 rows exits: one with amplitude zero, one with the calculated amplitude, one with apmplitude zero. 
+Thus, easily the second column (amplitude) can be plotted versus the first column (frequency). 
 As expected, one can see the 11<sup>th</sup>, 13<sup>th</sup>, 23<sup>th</sup>, 25<sup>th</sup>, ... harmonic in the result.
 </p>
 </html>"));

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1125,29 +1125,38 @@ just potential signals. The user might still add different signal names.
     annotation (Placement(
           transformation(
           extent={{-10,-10},{10,10}},
-          rotation=270,
-          origin={-70,-30})));
+          rotation=0,
+          origin={-40,-20})));
   equation
     connect(currentSensor.i[1], realFFT.u)
-      annotation (Line(points={{-70,-11},{-70,-18}}, color={0,0,127}));
+      annotation (Line(points={{-70,-11},{-70,-20},{-52,-20}},
+                                                     color={0,0,127}));
     annotation (experiment(StopTime=0.25, Interval=0.0001),
       Documentation(info="<html>
 <p>
-This example is based on a <a href=\"modelica://Modelica.Electrical.Machines.Examples.Transformers.Rectifier6pulse\">6-pulse rectifier example</a>,
+This example is based on a&nbsp;<a href=\"modelica://Modelica.Electrical.Machines.Examples.Transformers.Rectifier6pulse\">6-pulse rectifier example</a>,
 calculating the harmonics with the <a href=\"modelica://Modelica.Blocks.Math.RealFFT\">FFT block</a>.
 </p>
 <p>
-Sampling starts after the initial transients are settled - waiting for <code>2 periods = 0.04 s</code>. 
-Choosing a maximum frequency <code>f_max=2000 Hz</code>, a frequency resolution <code>f_res=5 Hz</code> and the default oversampling factor <code>f_max_factor=5</code>, 
-we have to acquire <code>n = 2*f_max/f_res*f_max_factor = 4000</code> sampling intervals. 
-The resulting sampling interval is <code>samplePeriod = 1/(n*f_res) = 0.05 ms</code>. 
-Thus, we have to sample for a period of <code>n*samplePeriod = 1/f_res = 0.2 s</code>.
+Sampling starts after the initial transients are settled - waiting for
+<code>2&nbsp;periods&nbsp;=&nbsp;0.04&nbsp;s</code>.
+Choosing a&nbsp;maximum frequency <code>f_max&nbsp;=&nbsp;2000&nbsp;Hz</code>,
+a&nbsp;frequency resolution <code>f_res&nbsp;=&nbsp;5&nbsp;Hz</code> and
+the default oversampling factor <code>f_max_factor&nbsp;=&nbsp;5</code>,
+we have to acquire <code>n&nbsp;= 2*f_max/f_res*f_max_factor&nbsp;=&nbsp;4000</code>
+sampling intervals.
+The resulting sampling interval is <code>samplePeriod&nbsp;=&nbsp;1/(n*f_res)&nbsp;=&nbsp;0.05&nbsp;ms</code>.
+Thus, we have to sample for a&nbsp;period of <code>n*samplePeriod&nbsp;=&nbsp;1/f_res&nbsp;=&nbsp;0.2&nbsp;s</code>.
 </p>
 <p>
-The resultfile rectifier6pulseFFTresult.mat can be used to plot amplitudes versus frequencies. 
-Note that for each frequency 3 rows exits: one with amplitude zero, one with the calculated amplitude, one with apmplitude zero. 
-Thus, easily the second column (amplitude) can be plotted versus the first column (frequency). 
-As expected, one can see the 5<sup>th</sup>, 7<sup>th</sup>, 11<sup>th</sup>, 13<sup>th</sup>, 17<sup>th</sup>, 19<sup>th</sup>, 23<sup>th</sup>, 25<sup>th</sup>, ... harmonic in the result.
+The result file &quot;rectifier6pulseFFTresult.mat&quot; can be used to plot
+amplitudes versus frequencies. 
+Note that for each frequency three rows exit: one with amplitude zero,
+one with the calculated amplitude, one with apmplitude zero. 
+Thus, the second column (amplitude) can be easily plotted versus the first column (frequency). 
+As expected, one can see the 5<sup>th</sup>, 7<sup>th</sup>, 11<sup>th</sup>,
+13<sup>th</sup>, 17<sup>th</sup>, 19<sup>th</sup>, 23<sup>th</sup>, 25<sup>th</sup>,
+&hellip; harmonic in the result.
 </p>
 </html>"));
   end Rectifier6pulseFFT;
@@ -1162,29 +1171,35 @@ As expected, one can see the 5<sup>th</sup>, 7<sup>th</sup>, 11<sup>th</sup>, 13
                                                 annotation (Placement(
           transformation(
           extent={{-10,-10},{10,10}},
-          rotation=270,
-          origin={-70,-30})));
+          rotation=0,
+          origin={-40,-20})));
   equation
-    connect(currentSensor.i[1], realFFT.u) annotation (Line(points={{-70,-11},{
-            -70,-14.5},{-70,-18}}, color={0,0,127}));
+    connect(currentSensor.i[1], realFFT.u) annotation (Line(points={{-70,-11},{-70,-20},{-52,-20}},
+                                   color={0,0,127}));
     annotation (experiment(StopTime=0.25, Interval=0.0001),
       Documentation(info="<html>
 <p>
-This example is based on a <a href=\"modelica://Modelica.Electrical.Machines.Examples.Transformers.Rectifier12pulse\">12-pulse rectifier example</a>,
+This example is based on a&nbsp;<a href=\"modelica://Modelica.Electrical.Machines.Examples.Transformers.Rectifier12pulse\">12-pulse rectifier example</a>,
 calculating the harmonics with the <a href=\"modelica://Modelica.Blocks.Math.RealFFT\">FFT block</a>.
 </p>
 <p>
-Sampling starts after the initial transients are settled - waiting for <code>2 periods = 0.04 s</code>. 
-Choosing a maximum frequency <code>f_max=2000 Hz</code>, a frequency resolution <code>f_res=5 Hz</code> and the default oversampling factor <code>f_max_factor=5</code>, 
-we have to acquire <code>n = 2*f_max/f_res*f_max_factor = 4000</code> sampling intervals. 
-The resulting sampling interval is <code>samplePeriod = 1/(n*f_res) = 0.05 ms</code>. 
-Thus, we have to sample for a period of <code>n*samplePeriod = 1/f_res = 0.2 s</code>.
+Sampling starts after the initial transients are settled - waiting for
+<code>2&nbsp;periods&nbsp;=&nbsp;0.04&nbsp;s</code>. 
+Choosing a&nbsp;maximum frequency <code>f_max&nbsp;=&nbsp;2000&nbsp;Hz</code>,
+a&nbsp;frequency resolution <code>f_res&nbsp;=&nbsp;5&nbsp;Hz</code> and
+the default oversampling factor <code>f_max_factor&nbsp;=&nbsp;5</code>, 
+we have to acquire <code>n&nbsp;= 2*f_max/f_res*f_max_factor&nbsp;=&nbsp;4000</code>
+sampling intervals. 
+The resulting sampling interval is <code>samplePeriod&nbsp;=&nbsp;1/(n*f_res)&nbsp;=&nbsp;0.05&nbsp;ms</code>. 
+Thus, we have to sample for a&nbsp;period of <code>n*samplePeriod = 1/f_res = 0.2 s</code>.
 </p>
 <p>
-The resultfile rectifier6pulseFFTresult.mat can be used to plot amplitudes versus frequencies. 
-Note that for each frequency 3 rows exits: one with amplitude zero, one with the calculated amplitude, one with apmplitude zero. 
-Thus, easily the second column (amplitude) can be plotted versus the first column (frequency). 
-As expected, one can see the 11<sup>th</sup>, 13<sup>th</sup>, 23<sup>th</sup>, 25<sup>th</sup>, ... harmonic in the result.
+The resultfile &quot;rectifier12pulseFFTresult.mat&quot; can be used to plot amplitudes versus frequencies. 
+Note that for each frequency three rows exit: one with amplitude zero,
+one with the calculated amplitude, one with apmplitude zero. 
+Thus, the second column (amplitude) can be easily plotted versus the first column (frequency). 
+As expected, one can see the 11<sup>th</sup>, 13<sup>th</sup>, 23<sup>th</sup>, 25<sup>th</sup>,
+&hellip; harmonic in the result.
 </p>
 </html>"));
   end Rectifier12pulseFFT;


### PR DESCRIPTION
I reduced stop time, adding some hints in the documentation about maximum frequency, frequency resolution, sample time and sample period. 
If needed, we could try some HideResult=true annotations additionally.

Resolves #3349.