### PR TITLE
Add synchronous language elements to ModelicaReference

### DIFF
--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -2940,6 +2940,31 @@ The atan2 function can also be accessed as Modelica.Math.atan2.
  = 1.5707963267949</pre></blockquote>
 </html>"));
   end 'atan2()';
+  
+  class 'backSample()' "backSample()"
+  extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+Shifts a clocked expressions to undo a delay as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>backSample</strong>(u, shiftCounter, resolution)<pre></blockquote>
+<h4>Examples</h4>
+<blockquote><pre>
+  
+  Real x=sample(time, u); 
+  // Ticks at 0, 3/10, 6/10 with values corresponding to time
+  
+  Real x2=shiftSample(x, 1, 3); 
+  // Ticks at 1/10 with value 0/10, and at 4/10 with value 3/10 etc
+  
+  Real x3=backSample(x2, 1, 3);
+  // Same as x.
+</pre></blockquote>
+<p>
+</p>
+</html>"));
+  end 'backSample()';  
 
   class 'cardinality()' "cardinality()"
     extends ModelicaReference.Icons.Information;
@@ -3066,6 +3091,47 @@ The same restrictions as for the pre() operator apply.</p>
 <img src=\"modelica://ModelicaReference/Resources/Images/change.png\" width=\"400\" height=\"280\" alt=\"Simulation result\">
 </html>"));
   end 'change()';
+  
+  class 'Clock()' "Clock()"
+  extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+Generates clocks as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
+</p>
+<h4>Examples</h4>
+<blockquote><pre>
+  Clock c=Clock(2, 1000); // Defines a clock variable
+  Real interval1(start=2e-3);
+equation
+  when Clock() then
+    // Inferred Clock
+    x=A*previous(x)+B*u;
+  end when;   
+  when Clock(2,1000) then      
+    // periodic clock that ticks at 0, 0.002, 0.004, ...      
+    // Could also use when c then
+    y1 = previous(y1) + 1;   
+  end when; 
+  when Clock(interval1) then
+    // Clock with a Real interval
+    // The clock starts at the start of the simulation, tstart, or when the controller is switched on.
+    // Here the next clock tick is scheduled at previous(interval1)=interval1.start=2e-3
+    // At the second clock tick at tstart+interval1.start the next clock tick is scheduled at
+    // previous(interval1)=5e-3
+    interval1=previous(interval1)+3e-3;
+  end when;
+  when Clock(angle>0, 0.1) then      
+    // clock with a boolean interval, triggers when angle>0 becomes true.
+    y2 = previous(y2) + 1;   
+  end when; 
+  when Clock(c, \"ImplicitTrapezoid\") then
+    // Solver Clock
+    // Ticks at the same rate as c but uses the ImplicitTrapezoid method to solve the differential equations
+    der(x)=x;
+  end when;
+</pre></blockquote>
+</html>"));
+  end 'Clock()';
 
   class 'connect()' "connect()"
     extends ModelicaReference.Icons.Information;
@@ -3582,6 +3648,22 @@ Boolean vb[3]   = fill(true,3);  // = {true, true, true}
 </pre></blockquote>
 </html>"));
   end 'fill()';
+  
+  class 'firstTick()' "firstTick()"
+  extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+Returns true for the first tick of the clock, part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>firstTick</strong>(u)<pre></blockquote>
+<h4>Description</h4>
+<p>
+This operator returns <strong>true</strong> at the first tick of the clock of the expression, in which this operator is called.
+The operator returns <strong>false</strong> at all subsequent ticks of the clock. The optional argument <strong>u</strong> is only used for clock inference.
+</p>
+</html>"));
+  end 'firstTick()';
 
   class 'floor()' "floor()"
     extends ModelicaReference.Icons.Information;
@@ -3601,6 +3683,25 @@ value changes discontinuously.]</em></p>
  = {-4.0, 3.0}</pre></blockquote>
 </html>"));
   end 'floor()';
+  
+  class 'hold()' "hold()"
+  extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+Returns a piecewise constant signal based ona  clocked variable as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>hold</strong>(u)<pre></blockquote>
+<h4>Description</h4>
+<p>
+Input argument <strong>u</strong> is a clocked Component Expression or a parameter expression. 
+The operator returns a piecewise constant signal of the same type of <strong>u</strong>. 
+When the clock of <strong>u</strong> ticks, the operator returns u and
+otherwise returns the value of <strong>u</strong> from the last clock activation. 
+Before the first clock activation of <strong>u</strong>, the operator returns the start value of <strong>u</strong>.
+</p>
+</html>"));
+  end 'hold()';  
 
   class 'homotopy()' "homotopy()"
     extends ModelicaReference.Icons.Information;
@@ -3995,6 +4096,22 @@ when the return value changes discontinuously.]</em></p>
  = {-4, 3}</pre></blockquote>
 </html>"));
   end 'integer()';
+  
+  class 'interval()' "interval()"
+  extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+Part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>interval</strong>(u)<pre></blockquote>
+<h4>Description</h4>
+<p>
+This operator returns the interval between the previous and present tick of the clock of the expression, in which this operator is called.
+The optional argument u is only used for clock inference.
+</p>
+</html>"));
+  end 'interval()';
 
   class 'linspace()' "linspace()"
     extends ModelicaReference.Icons.Information;
@@ -4190,7 +4307,24 @@ discontinuously.]</em></p>
  = -1.2</pre></blockquote>
 </html>"));
   end 'mod()';
-
+  
+  class 'noClock()' "noClock()"
+  extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+Part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>noClock</strong>(u)<pre></blockquote>
+<h4>Description</h4>
+<p>
+The clock of <strong>y = noClock(u)</strong> is always inferred. 
+At every tick of the clock of <strong>y</strong>, the operator returns the value of <strong>u</strong> from the last tick of the clock of <strong>u</strong>.
+If <strong>noClock(u)</strong> is called before the first tick of the clock of <strong>u</strong>, the start value of <strong>u</strong> is returned. 
+</p>
+</html>"));
+  end 'noClock()';
+  
   class 'ndims()' "ndims()"
     extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -4211,6 +4345,8 @@ Integer n = ndims(A);  // = 3
 </pre></blockquote>
 </html>"));
   end 'ndims()';
+  
+  
 
   class 'noEvent()' "noEvent()"
     extends ModelicaReference.Icons.Information;
@@ -4336,6 +4472,25 @@ for continuous-time variables inside when-clauses.
 <img src=\"modelica://ModelicaReference/Resources/Images/pre.png\" width=\"400\" height=\"280\" alt=\"Simulation result\">
 </html>"));
   end 'pre()';
+  
+  class 'previous()' "previous()"
+  extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+Gives the previous value of a clocked expression as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>previous</strong>(u)<pre></blockquote>
+<h4>Description</h4>
+<p>
+The return argument has the same type as the input argument. 
+Input and return arguments are on the same clock. 
+At the first tick of the clock of <strong>u</strong> or after a <a href=\"modelica://ModelicaReference.Operators.'transition()'\">reset transition</a>, 
+the start value of <strong>u</strong>  is returned. 
+At subsequent activations of the clock of <strong>u</strong>, the value of <strong>u</strong> from the previous clock activation is returned. 
+</p>
+</html>"));
+  end 'previous()';
 
   class 'product()' "product()"
     extends ModelicaReference.Icons.Information;
@@ -4494,6 +4649,28 @@ expressions and need to be a subtype of Real or Integer.
 <img src=\"modelica://ModelicaReference/Resources/Images/sample.png\" width=\"400\" height=\"280\" alt=\"Simulation result\">
 </html>"));
   end 'sample()';
