### PR TITLE
Fix typos and parameter name

### DIFF
--- a/Modelica/Electrical/Batteries/BaseClasses/BaseCellWithSensors.mo
+++ b/Modelica/Electrical/Batteries/BaseClasses/BaseCellWithSensors.mo
@@ -5,7 +5,7 @@ partial model BaseCellWithSensors "Partial cell with sensors"
     "Cell parameters"
     annotation (Placement(transformation(extent={{-10,40},{10,60}})));
   parameter Real SOC0=0.1 "Initial SOC";
-  parameter Real SOCtolerance=1e-9 "SOC tolerance for detection of depletec or overharged cell"
+  parameter Real SOCtolerance=1e-9 "SOC tolerance for detection of depleted or overcharged cell"
     annotation(Dialog(tab="Advanced"));
   extends Modelica.Electrical.Analog.Interfaces.TwoPin;
   output Modelica.SIunits.Current i = p.i "Current into the cell";
@@ -77,7 +77,7 @@ equation
           -20},{-60,-10}}, color={0,0,255}));
   connect(heatFlowSensor.port_a, temperatureSensor.port)
     annotation (Line(points={{0,-50},{0,-40},{-20,-40}}, color={191,0,0}));
-  annotation (                   Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <p>
 This is a single <a href=\"modelica://Modelica.Electrical.Batteries.BatteryStacks.CellStack\">cell[Np=1, Ns=1]</a> with measurement.
 </p>

--- a/Modelica/Electrical/Batteries/BaseClasses/BaseStackWithSensors.mo
+++ b/Modelica/Electrical/Batteries/BaseClasses/BaseStackWithSensors.mo
@@ -3,9 +3,9 @@ partial model BaseStackWithSensors "Partial stack with sensors"
   extends Modelica.Electrical.Batteries.Icons.BatteryIcon(final displaySOC=SOC);
   replaceable parameter BaseStackData stackData
     annotation (Placement(transformation(extent={{-10,40},{10,60}})));
-  parameter Boolean AllParallelConnections=true "Use all parallel connections?";
+  parameter Boolean useAllParallelConnections=true "= true, if all parallel connections are used";
   parameter Real SOC0[stackData.Ns, stackData.Np]=fill(0.1, stackData.Ns, stackData.Np) "Initial SOC";
-  parameter Real SOCtolerance=1e-9 "SOC tolerance for detection of depletec or overharged cell"
+  parameter Real SOCtolerance=1e-9 "SOC tolerance for detection of depleted or overcharged cell"
     annotation(Dialog(tab="Advanced"));
   extends Modelica.Electrical.Analog.Interfaces.TwoPin;
   output Modelica.SIunits.Current i = p.i "Current into the stack";
@@ -56,7 +56,7 @@ equation
       points={{-6,-8},{-6,-14},{60,-14},{60,-44},{60.1,-44},{60.1,-79.9}},
       color={255,204,51},
       thickness=0.5));
-  if AllParallelConnections then
+  if useAllParallelConnections then
     for ks in 1:stackData.Ns loop
       for kp in 1:stackData.Np-1 loop
         connect(cell[ks, kp].p, cell[ks, kp + 1].p);

--- a/Modelica/Electrical/Batteries/BatteryStacksWithSensors/Stack.mo
+++ b/Modelica/Electrical/Batteries/BatteryStacksWithSensors/Stack.mo
@@ -8,7 +8,7 @@ model Stack "Stack with sensors"
       each SOCtolerance=SOCtolerance,
       each useHeatPort=useHeatPort,
       each T=T));
