### PR TITLE
maint/3.2.3: Add missing property calculation for d and T in Modelica.Media.R134a.R134a_ph.setState_psX

### DIFF
--- a/Modelica/Media/R134a.mo
+++ b/Modelica/Media/R134a.mo
@@ -385,9 +385,9 @@ Example:
       SaturationProperties sat "Saturation temperature and pressure";
     algorithm
       state.p := p;
-
-      if (getPhase_ps(p, s) == 1) then
-        (state.d,state.T,error) := dtofpsOnePhase(
+      state.phase := getPhase_ps(p, s);
+      if state.phase == 1 then
+        (state.d, state.T, error) := dtofpsOnePhase(
               p=p,
               s=s,
               delp=delp,
@@ -396,6 +396,7 @@ Example:
         state.h := R134aData.R*state.T*(f.tau*f.ftau + f.delta*f.fdelta);
       else
         state.h := hofpsTwoPhase(p, s);
+        (state.d, state.T) := dt_ph(p, state.h);
       end if;
 
       annotation (Documentation(info="<html>
@@ -418,6 +419,8 @@ Example:
 
      h = Medium.specificEnthalpy(setState_psX(p, s, fill(0, Medium.nX)));
 </pre>
+</html>", revisions="<html>
+<p>2020-02-05 Stefan Wischhusen: Added missing property calculation for d and T.</p>
 </html>"));
     end setState_psX;
 


### PR DESCRIPTION
Back-port #3392 to fix #3320 also in maint/3.2.3 (since labeled as bug).