### PR TITLE
Avoid parameter dependency on Modelica.Constants.inf in Modelica.Fluid.Examples.Explanatory.MomentumBalanceFittings

### DIFF
--- a/Modelica/Fluid/Examples/Explanatory.mo
+++ b/Modelica/Fluid/Examples/Explanatory.mo
@@ -221,12 +221,12 @@ present as for T_twoPort.T.
     Modelica.Fluid.Fittings.AbruptAdaptor leftAdaptor(
       diameter_a=0.1,
       redeclare package Medium = Modelica.Media.Water.StandardWaterOnePhase,
-      diameter_b=Modelica.Constants.inf)
+      diameter_b=1e60)
       annotation (Placement(transformation(extent={{-40,-40},{-60,-20}})));
     Modelica.Fluid.Fittings.AbruptAdaptor rightAdaptor(
       redeclare package Medium = Modelica.Media.Water.StandardWaterOnePhase,
       diameter_a=0.2,
-      diameter_b=Modelica.Constants.inf)
+      diameter_b=1e60)
       annotation (Placement(transformation(extent={{40,-40},{60,-20}})));
     inner System system
       annotation (Placement(transformation(extent={{-92,56},{-72,76}})));
@@ -252,7 +252,7 @@ This example shows the use of a sudden expansion / contraction model, which is c
 The reason for this is that the boundary conditions model infinite reservoirs with an infinite diameter and thus zero flow velocity. The sudden expansion model does however have two ends with finite diameters, and, as explained in the <a href=\"modelica://Modelica.Fluid.UsersGuide.Overview\">Overview</a> of the Users' Guide, the momentum balance is not fulfilled exactly for this type of connections. Using a simple <code>connect()</code>-statement, the difference of the kinetic terms is neglected, which is not reasonable in the present model: At the left boundary condition it is zero, and on the left side of the sudden expansion it has a non-zero value. It is not reasonable to neglect it in the shown model, because there is little friction and therefore these kinetic effects dominate. Consequently, only modelling these effects explicitly leads to the correct results.
 </p>
 <p>
-To do so, two additional sudden expansions / contractions are included in the model. The diameter is set to <code>inf</code> close to the boundaries and the proper values close to the original model. These additional components now introduce <em>exact</em> momentum balances and the results are as expected.
+To do so, two additional sudden expansions / contractions are included in the model. The diameter is set to a large value (<code>1e60</code>) close to the boundaries and the proper values close to the original model. These additional components now introduce <em>exact</em> momentum balances and the results are as expected.
 </p>
 <p>
 The total pressures offer an additional perspective on the model. After setting the parameter <code>show_totalPressures</code> on the Advanced tab of the <code>AbruptAdaptor</code>s to <code>true</code>, the total pressures are included in said models and may be plotted. This allows to confirm that the <strong>total</strong> pressure <em>always</em> reduces along the flow direction, even in the upper model.

--- a/ModelicaTest/Fluid/TestComponents/Fittings/TestSuddenExpansion.mo
+++ b/ModelicaTest/Fluid/TestComponents/Fittings/TestSuddenExpansion.mo
@@ -43,13 +43,13 @@ model TestSuddenExpansion
     diameter_a=0.1,
     redeclare package Medium =
         Modelica.Media.Water.StandardWaterOnePhase,
-    diameter_b=Modelica.Constants.inf)
+    diameter_b=1e60)
     annotation (Placement(transformation(extent={{-40,-40},{-60,-20}})));
   Modelica.Fluid.Fittings.AbruptAdaptor rightAdapter(
     redeclare package Medium =
         Modelica.Media.Water.StandardWaterOnePhase,
     diameter_a=0.2,
-    diameter_b=Modelica.Constants.inf)
+    diameter_b=1e60)
     annotation (Placement(transformation(extent={{40,-40},{60,-20}})));
   inner Modelica.Fluid.System system
     annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
@@ -75,7 +75,7 @@ This example shows the use of a sudden expansion / contraction model, which is c
 The reason for this is that the boundary conditions model infinite reservoirs with an infinite diameter and thus zero flow velocity. The sudden expansion model does however have two ends with finite diameters, and, as explained in the <a href=\"modelica://Modelica.Fluid.UsersGuide.Overview\">Overview</a> of the Users' Guide, the momentum balance is not fulfilled exactly for this type of connections. Using a simple <code>connect()</code>-statement, the difference of the kinetic terms is neglected, which is not reasonable in the present model: At the left boundary condition it is zero, and on the left side of the sudden expansion it has a non-zero value. It is not reasonable to neglect it in the shown model, because there is little friction and therefore these kinetic effects dominate. Consequently, only modelling these effects explicitly leads to the correct results.
 </p>
 <p>
-To do so, two additional sudden expansions / contractions are included in the model. The diameter is set to <code>inf</code> close to the boundaries and the proper values close to the original model. These additional components now introduce <em>exact</em> momentum balances and the results are as expected.
+To do so, two additional sudden expansions / contractions are included in the model. The diameter is set to a large value (<code>1e60</code>) close to the boundaries and the proper values close to the original model. These additional components now introduce <em>exact</em> momentum balances and the results are as expected.
 </p>
 </html>"),
     experiment(StopTime=1.01));


### PR DESCRIPTION
Remove the parameter dependency on ModelicaServices.Machine.inf by utilizing the actual literal value of the default implementation of ModelicaServices.

Closes #3390.