### PR TITLE
Fully specify initial conditions in clocked models

### DIFF
--- a/Modelica/Clocked/Examples/Systems/Utilities/ComponentsThrottleControl/SpeedControl.mo
+++ b/Modelica/Clocked/Examples/Systems/Utilities/ComponentsThrottleControl/SpeedControl.mo
@@ -4,8 +4,8 @@ block SpeedControl
 
   parameter Real k_p = 0.0614 "Proportional gain";
   parameter Real k_I = 0.0723 "Integral gain";
-  Modelica.Blocks.Interfaces.RealInput N_des(unit="rad/s") "Desired speed, (rad/s)" annotation (Placement(transformation(extent={{-140,20},{-100,60}})));
-  Modelica.Blocks.Interfaces.RealInput N(unit="rad/s") "Measured speed, (rad/s)" annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
+  Modelica.Blocks.Interfaces.RealInput N_des(unit="rad/s", start=0) "Desired speed, (rad/s)" annotation (Placement(transformation(extent={{-140,20},{-100,60}})));
+  Modelica.Blocks.Interfaces.RealInput N(unit="rad/s", start=0) "Measured speed, (rad/s)" annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Modelica.Blocks.Interfaces.RealOutput Theta(start=8.9, unit="deg")
     "Throttle angle (deg)" annotation (Placement(transformation(extent={{100,-10},{120,10}})));
 protected

--- a/Modelica/Clocked/IntegerSignals/NonPeriodic/IntegerChange.mo
+++ b/Modelica/Clocked/IntegerSignals/NonPeriodic/IntegerChange.mo
@@ -2,7 +2,7 @@ within Modelica.Clocked.IntegerSignals.NonPeriodic;
 block IntegerChange "Indicate Integer signal changing"
   extends Clocked.ClockSignals.Interfaces.ClockedBlockIcon;
 
-  Modelica.Blocks.Interfaces.IntegerInput u
+  Modelica.Blocks.Interfaces.IntegerInput u(start=0)
     "Connector of Integer input signal."
     annotation (Placement(transformation(extent = {{-140,-20},{-100,20}})));
   Modelica.Blocks.Interfaces.BooleanOutput y


### PR DESCRIPTION
Fixes the pedantic translation issues reported in #3435 for the example models
- Modelica.Clocked.Examples.Systems.EngineThrottleControl
- Modelica.Clocked.Examples.Elementary.ClockSignals.RotationalSample
- Modelica.Clocked.Examples.Elementary.ClockSignals.LogicalSample