### PR TITLE
Improved controller of AST_BatchPlant example case

### DIFF
--- a/Modelica/Fluid/Examples/AST_BatchPlant.mo
+++ b/Modelica/Fluid/Examples/AST_BatchPlant.mo
@@ -720,8 +720,8 @@ Documentation for this example can be found on the <a href=\"modelica://Modelica
         pipeArea={bottom_pipeArea[i] for i in 1:n_BottomPorts},
         redeclare package Medium = Medium)
           annotation (Placement(transformation(extent={{-80,-80},{-60,-60}})));
-      Modelica.Fluid.Interfaces.FluidPort_b Condensed(redeclare package Medium
-          = Medium)
+      Modelica.Fluid.Interfaces.FluidPort_b Condensed(redeclare package Medium =
+            Medium)
         annotation (Placement(transformation(extent={{192,50},{212,70}})));
 
       // Heat transfer through boundary
@@ -985,10 +985,12 @@ Full steady state initialization is not supported, because the corresponding ini
 
       Modelica.Fluid.Examples.AST_BatchPlant.BaseClasses.ControllerUtilities.Port_Sensors
         sensors
-        annotation (Placement(transformation(extent={{-280,-40},{-200,40}})));
+        annotation (Placement(transformation(extent={{-360,-40},{-280,40}}),
+            iconTransformation(extent={{-280,-40},{-200,40}})));
       Modelica.Fluid.Examples.AST_BatchPlant.BaseClasses.ControllerUtilities.Port_Actuators
         actuators
-        annotation (Placement(transformation(extent={{200,-20},{240,20}})));
+        annotation (Placement(transformation(extent={{218,-20},{258,20}}),
+            iconTransformation(extent={{200,-20},{240,20}})));
 
       parameter Real w_dilution=0.003 "Dilution";
       parameter Real w_concentrate=0.005 "Concentrate";
@@ -1032,35 +1034,36 @@ Full steady state initialization is not supported, because the corresponding ini
         waitTime=300)
         annotation (Placement(transformation(extent={{-90,30},{-70,50}})));
       Modelica.StateGraph.Parallel Parallel1 annotation (Placement(
-            transformation(extent={{-176,-100},{194,0}})));
+            transformation(extent={{-234,-100},{220,0}})));
       Modelica.StateGraph.Step Step7(nIn=1, nOut=1) annotation (Placement(transformation(
-              extent={{-122,-80},{-102,-60}})));
+              extent={{-166,-80},{-146,-60}})));
       Modelica.StateGraph.Step Step8(nIn=1, nOut=1) annotation (Placement(transformation(
-              extent={{-62,-80},{-42,-60}})));
+              extent={{-110,-80},{-90,-60}})));
       Modelica.StateGraph.Step Step9(nIn=1, nOut=1) annotation (Placement(transformation(
-              extent={{-2,-80},{18,-60}})));
-      Modelica.StateGraph.Step Step10(nIn=1, nOut=1) annotation (Placement(transformation(
-              extent={{58,-80},{78,-60}})));
+              extent={{-54,-80},{-34,-60}})));
+      Modelica.StateGraph.Step Step10(       nOut=1, nIn=1)
+                                                     annotation (Placement(transformation(
+              extent={{76,-80},{96,-60}})));
       Modelica.StateGraph.Step Step11(nIn=1, nOut=1) annotation (Placement(transformation(
-              extent={{118,-80},{138,-60}})));
+              extent={{134,-80},{154,-60}})));
       Modelica.StateGraph.Step Step12(nIn=1, nOut=1) annotation (Placement(transformation(
-              extent={{-62,-40},{-42,-20}})));
-      Modelica.StateGraph.Step Step13(nIn=1, nOut=1) annotation (Placement(transformation(
-              extent={{-2,-40},{18,-20}})));
+              extent={{-80,-40},{-60,-20}})));
+      Modelica.StateGraph.Step Step13b(nIn=1, nOut=1)
+        annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
       Modelica.StateGraph.Step Step14(nIn=1, nOut=1) annotation (Placement(transformation(
-              extent={{58,-40},{78,-20}})));
+              extent={{100,-40},{120,-20}})));
       Modelica.StateGraph.Transition Transition8(condition=T7_idle)