+  
+    class 'sample()clocked' "sample() Clocked"
+  extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+Samples a value according to a clock as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>sample</strong>(u)<pre></blockquote>
+<blockquote><pre><strong>sample</strong>(u, c)<pre></blockquote>
+<h4>Description</h4>
+<p>
+ The operator returns a clocked variable that has c as associated clock and has the value of the
+ left limit of u when c is active (that is the value of u just before the event of c is triggered).
+ If argument c is not provided, it is inferred
+</p>
+<p> 
+The return argument has the same type as the first input argument. 
+The optional argument c is of type Clock.
+</p>
+</html>"));
+  end 'sample()clocked';
 
   class 'scalar()' "scalar()"
     extends ModelicaReference.Icons.Information;
@@ -4599,6 +4776,7 @@ flow direction.]</em>
 </html>"));
   end 'semiLinear()';
 
+
   class 'sign()' "sign()"
     extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -4617,6 +4795,33 @@ needs to be an Integer or Real expression.</p>
 </html>"));
   end 'sign()';
 
+  class 'shiftSample()' "shiftSample()"
+  extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+Shifts a clocked expressions to delay it as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>shiftSample</strong>(u, shiftCounter, resolution)<pre></blockquote>
+<h4>Examples</h4>
+<blockquote><pre>
+  Clock u  = Clock(3, 10);
+  // ticks: 0, 3/10, 6/10, .. 
+  
+  Clock y1 = shiftSample(u,1,3); 
+  // ticks: 1/10, 4/10, ... 
+  
+  Real x=sample(time, u); 
+  // Ticks at 0, 3/10, 6/10 with values corresponding to time
+  
+  Real x2=shiftSample(x, 1, 3); 
+  // Ticks at 1/10 with value 0/10, and at 4/10 with value 3/10 etc
+</pre></blockquote>
+<p>
+</p>
+</html>"));
+  end 'shiftSample()';  
+  
   class 'sin()' "sin()"
     extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -4854,6 +5059,24 @@ String(123, minimumLength=6, leftJustified=false)  // = \"   123\"
 </pre></blockquote>
 </html>"));
   end 'String()';
+  
+  class 'subSample()' "subSample()"
+  extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+Subsamples a clocked expressions as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>subSample</strong>(u, factor)<pre></blockquote>
+<h4>Description</h4>
+<p>
+The clock of <strong>y = subSample(u,factor)</strong> is <strong>factor</strong>-times slower than the clock of <strong>u</strong>. 
+At every <strong>factor</strong> ticks of the clock of <strong>u</strong>, the operator returns the value of <strong>u</strong>. 
+The first activation of the clock of <strong>y</strong> coincides with the first activation of the clock of <strong>u</strong>. 
+If argument <strong>factor</strong> is not provided or is equal to zero, it is inferred.
+</p>
+</html>"));
+  end 'subSample()';  
 
   class 'sum()' "sum()"
     extends ModelicaReference.Icons.Information;
@@ -4891,6 +5114,24 @@ u, ..., j <strong>in</strong> v) is the same as the type of e(i,...j).
 </pre></blockquote>
 </html>"));
   end 'sum()';
+  
+    class 'superSample()' "superSample()"
+  extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+Supersamples a clocked expressions as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>superSample</strong>(u, factor)<pre></blockquote>
+<h4>Description</h4>
+<p>
+The clock of <strong>y = superSample(u,factor)</strong> is <strong>factor</strong>-times faster than the clock of <strong>u</strong>. 
+At every tick of the clock of <strong>u</strong>, the operator returns the value of <strong>u</strong>. 
+The first activation of the clock of <strong>y</strong> coincides with the first activation of the clock of <strong>u</strong>. 
+If argument <strong>factor</strong> is not provided or is equal to zero, it is inferred.
+</p>
+</html>"));
+  end 'superSample()';  
 
   class 'symmetric()' "symmetric()"
     extends ModelicaReference.Icons.Information;
@@ -5056,7 +5297,7 @@ The <strong>from</strong> and <strong>to</strong> instances become states of a s
 The transition fires when <strong>condition = true</strong> if <strong>immediate = true</strong> (this is called an immediate transition) 
 or <strong>previous(condition)</strong> when <strong>immediate = false</strong> (this is called a delayed transition). 
 Argument <strong>priority</strong> defines the priority of firing when several transitions could fire. 
-In this case the transition with the smallest value of <strong>priority<strong> fires. 
+In this case the transition with the smallest value of <strong>priority</strong> fires. 
 It is required that priority is greater or equal to 1 and that for all transitions from the same state, the priorities are different. 
 If <strong>reset = true</strong>, the states of the target state are reinitialized, i.e. state machines are restarted in initial state and state variables are reset to their start values. If synchronize=true, any transition is disabled until all state machines of the from-state have reached final states, i.e. states without outgoing transitions.
 </p>

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -4017,8 +4017,7 @@ Additional equations need to be generated for the stream variables of outside co
 <p>
 Neglecting zero flow conditions, the above implicit equations can be
 analytically solved for the inStream(..) operators.
-The details are given in Section 15.2 of the
-<a href=\"https://www.modelica.org/documents/ModelicaSpec32Revision1.pdf\">Modelica Language Specification version 3.2 Revision 1</a>.
+The details are given in <a href=\"https://specification.modelica.org/v3.4/Ch15.html#stream-operator-instream-and-connection-equations\">Section 15.2 (Stream Operator inStream and Connection Equations) of the Modelica 3.4 specification</a>.
 The stream connection equations have singularities and/or multiple solutions if one or more
 of the flow variables become zero. When all the flows are zero, a singularity is always
 present, so it is necessary to approximate the solution in an open neighborhood
@@ -6799,8 +6798,7 @@ equation
 In this example we will start in <strong>increase</strong> and increase <strong>v</strong> until a limit, and then decrease it, and repeat.
 
 <h4>Description</h4>
-A detailed description of the State Machines using Synchronous Language Elements are given in Chapter 17 of the
-<a href=\"https://www.modelica.org/documents/ModelicaSpec34.pdf\">Modelica Language Specification version 3.4</a>.
+A detailed description of the State Machines using Synchronous Language Elements is given in <a href=\"https://specification.modelica.org/v3.4/Ch17.html\">Chapter 17 (State Machines) of the Modelica 3.4 specification</a>.
 </html>"));
 end StateMachines;
 
@@ -6943,8 +6941,9 @@ type_prefix :
 
 <p>
 A detailed description of the stream keyword and the inStream operator is given
-in Chapter 15 and Appendix D of the
-<a href=\"https://www.modelica.org/documents/ModelicaSpec32Revision1.pdf\">Modelica Language Specification version 3.2 Revision 1</a>.
+in <a href=\"https://specification.modelica.org/v3.4/Ch15.html\">Chapter 15 (Stream Connectors)</a>
+and <a href=\"https://specification.modelica.org/v3.4/A4.html\">Appendix D (Derivation of Stream Equations)</a>
+of the Modelica 3.4 specification.
 An overview and a rational is provided in a
 <a href=\"modelica://Modelica/Resources/Documentation/Fluid/Stream-Connectors-Overview-Rationale.pdf\">slide set</a>.
 </p>
@@ -7081,8 +7080,7 @@ In this example <strong>dc.xd</strong> and <strong>dc.ud</strong> are Clocked va
 At time instants where the associated clock is not active, the value of a clocked variable can be inquired by using an explicit cast operator, e.g., <strong>hold</strong>.
 
 <h4>Description</h4>
-A detailed description of the Synchronous Language Elements are given in Chapter 16 of the
-<a href=\"https://www.modelica.org/documents/ModelicaSpec34.pdf\">Modelica Language Specification version 3.4</a>.
+A detailed description of the Synchronous Language Elements is given in <a href=\"https://specification.modelica.org/v3.4/Ch16.html\">Chapter 16 (Synchronous Language Elements) of the Modelica 3.4 specification</a>.
 </html>"));
 end Synchronous;
 

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -3086,7 +3086,7 @@ The same restrictions as for the pre() operator apply.</p>
   end 'change()';
 
   class 'Clock()' "Clock()"
-  extends ModelicaReference.Icons.Information;
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 Generates clocks as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
@@ -3227,7 +3227,7 @@ connected as a pair of scalar connectors.</p>
   end 'connect()';
 
   class 'Connections.branch()' "Connections.branch()"
