### PR TITLE
Unify text and line colors of power converter icons

### DIFF
--- a/Modelica/Electrical/Analog/Ideal.mo
+++ b/Modelica/Electrical/Analog/Ideal.mo
@@ -1378,7 +1378,7 @@ For details of the arc effect, see partial model <a href=\"modelica://Modelica.E
     Modelica.Electrical.Analog.Interfaces.NegativePin n "Cathode"
       annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
     Modelica.Electrical.Analog.Interfaces.PositivePin p "Anode"
-      annotation (Placement(transformation(extent={{94,-10},{114,10}})));
+      annotation (Placement(transformation(extent={{90,-10},{110,10}})));
   equation
 
     connect(idealThyristor.n, capacitor.n) annotation (Line(
@@ -1398,7 +1398,7 @@ For details of the arc effect, see partial model <a href=\"modelica://Modelica.E
     connect(n, idealThyristor.p) annotation (Line(
         points={{-100,0},{-90,0},{-90,40},{-20,40},{-20,32}}, color={0,0,255}));
     connect(idealThyristor1.p, p) annotation (Line(
-        points={{0,-32},{0,-40},{80,-40},{80,0},{104,0}}, color={0,0,255}));
+        points={{0,-32},{0,-40},{80,-40},{80,0},{100,0}}, color={0,0,255}));
     annotation (defaultComponentName="triac",
       Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
               {100,100}}), graphics={
@@ -1422,7 +1422,7 @@ For details of the arc effect, see partial model <a href=\"modelica://Modelica.E
             fillColor={255,255,255},
             fillPattern=FillPattern.Solid),
           Line(points={{-40,0},{-90,0}}, color={0,0,255}),