-        annotation (Placement(transformation(extent={{-92,-80},{-72,-60}})));
+        annotation (Placement(transformation(extent={{-138,-80},{-118,-60}})));
       Modelica.StateGraph.Transition Transition9(condition=LIS_501 <= 0.01)
-        annotation (Placement(transformation(extent={{-32,-80},{-12,-60}})));
+        annotation (Placement(transformation(extent={{-82,-80},{-62,-60}})));
       Modelica.StateGraph.Transition Transition10(condition=TIS_702 <= 298)
-        annotation (Placement(transformation(extent={{28,-80},{48,-60}})));
+        annotation (Placement(transformation(extent={{-24,-80},{-4,-60}})));
       Modelica.StateGraph.Transition Transition11(condition=LIS_701 <= 0.01)
-        annotation (Placement(transformation(extent={{88,-80},{108,-60}})));
+        annotation (Placement(transformation(extent={{106,-80},{126,-60}})));
       Modelica.StateGraph.Transition Transition12(condition=TIS_602 <= 298)
-        annotation (Placement(transformation(extent={{-32,-40},{-12,-20}})));
+        annotation (Placement(transformation(extent={{-50,-40},{-30,-20}})));
       Modelica.StateGraph.Transition Transition13(condition=LIS_601 <= 0.01)
-        annotation (Placement(transformation(extent={{28,-40},{48,-20}})));
+        annotation (Placement(transformation(extent={{70,-40},{90,-20}})));
 
       Real LIS_301;
       Real LIS_501;
@@ -1081,6 +1084,20 @@ Full steady state initialization is not supported, because the corresponding ini
         annotation (Placement(transformation(extent={{-104,-148},{-18,-116}})));
       inner Modelica.StateGraph.StateGraphRoot stateGraphRoot
         annotation (Placement(transformation(extent={{-180,140},{-160,160}})));
+      StateGraph.Step Step13(nIn=1, nOut=1)
+        annotation (Placement(transformation(extent={{40,-40},{60,-20}})));
+      StateGraph.Transition Transition13b(
+        condition=true,
+        enableTimer=true,
+        waitTime=1)
+        annotation (Placement(transformation(extent={{10,-40},{30,-20}})));
+      StateGraph.Step Step10b(nIn=1, nOut=1)
+        annotation (Placement(transformation(extent={{10,-80},{30,-60}})));
+      StateGraph.Transition Transition10b(
+        condition=true,
+        enableTimer=true,
+        waitTime=1)
+        annotation (Placement(transformation(extent={{42,-80},{62,-60}})));
     equation
       LIS_301 = sensors.LIS_301;
       LIS_501 = sensors.LIS_501;
@@ -1095,17 +1112,17 @@ Full steady state initialization is not supported, because the corresponding ini
       T7_idle = not actuators.V15 and not actuators.V18 and not actuators.
         T7_Cooling and sensors.LIS_701 < 0.01;
 
-      actuators.P1 = Step10.active;
-      actuators.P2 = Step13.active;
+      actuators.P1 = Step10.active or Step10b.active;
+      actuators.P2 = Step13.active or Step13b.active;
       actuators.T5_Heater = Step6.active;
       actuators.T7_Cooling = Step9.active;
       actuators.T6_Cooling = Step12.active;
-      actuators.V1 = Step10.active;
+      actuators.V1 = Step10.active or Step10b.active;
       actuators.V2 = false;
       actuators.V3 = Step10.active;
       actuators.V4 = false;
-      actuators.V5 = Step13.active;
-      actuators.V6 = Step13.active;
+      actuators.V5 =Step13.active or Step13b.active;
+      actuators.V6 =Step13.active;
       actuators.V8 = Step1.active;
       actuators.V9 = Step2.active;
       actuators.V10 = false;
@@ -1114,12 +1131,12 @@ Full steady state initialization is not supported, because the corresponding ini
       actuators.V15 = Step8.active;
       actuators.V18 = Step10.active;
       actuators.V19 = false;
-      actuators.V20 = Step13.active;
+      actuators.V20 =Step13.active;
       actuators.V21 = false;
