### PR TITLE
Fix regression of numerically non-robust InverseIncompressible_sh_T

### DIFF
--- a/Modelica/Media/Incompressible.mo
+++ b/Modelica/Media/Incompressible.mo
@@ -490,7 +490,7 @@ which is only exactly true for a fluid with constant density d=d0.
 
     algorithm
       T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(
-        function f_nonlinear(p=p, h=h), T_min, T_max);
+        function f_nonlinear(p=p, h=h), T_min, T_max+100*Modelica.Constants.eps);
       annotation(Inline=false, LateInline=true, inverse(h=h_pT(p,T)));
     end T_ph;
 
@@ -510,7 +510,7 @@ which is only exactly true for a fluid with constant density d=d0.
 
     algorithm
       T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(
-        function f_nonlinear(s=s), T_min, T_max);
+        function f_nonlinear(s=s), T_min, T_max+100*Modelica.Constants.eps);
     end T_ps;
 
   annotation(Documentation(info="<html>


### PR DESCRIPTION
Modelica.Media.Examples.SolveOneNonlinearEquation.InverseIncompressible_sh_T of current master branch fails to simulate in Dymola 2020 with Dassl if the solver tolerance is decreased to 1e-6. This is  due to the changed numerics introduced by #3207.

Hm, might also be a tool-issue since simulation works with tolerances 1e-4, 1e-5, 1e-7, 1e-8 or 1e-9:

```
simulateModel("Modelica.Media.Examples.SolveOneNonlinearEquation.InverseIncompressible_sh_T", method="dassl", tolerance=1e-04, resultFile="InverseIncompressible_sh_T");
 = true
simulateModel("Modelica.Media.Examples.SolveOneNonlinearEquation.InverseIncompressible_sh_T", method="dassl", tolerance=1e-05, resultFile="InverseIncompressible_sh_T");
 = true
simulateModel("Modelica.Media.Examples.SolveOneNonlinearEquation.InverseIncompressible_sh_T", method="dassl", tolerance=1e-06, resultFile="InverseIncompressible_sh_T");
 = false
simulateModel("Modelica.Media.Examples.SolveOneNonlinearEquation.InverseIncompressible_sh_T", method="dassl", tolerance=1e-07, resultFile="InverseIncompressible_sh_T");
 = true
simulateModel("Modelica.Media.Examples.SolveOneNonlinearEquation.InverseIncompressible_sh_T", method="dassl", tolerance=1e-08, resultFile="InverseIncompressible_sh_T");
 = true
simulateModel("Modelica.Media.Examples.SolveOneNonlinearEquation.InverseIncompressible_sh_T", method="dassl", tolerance=1e-09, resultFile="InverseIncompressible_sh_T");
 = true
```