-          Line(points={{90,0},{40,0}}, color={0,0,255}),
+          Line(points={{100,0},{40,0}},color={0,0,255}),
           Line(points={{-100,-100},{-100,-60},{-40,-30}},
                                                       color={255,0,255})}),
                                     Documentation(info="<html>

--- a/Modelica/Electrical/Analog/Ideal.mo
+++ b/Modelica/Electrical/Analog/Ideal.mo
@@ -1402,30 +1402,29 @@ For details of the arc effect, see partial model <a href=\"modelica://Modelica.E
     annotation (defaultComponentName="triac",
       Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
               {100,100}}), graphics={
-          Polygon(
-            points={{-30,0},{-30,-100},{70,-50},{-30,0}},
-            lineColor={0,0,255}),
-          Polygon(
-            points={{70,100},{70,0},{-30,50},{70,100}},
-            lineColor={0,0,255}),
-          Line(
-            points={{70,0},{70,-100}}, color={0,0,255}),
-          Line(
-            points={{-30,0},{-30,100}}, color={0,0,255}),
-          Line(
-            points={{-30,0},{-90,0}}, color={0,0,255}),
-          Line(
-            points={{70,0},{110,0}}, color={0,0,255}),
-          Line(
-            points={{-100,-80},{-80,-80},{-30,-50}}, color={0,0,255}),
           Text(
-            extent={{-150,150},{150,110}},
+            extent={{-150,130},{150,90}},
             textString="%name",
             textColor={0,0,255}),
           Line(
             points={{-100,-100},{-100,-80}},
             color={255,0,255},
-            pattern=LinePattern.Dash)}),
+            pattern=LinePattern.Dash),
+          Line(points={{-40,-70},{-40,70}}, color={0,0,255}),
+          Line(points={{40,-72},{40,70}}, color={0,0,255}),
+          Polygon(points={{-40,-70},{40,-30},{-40,10},{-40,-70}},
+                                                               lineColor={0,0,
+                255},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Polygon(points={{40,-10},{-40,30},{40,70},{40,-10}}, lineColor={0,0,
+                255},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Line(points={{-40,0},{-90,0}}, color={0,0,255}),
+          Line(points={{90,0},{40,0}}, color={0,0,255}),
+          Line(points={{-100,-100},{-100,-60},{-40,-30}},
+                                                      color={255,0,255})}),
                                     Documentation(info="<html>
 <p>This is an ideal triac model based on an ideal thyristor model.</p>
 

--- a/Modelica/Electrical/Analog/Semiconductors.mo
+++ b/Modelica/Electrical/Analog/Semiconductors.mo
@@ -958,31 +958,25 @@ public
     annotation (defaultComponentName="triac",
       Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,100}}),
         graphics={
-          Polygon(
-            points={{-30,0},{-30,-100},{70,-50},{-30,0}},
-            lineColor={0,0,255}),
-          Polygon(
-            points={{70,100},{70,0},{-30,50},{70,100}},
-            lineColor={0,0,255}),
-          Line(
-            points={{70,0},{70,-100}},
-            color={0,0,255}),
-          Line(
-            points={{-30,0},{-30,100}},
-            color={0,0,255}),
-          Line(
-            points={{-30,0},{-90,0}},
-            color={0,0,255}),
-          Line(
-            points={{70,0},{110,0}},
-            color={0,0,255}),
-          Line(
-            points={{-100,-90},{-100,-80},{-30,-50}},
-            color={0,0,255}),
           Text(
-            extent={{-150,150},{150,110}},
+            extent={{-150,120},{150,80}},
             textString="%name",
-            textColor={0,0,255})}),
+            textColor={0,0,255}),
+          Line(points={{-40,-70},{-40,70}}, color={0,0,255}),
+          Line(points={{40,-72},{40,70}}, color={0,0,255}),
+          Polygon(points={{-40,-70},{40,-30},{-40,10},{-40,-70}},
+                                                               lineColor={0,0,
+                255},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Polygon(points={{40,-10},{-40,30},{40,70},{40,-10}}, lineColor={0,0,
+                255},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Line(points={{-40,0},{-90,0}}, color={0,0,255}),
+          Line(points={{90,0},{40,0}}, color={0,0,255}),
+          Line(points={{-100,-100},{-100,-60},{-40,-30}},
+                                                      color={0,0,255})}),
       Documentation(info="<html>
 <p>This is a simple TRIAC model based on the extended thyristor model Modelica.Electrical.Analog.Semiconductors.Thyristor.
 <br>Two thyristors are contrarily connected in parallel, whereas each transistor is connected with a diode.

--- a/Modelica/Electrical/PowerConverters/ACAC/PolyphaseTriac.mo
+++ b/Modelica/Electrical/PowerConverters/ACAC/PolyphaseTriac.mo
@@ -41,43 +41,25 @@ equation
   annotation (defaultComponentName="triac",
     Icon(graphics={
         Text(
-          extent={{-150,110},{150,70}},
+          extent={{-150,120},{150,80}},
           textString="%name",
           textColor={0,0,255}),
-        Line(points={{-40,70},{-40,-70}}, color={0,0,255}),
-        Line(points={{40,70},{40,-72}}, color={0,0,255}),
-        Polygon(points={{-40,70},{40,30},{-40,-10},{-40,70}},lineColor={0,0,
+        Line(points={{-60,-100},{-60,-40},{-40,-30}},
+                                                    color={255,0,255}),
+        Line(points={{60,-100},{60,20},{40,30}}, color={255,0,255}),
+        Line(points={{-40,-70},{-40,70}}, color={0,0,255}),
+        Line(points={{40,-72},{40,70}}, color={0,0,255}),
+        Polygon(points={{-40,-70},{40,-30},{-40,10},{-40,-70}},
+                                                             lineColor={0,0,
               255},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid),
-        Polygon(points={{40,8},{-40,-32},{40,-72},{40,8}},   lineColor={0,0,
+        Polygon(points={{40,-10},{-40,30},{40,70},{40,-10}}, lineColor={0,0,
               255},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid),
         Line(points={{-40,0},{-90,0}}, color={0,0,255}),
-        Line(points={{90,0},{40,0}}, color={0,0,255}),
-        Line(points={{-60,-100},{-60,-10},{-40,0}}, color={0,0,255}),
-        Line(points={{60,-100},{60,-10},{40,0}}, color={0,0,255}),
-        Line(
-          points={{-10,-5},{10,5},{10,5}},
-          color={0,0,255},
-          origin={50,-3},
-          rotation=180),
-        Line(
-          points={{-10,-5},{10,5},{10,5}},
-          color={0,0,255},
-          origin={50,-7},
-          rotation=180),
-        Line(
-          points={{-10,5},{10,-5},{10,-5}},
-          color={0,0,255},
-          origin={-50,-7},
-          rotation=180),
-        Line(
-          points={{-10,5},{10,-5},{10,-5}},
-          color={0,0,255},
-          origin={-50,-3},
-          rotation=180)}),
+        Line(points={{90,0},{40,0}}, color={0,0,255})}),
       Documentation(info="<html>
 <p>
 Simplified model of <code>m</code> 

--- a/Modelica/Electrical/PowerConverters/ACAC/SinglePhaseTriac.mo
+++ b/Modelica/Electrical/PowerConverters/ACAC/SinglePhaseTriac.mo
@@ -64,43 +64,25 @@ equation
   annotation (defaultComponentName="triac",
     Icon(graphics={
         Text(
-          extent={{-150,110},{150,70}},
+          extent={{-150,120},{150,80}},
           textString="%name",
           textColor={0,0,255}),
-        Line(points={{-40,70},{-40,-70}}, color={0,0,255}),
-        Line(points={{40,70},{40,-72}}, color={0,0,255}),
-        Polygon(points={{-40,70},{40,30},{-40,-10},{-40,70}},lineColor={0,0,
+        Line(points={{-60,-100},{-60,-40},{-40,-30}},
+                                                    color={255,0,255}),
+        Line(points={{-40,-70},{-40,70}}, color={0,0,255}),
+        Line(points={{40,-72},{40,70}}, color={0,0,255}),
+        Polygon(points={{-40,-70},{40,-30},{-40,10},{-40,-70}},
+                                                             lineColor={0,0,
               255},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid),
-        Polygon(points={{40,8},{-40,-32},{40,-72},{40,8}},   lineColor={0,0,
+        Polygon(points={{40,-10},{-40,30},{40,70},{40,-10}}, lineColor={0,0,
               255},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid),
         Line(points={{-40,0},{-90,0}}, color={0,0,255}),
         Line(points={{90,0},{40,0}}, color={0,0,255}),
-        Line(points={{-60,-100},{-60,-10},{-40,0}}, color={0,0,255}),
-        Line(points={{60,-100},{60,-10},{40,0}}, color={0,0,255}),
-        Line(
-          points={{-10,-5},{10,5},{10,5}},
-          color={0,0,255},
-          origin={50,-3},
-          rotation=180),
-        Line(
-          points={{-10,-5},{10,5},{10,5}},
-          color={0,0,255},
-          origin={50,-7},
-          rotation=180),
-        Line(
-          points={{-10,5},{10,-5},{10,-5}},
-          color={0,0,255},
-          origin={-50,-7},
-          rotation=180),
-        Line(
-          points={{-10,5},{10,-5},{10,-5}},
-          color={0,0,255},
-          origin={-50,-3},
-          rotation=180)}),
+        Line(points={{60,-100},{60,20},{40,30}}, color={255,0,255})}),
       Documentation(info="<html>
 <p>
 Simplified model of a triode for alternating current, built from two antiparallel thyristors. 

--- a/Modelica/Electrical/PowerConverters/ACDC/DiodeBridge2Pulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/DiodeBridge2Pulse.mo
@@ -86,11 +86,11 @@ equation
             100,100}}), graphics={
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="AC"),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC"),
         Rectangle(
           extent={{-40,24},{40,-24}},

--- a/Modelica/Electrical/PowerConverters/ACDC/DiodeBridge2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/DiodeBridge2mPulse.mo
@@ -69,11 +69,11 @@ equation
             100,100}}), graphics={
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="AC"),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC"),
         Rectangle(
           extent={{-40,24},{40,-24}},

--- a/Modelica/Electrical/PowerConverters/ACDC/DiodeCenterTap2Pulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/DiodeCenterTap2Pulse.mo
@@ -54,11 +54,11 @@ equation
         grid={2,2}), graphics={
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="AC"),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC"),
         Rectangle(
           extent={{-40,24},{40,-24}},

--- a/Modelica/Electrical/PowerConverters/ACDC/DiodeCenterTap2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/DiodeCenterTap2mPulse.mo
@@ -69,11 +69,11 @@ equation
             100,100}}), graphics={
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="AC"),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC"),
         Rectangle(
           extent={{-40,24},{40,-24}},

--- a/Modelica/Electrical/PowerConverters/ACDC/DiodeCenterTapmPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/DiodeCenterTapmPulse.mo
@@ -50,11 +50,11 @@ equation
             100,100}}), graphics={
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="AC"),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC"),
         Rectangle(
           extent={{-40,24},{40,-24}},

--- a/Modelica/Electrical/PowerConverters/ACDC/HalfControlledBridge2Pulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/HalfControlledBridge2Pulse.mo
@@ -102,11 +102,11 @@ equation
             100,100}}), graphics={
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="AC"),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC"),
         Rectangle(
           extent={{-44,50},{36,2}},

--- a/Modelica/Electrical/PowerConverters/ACDC/HalfControlledBridge2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/HalfControlledBridge2mPulse.mo
@@ -89,11 +89,11 @@ equation
             100,100}}), graphics={
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="AC"),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC"),
         Rectangle(
           extent={{-46,52},{34,4}},

--- a/Modelica/Electrical/PowerConverters/ACDC/ThyristorBridge2Pulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/ThyristorBridge2Pulse.mo
@@ -111,11 +111,11 @@ equation
             100,100}}), graphics={
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="AC"),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC"),
         Rectangle(
           extent={{-40,24},{40,-24}},

--- a/Modelica/Electrical/PowerConverters/ACDC/ThyristorBridge2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/ThyristorBridge2mPulse.mo
@@ -93,11 +93,11 @@ equation
             100,100}}), graphics={
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="AC"),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC"),
         Rectangle(
           extent={{-40,24},{40,-24}},

--- a/Modelica/Electrical/PowerConverters/ACDC/ThyristorCenterTap2Pulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/ThyristorCenterTap2Pulse.mo
@@ -70,11 +70,11 @@ equation
         grid={2,2}), graphics={
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="AC"),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC"),
         Rectangle(
           extent={{-40,24},{40,-24}},

--- a/Modelica/Electrical/PowerConverters/ACDC/ThyristorCenterTap2mPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/ThyristorCenterTap2mPulse.mo
@@ -85,11 +85,11 @@ equation
             100,100}}), graphics={
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="AC"),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC"),
         Rectangle(
           extent={{-40,24},{40,-24}},

--- a/Modelica/Electrical/PowerConverters/ACDC/ThyristorCenterTapmPulse.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/ThyristorCenterTapmPulse.mo
@@ -58,11 +58,11 @@ equation
             100,100}}), graphics={
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="AC"),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC"),
         Rectangle(
           extent={{-40,24},{40,-24}},

--- a/Modelica/Electrical/PowerConverters/ACDC/package.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/package.mo
@@ -1,7 +1,6 @@
 within Modelica.Electrical.PowerConverters;
 package ACDC "AC to DC converters"
   extends Modelica.Icons.Package;
-
   annotation (Documentation(info="<html>
 <p>
 General information about AC/DC converters can be found at the

--- a/Modelica/Electrical/PowerConverters/ACDC/package.mo
+++ b/Modelica/Electrical/PowerConverters/ACDC/package.mo
@@ -1,6 +1,7 @@
 within Modelica.Electrical.PowerConverters;
 package ACDC "AC to DC converters"
   extends Modelica.Icons.Package;
+
   annotation (Documentation(info="<html>
 <p>
 General information about AC/DC converters can be found at the

--- a/Modelica/Electrical/PowerConverters/DCAC/Polyphase2Level.mo
+++ b/Modelica/Electrical/PowerConverters/DCAC/Polyphase2Level.mo
@@ -146,11 +146,11 @@ equation
           color={0,0,255}),
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC"),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="AC")}),
     Documentation(info="<html>
 <p>

--- a/Modelica/Electrical/PowerConverters/DCAC/SinglePhase2Level.mo
+++ b/Modelica/Electrical/PowerConverters/DCAC/SinglePhase2Level.mo
@@ -123,11 +123,11 @@ equation
           color={0,0,255}),
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC"),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="AC")}),
     Documentation(info="<html>
 <p>

--- a/Modelica/Electrical/PowerConverters/DCDC/ChopperStepDown.mo
+++ b/Modelica/Electrical/PowerConverters/DCDC/ChopperStepDown.mo
@@ -62,11 +62,11 @@ equation
             100,100}}), graphics={
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC in"),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC out"),
         Text(
           extent={{-150,150},{150,110}},
@@ -77,7 +77,7 @@ equation
           lineColor={255,255,255},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid),
-        Line(points={{-30,20},{-30,0}}, color={217,67,180}),
+        Line(points={{-30,20},{-30,0}}, color={255,0,255}),
         Line(points={{-40,30},{-30,20},{-20,30}}, color={0,0,255}),
         Polygon(
           points={{-20,30},{-26,26},{-24,24},{-20,30}},

--- a/Modelica/Electrical/PowerConverters/DCDC/ChopperStepUp.mo
+++ b/Modelica/Electrical/PowerConverters/DCDC/ChopperStepUp.mo
@@ -62,11 +62,11 @@ equation
             100,100}}), graphics={
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC in"),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC out"),
         Text(
           extent={{-150,150},{150,110}},
@@ -82,7 +82,7 @@ equation
         Line(points={{-60,30},{60,30}}, color={0,0,255}),
         Ellipse(extent={{-22,32},{-18,28}},
                                           lineColor={0,0,255}),
-        Line(points={{0,10},{0,-10}},   color={217,67,180},
+        Line(points={{0,10},{0,-10}},   color={255,0,255},
           origin={-40,0},
           rotation=90),
         Line(points={{-20,30},{-20,10}},color={0,0,255}),
@@ -109,7 +109,7 @@ equation
         Line(points={{-10,0},{10,0}},    color={0,0,255},
           origin={-30,0},
           rotation=90),
-        Line(points={{-20,10},{-30,0},{-20,-10}}, color={28,108,200}),
+        Line(points={{-20,10},{-30,0},{-20,-10}}, color={0,0,255}),
         Line(points={{-20,-10},{-20,-30}},
                                         color={0,0,255})}),
     Documentation(info="<html>

--- a/Modelica/Electrical/PowerConverters/DCDC/HBridge.mo
+++ b/Modelica/Electrical/PowerConverters/DCDC/HBridge.mo
@@ -84,11 +84,11 @@ equation
           fillPattern=FillPattern.Solid),
         Text(
           extent={{0,-50},{100,-70}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC out"),
         Text(
           extent={{-100,70},{0,50}},
-          textColor={0,0,127},
+          textColor={0,0,255},
           textString="DC in"),
         Line(
           points={{-40,0},{-28,0}},


### PR DESCRIPTION
- Unify triac icons of `Analog` and `PowerConverters` pacakge
- Make icon text color blue `{0,0,255}`
- Unify icon line colors to match domain specification