-      actuators.V22 = Step10.active;
-      actuators.V23 = Step10.active;
-      actuators.V25 = Step13.active;
-      actuators.V24 = Step13.active;
+      actuators.V22 = Step10.active or Step10b.active;
+      actuators.V23 = Step10.active or Step10b.active;
+      actuators.V25 =Step13.active or Step13b.active;
+      actuators.V24 =Step13.active or Step13b.active;
 
       connect(InitialStep1.outPort[1], Transition1.inPort) annotation (Line(
             points={{-159.5,100},{-144,100}}));
@@ -1147,46 +1164,54 @@ Full steady state initialization is not supported, because the corresponding ini
               161.5,100},{184,100},{184,70},{-160,70},{-160,40},{-121,40}}));
       connect(Step6.outPort[1], Transition7.inPort)
         annotation (Line(points={{-99.5,40},{-84,40}}));
-      connect(Step12.inPort[1], Parallel1.split[1]) annotation (Line(points={{
-              -63,-30},{-134.375,-30},{-134.375,-25}}));
+      connect(Step12.inPort[1], Parallel1.split[1]) annotation (Line(points={{-81,-30},
+              {-182.925,-30},{-182.925,-50}}));
       connect(Step12.outPort[1], Transition12.inPort)
-        annotation (Line(points={{-41.5,-30},{-26,-30}}));
-      connect(Transition12.outPort, Step13.inPort[1])
-        annotation (Line(points={{-20.5,-30},{-3,-30}}));
-      connect(Step13.outPort[1], Transition13.inPort)
-        annotation (Line(points={{18.5,-30},{34,-30}}));
+        annotation (Line(points={{-59.5,-30},{-44,-30}}));
+      connect(Transition12.outPort, Step13b.inPort[1])
+        annotation (Line(points={{-38.5,-30},{-21,-30}}));
       connect(Transition13.outPort, Step14.inPort[1])
-        annotation (Line(points={{39.5,-30},{57,-30}}));
-      connect(Step14.outPort[1], Parallel1.join[1]) annotation (Line(points={{78.5,
-              -30},{152.375,-30},{152.375,-25}}));
-      connect(Step7.inPort[1], Parallel1.split[2]) annotation (Line(points={{
-              -123,-70},{-138,-70},{-138,-75},{-134.375,-75}}));
-      connect(Step7.outPort[1], Transition8.inPort) annotation (Line(points={{
-              -101.5,-70},{-86,-70}}));
+        annotation (Line(points={{81.5,-30},{99,-30}}));
+      connect(Step14.outPort[1], Parallel1.join[1]) annotation (Line(points={{120.5,
+              -30},{168.925,-30},{168.925,-50}}));
+      connect(Step7.inPort[1], Parallel1.split[2]) annotation (Line(points={{-167,-70},
+              {-182,-70},{-182,-50},{-182.925,-50}}));
+      connect(Step7.outPort[1], Transition8.inPort) annotation (Line(points={{-145.5,
+              -70},{-132,-70}}));
       connect(Transition8.outPort, Step8.inPort[1])
-        annotation (Line(points={{-80.5,-70},{-63,-70}}));
+        annotation (Line(points={{-126.5,-70},{-111,-70}}));
       connect(Step8.outPort[1], Transition9.inPort)
-        annotation (Line(points={{-41.5,-70},{-26,-70}}));
+        annotation (Line(points={{-89.5,-70},{-76,-70}}));
       connect(Transition9.outPort, Step9.inPort[1])
-        annotation (Line(points={{-20.5,-70},{-3,-70}}));
+        annotation (Line(points={{-70.5,-70},{-55,-70}}));
       connect(Step9.outPort[1], Transition10.inPort)
-        annotation (Line(points={{18.5,-70},{34,-70}}));
-      connect(Transition10.outPort, Step10.inPort[1])
-        annotation (Line(points={{39.5,-70},{57,-70}}));
+        annotation (Line(points={{-33.5,-70},{-18,-70}}));
       connect(Step10.outPort[1], Transition11.inPort)
-        annotation (Line(points={{78.5,-70},{94,-70}}));
+        annotation (Line(points={{96.5,-70},{112,-70}}));
       connect(Transition11.outPort, Step11.inPort[1])