-      extends ModelicaReference.Icons.Information;
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 Defines <em>required</em> branch of spanning-tree
@@ -3256,7 +3256,7 @@ This definition shall be used if in a model with connectors <code>A</code> and <
   end 'Connections.branch()';
 
   class 'Connections.root()' "Connections.root()"
-      extends ModelicaReference.Icons.Information;
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 Defines a <em>definite</em> root node.
@@ -3279,7 +3279,7 @@ This definition shall be used if in a model with connector <code>A</code> the ov
   end 'Connections.root()';
 
   class 'Connections.potentialRoot()' "Connection.potentialRoot()"
-      extends ModelicaReference.Icons.Information;
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 Defines a <em>potential</em> root node.
@@ -3305,7 +3305,7 @@ This definition may  be used if in a model with connector <code>A</code> the ove
   end 'Connections.potentialRoot()';
 
   class 'Connections.isRoot()' "Connections.isRoot()"
-      extends ModelicaReference.Icons.Information;
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 Returns root status.
@@ -3323,7 +3323,7 @@ Returns true, if the overdetermined type or record instance <code>R</code> in co
   end 'Connections.isRoot()';
 
   class 'Connections.rooted()' "Connections.rooted()"
-      extends ModelicaReference.Icons.Information;
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 Returns which node of a connection branch is closer to root.
@@ -3643,7 +3643,7 @@ Boolean vb[3]   = fill(true,3);  // = {true, true, true}
   end 'fill()';
 
   class 'firstTick()' "firstTick()"
-  extends ModelicaReference.Icons.Information;
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 Returns true for the first tick of the clock, part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
@@ -3678,10 +3678,10 @@ value changes discontinuously.]</em></p>
   end 'floor()';
 
   class 'hold()' "hold()"
-  extends ModelicaReference.Icons.Information;
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
-Returns a piecewise constant signal based ona  clocked variable as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
+Returns a piecewise constant signal based on a clocked variable as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
 </p>
 <h4>Syntax</h4>
 <blockquote><pre><strong>hold</strong>(u)</pre></blockquote>
@@ -4091,7 +4091,7 @@ when the return value changes discontinuously.]</em></p>
   end 'integer()';
 
   class 'interval()' "interval()"
-  extends ModelicaReference.Icons.Information;
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 Part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
@@ -4214,7 +4214,6 @@ C[i_1, ..., i_nA, 1, ..., 1] = A[i_1, ..., i_nA].
 
   class 'max()' "max()"
     extends ModelicaReference.Icons.Information;
-
     annotation (Documentation(info="<html>
 <p>
 Returns the largest element
@@ -4323,7 +4322,7 @@ Integer n = ndims(A);  // = 3
   end 'ndims()';
 
   class 'noClock()' "noClock()"
-  extends ModelicaReference.Icons.Information;
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 Part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
@@ -4465,7 +4464,7 @@ for continuous-time variables inside when-clauses.
   end 'pre()';
 
   class 'previous()' "previous()"
-  extends ModelicaReference.Icons.Information;
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 Gives the previous value of a clocked expression as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
@@ -4641,8 +4640,8 @@ expressions and need to be a subtype of Real or Integer.
 </html>"));
   end 'sample()';
 
-    class 'sample()clocked' "sample() Clocked"
-  extends ModelicaReference.Icons.Information;
+  class 'sample()clocked' "sample() Clocked"
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 Samples a value according to a clock as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
@@ -4768,7 +4767,7 @@ flow direction.]</em>
   end 'semiLinear()';
 
   class 'shiftSample()' "shiftSample()"
-  extends ModelicaReference.Icons.Information;
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 Shifts a clocked expressions to delay it as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
@@ -5049,7 +5048,7 @@ String(123, minimumLength=6, leftJustified=false)  // = \"   123\"
   end 'String()';
 
   class 'subSample()' "subSample()"
-  extends ModelicaReference.Icons.Information;
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 Subsamples a clocked expressions as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
@@ -5103,8 +5102,8 @@ u, ..., j <strong>in</strong> v) is the same as the type of e(i,...j).
 </html>"));
   end 'sum()';
 
-    class 'superSample()' "superSample()"
-  extends ModelicaReference.Icons.Information;
+  class 'superSample()' "superSample()"
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 Supersamples a clocked expressions as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
@@ -5241,7 +5240,7 @@ end</strong> ThrowingBall;</pre></blockquote>
   end 'terminate()';
 
   class 'ticksInState()' "ticksInState()"
-extends ModelicaReference.Icons.Information;
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 This operator returns the number of ticks since a transition was made to the active state in a <a href=\"modelica://ModelicaReference.StateMachines\">state machine</a>.
@@ -5255,8 +5254,8 @@ Returns the number of ticks of the clock of the state machine since a transition
 </html>"));
   end 'ticksInState()';
 
-    class 'timeInState()' "timeInState()"
-extends ModelicaReference.Icons.Information;
+  class 'timeInState()' "timeInState()"
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 This operator returns the time (in seconds) since a transition was made to the active state in a <a href=\"modelica://ModelicaReference.StateMachines\">state machine</a>.
@@ -5271,7 +5270,7 @@ Returns the time duration as Real in [s] since a transition was made to the curr
   end 'timeInState()';
 
   class 'transition()' "transition()"
-extends ModelicaReference.Icons.Information;
+    extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
 <p>
 This operator defines a transition in a <a href=\"modelica://ModelicaReference.StateMachines\">state machine</a>.
@@ -6018,7 +6017,7 @@ another kind):</p>
   <td style=\"background-color:lightgray\">yes</td>
 </tr>
 <tr>