-  annotation (                   Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <p>
 This is a stack of <code>Ns</code> x <code>Np</code> <a href=\"modelica://Modelica.Electrical.Batteries.StacksWithMeasurement.Cell\">cell[Np=1, Ns=1]</a> with measurement, arranged in a matrix.
 </p>

--- a/Modelica/Electrical/Batteries/Interfaces/StackBus.mo
+++ b/Modelica/Electrical/Batteries/Interfaces/StackBus.mo
@@ -3,7 +3,7 @@ expandable connector StackBus "Measurement signal bus for a stack"
   extends Modelica.Icons.SignalBus;
   parameter Integer Ns(final min = 1) = 1 "Number of series connected cells";
   parameter Integer Np(final min = 1) = 1 "Number of parallel connected cells";
-  CellBus cellBus[Ns,Np] "Cell busses";
+  CellBus cellBus[Ns,Np] "Cell buses";
   annotation (Documentation(info="<html>
 <p>
 Measurement bus of a stack, containing a <a href=\"modelica://Modelica.Electrical.Batteries.Interfaces.CellBus\">cellBus</a> per cell.

--- a/Modelica/Electrical/Batteries/UsersGuide/Concept.mo
+++ b/Modelica/Electrical/Batteries/UsersGuide/Concept.mo
@@ -5,7 +5,7 @@ class Concept "Concept of battery models"
 <p>
 The core of the cell models is a <a href=\"modelica://Modelica.Electrical.Analog.Sources.SignalVoltage\">signal voltage</a>
 controlled by a look-up table OCV (open circuit voltage) dependent on SOC (state of charge). <br>
-However, other dependencies (e.g. on temperature) are not implemented yet.
+However, other dependencies (e.g., on temperature) are not implemented yet.
 </p>
 <p>
 Current flowing to or from the battery is measured and integrated, thus calculating the charge contained in the battery.
@@ -29,23 +29,23 @@ Both models can be used for a single cell <code>Ns = Np = 1</code> as well as a 
 Note that the total inner resistance <code>Ri</code> is the sum of the resistance of resistor <code>r0</code> and the sum of the resistances of the resistors of the RC-elements.
 </p>
 <p>
-Additonally to these batteries that model a single cell scaled by the number of series connected cells <code>Ns</code> and the number of parallel connected cells <code>Np</code>, 
+Additionally to these batteries that model a single cell scaled by the number of series connected cells <code>Ns</code> and the number of parallel connected cells <code>Np</code>, 
 single cell models and stacks are provided in <a href=\"modelica://Modelica.Electrical.Batteries.BatteryStacksWithSensors\">BatteryStacksWithSensors</a>. 
 The cells are equipped with sensors, the measured signals are provided in the <a href=\"modelica://Modelica.Electrical.Batteries.Interfaces.CellBus\">CellBus</a>. 
 The stack models contain a matrix of <code>Ns</code> x <code>Np</code> single cells which can be parameterized differently 
 to investigate the influence of a degraded cell on the behaviour of the whole stack, as well as to design battery management systems.  
-The stack provides the <a href=\"modelica://Modelica.Electrical.Batteries.Interfaces.StackBus\">StackBus</a> which contains <code>Ns</code> x <code>Np</code> cell busses of the cells. 
+The stack provides the <a href=\"modelica://Modelica.Electrical.Batteries.Interfaces.StackBus\">StackBus</a> which contains <code>Ns</code> x <code>Np</code> cell buses of the cells. 
 Additionally, the signals of the whole stack - the same signals as of a single cell - are provided in the BatteryBus.
 </p>
 <p>
 There are two options of series and parallel connections of cells in stacks:
 </p>
 <ul>
-<li><code>AllParallelConnections=true </code>: <code>Np</code> cells are connected in parallel, and these groups are connected in series.</li>
-<li><code>AllParallelConnections=false</code>: <code>Ns</code> cells are connected in series, and these groups are connected in parallel.</li>
+<li><code>useAllParallelConnections=true </code>: <code>Np</code> cells are connected in parallel, and these groups are connected in series.</li>
+<li><code>useAllParallelConnections=false</code>: <code>Ns</code> cells are connected in series, and these groups are connected in parallel.</li>
 </ul>
 <p>
-For convenience, a block <a href=\"modelica://Modelica.Electrical.Batteries.Utilities.BusTranscription\">BusTranscription</a> transfers the signals of all cell busses in the stack bus 
+For convenience, a block <a href=\"modelica://Modelica.Electrical.Batteries.Utilities.BusTranscription\">BusTranscription</a> transfers the signals of all cell buses in the stack bus 
 to the <a href=\"modelica://Modelica.Electrical.Batteries.Interfaces.StackBusArrays\">StackBusArrays</a>, arranged as <code>Ns</code> x <code>Np</code> matrix per measurement signal.
 </p>
 <p>


### PR DESCRIPTION
- [x] Fix some typos
- [x] Change name of Boolean parameter Modelica.Electrical.Batteries.BaseClasses.BaseStackWithSensors.AllParallelConnections to useAllParallelConnections.