-        annotation (Line(points={{99.5,-70},{117,-70}}));
-      connect(Step11.outPort[1], Parallel1.join[2]) annotation (Line(points={{138.5,
-              -70},{154,-70},{154,-75},{152.375,-75}}));
-      connect(Transition7.outPort, Parallel1.inPort) annotation (Line(points={{
-              -78.5,40},{-40,40},{-40,20},{-190,20},{-190,-50},{-181.55,-50}}));
+        annotation (Line(points={{117.5,-70},{133,-70}}));
+      connect(Step11.outPort[1], Parallel1.join[2]) annotation (Line(points={{154.5,
+              -70},{174,-70},{174,-50},{168.925,-50}}));
+      connect(Transition7.outPort, Parallel1.inPort) annotation (Line(points={{-78.5,
+              40},{-38,40},{-38,10},{-252,10},{-252,-50},{-240.81,-50}}));
       connect(TransitionWithSignal1.inPort, Parallel1.outPort) annotation (Line(
-            points={{2,-150},{208,-150},{208,-50},{197.7,-50}}));
+            points={{2,-150},{238,-150},{238,-50},{224.54,-50}}));
       connect(TransitionWithSignal1.outPort, InitialStep1.inPort[1]) annotation (Line(
-            points={{-3.5,-150},{-194,-150},{-194,100},{-181,100}}));
+            points={{-3.5,-150},{-270,-150},{-270,100},{-181,100}}));
       connect(BooleanExpression1.y, TransitionWithSignal1.condition) annotation (Line(
             points={{-13.7,-132},{-2,-132},{-2,-138}}, color={255,0,255}));
+      connect(Step13b.outPort[1], Transition13b.inPort)
+        annotation (Line(points={{0.5,-30},{16,-30}}, color={0,0,0}));
+      connect(Transition13b.outPort, Step13.inPort[1])
+        annotation (Line(points={{21.5,-30},{39,-30}}, color={0,0,0}));
+      connect(Step13.outPort[1], Transition13.inPort)
+        annotation (Line(points={{60.5,-30},{76,-30}}, color={0,0,0}));
+      connect(Transition10.outPort, Step10b.inPort[1])
+        annotation (Line(points={{-12.5,-70},{9,-70}}, color={0,0,0}));
+      connect(Step10b.outPort[1], Transition10b.inPort)
+        annotation (Line(points={{30.5,-70},{48,-70}}, color={0,0,0}));
+      connect(Transition10b.outPort, Step10.inPort[1])
+        annotation (Line(points={{53.5,-70},{75,-70}}, color={0,0,0}));
       annotation (
         Icon(coordinateSystem(preserveAspectRatio=false, extent={{-200,-200},{
                 200,200}}), graphics={
@@ -1211,7 +1236,7 @@ Full steady state initialization is not supported, because the corresponding ini
               points={{-24,10},{0,0},{-24,-10},{-24,10}},
               fillPattern=FillPattern.Solid)}),
             Diagram(coordinateSystem(
-              preserveAspectRatio=false, extent={{-200,-160},{200,160}})));
+              preserveAspectRatio=false, extent={{-320,-180},{260,180}})));
     end Controller;
 
     package ControllerUtilities

--- a/Modelica/Fluid/Examples/AST_BatchPlant.mo
+++ b/Modelica/Fluid/Examples/AST_BatchPlant.mo
@@ -28,18 +28,20 @@ package AST_BatchPlant
           Modelica.Fluid.Vessels.BaseClasses.HeatTransfer.IdealHeatTransfer (k=
               4.9))
       annotation (Placement(transformation(extent={{-110,-60},{-30,-20}})));
-    Modelica.Fluid.Valves.ValveDiscrete V12(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V12(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
-      dp_nominal = 100)
+      dp_nominal = 100,
+      Topen = 0.1)
       annotation (Placement(transformation(
           origin={-90,2},
           extent={{-10,-10},{10,10}},
           rotation=90)));
