### PR TITLE
Refs #3439: Remove %name from FixedShape icon graphics to avoid duplicate display

### DIFF
--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/BaseClasses/FixedShape.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/BaseClasses/FixedShape.mo
@@ -30,9 +30,7 @@ equation
   B = Phi/A;
   H = B/(mu_0*mu_r);
 
-  annotation (Icon(coordinateSystem(
-      preserveAspectRatio=false,
-      extent={{-100,-100},{100,100}})), Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <p>
 Please refer to the description of  the subpackage
 <a href=\"modelica://Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape\">Shapes.FixedShape</a>

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/BaseClasses/FixedShape.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/BaseClasses/FixedShape.mo
@@ -32,11 +32,7 @@ equation
 
   annotation (Icon(coordinateSystem(
       preserveAspectRatio=false,
-      extent={{-100,-100},{100,100}}), graphics={
-      Text(
-        extent={{-150,50},{150,90}},
-        textString="%name",
-        textColor={0,0,255})}), Documentation(info="<html>
+      extent={{-100,-100},{100,100}})), Documentation(info="<html>
 <p>
 Please refer to the description of  the subpackage
 <a href=\"modelica://Modelica.Magnetic.QuasiStatic.FluxTubes.Shapes.FixedShape\">Shapes.FixedShape</a>


### PR DESCRIPTION
Removing `%name` from `FixedShape` seems to resolve this issue entirely. There are no other dependencies of `%name` which shall be considered`.

Resolves #3439.