### PR TITLE
Fix icons of QuasiStatic.SinglePhase and QuasiStatic.Polyphase

### DIFF
--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/Capacitor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/Capacitor.mo
@@ -20,10 +20,11 @@ equation
           textColor={0,0,255}),
         Line(
           points={{-6,28},{-6,-28}},
-          color={0,128,255}),
+          color={85,170,255}),
         Line(
           points={{6,28},{6,-28}},
-          color={0,128,255}),Line(points={{-90,0},{-6,0}}, color={85,170,255}),
+          color={85,170,255}),
+                             Line(points={{-90,0},{-6,0}}, color={85,170,255}),
           Line(points={{6,0},{90,0}}, color={85,170,255})}), Documentation(info="<html>
 <p>
 The linear capacitor connects the complex currents <code><u>i</u></code> with the complex

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/Inductor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/Inductor.mo
@@ -19,19 +19,19 @@ equation
               textString="m=%m"),
         Line(
           points={{-60,0},{-59,6},{-52,14},{-38,14},{-31,6},{-30,0}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{-30,0},{-29,6},{-22,14},{-8,14},{-1,6},{0,0}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{0,0},{1,6},{8,14},{22,14},{29,6},{30,0}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{30,0},{31,6},{38,14},{52,14},{59,6},{60,0}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Text(
           extent={{-150,90},{150,50}},

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/MutualInductor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/MutualInductor.mo
@@ -33,40 +33,38 @@ v[m] = j*omega*L[m,1]*i[1] + j*omega*L[m,2]*i[2] + ... + j*omega*L[m,m]*i[m]
         Line(points={{80,20},{80,-20},{60,-20}}, color={85,170,255}),
         Line(points={{-90,0},{-80,0}}, color={85,170,255}),
         Line(points={{80,0},{90,0}}, color={85,170,255}),
-        Text(
-          extent={{-150,-80},{150,-40}},
-          textString="m=%m"),
+        Text(extent={{-150,-80},{150,-40}}, textString="m=%m"),
         Line(
           points={{-60,20},{-59,26},{-52,34},{-38,34},{-31,26},{-30,20}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{-30,20},{-29,26},{-22,34},{-8,34},{-1,26},{0,20}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{0,20},{1,26},{8,34},{22,34},{29,26},{30,20}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{30,20},{31,26},{38,34},{52,34},{59,26},{60,20}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{-60,-20},{-59,-26},{-52,-34},{-38,-34},{-31,-26},{-30,-20}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{-30,-20},{-29,-26},{-22,-34},{-8,-34},{-1,-26},{0,-20}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{0,-20},{1,-26},{8,-34},{22,-34},{29,-26},{30,-20}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{30,-20},{31,-26},{38,-34},{52,-34},{59,-26},{60,-20}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Text(
           extent={{-150,90},{150,50}},

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/VariableCapacitor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/VariableCapacitor.mo
@@ -23,10 +23,10 @@ equation
           Line(points={{6,0},{90,0}}, color={85,170,255}),
         Line(
           points={{-6,28},{-6,-28}},
-          color={0,128,255}),
+          color={85,170,255}),
         Line(
           points={{6,28},{6,-28}},
-          color={0,128,255}),
+          color={85,170,255}),
         Text(
           extent={{-150,90},{150,50}},
               textString="%name",

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/VariableInductor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/VariableInductor.mo
@@ -22,19 +22,19 @@ equation
           color={85,170,255}),Line(points={{-90,0},{-60,0}}, color={85,170,255}),
         Line(
           points={{-60,0},{-59,6},{-52,14},{-38,14},{-31,6},{-30,0}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{-30,0},{-29,6},{-22,14},{-8,14},{-1,6},{0,0}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{0,0},{1,6},{8,14},{22,14},{29,6},{30,0}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{30,0},{31,6},{38,14},{52,14},{59,6},{60,0}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Text(
           extent={{-150,90},{150,50}},

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Ideal/IdealIntermediateSwitch.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Ideal/IdealIntermediateSwitch.mo
@@ -65,7 +65,7 @@ equation
       points={{-10,4},{-10,60},{-78,60}}, color={85,170,255}));
   annotation (defaultComponentName="switch", Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
             -100},{100,100}}), graphics={
-                               Ellipse(extent={{-4,14},{4,6}},  lineColor={
+                               Ellipse(extent={{-4,24},{4,16}}, lineColor={
           85,170,255}),Line(points={{-90,0},{-40,0}}, color={85,170,255}),
           Line(points={{-90,40},{-40,40}}, color={85,170,255}),Line(points={{-40,0},{40,40}},
                              color={85,170,255}),Line(points={{-40,40},{40,0}},

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Interfaces/ReferenceSource.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Interfaces/ReferenceSource.mo
@@ -16,7 +16,7 @@ equation
           extent={{160,-100},{-160,-60}},
           textString="m=%m"),
                            Text(
-              extent={{-160,60},{160,100}},
+              extent={{-150,60},{150,100}},
               textString="%name",
               textColor={0,0,255})}), Documentation(info="<html>
 <p>

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Interfaces/RelativeSensorElementary.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Interfaces/RelativeSensorElementary.mo
@@ -11,7 +11,7 @@ partial model RelativeSensorElementary "Elementary partial voltage / current sen
           textString="m=%m"),
         Text(
           textColor={0,0,255},
-          extent={{-150,90},{150,130}},
+          extent={{-150,80},{150,120}},
           textString="%name")}), Documentation(info="<html>
 <p>
 The relative sensor partial model relies on the

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Interfaces/Source.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Interfaces/Source.mo
@@ -17,7 +17,7 @@ equation
           extent={{160,-100},{-160,-60}},
           textString="m=%m"),
                            Text(
-              extent={{-160,60},{160,100}},
+              extent={{-150,60},{150,100}},
               textString="%name",
               textColor={0,0,255})}),
     Documentation(info="<html>

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/CurrentQuasiRMSSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/CurrentQuasiRMSSensor.mo
@@ -34,10 +34,7 @@ equation
   annotation (defaultComponentName="currentRMSSensor",
     Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
             100,100}}), graphics={
-        Line(points={{0,-70},{0,-100}}, color={85,170,255}),
-        Text(
-          extent={{150,-100},{-150,-70}},
-          textString="m=%m"),
+        Line(points={{0,-70},{0,-100}}, color={0,0,127}),
         Text(
           extent={{-30,-10},{30,-70}},
           textColor={64,64,64},

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/VoltageQuasiRMSSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sensors/VoltageQuasiRMSSensor.mo
@@ -34,7 +34,7 @@ equation
         Text(
           extent={{150,-100},{-150,-70}},
           textString="m=%m"),
-        Line(points={{0,-70},{0,-100}}, color={85,170,255}),
+        Line(points={{0,-70},{0,-100}}, color={0,0,127}),
         Text(
           extent={{-30,-10},{30,-70}},
           textColor={64,64,64},

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sources/VariableCurrentSource.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sources/VariableCurrentSource.mo
@@ -16,7 +16,7 @@ model VariableCurrentSource "Variable polyphase AC current"
         rotation=270), iconTransformation(
         extent={{-20,-20},{20,20}},
         rotation=270,
-        origin={-62,120})));
+        origin={-60,120})));
 equation
   omega = 2*Modelica.Constants.pi*f;
   i = I;

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/Inductor.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/Inductor.mo
@@ -11,19 +11,19 @@ equation
         Text(extent={{150,-40},{-150,-80}}, textString="L=%L"),
         Line(
           points={{-60,0},{-59,6},{-52,14},{-38,14},{-31,6},{-30,0}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{-30,0},{-29,6},{-22,14},{-8,14},{-1,6},{0,0}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{0,0},{1,6},{8,14},{22,14},{29,6},{30,0}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{30,0},{31,6},{38,14},{52,14},{59,6},{60,0}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Text(
           extent={{-150,90},{150,50}},

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/VariableCapacitor.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/VariableCapacitor.mo
@@ -22,10 +22,10 @@ equation
           textColor={0,0,255}),
         Line(
           points={{-6,28},{-6,-28}},
-          color={0,128,255}),
+          color={85,170,255}),
         Line(
           points={{6,28},{6,-28}},
-          color={0,128,255})}),
+          color={85,170,255})}),
     Documentation(info="<html>
 
 <p>

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/VariableInductor.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/VariableInductor.mo
@@ -18,19 +18,19 @@ equation
         Line(points={{-90,0},{-60,0}}, color={85,170,255}),
         Line(
           points={{-60,0},{-59,6},{-52,14},{-38,14},{-31,6},{-30,0}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{-30,0},{-29,6},{-22,14},{-8,14},{-1,6},{0,0}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{0,0},{1,6},{8,14},{22,14},{29,6},{30,0}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Line(
           points={{30,0},{31,6},{38,14},{52,14},{59,6},{60,0}},
-          color={0,128,255},
+          color={85,170,255},
           smooth=Smooth.Bezier),
         Text(
           extent={{-150,90},{150,50}},


### PR DESCRIPTION
Resolves #3354

This fix includes

- location of `%name`
- redundant `%m`
- color of icons to match domain color
- color of `%m`
- location of slightly displaced connectors (most likely accidentally caused in previous commits)