-    Modelica.Fluid.Valves.ValveDiscrete V15(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V15(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
-      dp_nominal = 100)
+      dp_nominal = 100,
+      Topen = 0.1)
       annotation (Placement(transformation(
           origin={-90,-82},
           extent={{10,-10},{-10,10}},
@@ -61,42 +63,48 @@ package AST_BatchPlant
         waitTime=300)) annotation (Placement(transformation(extent={{60,38},
               {100,78}})));
 
-    Modelica.Fluid.Valves.ValveDiscrete V11(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V11(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
-      dp_nominal = 100)
+      dp_nominal = 100,
+      Topen = 0.1)
       annotation (Placement(transformation(extent={{-50,80},{-70,100}})));
-    Modelica.Fluid.Valves.ValveDiscrete V8(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V8(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
-      dp_nominal = 100)
+      dp_nominal = 100,
+      Topen = 0.1)
       annotation (Placement(transformation(
           origin={-90,160},
           extent={{10,-10},{-10,10}},
           rotation=90)));
-    Modelica.Fluid.Valves.ValveDiscrete V9(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V9(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
-      dp_nominal = 100)
+      dp_nominal = 100,
+      Topen = 0.1)
       annotation (Placement(transformation(
           origin={70,160},
           extent={{10,10},{-10,-10}},
           rotation=90)));
-    Modelica.Fluid.Valves.ValveDiscrete V2(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V2(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
-      dp_nominal = 100)
+      dp_nominal = 100,
+      Topen = 0.1)
       annotation (Placement(transformation(extent={{-60,230},{-40,250}})));
-    Modelica.Fluid.Valves.ValveDiscrete V4(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V4(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
-      dp_nominal = 100)
+      dp_nominal = 100,
+      Topen = 0.1)
       annotation (Placement(transformation(extent={{40,230},{20,250}})));
-    Modelica.Fluid.Valves.ValveDiscrete V3(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V3(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
       opening_min = 1e-5,
-      dp_nominal = 100)
+      dp_nominal = 100,
+      Topen = 0.1)
       annotation (Placement(transformation(extent={{-150,210},{-130,230}})));
     Fittings.TeeJunctionIdeal volume2(
       redeclare package Medium = BatchMedium)
@@ -104,11 +112,12 @@ package AST_BatchPlant
           origin={-180,220},
           extent={{-10,10},{10,-10}},
           rotation=90)));
-    Modelica.Fluid.Valves.ValveDiscrete V6(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V6(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
       opening_min = 1e-5,
-      dp_nominal = 100)
+      dp_nominal = 100,
+      Topen = 0.1)
       annotation (Placement(transformation(extent={{130,210},{110,230}})));
     Fittings.TeeJunctionIdeal volume8(
       redeclare package Medium = BatchMedium)
@@ -116,82 +125,92 @@ package AST_BatchPlant
           origin={160,220},
           extent={{-10,-10},{10,10}},
           rotation=90)));
-    Modelica.Fluid.Valves.ValveDiscrete V23(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V23(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
-      dp_nominal = 100)
+      dp_nominal = 100,
+      Topen = 0.1)
       annotation (Placement(transformation(
           origin={-110,-250},
           extent={{-10,10},{10,-10}},
           rotation=180)));
-    Modelica.Fluid.Valves.ValveDiscrete V1(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V1(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 0.1,
-      dp_nominal = 1000)
+      dp_nominal = 1000,
+      Topen = 0.1)
       annotation (Placement(transformation(
           origin={-180,110},
           extent={{-10,10},{10,-10}},
           rotation=90)));
-    Modelica.Fluid.Valves.ValveDiscrete V22(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V22(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 0.1,
-      dp_nominal = 1000)
+      dp_nominal = 1000,
+      Topen = 0.1)
       annotation (Placement(transformation(
           origin={-180,-170},
           extent={{-10,10},{10,-10}},
           rotation=90)));
-    Modelica.Fluid.Valves.ValveDiscrete V5(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V5(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 0.1,
-      dp_nominal = 1000)
+      dp_nominal = 1000,
+      Topen = 0.1)
       annotation (Placement(transformation(
           origin={160,110},
           extent={{10,-10},{-10,10}},
           rotation=270)));