-  <td>exapandable<br>connector</td>
+  <td>expandable<br>connector</td>
   <td></td>
   <td></td>
   <td></td>

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -6466,7 +6466,7 @@ class StateMachines "State Machines"
   extends ModelicaReference.Icons.Information;
   annotation (Documentation(info="<html>
 <p>
-The state machines defined in the Modelica Language are based on the <a href=\"modelica://Synchronous\">synchronous language elements</a>.
+The state machines defined in the Modelica Language are based on the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
 Note that the state machines defined in the Modelica Standard Library are not based on this.
 </p>
 <h4>Examples</h4>
@@ -6745,11 +6745,11 @@ For further details, see the definition of the
 </html>"));
 end 'stream';
 
-class Synhronous "Synhronous Language Elements"
+class Synchronous "Synchronous Language Elements"
   extends ModelicaReference.Icons.Information;
   annotation (Documentation(info="<html>
 <p>
-Synhronous language elements are added to Modelica as an alternative to normal <a href=\"modelica://'when'\">when</a>-clauses to
+Synchronous language elements are added to Modelica as an alternative to normal <a href=\"modelica://ModelicaReference.'when'\">when</a>-clauses to
 making modeling of complex sampled systems safer and easier.
 </p>
 <h4>Examples</h4>
@@ -6777,7 +6777,7 @@ At time instants where the associated clock is not active, the value of a clocke
 A detailed description of the Synchronous Language Elements are given in Chapter 16 of the
 <a href=\"https://www.modelica.org/documents/ModelicaSpec34.pdf\">Modelica Language Specification version 3.4</a>.
 </html>"));
-end Synhronous;
+end Synchronous;
 
 class 'time' "time"
   extends ModelicaReference.Icons.Information;

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -2956,8 +2956,6 @@ Shifts a clocked expressions to undo a delay as part of the <a href=\"modelica:/
   Real x3=backSample(x2, 1, 3);
   // Same as x.
 </pre></blockquote>
-<p>
-</p>
 </html>"));
   end 'backSample()';
 
@@ -4791,8 +4789,6 @@ Shifts a clocked expressions to delay it as part of the <a href=\"modelica://Mod
   Real x2=shiftSample(x, 1, 3);
   // Ticks at 1/10 with value 0/10, and at 4/10 with value 3/10 etc
 </pre></blockquote>
-<p>
-</p>
 </html>"));
   end 'shiftSample()';
 

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -2714,7 +2714,24 @@ The acos function can also be accessed as Modelica.Math.acos.
  = 1.5707963267949</pre></blockquote>
 </html>"));
   end 'acos()';
-
+  
+    class 'activeState()' "activeState()"
+extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+This operator returns true if state is active in a <a href=\"modelica://ModelicaReference.StateMachines\">state machine</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>activeState</strong>(state)</pre></blockquote>
+<h4>Description</h4>
+<p>
+Argument <strong>state</strong> is a block instance. 
+The operator returns <strong>true</strong>, if this instance is a state of a state machine and this state is active at the actual clock tick. 
+If it is not active, the operator returns <strong>false</strong>.
+</p>
+</html>"));
+  end 'activeState()';
+  
   class 'actualStream()' "actualStream()"
     extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -3781,6 +3798,20 @@ True during initialization
   off = x &lt; -2 or <strong>initial</strong>();</pre></blockquote>
 </html>"));
   end 'initial()';
+  
+  class 'initialState()' "initialState()"
+    extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+Defines the initially active block instance of the <a href=\"modelica://ModelicaReference.StateMachines\">state machine</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>initialState</strong>(state)</pre></blockquote>
+<h4>Description</h4>
+<p>Argument <strong>state</strong> is the block instance that is defined to be the initial state of a state machine. 
+At the first clock tick of the state machine, this state becomes active. </p>
+</html>"));
+  end 'initialState()';
 
   class 'inStream()' "inStream()"
     extends ModelicaReference.Icons.Information;
@@ -4979,7 +5010,65 @@ give more complex stopping criteria than a fixed point in time.]</em></p>
 end</strong> ThrowingBall;</pre></blockquote>
 </html>"));
   end 'terminate()';
-
+  
+  class 'ticksInState()' "ticksInState()"
+extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+This operator returns the number of ticks since a transition was made to the active state in a <a href=\"modelica://ModelicaReference.StateMachines\">state machine</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>ticksInState</strong>()</pre></blockquote>
+<h4>Description</h4>
+<p>
+Returns the number of ticks of the clock of the state machine since a transition was made to the currently active state. 
+</p>
+</html>"));
+  end 'ticksInState()';
+  
+    class 'timeInState()' "timeInState()"
+extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+This operator returns the time (in seconds) since a transition was made to the active state in a <a href=\"modelica://ModelicaReference.StateMachines\">state machine</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>timeInState</strong>()</pre></blockquote>
+<h4>Description</h4>
+<p>
+Returns the time duration as Real in [s] since a transition was made to the currently active state.
+</p>
+</html>"));
+  end 'timeInState()';
+  
+  class 'transition()' "transition()"
+extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+This operator defines a transition in a <a href=\"modelica://ModelicaReference.StateMachines\">state machine</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>transition</strong>(from, to, condition, immediate, reset, synchronize, priority)</pre></blockquote>
+<h4>Description</h4>
+<p>
+This operator defines a transition from instance <strong>from</strong> to instance <strong>to</strong>. 
+The <strong>from</strong> and <strong>to</strong> instances become states of a state machine. 
+The transition fires when <strong>condition = true</strong> if <strong>immediate = true</strong> (this is called an immediate transition) 
+or <strong>previous(condition)</strong> when <strong>immediate = false</strong> (this is called a delayed transition). 
+Argument <strong>priority</strong> defines the priority of firing when several transitions could fire. 
+In this case the transition with the smallest value of <strong>priority<strong> fires. 
+It is required that priority is greater or equal to 1 and that for all transitions from the same state, the priorities are different. 
+If <strong>reset = true</strong>, the states of the target state are reinitialized, i.e. state machines are restarted in initial state and state variables are reset to their start values. If synchronize=true, any transition is disabled until all state machines of the from-state have reached final states, i.e. states without outgoing transitions.
+</p>
+<p>
+Arguments <strong>from</strong> and <strong>to</strong> are block instances and <strong>condition</strong>
+is a Boolean argument. The optional arguments <strong>immediate</strong>, <strong>reset</strong>, and <strong>synchronize</strong>
+are of type Boolean, have parametric variability and a default of true, true, false respectively. 
+The optional argument <strong>priority</strong> is of type Integer, has parametric variability and a default of 1. 
+</p>
+</html>"));
+  end 'transition()';
+  
   class 'transpose()' "transpose()"
     extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -6492,7 +6581,7 @@ equation
 In this example we will start in <strong>increase</strong> and increase <strong>v</strong> until a limit, and then decrease it, and repeat.
 
 <h4>Description</h4>
-A detailed description of the Synchronous Language Elements are given in Chapter 17 of the
+A detailed description of the State Machines using Synchronous Language Elements are given in Chapter 17 of the
 <a href=\"https://www.modelica.org/documents/ModelicaSpec34.pdf\">Modelica Language Specification version 3.4</a>.
 </html>"));
 end StateMachines;

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -2,7 +2,6 @@ within ;
 package ModelicaReference "Modelica Reference"
 extends ModelicaReference.Icons.Information;
 
-
 class ModelicaGrammar "Modelica Grammar"
   extends ModelicaReference.Icons.Information;
 
@@ -332,7 +331,6 @@ readability. The following typographic conventions are used:</p>
 </p>
 </body></html>"));
 end ModelicaGrammar;
-
 
 package Annotations "Annotations"
   extends ModelicaReference.Icons.Information;
@@ -1931,8 +1929,6 @@ The external C-functions may be defined in the following way:
   class 'function' "function"
     extends ModelicaReference.Icons.Information;
 
-
-
 class 'function partial application' "function partial application"
     extends ModelicaReference.Icons.Information;
 
@@ -2742,7 +2738,6 @@ The <code><strong>actualStream</strong>(v)</code> operator is provided for conve
 <strong>actualStream</strong>(port.h_outflow) = <strong>if</strong> port.m_flow &gt; 0 <strong>then inStream</strong>(port.h_outflow)
                                                   <strong>else</strong> port.h_outflow;
 </pre></blockquote>
-
 
 <h4>Example</h4>
 <p>
@@ -4776,7 +4771,6 @@ flow direction.]</em>
 </html>"));
   end 'semiLinear()';
 
-
   class 'sign()' "sign()"
     extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -5384,7 +5378,6 @@ log, log10 that are provided for convenience as built-in functions).
 </html>"));
 end Operators;
 
-
 class BalancedModel "Balanced model"
   extends ModelicaReference.Icons.Information;
   annotation (Documentation(info="<html>
@@ -5781,7 +5774,6 @@ Therefore, FixedBoundary_pTX is a locally balanced model. The predefined boundar
 </html>"));
 end BalancedModel;
 
-
 class 'encapsulated' "encapsulated"
   extends ModelicaReference.Icons.Information;
   annotation (Documentation(info="<html>
@@ -5822,7 +5814,6 @@ abs cannot be redefined in the global scope, because an existing class
 cannot be redefined at the same level.]</em></p>
 </html>"));
 end 'encapsulated';
-
 
 class 'extends' "extends"
   extends ModelicaReference.Icons.Information;
@@ -6118,7 +6109,6 @@ of a package)</em>] and from <code>class</code>.</p>
 </html>"));
 end 'extends';
 
-
 class 'flow' "flow"
   extends ModelicaReference.Icons.Information;
   annotation (Documentation(info="<html>
@@ -6204,7 +6194,6 @@ type_prefix :
 whereas variables without the flow prefix are identical in a connection.</p>
 </html>"));
 end 'flow';
-
 
 class 'for' "for"
   extends ModelicaReference.Icons.Information;
@@ -6307,7 +6296,6 @@ prepending the reduction-expression with <code>'function-name('</code>.</p>
 </html>"));
 end 'for';
 
-
 class 'if' "if"
   extends ModelicaReference.Icons.Information;
   annotation (Documentation(info="<html>
@@ -6392,7 +6380,6 @@ type of the if-expression. If-expressions with <strong>elseif</strong> are defin
 </html>"));
 end 'if';
 
-
 class 'import' "import"
   extends ModelicaReference.Icons.Information;
   annotation (Documentation(info="<html>
@@ -6468,7 +6455,6 @@ The generated import names are:</p>
 <p><em>Especially the renaming and wildcard import statements should be avoided since they might lead to name-lookup conflicts.</em></p>
 </html>"));
 end 'import';
-
 
 class 'input' "input"
   extends ModelicaReference.Icons.Information;
@@ -6596,7 +6582,6 @@ The prefixes <strong>input</strong> and <strong>output</strong> have a slightly 
 </html>"));
 end 'input';
 
-
 class 'output' "output"
   extends ModelicaReference.Icons.Information;
   annotation (Documentation(info="<html>
@@ -6723,7 +6708,6 @@ The prefixes <strong>input</strong> and <strong>output</strong> have a slightly 
 
 </html>"));
 end 'output';
-
 
 class 'partial' "partial"
   extends ModelicaReference.Icons.Information;
@@ -7143,7 +7127,6 @@ the time instant at which the simulation is started.</p>
 </html>"));
 end 'time';
 
-
 class 'when' "when"
   extends ModelicaReference.Icons.Information;
   annotation (Documentation(info="<html>
@@ -7328,7 +7311,6 @@ parameter variable. The start-values of the special functions
 </html>"));
 end 'when';
 
-
 class 'while' "while"
   extends ModelicaReference.Icons.Information;
   annotation (Documentation(info="<html>
@@ -7368,7 +7350,6 @@ and is formally defined as follows</p>
 </html>"));
 end 'while';
 
-
 class Contact "Contact"
   extends ModelicaReference.Icons.Contact;
 
@@ -7394,7 +7375,6 @@ class Contact "Contact"
 </html>"));
 
 end Contact;
-
 
 package Icons "Library of icons"
   extends ModelicaReference.Icons.IconsPackage;
@@ -7487,7 +7467,6 @@ package Icons "Library of icons"
 </html>"));
   end Package;
 end Icons;
-
 
 annotation (
   DocumentationClass=true,

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -2943,7 +2943,7 @@ The atan2 function can also be accessed as Modelica.Math.atan2.
 Shifts a clocked expressions to undo a delay as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
 </p>
 <h4>Syntax</h4>
-<blockquote><pre><strong>backSample</strong>(u, shiftCounter, resolution)<pre></blockquote>
+<blockquote><pre><strong>backSample</strong>(u, shiftCounter, resolution)</pre></blockquote>
 <h4>Examples</h4>
 <blockquote><pre>
 
@@ -3651,7 +3651,7 @@ Boolean vb[3]   = fill(true,3);  // = {true, true, true}
 Returns true for the first tick of the clock, part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
 </p>
 <h4>Syntax</h4>
-<blockquote><pre><strong>firstTick</strong>(u)<pre></blockquote>
+<blockquote><pre><strong>firstTick</strong>(u)</pre></blockquote>
 <h4>Description</h4>
 <p>
 This operator returns <strong>true</strong> at the first tick of the clock of the expression, in which this operator is called.
@@ -3686,7 +3686,7 @@ value changes discontinuously.]</em></p>
 Returns a piecewise constant signal based ona  clocked variable as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
 </p>
 <h4>Syntax</h4>
-<blockquote><pre><strong>hold</strong>(u)<pre></blockquote>
+<blockquote><pre><strong>hold</strong>(u)</pre></blockquote>
 <h4>Description</h4>
 <p>
 Input argument <strong>u</strong> is a clocked Component Expression or a parameter expression.
@@ -4099,7 +4099,7 @@ when the return value changes discontinuously.]</em></p>
 Part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
 </p>
 <h4>Syntax</h4>
-<blockquote><pre><strong>interval</strong>(u)<pre></blockquote>
+<blockquote><pre><strong>interval</strong>(u)</pre></blockquote>
 <h4>Description</h4>
 <p>
 This operator returns the interval between the previous and present tick of the clock of the expression, in which this operator is called.
@@ -4331,7 +4331,7 @@ Integer n = ndims(A);  // = 3
 Part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
 </p>
 <h4>Syntax</h4>
-<blockquote><pre><strong>noClock</strong>(u)<pre></blockquote>
+<blockquote><pre><strong>noClock</strong>(u)</pre></blockquote>
 <h4>Description</h4>
 <p>
 The clock of <strong>y = noClock(u)</strong> is always inferred.
@@ -4473,7 +4473,7 @@ for continuous-time variables inside when-clauses.
 Gives the previous value of a clocked expression as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
 </p>
 <h4>Syntax</h4>
-<blockquote><pre><strong>previous</strong>(u)<pre></blockquote>
+<blockquote><pre><strong>previous</strong>(u)</pre></blockquote>
 <h4>Description</h4>
 <p>
 The return argument has the same type as the input argument.
@@ -4650,8 +4650,8 @@ expressions and need to be a subtype of Real or Integer.
 Samples a value according to a clock as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
 </p>
 <h4>Syntax</h4>
-<blockquote><pre><strong>sample</strong>(u)<pre></blockquote>
-<blockquote><pre><strong>sample</strong>(u, c)<pre></blockquote>
+<blockquote><pre><strong>sample</strong>(u)</pre></blockquote>
+<blockquote><pre><strong>sample</strong>(u, c)</pre></blockquote>
 <h4>Description</h4>
 <p>
  The operator returns a clocked variable that has c as associated clock and has the value of the
@@ -4776,7 +4776,7 @@ flow direction.]</em>
 Shifts a clocked expressions to delay it as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
 </p>
 <h4>Syntax</h4>
-<blockquote><pre><strong>shiftSample</strong>(u, shiftCounter, resolution)<pre></blockquote>
+<blockquote><pre><strong>shiftSample</strong>(u, shiftCounter, resolution)</pre></blockquote>
 <h4>Examples</h4>
 <blockquote><pre>
   Clock u  = Clock(3, 10);
@@ -5059,7 +5059,7 @@ String(123, minimumLength=6, leftJustified=false)  // = \"   123\"
 Subsamples a clocked expressions as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
 </p>
 <h4>Syntax</h4>
-<blockquote><pre><strong>subSample</strong>(u, factor)<pre></blockquote>
+<blockquote><pre><strong>subSample</strong>(u, factor)</pre></blockquote>
 <h4>Description</h4>
 <p>
 The clock of <strong>y = subSample(u,factor)</strong> is <strong>factor</strong>-times slower than the clock of <strong>u</strong>.
@@ -5114,7 +5114,7 @@ u, ..., j <strong>in</strong> v) is the same as the type of e(i,...j).
 Supersamples a clocked expressions as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
 </p>
 <h4>Syntax</h4>
-<blockquote><pre><strong>superSample</strong>(u, factor)<pre></blockquote>
+<blockquote><pre><strong>superSample</strong>(u, factor)</pre></blockquote>
 <h4>Description</h4>
 <p>
 The clock of <strong>y = superSample(u,factor)</strong> is <strong>factor</strong>-times faster than the clock of <strong>u</strong>.

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -2710,7 +2710,7 @@ The acos function can also be accessed as Modelica.Math.acos.
  = 1.5707963267949</pre></blockquote>
 </html>"));
   end 'acos()';
-  
+
     class 'activeState()' "activeState()"
 extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -2721,13 +2721,13 @@ This operator returns true if state is active in a <a href=\"modelica://Modelica
 <blockquote><pre><strong>activeState</strong>(state)</pre></blockquote>
 <h4>Description</h4>
 <p>
-Argument <strong>state</strong> is a block instance. 
-The operator returns <strong>true</strong>, if this instance is a state of a state machine and this state is active at the actual clock tick. 
+Argument <strong>state</strong> is a block instance.
+The operator returns <strong>true</strong>, if this instance is a state of a state machine and this state is active at the actual clock tick.
 If it is not active, the operator returns <strong>false</strong>.
 </p>
 </html>"));
   end 'activeState()';
-  
+
   class 'actualStream()' "actualStream()"
     extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -2935,7 +2935,7 @@ The atan2 function can also be accessed as Modelica.Math.atan2.
  = 1.5707963267949</pre></blockquote>
 </html>"));
   end 'atan2()';
-  
+
   class 'backSample()' "backSample()"
   extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -2946,20 +2946,20 @@ Shifts a clocked expressions to undo a delay as part of the <a href=\"modelica:/
 <blockquote><pre><strong>backSample</strong>(u, shiftCounter, resolution)<pre></blockquote>
 <h4>Examples</h4>
 <blockquote><pre>
-  
-  Real x=sample(time, u); 
+
+  Real x=sample(time, u);
   // Ticks at 0, 3/10, 6/10 with values corresponding to time
-  
-  Real x2=shiftSample(x, 1, 3); 
+
+  Real x2=shiftSample(x, 1, 3);
   // Ticks at 1/10 with value 0/10, and at 4/10 with value 3/10 etc
-  
+
   Real x3=backSample(x2, 1, 3);
   // Same as x.
 </pre></blockquote>
 <p>
 </p>
 </html>"));
-  end 'backSample()';  
+  end 'backSample()';
 
   class 'cardinality()' "cardinality()"
     extends ModelicaReference.Icons.Information;
@@ -3086,7 +3086,7 @@ The same restrictions as for the pre() operator apply.</p>
 <img src=\"modelica://ModelicaReference/Resources/Images/change.png\" width=\"400\" height=\"280\" alt=\"Simulation result\">
 </html>"));
   end 'change()';
-  
+
   class 'Clock()' "Clock()"
   extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -3101,12 +3101,12 @@ equation
   when Clock() then
     // Inferred Clock
     x=A*previous(x)+B*u;
-  end when;   
-  when Clock(2,1000) then      
-    // periodic clock that ticks at 0, 0.002, 0.004, ...      
+  end when;
+  when Clock(2,1000) then
+    // periodic clock that ticks at 0, 0.002, 0.004, ...
     // Could also use when c then
-    y1 = previous(y1) + 1;   
-  end when; 
+    y1 = previous(y1) + 1;
+  end when;
   when Clock(interval1) then
     // Clock with a Real interval
     // The clock starts at the start of the simulation, tstart, or when the controller is switched on.
@@ -3115,10 +3115,10 @@ equation
     // previous(interval1)=5e-3
     interval1=previous(interval1)+3e-3;
   end when;
-  when Clock(angle>0, 0.1) then      
+  when Clock(angle>0, 0.1) then
     // clock with a boolean interval, triggers when angle>0 becomes true.
-    y2 = previous(y2) + 1;   
-  end when; 
+    y2 = previous(y2) + 1;
+  end when;
   when Clock(c, \"ImplicitTrapezoid\") then
     // Solver Clock
     // Ticks at the same rate as c but uses the ImplicitTrapezoid method to solve the differential equations
@@ -3643,7 +3643,7 @@ Boolean vb[3]   = fill(true,3);  // = {true, true, true}
 </pre></blockquote>
 </html>"));
   end 'fill()';
-  
+
   class 'firstTick()' "firstTick()"
   extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -3678,7 +3678,7 @@ value changes discontinuously.]</em></p>
  = {-4.0, 3.0}</pre></blockquote>
 </html>"));
   end 'floor()';
-  
+
   class 'hold()' "hold()"
   extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -3689,14 +3689,14 @@ Returns a piecewise constant signal based ona  clocked variable as part of the <
 <blockquote><pre><strong>hold</strong>(u)<pre></blockquote>
 <h4>Description</h4>
 <p>
-Input argument <strong>u</strong> is a clocked Component Expression or a parameter expression. 
-The operator returns a piecewise constant signal of the same type of <strong>u</strong>. 
+Input argument <strong>u</strong> is a clocked Component Expression or a parameter expression.
+The operator returns a piecewise constant signal of the same type of <strong>u</strong>.
 When the clock of <strong>u</strong> ticks, the operator returns u and
-otherwise returns the value of <strong>u</strong> from the last clock activation. 
+otherwise returns the value of <strong>u</strong> from the last clock activation.
 Before the first clock activation of <strong>u</strong>, the operator returns the start value of <strong>u</strong>.
 </p>
 </html>"));
-  end 'hold()';  
+  end 'hold()';
 
   class 'homotopy()' "homotopy()"
     extends ModelicaReference.Icons.Information;
@@ -3894,7 +3894,7 @@ True during initialization
   off = x &lt; -2 or <strong>initial</strong>();</pre></blockquote>
 </html>"));
   end 'initial()';
-  
+
   class 'initialState()' "initialState()"
     extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -3904,7 +3904,7 @@ Defines the initially active block instance of the <a href=\"modelica://Modelica
 <h4>Syntax</h4>
 <blockquote><pre><strong>initialState</strong>(state)</pre></blockquote>
 <h4>Description</h4>
-<p>Argument <strong>state</strong> is the block instance that is defined to be the initial state of a state machine. 
+<p>Argument <strong>state</strong> is the block instance that is defined to be the initial state of a state machine.
 At the first clock tick of the state machine, this state becomes active. </p>
 </html>"));
   end 'initialState()';
@@ -4091,7 +4091,7 @@ when the return value changes discontinuously.]</em></p>
  = {-4, 3}</pre></blockquote>
 </html>"));
   end 'integer()';
-  
+
   class 'interval()' "interval()"
   extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -4302,24 +4302,7 @@ discontinuously.]</em></p>
  = -1.2</pre></blockquote>
 </html>"));
   end 'mod()';
-  
-  class 'noClock()' "noClock()"
-  extends ModelicaReference.Icons.Information;
-    annotation (Documentation(info="<html>
-<p>
-Part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
-</p>
-<h4>Syntax</h4>
-<blockquote><pre><strong>noClock</strong>(u)<pre></blockquote>
-<h4>Description</h4>
-<p>
-The clock of <strong>y = noClock(u)</strong> is always inferred. 
-At every tick of the clock of <strong>y</strong>, the operator returns the value of <strong>u</strong> from the last tick of the clock of <strong>u</strong>.
-If <strong>noClock(u)</strong> is called before the first tick of the clock of <strong>u</strong>, the start value of <strong>u</strong> is returned. 
-</p>
-</html>"));
-  end 'noClock()';
-  
+
   class 'ndims()' "ndims()"
     extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -4340,8 +4323,23 @@ Integer n = ndims(A);  // = 3
 </pre></blockquote>
 </html>"));
   end 'ndims()';
-  
-  
+
+  class 'noClock()' "noClock()"
+  extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+Part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>noClock</strong>(u)<pre></blockquote>
+<h4>Description</h4>
+<p>
+The clock of <strong>y = noClock(u)</strong> is always inferred.
+At every tick of the clock of <strong>y</strong>, the operator returns the value of <strong>u</strong> from the last tick of the clock of <strong>u</strong>.
+If <strong>noClock(u)</strong> is called before the first tick of the clock of <strong>u</strong>, the start value of <strong>u</strong> is returned.
+</p>
+</html>"));
+  end 'noClock()';
 
   class 'noEvent()' "noEvent()"
     extends ModelicaReference.Icons.Information;
@@ -4467,7 +4465,7 @@ for continuous-time variables inside when-clauses.
 <img src=\"modelica://ModelicaReference/Resources/Images/pre.png\" width=\"400\" height=\"280\" alt=\"Simulation result\">
 </html>"));
   end 'pre()';
-  
+
   class 'previous()' "previous()"
   extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -4478,11 +4476,11 @@ Gives the previous value of a clocked expression as part of the <a href=\"modeli
 <blockquote><pre><strong>previous</strong>(u)<pre></blockquote>
 <h4>Description</h4>
 <p>
-The return argument has the same type as the input argument. 
-Input and return arguments are on the same clock. 
-At the first tick of the clock of <strong>u</strong> or after a <a href=\"modelica://ModelicaReference.Operators.'transition()'\">reset transition</a>, 
-the start value of <strong>u</strong>  is returned. 
-At subsequent activations of the clock of <strong>u</strong>, the value of <strong>u</strong> from the previous clock activation is returned. 
+The return argument has the same type as the input argument.
+Input and return arguments are on the same clock.
+At the first tick of the clock of <strong>u</strong> or after a <a href=\"modelica://ModelicaReference.Operators.'transition()'\">reset transition</a>,
+the start value of <strong>u</strong>  is returned.
+At subsequent activations of the clock of <strong>u</strong>, the value of <strong>u</strong> from the previous clock activation is returned.
 </p>
 </html>"));
   end 'previous()';
@@ -4644,7 +4642,7 @@ expressions and need to be a subtype of Real or Integer.
 <img src=\"modelica://ModelicaReference/Resources/Images/sample.png\" width=\"400\" height=\"280\" alt=\"Simulation result\">
 </html>"));
   end 'sample()';
-  
+
     class 'sample()clocked' "sample() Clocked"
   extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -4660,8 +4658,8 @@ Samples a value according to a clock as part of the <a href=\"modelica://Modelic
  left limit of u when c is active (that is the value of u just before the event of c is triggered).
  If argument c is not provided, it is inferred
 </p>
-<p> 
-The return argument has the same type as the first input argument. 
+<p>
+The return argument has the same type as the first input argument.
 The optional argument c is of type Clock.
 </p>
 </html>"));
@@ -4771,6 +4769,33 @@ flow direction.]</em>
 </html>"));
   end 'semiLinear()';
 
+  class 'shiftSample()' "shiftSample()"
+  extends ModelicaReference.Icons.Information;
+    annotation (Documentation(info="<html>
+<p>
+Shifts a clocked expressions to delay it as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
+</p>
+<h4>Syntax</h4>
+<blockquote><pre><strong>shiftSample</strong>(u, shiftCounter, resolution)<pre></blockquote>
+<h4>Examples</h4>
+<blockquote><pre>
+  Clock u  = Clock(3, 10);
+  // ticks: 0, 3/10, 6/10, ..
+
+  Clock y1 = shiftSample(u,1,3);
+  // ticks: 1/10, 4/10, ...
+
+  Real x=sample(time, u);
+  // Ticks at 0, 3/10, 6/10 with values corresponding to time
+
+  Real x2=shiftSample(x, 1, 3);
+  // Ticks at 1/10 with value 0/10, and at 4/10 with value 3/10 etc
+</pre></blockquote>
+<p>
+</p>
+</html>"));
+  end 'shiftSample()';
+
   class 'sign()' "sign()"
     extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -4789,33 +4814,6 @@ needs to be an Integer or Real expression.</p>
 </html>"));
   end 'sign()';
 
-  class 'shiftSample()' "shiftSample()"
-  extends ModelicaReference.Icons.Information;
-    annotation (Documentation(info="<html>
-<p>
-Shifts a clocked expressions to delay it as part of the <a href=\"modelica://ModelicaReference.Synchronous\">synchronous language elements</a>.
-</p>
-<h4>Syntax</h4>
-<blockquote><pre><strong>shiftSample</strong>(u, shiftCounter, resolution)<pre></blockquote>
-<h4>Examples</h4>
-<blockquote><pre>
-  Clock u  = Clock(3, 10);
-  // ticks: 0, 3/10, 6/10, .. 
-  
-  Clock y1 = shiftSample(u,1,3); 
-  // ticks: 1/10, 4/10, ... 
-  
-  Real x=sample(time, u); 
-  // Ticks at 0, 3/10, 6/10 with values corresponding to time
-  
-  Real x2=shiftSample(x, 1, 3); 
-  // Ticks at 1/10 with value 0/10, and at 4/10 with value 3/10 etc
-</pre></blockquote>
-<p>
-</p>
-</html>"));
-  end 'shiftSample()';  
-  
   class 'sin()' "sin()"
     extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -5053,7 +5051,7 @@ String(123, minimumLength=6, leftJustified=false)  // = \"   123\"
 </pre></blockquote>
 </html>"));
   end 'String()';
-  
+
   class 'subSample()' "subSample()"
   extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -5064,13 +5062,13 @@ Subsamples a clocked expressions as part of the <a href=\"modelica://ModelicaRef
 <blockquote><pre><strong>subSample</strong>(u, factor)<pre></blockquote>
 <h4>Description</h4>
 <p>
-The clock of <strong>y = subSample(u,factor)</strong> is <strong>factor</strong>-times slower than the clock of <strong>u</strong>. 
-At every <strong>factor</strong> ticks of the clock of <strong>u</strong>, the operator returns the value of <strong>u</strong>. 
-The first activation of the clock of <strong>y</strong> coincides with the first activation of the clock of <strong>u</strong>. 
+The clock of <strong>y = subSample(u,factor)</strong> is <strong>factor</strong>-times slower than the clock of <strong>u</strong>.
+At every <strong>factor</strong> ticks of the clock of <strong>u</strong>, the operator returns the value of <strong>u</strong>.
+The first activation of the clock of <strong>y</strong> coincides with the first activation of the clock of <strong>u</strong>.
 If argument <strong>factor</strong> is not provided or is equal to zero, it is inferred.
 </p>
 </html>"));
-  end 'subSample()';  
+  end 'subSample()';
 
   class 'sum()' "sum()"
     extends ModelicaReference.Icons.Information;
@@ -5108,7 +5106,7 @@ u, ..., j <strong>in</strong> v) is the same as the type of e(i,...j).
 </pre></blockquote>
 </html>"));
   end 'sum()';
-  
+
     class 'superSample()' "superSample()"
   extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -5119,13 +5117,13 @@ Supersamples a clocked expressions as part of the <a href=\"modelica://ModelicaR
 <blockquote><pre><strong>superSample</strong>(u, factor)<pre></blockquote>
 <h4>Description</h4>
 <p>
-The clock of <strong>y = superSample(u,factor)</strong> is <strong>factor</strong>-times faster than the clock of <strong>u</strong>. 
-At every tick of the clock of <strong>u</strong>, the operator returns the value of <strong>u</strong>. 
-The first activation of the clock of <strong>y</strong> coincides with the first activation of the clock of <strong>u</strong>. 
+The clock of <strong>y = superSample(u,factor)</strong> is <strong>factor</strong>-times faster than the clock of <strong>u</strong>.
+At every tick of the clock of <strong>u</strong>, the operator returns the value of <strong>u</strong>.
+The first activation of the clock of <strong>y</strong> coincides with the first activation of the clock of <strong>u</strong>.
 If argument <strong>factor</strong> is not provided or is equal to zero, it is inferred.
 </p>
 </html>"));
-  end 'superSample()';  
+  end 'superSample()';
 
   class 'symmetric()' "symmetric()"
     extends ModelicaReference.Icons.Information;
@@ -5245,7 +5243,7 @@ give more complex stopping criteria than a fixed point in time.]</em></p>
 end</strong> ThrowingBall;</pre></blockquote>
 </html>"));
   end 'terminate()';
-  
+
   class 'ticksInState()' "ticksInState()"
 extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -5256,11 +5254,11 @@ This operator returns the number of ticks since a transition was made to the act
 <blockquote><pre><strong>ticksInState</strong>()</pre></blockquote>
 <h4>Description</h4>
 <p>
-Returns the number of ticks of the clock of the state machine since a transition was made to the currently active state. 
+Returns the number of ticks of the clock of the state machine since a transition was made to the currently active state.
 </p>
 </html>"));
   end 'ticksInState()';
-  
+
     class 'timeInState()' "timeInState()"
 extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -5275,7 +5273,7 @@ Returns the time duration as Real in [s] since a transition was made to the curr
 </p>
 </html>"));
   end 'timeInState()';
-  
+
   class 'transition()' "transition()"
 extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -5286,24 +5284,24 @@ This operator defines a transition in a <a href=\"modelica://ModelicaReference.S
 <blockquote><pre><strong>transition</strong>(from, to, condition, immediate, reset, synchronize, priority)</pre></blockquote>
 <h4>Description</h4>
 <p>
-This operator defines a transition from instance <strong>from</strong> to instance <strong>to</strong>. 
-The <strong>from</strong> and <strong>to</strong> instances become states of a state machine. 
-The transition fires when <strong>condition = true</strong> if <strong>immediate = true</strong> (this is called an immediate transition) 
-or <strong>previous(condition)</strong> when <strong>immediate = false</strong> (this is called a delayed transition). 
-Argument <strong>priority</strong> defines the priority of firing when several transitions could fire. 
-In this case the transition with the smallest value of <strong>priority</strong> fires. 
-It is required that priority is greater or equal to 1 and that for all transitions from the same state, the priorities are different. 
+This operator defines a transition from instance <strong>from</strong> to instance <strong>to</strong>.
+The <strong>from</strong> and <strong>to</strong> instances become states of a state machine.
+The transition fires when <strong>condition = true</strong> if <strong>immediate = true</strong> (this is called an immediate transition)
+or <strong>previous(condition)</strong> when <strong>immediate = false</strong> (this is called a delayed transition).
+Argument <strong>priority</strong> defines the priority of firing when several transitions could fire.
+In this case the transition with the smallest value of <strong>priority</strong> fires.
+It is required that priority is greater or equal to 1 and that for all transitions from the same state, the priorities are different.
 If <strong>reset = true</strong>, the states of the target state are reinitialized, i.e. state machines are restarted in initial state and state variables are reset to their start values. If synchronize=true, any transition is disabled until all state machines of the from-state have reached final states, i.e. states without outgoing transitions.
 </p>
 <p>
 Arguments <strong>from</strong> and <strong>to</strong> are block instances and <strong>condition</strong>
 is a Boolean argument. The optional arguments <strong>immediate</strong>, <strong>reset</strong>, and <strong>synchronize</strong>
-are of type Boolean, have parametric variability and a default of true, true, false respectively. 
-The optional argument <strong>priority</strong> is of type Integer, has parametric variability and a default of 1. 
+are of type Boolean, have parametric variability and a default of true, true, false respectively.
+The optional argument <strong>priority</strong> is of type Integer, has parametric variability and a default of 1.
 </p>
 </html>"));
   end 'transition()';
-  
+
   class 'transpose()' "transpose()"
     extends ModelicaReference.Icons.Information;
     annotation (Documentation(info="<html>
@@ -6785,19 +6783,19 @@ Note that the state machines defined in the Modelica Standard Library are not ba
 </p>
 <h4>Examples</h4>
 <blockquote><pre>
-  inner Integer v(start=0); 
-  block Increase       
-    outer output Integer v;     
-  equation        
+  inner Integer v(start=0);
+  block Increase
+    outer output Integer v;
+  equation
     v = previous(v) + 2;
   end Increase;
-  Increase increase; 
-  block Decrease       
-    outer output Integer v;     
-  equation        
+  Increase increase;
+  block Decrease
+    outer output Integer v;
+  equation
     v = previous(v) - 1;
   end Decrease;
-  Decrease decrease; 
+  Decrease decrease;
 equation
   initialState(increase);
   transition(increase, decrease, v>=6, immediate=false);
@@ -7073,14 +7071,14 @@ making modeling of complex sampled systems safer and easier.
     E*dc.xd=A*previous(dc.xd)+B*dc.yd;
       dc.ud=C*previous(dc.xd)+D*dc.yd;
   end when;
-  
+
   // hold controller output:
   plant.u=hold(dc.ud);
-  
+
   // Plant
   0=f(der(plant.x),plant.x,plant.u);
   plant.y=g(plant.x);
-  
+
   // Sample continuous signal
   dc.yd=sample(plant.y, Clock(3));
 </pre></blockquote>

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -6462,6 +6462,40 @@ or in a \"constrainedby\" clause to define the constraints of a replaceable clas
 </html>"));
 end 'partial';
 
+class StateMachines "State Machines"
+  extends ModelicaReference.Icons.Information;
+  annotation (Documentation(info="<html>
+<p>
+The state machines defined in the Modelica Language are based on the <a href=\"modelica://Synchronous\">synchronous language elements</a>.
+Note that the state machines defined in the Modelica Standard Library are not based on this.
+</p>
+<h4>Examples</h4>
+<blockquote><pre>
+  inner Integer v(start=0); 
+  block Increase       
+    outer output Integer v;     
+  equation        
+    v = previous(v) + 2;
+  end Increase;
+  Increase increase; 
+  block Decrease       
+    outer output Integer v;     
+  equation        
+    v = previous(v) - 1;
+  end Decrease;
+  Decrease decrease; 
+equation
+  initialState(increase);
+  transition(increase, decrease, v>=6, immediate=false);
+  transition(decrease, increase, v==0, immediate=false);
+</pre></blockquote>
+In this example we will start in <strong>increase</strong> and increase <strong>v</strong> until a limit, and then decrease it, and repeat.
+
+<h4>Description</h4>
+A detailed description of the Synchronous Language Elements are given in Chapter 17 of the
+<a href=\"https://www.modelica.org/documents/ModelicaSpec34.pdf\">Modelica Language Specification version 3.4</a>.
+</html>"));
+end StateMachines;
 
 class 'stream' "stream"
   extends ModelicaReference.Icons.Information;
@@ -6711,6 +6745,39 @@ For further details, see the definition of the
 </html>"));
 end 'stream';
 
+class Synhronous "Synhronous Language Elements"
+  extends ModelicaReference.Icons.Information;
+  annotation (Documentation(info="<html>
+<p>
+Synhronous language elements are added to Modelica as an alternative to normal <a href=\"modelica://'when'\">when</a>-clauses to
+making modeling of complex sampled systems safer and easier.
+</p>
+<h4>Examples</h4>
+<blockquote><pre>
+  // Discrete controller
+  when Clock() then
+    E*dc.xd=A*previous(dc.xd)+B*dc.yd;
+      dc.ud=C*previous(dc.xd)+D*dc.yd;
+  end when;
+  
+  // hold controller output:
+  plant.u=hold(dc.ud);
+  
+  // Plant
+  0=f(der(plant.x),plant.x,plant.u);
+  plant.y=g(plant.x);
+  
+  // Sample continuous signal
+  dc.yd=sample(plant.y, Clock(3));
+</pre></blockquote>
+In this example <strong>dc.xd</strong> and <strong>dc.ud</strong> are Clocked variables, and only defined when the Clock is active (every 3rd second).
+At time instants where the associated clock is not active, the value of a clocked variable can be inquired by using an explicit cast operator, e.g., <strong>hold</strong>.
+
+<h4>Description</h4>
+A detailed description of the Synchronous Language Elements are given in Chapter 16 of the
+<a href=\"https://www.modelica.org/documents/ModelicaSpec34.pdf\">Modelica Language Specification version 3.4</a>.
+</html>"));
+end Synhronous;
 
 class 'time' "time"
   extends ModelicaReference.Icons.Information;
@@ -7122,6 +7189,14 @@ Copyright &copy; 2003-2020, Modelica Association and contributors
       <th>Date</th>
       <th>Author</th>
       <th>Comment</th>
+    </tr>
+    <tr>
+      <td></td>
+      <td>2020-02-24</td>
+      <td><a href=\"https://github.com/HansOlsson\">Hans Olsson</a></td>
+      <td>
+      Add minimal parts for synchronous and state machines - making the reference feature-complete.
+      </td>
     </tr>
     <tr>
       <td></td>

--- a/ModelicaReference/package.order
+++ b/ModelicaReference/package.order
@@ -12,7 +12,9 @@ BalancedModel
 'input'
 'output'
 'partial'
+StateMachines
 'stream'
+Synchronous
 'time'
 'when'
 'while'


### PR DESCRIPTION
Add something for synchronous ans state machines.
The main idea was to add operators so that they can be found.

Resolves #2820