### PR TITLE
Fix unconsidered change of parameter c_usefulFlux from default to start

### DIFF
--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -255,6 +255,10 @@ convertClass("Modelica.Magnetic.FluxTubes.Interfaces.PartialGenericHysteresis",
               "Modelica.Magnetic.FluxTubes.BaseClasses.GenericHysteresis")
 convertClass("Modelica.Magnetic.FluxTubes.Interfaces.PartialGenericHysteresisTellinen",
               "Modelica.Magnetic.FluxTubes.BaseClasses.GenericHysteresisTellinen")
+// Issues #3300, #3424              
+convertModifiers({"Modelica.Magnetic.FluxTubes.Basic.LeakageWithCoefficient",
+                  "Modelica.Magnetic.QuasiStatic.FluxTubes.Basic.LeakageWithCoefficient"},
+                  fill("",0), {"c_usefulFlux=0.7"})
 convertClass("Modelica.Thermal.FluidHeatFlow.Components.IsolatedPipe",
               "Modelica.Thermal.FluidHeatFlow.Components.Pipe")
 convertClass("Modelica.Thermal.FluidHeatFlow.Components.HeatedPipe",

--- a/ModelicaTestConversion4.mo
+++ b/ModelicaTestConversion4.mo
@@ -1361,6 +1361,40 @@ Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrar
 </p>
 </html>"));
       end Issue496;
+
+      model Issue3300 "Conversion test for #3300"
+        extends Modelica.Icons.Example;
+        parameter Modelica.SIunits.Reluctance R_m = 1 "Reluctance";
+
+        Modelica.Magnetic.FluxTubes.Basic.Ground ground annotation (Placement(transformation(extent={{-50,-40},{-30,-20}})));
+        Modelica.Magnetic.FluxTubes.Sources.ConstantMagneticPotentialDifference magVoltageSource(V_m=1)
+          annotation (Placement(transformation(
+              extent={{-10,-10},{10,10}},
+              rotation=270,
+              origin={-40,10})));
+        Modelica.Magnetic.FluxTubes.Basic.LeakageWithCoefficient leakage1(R_mUsefulTot=R_m)
+          annotation (Placement(transformation(
+              extent={{-10,-10},{10,10}},
+              rotation=270,
+              origin={0,10})));
+        Modelica.Magnetic.FluxTubes.Basic.LeakageWithCoefficient leakage2(c_usefulFlux=0.5, R_mUsefulTot=R_m)
+          annotation (Placement(transformation(
+              extent={{-10,-10},{10,10}},
+              rotation=270,
+              origin={30,10})));
+      equation
+        assert(leakage1.c_usefulFlux <> leakage2.c_usefulFlux, "Parameter c_usefulFlux must not be equal to 0.7: conversion failed");
+        connect(magVoltageSource.port_n, ground.port) annotation (Line(points={{-40,-3.55271e-15},{-40,-20}}, color={255,127,0}));
+        connect(ground.port, leakage1.port_n) annotation (Line(points={{-40,-20},{-40,-10},{0,-10},{0,-3.55271e-15}}, color={255,127,0}));
+        connect(ground.port, leakage2.port_n) annotation (Line(points={{-40,-20},{-40,-10},{30,-10},{30,0}}, color={255,127,0}));
+        connect(magVoltageSource.port_p, leakage1.port_p) annotation (Line(points={{-40,20},{-40,30},{0,30},{0,20}}, color={255,127,0}));
+        connect(magVoltageSource.port_p, leakage2.port_p) annotation (Line(points={{-40,20},{-40,30},{30,30},{30,20}}, color={255,127,0}));
+        annotation(experiment(StopTime=1), Documentation(info="<html>
+<p>
+Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/3300\">#3300</a>.
+</p>
+</html>"));
+      end Issue3300;
     end FluxTubes;
 
     package FundamentalWave


### PR DESCRIPTION
Fixes #3300
Refs #3424

@beutlich: I suppose there is some scheme on how the conversion script commands are sorted and arranged in `ConvertModelica_from_3.2.3_to_4.0.0.mos`, respectively. I hope you agree with on where I put the code.

I also added a test model to `ModelicaTestConversion4.mo` to test both cases: with and without default parameter. Both cases are converted OK. 