-    Modelica.Fluid.Valves.ValveDiscrete V24(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V24(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
-      dp_nominal = 100)
+      dp_nominal = 100,
+      Topen = 0.1)
       annotation (Placement(transformation(
           origin={90,-250},
           extent={{10,10},{-10,-10}},
           rotation=180)));
-    Modelica.Fluid.Valves.ValveDiscrete V25(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V25(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 0.1,
-      dp_nominal = 1000)
+      dp_nominal = 1000,
+      Topen = 0.1)
       annotation (Placement(transformation(
           origin={160,-170},
           extent={{10,-10},{-10,10}},
           rotation=270)));
-    Modelica.Fluid.Valves.ValveDiscrete V20(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V20(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
-      dp_nominal = 100)
+      dp_nominal = 100,
+      Topen = 0.1)
       annotation (Placement(transformation(
           origin={60,-210},
           extent={{10,10},{-10,-10}},
           rotation=90)));
-    Modelica.Fluid.Valves.ValveDiscrete V19(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V19(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
-      dp_nominal = 100)
+      dp_nominal = 100,
+      Topen = 0.1)
       annotation (Placement(transformation(
           origin={10,-200},
           extent={{-10,10},{10,-10}},
           rotation=180)));
-    Modelica.Fluid.Valves.ValveDiscrete V10(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V10(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
-      dp_nominal = 100)
+      dp_nominal = 100,
+      Topen = 0.1)
       annotation (Placement(transformation(
           origin={-21,-170},
           extent={{10,10},{-10,-10}},
           rotation=90)));
