### PR TITLE
Changed default of PadeDelay to robust implementation (balance = true)

### DIFF
--- a/Modelica/Blocks/Nonlinear.mo
+++ b/Modelica/Blocks/Nonlinear.mo
@@ -327,7 +327,7 @@ y = u(time - delayTime) for time &gt; time.start + delayTime
   end FixedDelay;
 
   block PadeDelay
-    "Pade approximation of delay block with fixed delayTime (use balance=true; this is not the default to be backwards compatible)"
+    "Pade approximation of delay block with fixed delayTime"
     extends Modelica.Blocks.Interfaces.SISO;
     parameter SI.Time delayTime(start=1)
       "Delay time of output with respect to input signal";
@@ -420,13 +420,7 @@ y = u(time - delayTime) for time &gt; time.start + delayTime
 
   initial equation
     (a1,b11,c,d,s) = padeCoefficients2(delayTime, n, m, balance);
-
-    if balance then
-       der(x) = zeros(n);
-    else
-       // In order to be backwards compatible
-       x[n] = u;
-    end if;
+    der(x) = zeros(n);
     annotation (
       Documentation(info="<html>
 <p>
@@ -465,10 +459,7 @@ also the default setting of this block. The setting
 
 <p>
 It is strongly recommended to always set parameter <strong>balance</strong> = true,
-in order to arrive at a much better reliable numerical computation.
-This is not the default, in order to be backwards compatible, so you have
-to explicitly set it. Besides better numerics, also all states are initialized
-with <strong>balance</strong> = true (in steady-state, so der(x)=0). Longer explanation:
+in order to arrive at a much better reliable numerical computation. Longer explanation:
 </p>
 
 <p>
@@ -495,6 +486,12 @@ chapter 11.9, page 412-414, Huethig Verlag Heidelberg, 1994
 <th>Date</th>
 <th>Author</th>
 <th>Comment</th>
+</tr>
+<tr>
+<td>2020-02-28</td>
+<td>Francesco Casella (Politecnico di Milano)</td>
+<td>Made balance = true default for version 4.0.0 of MSL; added steady-state
+initialization also to balance = false case</td>
 </tr>
 <tr>
 <td>2015-01-05</td>

--- a/ModelicaTest/Blocks.mo
+++ b/ModelicaTest/Blocks.mo
@@ -1329,7 +1329,7 @@ if homotopy is active, the solution accepted by the assert statement (x = 100) i
   end ConversionBlocks;
 
   model PadeDelay1
-    "Check that new implementation gives the same result as the old implementation for the default balance = false"
+    "Check that new implementation gives the same result as the old implementation for balance = false"
     extends Modelica.Icons.Example;
     parameter Integer n=10 "Order of Pade approximation";
     parameter SI.Time delayTime=0.2
@@ -1389,7 +1389,7 @@ if homotopy is active, the solution accepted by the assert statement (x = 100) i
     [y] = transpose([zeros(n - m, 1); b])*[x1dot; x];
 
     initial equation
-    x[n] = u;
+      der(x) = zeros(n);
     annotation (
       Documentation(info="<html>
 <p>


### PR DESCRIPTION
A few days ago @GiovanniMangola brought my attention on the `Modelica.Blocks.Nonlinear.PadeDelay` model.

If `balance = true`, the model works just fine: the implementation is numerically sound, and so it is the initialization, which is full steady-state and corresponds exactly to what would happen if you had a pure delay model, which is by definition initialized in steady-state, see the [Specification](https://specification.modelica.org/v3.4/Ch3.html#derivative-and-special-purpose-operators-with-function-syntax).

However, for reasons of backwards compatibility with MSL 3.2.1, the default is still balanced = false, which provides a numerically ill-conditiond textbook implementation, and furthermore has only one initial equation instead of N, leading to a model with missing initial equations, which is in general not a good idea. 

In the case of our application, the block (with the default choice) was put inside a big plant model, which failed miserably to initialize because some other (unfortunately unwanted and wrong) initial equations were picked instead by Dymola, because of the incompletely specified initial problem stemming from the lack of initial equations in the block. I think this a very dangerous behaviour that should be avoided. What initial equations are needed is very clear for this model, there is really no point at leaving them out for reasons of backwards compatibility.

I think the transition to MSL 4.0.0 is a good opportunity to get a better behaviour, even though it is slightly non-backwards compatible. This means:
- making balance = true the default (there's no point having a numerically ill-conditioned implementation as default if we have a sound one available)
- adding full initial equations for the case balance = false, so one does not have to rely on the tool to pick them, potentially in an incorrect way, as it happened to us, in case you really want to use that implementation for some reason

I guess this may be listed in the release notes.

I also updated the two tests in ModelicaTest accordingly. Both compare the output and performance of the block with the old one from MSL 3.2.1, which is copied inside the test cases. I slightly changed that copy to always have full initial equations. We agreed long time ago that all the examples in MSL and ModelicaTest should have fully specified initial conditions to avoid ambiguities in the selection of initial equations with different tools, so this change is necessary to fulfill that requirement.