-    Modelica.Fluid.Valves.ValveDiscrete V21(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V21(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
-      dp_nominal = 100)
+      dp_nominal = 100,
+      Topen = 0.1)
       annotation (Placement(transformation(
           origin={30,-250},
           extent={{10,10},{-10,-10}},
@@ -199,10 +218,11 @@ package AST_BatchPlant
     Modelica.Fluid.Fittings.TeeJunctionVolume volume5(
       redeclare package Medium = BatchMedium,
       V=0.001) annotation (Placement(transformation(extent={{50,-260},{70,-240}})));
-    Modelica.Fluid.Valves.ValveDiscrete V18(
+    Modelica.Fluid.Valves.ValveDiscreteRamp V18(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
-      dp_nominal = 100)
+      dp_nominal = 100,
+      Topen = 0.1)
       annotation (Placement(transformation(
           origin={-50,-200},
           extent={{10,10},{-10,-10}},
@@ -256,10 +276,10 @@ package AST_BatchPlant
     inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial, dp_small=1000)
                           annotation (Placement(transformation(extent={{180,250},
               {200,270}})));
-    Modelica.Blocks.Logical.TriggeredTrapezoid P1_on(rising=0,
+    Modelica.Blocks.Logical.TriggeredTrapezoid P1_on(rising=0.3,
         amplitude=200)
       annotation (Placement(transformation(extent={{-122,-230},{-142,-210}})));
-    Modelica.Blocks.Logical.TriggeredTrapezoid P2_on(rising=0,
+    Modelica.Blocks.Logical.TriggeredTrapezoid P2_on(rising=0.3,
         amplitude=200)
       annotation (Placement(transformation(extent={{100,-230},{120,-210}})));
     Modelica.Fluid.Examples.AST_BatchPlant.BaseClasses.TankWithTopPorts B2(

--- a/Modelica/Fluid/Examples/AST_BatchPlant.mo
+++ b/Modelica/Fluid/Examples/AST_BatchPlant.mo
@@ -102,7 +102,6 @@ package AST_BatchPlant
     Modelica.Fluid.Valves.ValveDiscreteRamp V3(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
-      opening_min = 1e-5,
       dp_nominal = 100,
       Topen = 0.1)
       annotation (Placement(transformation(extent={{-150,210},{-130,230}})));
@@ -115,7 +114,6 @@ package AST_BatchPlant
     Modelica.Fluid.Valves.ValveDiscreteRamp V6(
       redeclare package Medium = BatchMedium,
       m_flow_nominal = 1,
-      opening_min = 1e-5,
       dp_nominal = 100,
       Topen = 0.1)
       annotation (Placement(transformation(extent={{130,210},{110,230}})));

--- a/Modelica/Fluid/Valves.mo
+++ b/Modelica/Fluid/Valves.mo
@@ -412,6 +412,79 @@ it is open.
 </html>"));
   end ValveDiscrete;
 
+  model ValveDiscreteRamp
+    "Valve for water/steam flows with discrete opening signal and ramp opening"
+    extends Modelica.Fluid.Interfaces.PartialTwoPortTransport;
+    parameter SI.AbsolutePressure dp_nominal
+      "Nominal pressure drop at full opening"
+      annotation(Dialog(group="Nominal operating point"));
+    parameter Medium.MassFlowRate m_flow_nominal
+      "Nominal mass flowrate at full opening";
+    parameter Real opening_min(min=0)=0
+      "Remaining opening if closed, causing small leakage flow";
+    final parameter Types.HydraulicConductance k = m_flow_nominal/dp_nominal
+      "Hydraulic conductance at full opening";
+    parameter SI.Time Topen "Time to fully open the valve";
+    parameter SI.Time Tclose = Topen "Time to fully close the valve";
+
+    Modelica.Blocks.Interfaces.BooleanInput open
+    annotation (Placement(transformation(
+          origin={0,80},
+          extent={{-20,-20},{20,20}},
+          rotation=270)));
+    Blocks.Logical.TriggeredTrapezoid openingGenerator(
+      amplitude=1 - opening_min,                       rising=Topen, falling=
+          Tclose,
+      offset=opening_min)
+                  annotation (Placement(transformation(
+          extent={{-10,-10},{10,10}},
+          rotation=-90,
+          origin={0,30})));
+
+
+
+  equation
+    m_flow = openingGenerator.y*k*dp;
+
+    // Isenthalpic state transformation (no storage and no loss of energy)
+    port_a.h_outflow = inStream(port_b.h_outflow);
+    port_b.h_outflow = inStream(port_a.h_outflow);
+    connect(open, openingGenerator.u) annotation (Line(points={{0,80},{0,42},{2.22045e-15,
+            42}}, color={255,0,255}));
+    annotation (Placement(transformation(
+          origin={0,90},
+          extent={{-20,-20},{20,20}},
+          rotation=270), iconTransformation(
+          extent={{-20,-20},{20,20}},
+          rotation=270,
+          origin={0,80})),
+    Icon(coordinateSystem(
+          preserveAspectRatio=false,
+          extent={{-100,-100},{100,100}}), graphics={
+          Line(points={{0,50},{0,0}}),
+          Rectangle(
+            extent={{-20,60},{20,50}},
+            fillPattern=FillPattern.Solid),
+          Polygon(
+            points={{-100,50},{100,-50},{100,50},{0,0},{-100,-50},{-100,50}},
+            fillColor=DynamicSelect({255,255,255}, if open then {0,255,0} else {255,255,255}),
+            fillPattern=FillPattern.Solid)}),
+    Documentation(info="<html>
+<p>
+This model is similar to <a href=\"modelica://Modelica.Fluid.Valves.ValveDiscrete\">ValveDiscrete</a>,
+except that the valve opens gradually with an opening time <code>Topen</code> and closes gradually with
+a closing time <code>Tclose</code> instead of doing so abruptly. This can help to avoid unrealistic phenomena such
+as reversing flows when accurate fluid models with small compressiblity are employed.
+</p>
+</html>",
+      revisions="<html>
+<ul>
+<li><em>Mar 2020</em>
+    by Francesco Casella (based on ValveLinear and ValveDiscrete).</li>
+</ul>
+</html>"));
+  end ValveDiscreteRamp;
+
   package BaseClasses
     "Base classes used in the Valves package (only of interest to build new component models)"
     extends Modelica.Icons.BasesPackage;


### PR DESCRIPTION
This PR improves the controller of AST_BatchPlant by adding a suitable delay between the activation of the pumps and valves upstream V3 and V6 and their actual opening. This is more realistic, as it allows the pressure to stabilize, and it avoids a very short, but quite large, unrealistic backflow through those valves.

A bit of backflow is still present, but that cannot be eliminated unless the valve opening is a ramp and is not governed by a boolean signal.

This PR fixes #2686 