### PR TITLE
Change doc strings to start with uppercase letter and fix spellings of Units.mo

### DIFF
--- a/Modelica/Blocks/Continuous.mo
+++ b/Modelica/Blocks/Continuous.mo
@@ -1240,8 +1240,8 @@ y = --------- * u
     output Real x[size(A, 1)](start=x_start) "State vector";
 
   protected
-    parameter Integer nx = size(A, 1) "number of states";
-    parameter Integer ny = size(C, 1) "number of outputs";
+    parameter Integer nx = size(A, 1) "Number of states";
+    parameter Integer ny = size(C, 1) "Number of outputs";
   initial equation
     if initType == Init.SteadyState then
       der(x) = zeros(nx);
@@ -1364,10 +1364,10 @@ the model.
             "Initialization"));
 
     output Real x1[m](start=x1_start)
-      "states 1 of second order filters (der(x1) = x2)";
+      "States 1 of second order filters (der(x1) = x2)";
     output Real x2[m](start=x2_start) "states 2 of second order filters";
     output Real xr(start=xr_start)
-      "state of real pole for uneven order otherwise dummy";
+      "State of real pole for uneven order otherwise dummy";
   protected
     parameter Integer m=integer(n/2);
     parameter Boolean evenOrder = 2*m == n;

--- a/Modelica/Blocks/Continuous.mo
+++ b/Modelica/Blocks/Continuous.mo
@@ -1365,7 +1365,7 @@ the model.
 
     output Real x1[m](start=x1_start)
       "States 1 of second order filters (der(x1) = x2)";
-    output Real x2[m](start=x2_start) "states 2 of second order filters";
+    output Real x2[m](start=x2_start) "States 2 of second order filters";
     output Real xr(start=xr_start)
       "State of real pole for uneven order otherwise dummy";
   protected
@@ -4040,7 +4040,7 @@ b2_k = 1/(beta_k^2 + gamma_k^2) b1_k = -2*beta_k/(beta_k^2 + gamma_k^2)
           output Real u "Value of independent variable so that f(u) = 0";
 
           protected
-          constant Real eps=Modelica.Constants.eps "machine epsilon";
+          constant Real eps=Modelica.Constants.eps "Machine epsilon";
           Real a=u_min "Current best minimum interval value";
           Real b=u_max "Current best maximum interval value";
           Real c "Intermediate point a <= c <= b";
@@ -4231,7 +4231,7 @@ function. The solver function is a direct mapping of the Algol 60 procedure
           output Real u "Value of independent variable so that f(u) = 0";
 
           protected
-          constant Real eps=Modelica.Constants.eps "machine epsilon";
+          constant Real eps=Modelica.Constants.eps "Machine epsilon";
           Real a=u_min "Current best minimum interval value";
           Real b=u_max "Current best maximum interval value";
           Real c "Intermediate point a <= c <= b";

--- a/Modelica/Blocks/Interfaces.mo
+++ b/Modelica/Blocks/Interfaces.mo
@@ -1559,10 +1559,10 @@ Note, the input signals must be consistent to each other
       parameter String Name_f="f" "Name of flow variable";
       parameter String Name_fder="der(f)" "Name of 1st derivative of flow variable";
       parameter String Name_fder2="der2(f)" "Name of 2nd derivative of flow variable";
-      Real y "output signal" annotation(HideResult=true);
+      Real y "Output signal" annotation(HideResult=true);
       Modelica.Blocks.Interfaces.RealOutput y1 "Optional 1st derivative of output" annotation(HideResult=true);
       Modelica.Blocks.Interfaces.RealOutput y2 "Optional 2nd derivative of output" annotation(HideResult=true);
-      Real u "input signal" annotation(HideResult=true);
+      Real u "Input signal" annotation(HideResult=true);
       Modelica.Blocks.Interfaces.RealInput u1 "Optional 1st derivative of input" annotation (HideResult=true);
       Modelica.Blocks.Interfaces.RealInput u2 "Optional 2nd derivative of input" annotation (HideResult=true);
     equation

--- a/Modelica/Blocks/Interfaces.mo
+++ b/Modelica/Blocks/Interfaces.mo
@@ -1447,10 +1447,10 @@ of noise blocks.
       parameter String Name_f="f" "Name of flow variable";
       parameter String Name_fder="der(f)" "Name of 1st derivative of flow variable";
       parameter String Name_fder2="der2(f)" "Name of 2nd derivative of flow variable";
-      Real y "output signal" annotation(HideResult=true);
+      Real y "Output signal" annotation(HideResult=true);
       Modelica.Blocks.Interfaces.RealOutput y1 "Optional 1st derivative of output" annotation(HideResult=true);
       Modelica.Blocks.Interfaces.RealOutput y2 "Optional 2nd derivative of output" annotation(HideResult=true);
-      Real u "input signal" annotation(HideResult=true);
+      Real u "Input signal" annotation(HideResult=true);
       Modelica.Blocks.Interfaces.RealInput u1 "Optional 1st derivative of input" annotation (HideResult=true);
       Modelica.Blocks.Interfaces.RealInput u2 "Optional 2nd derivative of input" annotation (HideResult=true);
     equation

--- a/Modelica/Blocks/Nonlinear.mo
+++ b/Modelica/Blocks/Nonlinear.mo
@@ -349,9 +349,9 @@ y = u(time - delayTime) for time &gt; time.start + delayTime
 
   function padeCoefficients2
     extends Modelica.Icons.Function;
-    input Real T "delay time";
-    input Integer n "order of denominator";
-    input Integer m "order of numerator";
+    input Real T "Delay time";
+    input Integer n "Order of denominator";
+    input Integer m "Order of numerator";
     input Boolean balance=false;
     output Real a1[n] "First row of A";
     output Real b11 "= B[1,1]";
@@ -359,8 +359,8 @@ y = u(time - delayTime) for time &gt; time.start + delayTime
     output Real d "D matrix";
     output Real s[n-1] "Scaling such that x[i] = s[i-1]*x[i-1], i > 1";
     protected
-    Real b[m + 1] "numerator coefficients of transfer function";
-    Real a[n + 1] "denominator coefficients of transfer function";
+    Real b[m + 1] "Numerator coefficients of transfer function";
+    Real a[n + 1] "Denominator coefficients of transfer function";
     Real nm;
     Real bb[n + 1];
     Real A[n,n];

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -1972,7 +1972,7 @@ The Boolean output y is a step signal:
 
   protected
     parameter SI.Time Twidth=period*width/100
-      "width of one pulse" annotation (HideResult=true);
+      "Width of one pulse" annotation (HideResult=true);
     discrete SI.Time pulseStart "Start time of pulse"
       annotation (HideResult=true);
   initial equation

--- a/Modelica/Clocked/BooleanSignals/TimeBasedSources/Pulse.mo
+++ b/Modelica/Clocked/BooleanSignals/TimeBasedSources/Pulse.mo
@@ -12,7 +12,7 @@ block Pulse "Generate pulse signal of type Boolean"
 protected
   SI.Time simTime;
   parameter SI.Duration Twidth=period*width/100
-  "width of one pulse" annotation(HideResult=true);
+  "Width of one pulse" annotation(HideResult=true);
 
   SI.Time next(start=startTime, fixed=true)
   "next = startTime + n*period, for smallest n such that next>simTime";

--- a/Modelica/Constants.mo
+++ b/Modelica/Constants.mo
@@ -12,7 +12,7 @@ package Constants
   final constant Real D2R=pi/180 "Degree to Radian";
   final constant Real R2D=180/pi "Radian to Degree";
   final constant Real gamma=0.57721566490153286061
-    "see http://en.wikipedia.org/wiki/Euler_constant";
+    "See http://en.wikipedia.org/wiki/Euler_constant";
 
   // Machine dependent constants
   final constant Real eps=ModelicaServices.Machine.eps

--- a/Modelica/Electrical/Analog/Ideal/IdealOpAmpLimited.mo
+++ b/Modelica/Electrical/Analog/Ideal/IdealOpAmpLimited.mo
@@ -10,7 +10,7 @@ model IdealOpAmpLimited "Ideal operational amplifier with limitation"
     annotation (Placement(transformation(extent={{-10,90},{10,110}}), iconTransformation(extent={{-10,90},{10,110}})));
   Interfaces.NegativePin VMin "Negative output voltage limitation"
     annotation (Placement(transformation(extent={{-10,-110},{10,-90}}), iconTransformation(extent={{-10,-110},{10,-90}})));
-  SI.Voltage vin "input voltage";
+  SI.Voltage vin "Input voltage";
 protected
   Real s(start=0, final unit="1") "Auxiliary variable";
   constant SI.Voltage unitVoltage=1 annotation (HideResult=true);

--- a/Modelica/Electrical/Analog/Sensors/CurrentSensor.mo
+++ b/Modelica/Electrical/Analog/Sensors/CurrentSensor.mo
@@ -2,9 +2,9 @@ within Modelica.Electrical.Analog.Sensors;
 model CurrentSensor "Sensor to measure the current in a branch"
   extends Modelica.Icons.RoundSensor;
 
-  Interfaces.PositivePin p "positive pin" annotation (Placement(
+  Interfaces.PositivePin p "Positive pin" annotation (Placement(
         transformation(extent={{-110,-10},{-90,10}})));
-  Interfaces.NegativePin n "negative pin" annotation (Placement(
+  Interfaces.NegativePin n "Negative pin" annotation (Placement(
         transformation(extent={{90,-10},{110,10}})));
   Modelica.Blocks.Interfaces.RealOutput i(unit="A")
     "Current in the branch from p to n as output signal"

--- a/Modelica/Electrical/Analog/Sensors/PotentialSensor.mo
+++ b/Modelica/Electrical/Analog/Sensors/PotentialSensor.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.Analog.Sensors;
 model PotentialSensor "Sensor to measure the potential"
   extends Modelica.Icons.RoundSensor;
 
-  Interfaces.PositivePin p "pin to be measured" annotation (Placement(
+  Interfaces.PositivePin p "Pin to be measured" annotation (Placement(
         transformation(extent={{-110,-10},{-90,10}})));
   Modelica.Blocks.Interfaces.RealOutput phi(unit="V")
     "Absolute voltage potential as output signal"

--- a/Modelica/Electrical/Analog/Sensors/VoltageSensor.mo
+++ b/Modelica/Electrical/Analog/Sensors/VoltageSensor.mo
@@ -2,9 +2,9 @@ within Modelica.Electrical.Analog.Sensors;
 model VoltageSensor "Sensor to measure the voltage between two pins"
   extends Modelica.Icons.RoundSensor;
 
-  Interfaces.PositivePin p "positive pin" annotation (Placement(
+  Interfaces.PositivePin p "Positive pin" annotation (Placement(
         transformation(extent={{-110,-10},{-90,10}})));
-  Interfaces.NegativePin n "negative pin" annotation (Placement(
+  Interfaces.NegativePin n "Negative pin" annotation (Placement(
         transformation(extent={{90,-10},{110,10}})));
   Modelica.Blocks.Interfaces.RealOutput v(unit="V")
     "Voltage between pin p and n (= p.v - n.v) as output signal"

--- a/Modelica/Electrical/Digital.mo
+++ b/Modelica/Electrical/Digital.mo
@@ -2333,8 +2333,8 @@ sum   <strong>Adder4</strong>.c_out  <strong>Adder4.s</strong>  <strong>Adder3.s
               function getMemory "Get Memory"
                 extends Modelica.Icons.Function;
                 input String filename;
-                input Integer n_addr "addr width";
-                input Integer n_data "data width";
+                input Integer n_addr "Addr width";
+                input Integer n_data "Data width";
                 output L m[integer(2^n_addr),n_data] "Memory with data, lowest bit on left side";
                 output String data;
                 output Integer bit;
@@ -6992,16 +6992,16 @@ Z  = L.'Z'
       parameter SI.Time tHL=0 "High->Low delay";
       parameter SI.Time tLH=0 "Low->High delay";
       parameter D.Interfaces.Strength strength = S.'S_X01' "Output strength";
-      D.Interfaces.DigitalInput in1 "data input 1"
+      D.Interfaces.DigitalInput in1 "Data input 1"
         annotation (Placement(transformation(extent={{-100,40},{-80,60}}),
             iconTransformation(extent={{-100,40},{-80,60}})));
-      D.Interfaces.DigitalInput in0 "data input 0"
+      D.Interfaces.DigitalInput in0 "Data input 0"
         annotation (Placement(transformation(extent={{-100,-60},{-80,-40}}),
             iconTransformation(extent={{-100,-60},{-80,-40}})));
-      D.Interfaces.DigitalInput sel "select input"
+      D.Interfaces.DigitalInput sel "Select input"
       annotation (Placement(transformation(extent={{-10,80},{10,100}}),
             iconTransformation(extent={{-10,80},{10,100}})));
-      D.Interfaces.DigitalOutput out "output"
+      D.Interfaces.DigitalOutput out "Output"
         annotation (Placement(transformation(extent={{80,-10},{100,10}}),
             iconTransformation(extent={{80,-10},{100,10}})));
 

--- a/Modelica/Electrical/Machines/Sensors/RotorDisplacementAngle.mo
+++ b/Modelica/Electrical/Machines/Sensors/RotorDisplacementAngle.mo
@@ -36,7 +36,7 @@ model RotorDisplacementAngle "Rotor lagging angle"
   Modelica.Electrical.Machines.SpacePhasors.Blocks.ToPolar ToPolarVSR
     annotation (Placement(transformation(extent={{10,-10},{30,10}})));
   Modelica.Mechanics.Rotational.Interfaces.Flange_a support if useSupport
-    "support at which the reaction torque is acting" annotation (Placement(
+    "Support at which the reaction torque is acting" annotation (Placement(
         transformation(extent={{90,90},{110,110}})));
   Modelica.Mechanics.Rotational.Components.Fixed fixed if (not useSupport)
     annotation (Placement(transformation(extent={{90,70},{110,90}})));

--- a/Modelica/Electrical/Machines/SpacePhasors/Functions/activePower.mo
+++ b/Modelica/Electrical/Machines/SpacePhasors/Functions/activePower.mo
@@ -3,8 +3,8 @@ function activePower
   "Calculate active power of voltage and current input"
   import Modelica.Constants.pi;
   extends Modelica.Icons.Function;
-  input SI.Voltage v[m] "phase voltages";
-  input SI.Current i[m] "phase currents";
+  input SI.Voltage v[m] "Phase voltages";
+  input SI.Current i[m] "Phase currents";
   output SI.Power p "Active power";
 protected
   constant Integer m=3 "Number of phases";

--- a/Modelica/Electrical/PowerConverters/DCAC/Control/IntersectivePWM.mo
+++ b/Modelica/Electrical/PowerConverters/DCAC/Control/IntersectivePWM.mo
@@ -10,9 +10,9 @@ block IntersectivePWM "Intersective PWM"
     "Type of reference signal" annotation (Evaluate=true);
   Modelica.Blocks.Interfaces.RealInput u[2] "Reference space phasor"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
-  Modelica.Blocks.Interfaces.BooleanOutput fire_p[m] "positive fire signal"
+  Modelica.Blocks.Interfaces.BooleanOutput fire_p[m] "Positive fire signal"
     annotation (Placement(transformation(extent={{100,50},{120,70}})));
-  Modelica.Blocks.Interfaces.BooleanOutput fire_n[m] "negative fire signal"
+  Modelica.Blocks.Interfaces.BooleanOutput fire_n[m] "Negative fire signal"
     annotation (Placement(transformation(extent={{100,-70},{120,-50}})));
   Modelica.Electrical.Machines.SpacePhasors.Blocks.FromSpacePhasor
     fromSpacePhasor

--- a/Modelica/Electrical/PowerConverters/DCAC/Control/PWM.mo
+++ b/Modelica/Electrical/PowerConverters/DCAC/Control/PWM.mo
@@ -12,9 +12,9 @@ block PWM "PulseWidthModulation"
            == PowerConverters.Types.PWMType.Intersective));
   Modelica.Blocks.Interfaces.RealInput u[2] "Reference space phasor"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
-  Modelica.Blocks.Interfaces.BooleanOutput fire_p[m] "positive fire signal"
+  Modelica.Blocks.Interfaces.BooleanOutput fire_p[m] "Positive fire signal"
     annotation (Placement(transformation(extent={{100,50},{120,70}})));
-  Modelica.Blocks.Interfaces.BooleanOutput fire_n[m] "negative fire signal"
+  Modelica.Blocks.Interfaces.BooleanOutput fire_n[m] "Negative fire signal"
     annotation (Placement(transformation(extent={{100,-70},{120,-50}})));
   PowerConverters.DCAC.Control.SVPWM svPWM(
     f=f,

--- a/Modelica/Electrical/PowerConverters/DCAC/Control/SVPWM.mo
+++ b/Modelica/Electrical/PowerConverters/DCAC/Control/SVPWM.mo
@@ -16,12 +16,12 @@ block SVPWM "SpaceVector Pulse Width Modulation"
                               true, false,true] "Switching patterns";
   Modelica.Blocks.Interfaces.RealInput u[2] "Reference space phasor"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
-  Modelica.Blocks.Interfaces.BooleanOutput fire_p[m] "positive fire signal"
+  Modelica.Blocks.Interfaces.BooleanOutput fire_p[m] "Positive fire signal"
     annotation (Placement(transformation(extent={{100,50},{120,70}})));
-  Modelica.Blocks.Interfaces.BooleanOutput fire_n[m] "negative fire signal"
+  Modelica.Blocks.Interfaces.BooleanOutput fire_n[m] "Negative fire signal"
     annotation (Placement(transformation(extent={{100,-70},{120,-50}})));
 protected
-  discrete Real uRef(start=0, fixed=true) "length of reference vector";
+  discrete Real uRef(start=0, fixed=true) "Length of reference vector";
   discrete SI.Angle phiRef(start=0, fixed=true) "Angle of reference vector within (-pi, +pi]";
   discrete SI.Angle phiPos(start=0, fixed=true) "Angle of reference vector within [0, 2*pi)";
   Integer ka(start=0, fixed=true), kb(start=0, fixed=true) "Switching patterns limiting the sector";

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Examples/UnsymmetricalLoad.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Examples/UnsymmetricalLoad.mo
@@ -3,21 +3,21 @@ model UnsymmetricalLoad "Unsymmetrical three-phase load"
   extends Modelica.Icons.Example;
   import Modelica.ComplexMath.abs;
   output SI.Current i1_d=symmetricalComponents_1.abs_y[1]
-    "with neutral, direct component";
+    "With neutral, direct component";
   output SI.Current i1_i=symmetricalComponents_1.abs_y[2]
-    "with neutral, inverse component";
+    "With neutral, inverse component";
   output SI.Current i1_0=symmetricalComponents_1.abs_y[3]
-    "with neutral, zero component";
+    "With neutral, zero component";
   output SI.Current i1_n=abs(currentSensorN.i)
-    "with neutral, neutral current";
+    "With neutral, neutral current";
   output SI.Current i2_d=symmetricalComponents_2.abs_y[1]
-    "w/o neutral, direct component";
+    "Without neutral, direct component";
   output SI.Current i2_i=symmetricalComponents_2.abs_y[2]
-    "w/o neutral, inverse component";
+    "Without neutral, inverse component";
   output SI.Current i2_0=symmetricalComponents_2.abs_y[3]
-    "w/o neutral, zero component";
+    "Without neutral, zero component";
   output SI.Voltage v2_n=abs(voltageSensorN.v)
-    "w/o neutral, neutral voltage";
+    "Without neutral, neutral voltage";
 
   Sources.VoltageSource voltageSource1(
     m=3,

--- a/Modelica/Electrical/Spice3.mo
+++ b/Modelica/Electrical/Spice3.mo
@@ -4469,13 +4469,13 @@ on the model behaviour.
 
   model MOS "Metal-Oxide Semiconductor Field-Effect Transistor"
 
-    Modelica.Electrical.Analog.Interfaces.PositivePin G "gate node" annotation (Placement(transformation(
+    Modelica.Electrical.Analog.Interfaces.PositivePin G "Gate node" annotation (Placement(transformation(
               extent={{-110,-12},{-90,10}})));
-    Modelica.Electrical.Analog.Interfaces.PositivePin D "drain node" annotation (Placement(transformation(
+    Modelica.Electrical.Analog.Interfaces.PositivePin D "Drain node" annotation (Placement(transformation(
               extent={{-10,90},{10,110}})));
-    Modelica.Electrical.Analog.Interfaces.NegativePin S "source node" annotation (Placement(
+    Modelica.Electrical.Analog.Interfaces.NegativePin S "Source node" annotation (Placement(
             transformation(extent={{-10,-110},{10,-90}})));
-    Modelica.Electrical.Analog.Interfaces.PositivePin B "bulk node" annotation (Placement(transformation(
+    Modelica.Electrical.Analog.Interfaces.PositivePin B "Bulk node" annotation (Placement(transformation(
               extent={{90,-10},{110,10}})));
 
     parameter Integer mtype(start = 0)
@@ -4673,16 +4673,16 @@ on the model behaviour.
 
   model MOS2 "Metal-Oxide Semiconductor Field-Effect Transistor"
 
-    Modelica.Electrical.Analog.Interfaces.PositivePin G "gate node"
+    Modelica.Electrical.Analog.Interfaces.PositivePin G "Gate node"
                                           annotation (Placement(transformation(
               extent={{-110,-12},{-90,10}})));
-    Modelica.Electrical.Analog.Interfaces.PositivePin D "drain node"
+    Modelica.Electrical.Analog.Interfaces.PositivePin D "Drain node"
                                            annotation (Placement(transformation(
               extent={{-10,90},{10,110}})));
-    Modelica.Electrical.Analog.Interfaces.NegativePin S "source node"
+    Modelica.Electrical.Analog.Interfaces.NegativePin S "Source node"
                                             annotation (Placement(
             transformation(extent={{-10,-110},{10,-90}})));
-    Modelica.Electrical.Analog.Interfaces.PositivePin B "bulk node"
+    Modelica.Electrical.Analog.Interfaces.PositivePin B "Bulk node"
                                           annotation (Placement(transformation(
               extent={{90,-10},{110,10}})));
 
@@ -5090,11 +5090,11 @@ on the model behaviour.
 
   model JFET "Junction Field-Effect Transistor"
 
-    Modelica.Electrical.Analog.Interfaces.PositivePin G "gate node" annotation (Placement(transformation(
+    Modelica.Electrical.Analog.Interfaces.PositivePin G "Gate node" annotation (Placement(transformation(
               extent={{-110,-12},{-90,10}})));
-    Modelica.Electrical.Analog.Interfaces.PositivePin D "drain node" annotation (Placement(transformation(
+    Modelica.Electrical.Analog.Interfaces.PositivePin D "Drain node" annotation (Placement(transformation(
               extent={{-10,90},{10,110}})));
-    Modelica.Electrical.Analog.Interfaces.NegativePin S "source node" annotation (Placement(
+    Modelica.Electrical.Analog.Interfaces.NegativePin S "Source node" annotation (Placement(
             transformation(extent={{-10,-110},{10,-90}})));
 
     parameter Integer mtype( start = 0)
@@ -5654,7 +5654,7 @@ on the model behaviour.
 
       function junctionVCrit "Voltage limitation"
       extends Modelica.Icons.Function;
-        input SI.Temperature temp "temperature";
+        input SI.Temperature temp "Temperature";
         input Real ncoeff;
         input SI.Current satcur "Saturation current";
 
@@ -6380,7 +6380,7 @@ on the model behaviour.
 
       record MosfetModelLine "Type of the transistor"
         extends Modelica.Icons.Record;
-        Integer m_type(   start = 1) "device type : 1 = n,  -1 = p";
+        Integer m_type(   start = 1) "Device type : 1 = n,  -1 = p";
 
         annotation (Documentation(info="<html>
 <p>This record contains only one variable and it provides the information on the transistor type (PMOS or nmos).</p>
@@ -7785,9 +7785,9 @@ This record MosCalc contains further MOSFET variables (for level 1, 2, 3 and 6).
          intern.m_bulkJctPotential := ex.PB
           "V bulk junction potential (default 0.8)";
          intern.m_bulkJctBotGradingCoeff := ex.MJ
-          "bulk junction bottom grading coeff. (default 0.5)";
+          "Bulk junction bottom grading coeff. (default 0.5)";
          intern.m_bulkJctSideGradingCoeff := ex.MJSW
-          "bulk junction sidewall grading coeff. (default 0.5)";
+          "Bulk junction sidewall grading coeff. (default 0.5)";
 
          intern.m_oxideThicknessIsGiven := if          (ex.TOX > -1e40) then 1 else 0;
           intern.m_oxideThickness := if         (ex.TOX > -1e40) then ex.TOX else 0;
@@ -9050,7 +9050,7 @@ to the internal parameters (e.g., m_area). It also does the analysis of the IsGi
         SI.Length m_dLength "Length";
         Real m_dLengthIsGiven "Length is given value";
         Boolean m_bSensResist( start = false)
-          "flag to request sensitivity WRT resistance";
+          "Flag to request sensitivity WRT resistance";
         Modelica.Units.NonSI.Temperature_degC m_dTemp(start = 27) "Resistor device temperature";
 
         annotation (Documentation(info="<html>
@@ -9223,7 +9223,7 @@ to the internal parameters (e.g., m_area). It also does the analysis of the IsGi
 
       record BjtModelLineParams "Record for bjt model line parameters"
         extends Modelica.Icons.Record;
-        Real m_type( start = 1) "device type : 1 = n,  -1 = p";
+        Real m_type( start = 1) "Device type : 1 = n,  -1 = p";
 
         SI.Temperature m_tnom(start=Spice3.Internal.SpiceConstants.CKTnomTemp)
           "TNOM, Parameter measurement temperature";
@@ -10457,7 +10457,7 @@ to the internal parameters (e.g. m_drainResistance). It also does the analysis o
             SI.Length  m_dWidth(start=0) "Width";
             SI.Length  m_dLength(start=0) "Length";
             Boolean m_bSensCapac( start = false)
-          "flag to request sensitivity WRT Capacitor";
+          "Flag to request sensitivity WRT Capacitor";
 
         end Capacitor;
 

--- a/Modelica/Electrical/Spice3.mo
+++ b/Modelica/Electrical/Spice3.mo
@@ -7776,7 +7776,7 @@ This record MosCalc contains further MOSFET variables (for level 1, 2, 3 and 6).
           intern.m_transconductance := if         (ex.KP > -1e40) then ex.KP else 2e-5;
 
           intern.m_tnom := if (ex.TNOM > -1e40) then ex.TNOM + SpiceConstants.CONSTCtoK else 300.15
-          "parameter measurement temperature (default 27 deg C)";
+          "Parameter measurement temperature (default 27 deg C)";
 
          intern.m_jctSatCurDensity := ex.JS
           "A/(m*m) bulk junction saturation current per sq-meter of junction area (default 0)";

--- a/Modelica/Fluid/Examples/AST_BatchPlant.mo
+++ b/Modelica/Fluid/Examples/AST_BatchPlant.mo
@@ -947,7 +947,7 @@ Full steady state initialization is not supported, because the corresponding ini
             extent={{-10,-10},{10,10}},
             rotation=90)));
         Boolean m_flow_negative( start = true, fixed = true)
-        "true= mass flow out of tank";
+        "= true, if mass flow out of tank";
         constant SI.Acceleration g=Modelica.Constants.g_n;
         input Real aboveLevel;
         input Real d;

--- a/Modelica/Fluid/Examples/HeatExchanger.mo
+++ b/Modelica/Fluid/Examples/HeatExchanger.mo
@@ -2,7 +2,7 @@ within Modelica.Fluid.Examples;
 package HeatExchanger "Demo of a heat exchanger model"
   extends Modelica.Icons.ExamplesPackage;
 
-  model HeatExchangerSimulation "simulation for the heat exchanger model"
+  model HeatExchangerSimulation "Simulation for the heat exchanger model"
 
   extends Modelica.Icons.Example;
 
@@ -154,7 +154,7 @@ package HeatExchanger "Demo of a heat exchanger model"
 
       // Assumptions
       parameter Boolean allowFlowReversal = system.allowFlowReversal
-        "allow flow reversal, false restricts to design direction (port_a -> port_b)"
+        "Allow flow reversal, false restricts to design direction (port_a -> port_b)"
         annotation(Dialog(tab="Assumptions"), Evaluate=true);
       parameter Modelica.Fluid.Types.Dynamics energyDynamics=system.energyDynamics
         "Formulation of energy balance"

--- a/Modelica/Fluid/Examples/TraceSubstances.mo
+++ b/Modelica/Fluid/Examples/TraceSubstances.mo
@@ -6,7 +6,7 @@ package TraceSubstances "Library demonstrating the usage of trace substances"
     package Medium=Modelica.Media.Air.MoistAir(extraPropertiesNames={"CO2"},
                                                C_nominal={1.519E-3});
     Modelica.Blocks.Sources.Constant C(k=0.3*1.519E-3)
-      "substance concentration, raising to 1000 PPM CO2"
+      "Substance concentration, raising to 1000 PPM CO2"
       annotation (Placement(transformation(extent={{-94,-28},{-74,-8}})));
     Sources.FixedBoundary boundary4(nPorts=1,redeclare package Medium = Medium)
       annotation (Placement(transformation(extent={{80,-20},{60,0}})));

--- a/Modelica/Fluid/Fittings.mo
+++ b/Modelica/Fluid/Fittings.mo
@@ -319,9 +319,9 @@ model SimpleGenericOrifice
   Real zeta_nominal;
   Medium.Density d = 0.5*(Medium.density(state_a) + Medium.density(state_b));
   SI.Pressure dp_fg(start=dp_start)
-      "pressure loss due to friction and gravity";
+      "Pressure loss due to friction and gravity";
   SI.Area A_mean = Modelica.Constants.pi/4*diameter^2
-      "mean cross flow area";
+      "Mean cross flow area";
 
   constant SI.ReynoldsNumber Re_turbulent = 10000 "cf. sharpEdgedOrifice";
   SI.MassFlowRate m_flow_turbulent=if not use_Re then m_flow_small else
@@ -815,7 +815,7 @@ of the modeller.
          output LossFactorData data
             "Pressure loss factors for both flow directions";
         protected
-         Real Delta(min=0) = roughness/diameter "relative roughness";
+         Real Delta(min=0) = roughness/diameter "Relative roughness";
        algorithm
          data.diameter_a          := diameter;
          data.diameter_b          := diameter;

--- a/Modelica/Fluid/Fittings.mo
+++ b/Modelica/Fluid/Fittings.mo
@@ -1591,9 +1591,9 @@ The used sufficient criteria for monotonicity follows from:
 
         // Variables
         SI.Pressure dp_fg
-          "pressure loss due to friction and gravity";
+          "Pressure loss due to friction and gravity";
         SI.Area A_mean = Modelica.Constants.pi/4*(data.diameter_a^2+data.diameter_b^2)/2
-          "mean cross flow area";
+          "Mean cross flow area";
 
       equation
         Ib_flow = 0;
@@ -1800,9 +1800,9 @@ The used sufficient criteria for monotonicity follows from:
 
         // Variables
         SI.Pressure dp_fg
-          "pressure loss due to friction and gravity";
+          "Pressure loss due to friction and gravity";
         SI.Area A_mean = Modelica.Constants.pi/4*(data.diameter_a^2+data.diameter_b^2)/2
-          "mean cross flow area";
+          "Mean cross flow area";
 
         Medium.ThermodynamicState state_b_des
           "Thermodynamic state at port b for flow a -> b";

--- a/Modelica/Fluid/Interfaces.mo
+++ b/Modelica/Fluid/Interfaces.mo
@@ -716,7 +716,7 @@ Further source terms must be defined by an extending class for fluid flow across
            start = m_flow_start,
            stateSelect = if momentumDynamics == Types.Dynamics.SteadyState then StateSelect.default else
                                      StateSelect.prefer)
-      "mass flow rates between states";
+      "Mass flow rates between states";
 
         // Parameters
         parameter Modelica.Fluid.Types.Dynamics momentumDynamics=system.momentumDynamics
@@ -1029,7 +1029,7 @@ end PartialDistributedVolume;
            each start = m_flow_start,
            each stateSelect = if momentumDynamics == Types.Dynamics.SteadyState then StateSelect.default else
                                      StateSelect.prefer)
-      "mass flow rates between states";
+      "Mass flow rates between states";
 
         // Parameters
         parameter Modelica.Fluid.Types.Dynamics momentumDynamics=system.momentumDynamics

--- a/Modelica/Fluid/Interfaces.mo
+++ b/Modelica/Fluid/Interfaces.mo
@@ -329,8 +329,8 @@ partial model PartialTwoPortTransport
                   m_flow_small) if show_T
       "Temperature close to port_b, if show_T = true";
   protected
-  Medium.ThermodynamicState state_a "state for medium inflowing through port_a";
-  Medium.ThermodynamicState state_b "state for medium inflowing through port_b";
+  Medium.ThermodynamicState state_a "State for medium inflowing through port_a";
+  Medium.ThermodynamicState state_b "State for medium inflowing through port_b";
 equation
   // medium states
   state_a = Medium.setState_phX(port_a.p, inStream(port_a.h_outflow), inStream(port_a.Xi_outflow));

--- a/Modelica/Fluid/Machines.mo
+++ b/Modelica/Fluid/Machines.mo
@@ -481,7 +481,7 @@ Then the model can be replaced with a Pump with rotational shaft or with a Presc
     port_a.h_outflow = medium.h;
     port_b.h_outflow = medium.h;
     port_b.p = medium.p
-        "outlet pressure is equal to medium pressure, which includes Wb_flow";
+        "Outlet pressure is equal to medium pressure, which includes Wb_flow";
 
     // Mass balance
     mb_flow = port_a.m_flow + port_b.m_flow;

--- a/Modelica/Fluid/Machines.mo
+++ b/Modelica/Fluid/Machines.mo
@@ -3,13 +3,13 @@ package Machines
   "Devices for converting between energy held in a fluid and mechanical energy"
   extends Modelica.Icons.VariantsPackage;
   model SweptVolume
-    "varying cylindric volume depending on the position of the piston"
+    "Varying cylindric volume depending on the position of the piston"
     import Modelica.Constants.pi;
 
     parameter SI.Area pistonCrossArea "Cross sectional area of piston";
     parameter SI.Volume clearance "Remaining volume at zero piston stroke";
 
-    SI.Volume V "fluid volume";
+    SI.Volume V "Fluid volume";
 
     // Mass and energy balance, ports
     extends Modelica.Fluid.Vessels.BaseClasses.PartialLumpedVessel(
@@ -17,7 +17,7 @@ package Machines
       heatTransfer(surfaceAreas={pistonCrossArea+2*sqrt(pistonCrossArea*pi)*(flange.s+clearance/pistonCrossArea)}));
 
     Modelica.Mechanics.Translational.Interfaces.Flange_b flange
-      "translation flange for piston" annotation (Placement(transformation(
+      "Translation flange for piston" annotation (Placement(transformation(
             extent={{-10,90},{10,110}})));
 
   equation

--- a/Modelica/Fluid/Utilities.mo
+++ b/Modelica/Fluid/Utilities.mo
@@ -357,14 +357,14 @@ k1=1, k2=3 is shown in the next figure:</p>
   function regSquare2
     "Anti-symmetric approximation of square with discontinuous factor so that the first derivative is non-zero and is continuous"
     extends Modelica.Icons.Function;
-    input Real x "abscissa value";
+    input Real x "Abscissa value";
     input Real x_small(min=0)=0.01
-      "approximation of function for |x| <= x_small";
+      "Approximation of function for |x| <= x_small";
     input Real k1(min=0)=1 "y = (if x>=0 then k1 else k2)*x*|x|";
     input Real k2(min=0)=1 "y = (if x>=0 then k1 else k2)*x*|x|";
     input Boolean use_yd0 = false "= true, if yd0 shall be used";
     input Real yd0(min=0)=1 "Desired derivative at x=0: dy/dx = yd0";
-    output Real y "ordinate value";
+    output Real y "Ordinate value";
   protected
     encapsulated function regSquare2_utility
       "Interpolating with two 3-order polynomials with a prescribed derivative at x=0"
@@ -372,7 +372,7 @@ k1=1, k2=3 is shown in the next figure:</p>
       extends Modelica.Icons.Function;
       import Modelica.Fluid.Utilities.evaluatePoly3_derivativeAtZero;
        input Real x;
-       input Real x1 "approximation of function abs(x) < x1";
+       input Real x1 "Approximation of function abs(x) < x1";
        input Real k1 "y = (if x>=0 then k1 else -k2)*x*|x|; k1 >= k2";
        input Real k2 "y = (if x>=0 then k1 else -k2)*x*|x|";
        input Boolean use_yd0 = false "= true, if yd0 shall be used";
@@ -796,7 +796,7 @@ The second graph shows the continuous derivative of this regularization function
     output Real y "Interpolated ordinate value";
   protected
     Real h "Distance between x1 and x2";
-    Real t "abscissa scaled with h, i.e., t=[0..1] within x=[x1..x2]";
+    Real t "Abscissa scaled with h, i.e., t=[0..1] within x=[x1..x2]";
     Real h00 "Basis function 00 of cubic Hermite spline";
     Real h10 "Basis function 10 of cubic Hermite spline";
     Real h01 "Basis function 01 of cubic Hermite spline";
@@ -845,7 +845,7 @@ The second graph shows the continuous derivative of this regularization function
     output Real dy_dx "Derivative dy/dx at abscissa value x";
   protected
     Real h "Distance between x1 and x2";
-    Real t "abscissa scaled with h, i.e., t=[0..1] within x=[x1..x2]";
+    Real t "Abscissa scaled with h, i.e., t=[0..1] within x=[x1..x2]";
     Real h00 "Basis function 00 of cubic Hermite spline";
     Real h10 "Basis function 10 of cubic Hermite spline";
     Real h01 "Basis function 01 of cubic Hermite spline";

--- a/Modelica/Fluid/Vessels.mo
+++ b/Modelica/Fluid/Vessels.mo
@@ -243,22 +243,22 @@ end OpenTank;
 
         // Conservation of kinetic energy
         Medium.Density[nPorts] portInDensities
-        "densities of the fluid at the device boundary";
+        "Densities of the fluid at the device boundary";
         SI.Velocity[nPorts] portVelocities
-        "velocities of fluid flow at device boundary";
+        "Velocities of fluid flow at device boundary";
         SI.EnergyFlowRate[nPorts] ports_E_flow
-        "flow of kinetic and potential energy at device boundary";
+        "Flow of kinetic and potential energy at device boundary";
 
         // Note: should use fluidLevel_start - portsData.height
         Real[nPorts] s(each start = fluidLevel_max)
-        "curve parameters for port flows vs. port pressures; for further details see, Modelica Tutorial: Ideal switching devices";
+        "Curve parameters for port flows vs. port pressures; for further details see, Modelica Tutorial: Ideal switching devices";
         Real[nPorts] ports_penetration
-        "penetration of port with fluid, depending on fluid level and port diameter";
+        "Penetration of port with fluid, depending on fluid level and port diameter";
 
         // treatment of pressure losses at ports
         SI.Area[nPorts] portAreas = {Modelica.Constants.pi/4*portsData_diameter[i]^2 for i in 1:nPorts};
         Medium.AbsolutePressure[nPorts] vessel_ps_static
-        "static pressures inside the vessel at the height of the corresponding ports, zero flow velocity";
+        "Static pressures inside the vessel at the height of the corresponding ports, zero flow velocity";
 
         // determination of turbulent region
         constant SI.ReynoldsNumber Re_turbulent = 100 "cf. suddenExpansion";
@@ -266,9 +266,9 @@ end OpenTank;
 
     protected
         input SI.Height fluidLevel = 0
-        "level of fluid in the vessel for treating heights of ports";
+        "Level of fluid in the vessel for treating heights of ports";
         parameter SI.Height fluidLevel_max = 1
-        "maximum level of fluid in the vessel";
+        "Maximum level of fluid in the vessel";
         parameter SI.Area vesselArea = Modelica.Constants.inf
         "Area of the vessel used to relate to cross flow area of ports";
 
@@ -511,7 +511,7 @@ Ideal heat transfer without thermal resistance.
         "ConstantHeatTransfer: Constant heat transfer coefficient"
       extends PartialVesselHeatTransfer;
       parameter SI.CoefficientOfHeatTransfer alpha0
-          "constant heat transfer coefficient";
+          "Constant heat transfer coefficient";
 
     equation
       Q_flows = {(alpha0+k)*surfaceAreas[i]*(heatPorts[i].T - Ts[i]) for i in 1:n};

--- a/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/Components/Transformer1PhaseWithHysteresis.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/Components/Transformer1PhaseWithHysteresis.mo
@@ -54,7 +54,7 @@ model Transformer1PhaseWithHysteresis
         group="Material"), choicesAllMatching=true);
 
   output SI.Voltage v1 "Primary voltage drop";
-  output SI.Voltage v2 "secondary voltage drop";
+  output SI.Voltage v2 "Secondary voltage drop";
 
   output SI.Resistance R1 "Primary resistance of Winding";
   output SI.Resistance R2 "Secondary resistance of Winding";

--- a/Modelica/Magnetic/FluxTubes/Shapes/HysteresisAndMagnets/GenericHystPreisachEverett.mo
+++ b/Modelica/Magnetic/FluxTubes/Shapes/HysteresisAndMagnets/GenericHystPreisachEverett.mo
@@ -13,13 +13,13 @@ model GenericHystPreisachEverett
     "Tolerance in Preisach history" annotation(Dialog(group="Advanced"));
   parameter SI.Time t1=1e-6 "Initialization time" annotation(Dialog(group="Advanced"));
 
-  extends BaseClasses.GenericHysteresis(      sigma=mat.sigma);
+  extends BaseClasses.GenericHysteresis(sigma=mat.sigma);
 
 protected
   final parameter Real mu0=mat.K*Modelica.Constants.mu_0;
 
   SI.MagneticFluxDensity J "Polarisation";
-  SI.MagneticFieldStrength hmax(start=0, min=0) "maximum value of h";
+  SI.MagneticFieldStrength hmax(start=0, min=0) "Maximum value of h";
 
   SI.MagneticFieldStrength alpha
     "Current alpha coordinate of Everett-Function everett(alpha,beta)";

--- a/Modelica/Magnetic/FluxTubes/Shapes/HysteresisAndMagnets/GenericHystPreisachEverett.mo
+++ b/Modelica/Magnetic/FluxTubes/Shapes/HysteresisAndMagnets/GenericHystPreisachEverett.mo
@@ -29,9 +29,9 @@ protected
   Boolean asc(start=true, fixed=true) "=asc without chatter";
   Boolean asc2 "Hstat is ascending der(Hstat)>0";
   Boolean delAsc(start=false)
-    "wipeout history vertex at ascending Hstat";
+    "Wipeout history vertex at ascending Hstat";
   Boolean delDesc(start=false)
-    "wipeout history vertex at descending Hstat";
+    "Wipeout history vertex at descending Hstat";
   Boolean del(start=false) "delAsc or delDesc";
   Boolean init(start=false, fixed=true)
     "If init=1 then J runs on the initial magnetization curve";

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Sensors/RotorDisplacementAngle.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Sensors/RotorDisplacementAngle.mo
@@ -26,7 +26,7 @@ model RotorDisplacementAngle "Rotor lagging angle"
         extent={{-10,-10},{10,10}},
         rotation=270)));
   Modelica.Mechanics.Rotational.Interfaces.Flange_a support if useSupport
-    "support at which the reaction torque is acting" annotation (Placement(
+    "Support at which the reaction torque is acting" annotation (Placement(
         transformation(extent={{90,90},{110,110}})));
   Modelica.Mechanics.Rotational.Components.Fixed fixed if (not useSupport)
     annotation (Placement(transformation(extent={{90,70},{110,90}})));

--- a/Modelica/Math/FastFourierTransform.mo
+++ b/Modelica/Math/FastFourierTransform.mo
@@ -552,7 +552,7 @@ which is a complete example where an FFT is computed during simulation and store
        annotation(choices(choice="4" "MATLAB v4 MAT-file",
                           choice="6" "MATLAB v6 MAT-file",
                           choice="7" "MATLAB v7 MAT-file"));
-    output Boolean success "true if successful";
+    output Boolean success "= true, if successful";
   protected
      Integer nA = size(amplitudes,1);
      Real fA[3*size(amplitudes,1),if size(phases,1)==0 then 2 else 3];

--- a/Modelica/Math/Nonlinear.mo
+++ b/Modelica/Math/Nonlinear.mo
@@ -639,7 +639,7 @@ See the examples in <a href=\"modelica://Modelica.Math.Nonlinear.Examples\">Mode
     output Real u "Value of independent variable u so that f(u) = 0";
 
   protected
-    constant Real eps=Modelica.Constants.eps "machine epsilon";
+    constant Real eps=Modelica.Constants.eps "Machine epsilon";
     Real a=u_min "Current best minimum interval value";
     Real b=u_max "Current best maximum interval value";
     Real c "Intermediate point a <= c <= b";

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -1326,9 +1326,9 @@ where Q1 consists of the first \"rank\" columns of Q.
     extends Modelica.Icons.Function;
     input Real A[:, :] "Minimize |A*x - a|^2";
     input Real a[size(A, 1)];
-    input Real B[:, size(A, 2)] "subject to B*x=b";
+    input Real B[:, size(A, 2)] "Subject to B*x=b";
     input Real b[size(B, 1)];
-    output Real x[size(A, 2)] "solution vector";
+    output Real x[size(A, 2)] "Solution vector";
 
   protected
     Integer info;
@@ -2696,7 +2696,7 @@ To be more precise:
   protected
     Real eps=1e-25;
     Real eps2 = 10*Modelica.Constants.eps;
-    Real s[size(A, 1)] "singular values";
+    Real s[size(A, 1)] "Singular values";
 
   algorithm
     if min(size(A)) > 0 then
@@ -2760,7 +2760,7 @@ r = 3.0
   protected
     Real LU[size(A, 1), size(A, 1)]
       "LU factorization of matrix A, returned by dgetrf";
-    Real anorm "norm of matrix A";
+    Real anorm "Norm of matrix A";
     String normspec=if inf then "I" else "1" "Specifies the norm 1 or inf";
 
   algorithm
@@ -5432,7 +5432,7 @@ Lapack documentation
       output Real x[max(size(A, 1), size(A, 2))]=cat(
                 1,
                 b,
-                zeros(nx - nrow)) "solution is in first size(A,2) rows";
+                zeros(nx - nrow)) "Solution is in first size(A,2) rows";
       output Integer info;
     protected
       Integer nrow=size(A, 1);
@@ -5672,9 +5672,9 @@ For details of the arguments, see documentation of dgesv.
       extends Modelica.Icons.Function;
       input Real A[:, :] "Minimize |A*x - c|^2";
       input Real c[size(A, 1)];
-      input Real B[:, size(A, 2)] "subject to B*x=d";
+      input Real B[:, size(A, 2)] "Subject to B*x=d";
       input Real d[size(B, 1)];
-      output Real x[size(A, 2)] "solution vector";
+      output Real x[size(A, 2)] "Solution vector";
       output Integer info;
     protected
       Integer nrow_A=size(A, 1);
@@ -7921,7 +7921,7 @@ For details of the arguments, see documentation of dgbsv.
       input Real LU_of_A[:, :] "LU factorization of a real matrix A";
       input Boolean inf=false
         "Is true if infinity norm is used and false for 1-norm";
-      input Real anorm "norm of A";
+      input Real anorm "Norm of A";
       output Real rcond "Reciprocal condition number of A";
       output Integer info;
     protected

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -2760,7 +2760,7 @@ r = 3.0
   protected
     Real LU[size(A, 1), size(A, 1)]
       "LU factorization of matrix A, returned by dgetrf";
-    Real anorm "Norm of matrix A";
+    Real anorm "norm of matrix A";
     String normspec=if inf then "I" else "1" "Specifies the norm 1 or inf";
 
   algorithm
@@ -2939,9 +2939,9 @@ r = 3.162;
 
   protected
     Real V[size(A, 2), size(A, 2)] "Right orthogonal matrix";
-    Real sigma[min(size(A, 1), size(A, 2))] "singular values";
-    Integer rank "rank of matrix A";
-    Real eps "tolerance for rank determination";
+    Real sigma[min(size(A, 1), size(A, 2))] "Singular values";
+    Integer rank "Rank of matrix A";
+    Real eps "Tolerance for rank determination";
     Integer n=min(size(A, 1), size(A, 2));
     Integer i=n;
 
@@ -3469,7 +3469,7 @@ is, e.g., described in
   protected
     Integer n=size(A, 1);
     Real R[size(A, 1), size(A, 2)] "rsf of A', i.e., R=U'A'U";
-    Real U[size(A, 1), size(A, 2)] "transformation matrix U for R=U'A'U";
+    Real U[size(A, 1), size(A, 2)] "Transformation matrix U for R=U'A'U";
     Real D[size(A, 1), size(A, 2)] "Matrix D=U'*C*U";
     Real R11[size(A, 1), size(A, 2)];
     Real R22[size(A, 1), size(A, 2)];
@@ -6848,10 +6848,10 @@ For details of the arguments, see documentation of dgbsv.
       input Real A[:, size(A, 1)] "Square matrix";
       output Real T[size(A, 1), size(A, 2)]=A "Real Schur form with A = Z*T*Z'";
       output Real Z[size(A, 1), size(A, 1)]
-        "orthogonal matrix Z of Schur vectors";
-      output Real eval_real[size(A, 1)] "real part of the eigenvectors of A";
+        "Orthogonal matrix Z of Schur vectors";
+      output Real eval_real[size(A, 1)] "Real part of the eigenvectors of A";
       output Real eval_imag[size(A, 1)]
-        "imaginary part of the eigenvectors of A";
+        "Imaginary part of the eigenvectors of A";
       output Integer info;
 
     protected
@@ -7264,7 +7264,7 @@ For details of the arguments, see documentation of dgbsv.
         "= true, if the equation to be solved is A'*X=B";
       output Real X[size(A, 1), size(B, 2)] "Solution matrix";
       output Integer info;
-      output Real rcond "reciprocal condition number of the matrix A";
+      output Real rcond "Reciprocal condition number of the matrix A";
 
     protected
       Integer n=size(A, 1);
@@ -7845,8 +7845,8 @@ For details of the arguments, see documentation of dgbsv.
       extends Modelica.Icons.Function;
 
       input Real A[:, :] "Real matrix A";
-      input String norm="1" "specifies the norm, i.e., 1, I, F, M";
-      output Real anorm "norm of A";
+      input String norm="1" "Specifies the norm, i.e., 1, I, F, M";
+      output Real anorm "Norm of A";
     protected
       Integer m=size(A, 1);
       Integer n=size(A, 2);

--- a/Modelica/Mechanics/MultiBody/Examples/Loops/Fourbar1.mo
+++ b/Modelica/Mechanics/MultiBody/Examples/Loops/Fourbar1.mo
@@ -3,10 +3,10 @@ model Fourbar1
   "One kinematic loop with four bars (with only revolute joints; 5 non-linear equations)"
   extends Modelica.Icons.Example;
 
-  output SI.Angle j1_phi "angle of revolute joint j1";
-  output SI.Position j2_s "distance of prismatic joint j2";
-  output SI.AngularVelocity j1_w "axis speed of revolute joint j1";
-  output SI.Velocity j2_v "axis velocity of prismatic joint j2";
+  output SI.Angle j1_phi "Angle of revolute joint j1";
+  output SI.Position j2_s "Distance of prismatic joint j2";
+  output SI.AngularVelocity j1_w "Axis speed of revolute joint j1";
+  output SI.Velocity j2_v "Axis velocity of prismatic joint j2";
 
   inner Modelica.Mechanics.MultiBody.World world annotation (Placement(
         transformation(extent={{-100,-70},{-80,-50}})));

--- a/Modelica/Mechanics/MultiBody/Examples/Loops/Fourbar2.mo
+++ b/Modelica/Mechanics/MultiBody/Examples/Loops/Fourbar2.mo
@@ -3,10 +3,10 @@ model Fourbar2
   "One kinematic loop with four bars (with UniversalSpherical joint; 1 non-linear equation)"
   extends Modelica.Icons.Example;
 
-  output SI.Angle j1_phi "angle of revolute joint j1";
-  output SI.Position j2_s "distance of prismatic joint j2";
-  output SI.AngularVelocity j1_w "axis speed of revolute joint j1";
-  output SI.Velocity j2_v "axis velocity of prismatic joint j2";
+  output SI.Angle j1_phi "Angle of revolute joint j1";
+  output SI.Position j2_s "Distance of prismatic joint j2";
+  output SI.AngularVelocity j1_w "Axis speed of revolute joint j1";
+  output SI.Velocity j2_v "Axis velocity of prismatic joint j2";
 
   inner Modelica.Mechanics.MultiBody.World world annotation (Placement(
         transformation(extent={{-100,-70},{-80,-50}})));

--- a/Modelica/Mechanics/MultiBody/Examples/Loops/Fourbar_analytic.mo
+++ b/Modelica/Mechanics/MultiBody/Examples/Loops/Fourbar_analytic.mo
@@ -3,10 +3,10 @@ model Fourbar_analytic
   "One kinematic loop with four bars (with JointSSP joint; analytic solution of non-linear algebraic loop)"
   extends Modelica.Icons.Example;
 
-  output SI.Angle j1_phi "angle of revolute joint j1";
-  output SI.Position j2_s "distance of prismatic joint j2";
-  output SI.AngularVelocity j1_w "axis speed of revolute joint j1";
-  output SI.Velocity j2_v "axis velocity of prismatic joint j2";
+  output SI.Angle j1_phi "Angle of revolute joint j1";
+  output SI.Position j2_s "Distance of prismatic joint j2";
+  output SI.AngularVelocity j1_w "Axis speed of revolute joint j1";
+  output SI.Velocity j2_v "Axis velocity of prismatic joint j2";
 
   inner Modelica.Mechanics.MultiBody.World world(animateGravity=false)
     annotation (Placement(transformation(extent={{-100,-70},{-80,-50}})));

--- a/Modelica/Mechanics/MultiBody/Joints/Internal/PrismaticWithLengthConstraint.mo
+++ b/Modelica/Mechanics/MultiBody/Joints/Internal/PrismaticWithLengthConstraint.mo
@@ -99,8 +99,8 @@ protected
     Real k2 "Constant of quadratic equation solution";
     Real k1a;
     Real k1b;
-    Real d1 "solution 1 of quadratic equation";
-    Real d2 "solution 2 of quadratic equation";
+    Real d1 "Solution 1 of quadratic equation";
+    Real d2 "Solution 2 of quadratic equation";
   algorithm
     /* The position vector r_rel from frame_a to frame_b of the length constraint
        element, resolved in frame_b of the prismatic joint (frame_a and frame_b

--- a/Modelica/Mechanics/MultiBody/Joints/Internal/RevoluteWithLengthConstraint.mo
+++ b/Modelica/Mechanics/MultiBody/Joints/Internal/RevoluteWithLengthConstraint.mo
@@ -109,8 +109,8 @@ protected
     Real ksin1 "k1*sin(angle1)";
     Real kcos2 "k2*cos(angle2)";
     Real ksin2 "k2*sin(angle2)";
-    SI.Angle angle1 "solution 1 of nonlinear equation";
-    SI.Angle angle2 "solution 2 of nonlinear equation";
+    SI.Angle angle1 "Solution 1 of nonlinear equation";
+    SI.Angle angle2 "Solution 2 of nonlinear equation";
   algorithm
     /* The position vector r_rel from frame_a to frame_b of the length constraint
        element, resolved in frame_b of the revolute joint is given by

--- a/Modelica/Mechanics/MultiBody/Parts/Body.mo
+++ b/Modelica/Mechanics/MultiBody/Parts/Body.mo
@@ -112,7 +112,7 @@ model Body
           useQuaternions));
 
   final parameter SI.Inertia I[3, 3]=[I_11, I_21, I_31; I_21, I_22, I_32;
-      I_31, I_32, I_33] "inertia tensor";
+      I_31, I_32, I_33] "Inertia tensor";
   final parameter Frames.Orientation R_start=
       Modelica.Mechanics.MultiBody.Frames.axesRotations(
         sequence_start,

--- a/Modelica/Mechanics/Rotational/Components/LossyGear.mo
+++ b/Modelica/Mechanics/Rotational/Components/LossyGear.mo
@@ -59,10 +59,10 @@ model LossyGear
 
   Boolean tau_aPos(start=true)
     "Only for backwards compatibility (was previously: true, if torque of flange_a is not negative)";
-  Boolean tau_etaPos(start=true) "true, if torque tau_eta is not negative";
-  Boolean startForward(start=false) "true, if starting to roll forward";
-  Boolean startBackward(start=false) "true, if starting to roll backward";
-  Boolean locked(start=false) "true, if gear is locked";
+  Boolean tau_etaPos(start=true) "= true, if torque tau_eta is not negative";
+  Boolean startForward(start=false) "= true, if starting to roll forward";
+  Boolean startBackward(start=false) "= true, if starting to roll backward";
+  Boolean locked(start=false) "= true, if gear is locked";
 
   Boolean ideal
     "= true, if losses are neglected (that is lossTable = [0, 1, 1, 0, 0])";

--- a/Modelica/Mechanics/Rotational/Components/OneWayClutch.mo
+++ b/Modelica/Mechanics/Rotational/Components/OneWayClutch.mo
@@ -20,15 +20,15 @@ model OneWayClutch "Parallel connection of freewheel and clutch"
   Real u "Normalized force input signal (0..1)";
   SI.Force fn "Normal force (fn=fn_max*inPort.signal)";
   Boolean startForward(start=false)
-    "true, if w_rel=0 and start of forward sliding or w_rel > w_small";
-  Boolean locked(start=false) "true, if w_rel=0 and not sliding";
+    "= true, if w_rel=0 and start of forward sliding or w_rel > w_small";
+  Boolean locked(start=false) "= true, if w_rel=0 and not sliding";
   Boolean stuck(start=false) "w_rel=0 (locked or start forward sliding)";
 
 protected
   SI.Torque tau0 "Friction torque for w=0 and sliding";
   SI.Torque tau0_max "Maximum friction torque for w=0 and locked";
   Real mu0 "Friction coefficient for w=0 and sliding";
-  Boolean free "true, if frictional element is not active";
+  Boolean free "= true, if frictional element is not active";
   Real sa(final unit="1")
     "Path parameter of tau = f(a_rel) Friction characteristic";
   constant Real eps0=1.0e-4 "Relative hysteresis epsilon";

--- a/Modelica/Mechanics/Rotational/Examples/SimpleGearShift.mo
+++ b/Modelica/Mechanics/Rotational/Examples/SimpleGearShift.mo
@@ -4,7 +4,7 @@ model SimpleGearShift "Simple Gearshift"
   output SI.AngularVelocity wEngine=engine.w
     "Speed of engine";
   output SI.AngularVelocity wLoad=load.w "Speed of load";
-  output Real gearRatio=wLoad/max(wEngine, 1E-6) "gear ratio load/engine";
+  output Real gearRatio=wLoad/max(wEngine, 1E-6) "Gear ratio load/engine";
   Modelica.Mechanics.Rotational.Sources.TorqueStep torqueStep(
     offsetTorque=0,
     startTime=0.5,

--- a/Modelica/Mechanics/Rotational/Interfaces/PartialFriction.mo
+++ b/Modelica/Mechanics/Rotational/Interfaces/PartialFriction.mo
@@ -21,7 +21,7 @@ partial model PartialFriction "Partial model of Coulomb friction elements"
     "= true, if w_relfric=0 and start of forward sliding";
   Boolean startBackward(start=false, fixed=true)
     "= true, if w_relfric=0 and start of backward sliding";
-  Boolean locked(start=false) "true, if w_rel=0 and not sliding";
+  Boolean locked(start=false) "= true, if w_rel=0 and not sliding";
   constant Integer Unknown=3 "Value of mode is not known";
   constant Integer Free=2 "Element is not active";
   constant Integer Forward=1 "w_relfric > 0 (forward sliding)";

--- a/Modelica/Mechanics/Translational/Components/MassWithStopAndFriction.mo
+++ b/Modelica/Mechanics/Translational/Components/MassWithStopAndFriction.mo
@@ -41,7 +41,7 @@ model MassWithStopAndFriction
       "Friction force (positive, if directed in opposite direction of v_rel)";
     Modelica.Units.SI.Force f0 "Friction force for v=0 and forward sliding";
     Modelica.Units.SI.Force f0_max "Maximum friction force for v=0 and locked";
-    Boolean free "true, if frictional element is not active";
+    Boolean free "= true, if frictional element is not active";
     // Equations to define the following variables are given in this class
     Real sa(unit="1")
       "Path parameter of friction characteristic f = f(a_relfric)";
@@ -49,7 +49,7 @@ model MassWithStopAndFriction
       "= true, if v_rel=0 and start of forward sliding or v_rel > v_small";
     Boolean startBackward(start=false, fixed=true)
       "= true, if v_rel=0 and start of backward sliding or v_rel < -v_small";
-    Boolean locked(start=false) "true, if v_rel=0 and not sliding";
+    Boolean locked(start=false) "= true, if v_rel=0 and not sliding";
     extends PartialRigid(s(start=0, stateSelect=StateSelect.always));
     constant Integer Unknown=3 "Value of mode is not known";
     constant Integer Free=2 "Element is not active";

--- a/Modelica/Media/Air/MoistAir.mo
+++ b/Modelica/Media/Air/MoistAir.mo
@@ -58,7 +58,7 @@ package MoistAir "Air: Moist air model (190 ... 647 K)"
       "Steam water mass fraction of saturation boundary in kg_water/kg_moistair";
     MassFraction x_sat
       "Steam water mass content of saturation boundary in kg_water/kg_dryair";
-    AbsolutePressure p_steam_sat "partial saturation pressure of steam";
+    AbsolutePressure p_steam_sat "Partial saturation pressure of steam";
   equation
     assert(T >= 190 and T <= 647, "
 Temperature T is not in the allowed range
@@ -762,7 +762,7 @@ Specific enthalpy of moist air is computed from the thermodynamic state record. 
     input SI.MassFraction X[:] "Mass fractions of moist air";
     output SI.SpecificEnthalpy h "Specific enthalpy at p, T, X";
   protected
-    SI.AbsolutePressure p_steam_sat "partial saturation pressure of steam";
+    SI.AbsolutePressure p_steam_sat "Partial saturation pressure of steam";
     SI.MassFraction X_sat "Absolute humidity per unit mass of moist air";
     SI.MassFraction X_liquid "Mass fraction of liquid water";
     SI.MassFraction X_steam "Mass fraction of steam water";
@@ -806,7 +806,7 @@ Specific enthalpy of moist air is computed from pressure, temperature and compos
     input Real dX[:](each unit="1/s") "Composition derivative";
     output Real h_der(unit="J/(kg.s)") "Time derivative of specific enthalpy";
   protected
-    SI.AbsolutePressure p_steam_sat "partial saturation pressure of steam";
+    SI.AbsolutePressure p_steam_sat "Partial saturation pressure of steam";
     SI.MassFraction X_sat "Absolute humidity per unit mass of moist air";
     SI.MassFraction X_liquid "Mass fraction of liquid water";
     SI.MassFraction X_steam "Mass fraction of steam water";

--- a/Modelica/Media/Air/MoistAir.mo
+++ b/Modelica/Media/Air/MoistAir.mo
@@ -932,7 +932,7 @@ Specific internal energy is determined from the thermodynamic state record, assu
     input SI.MassFraction X[:] "Mass fractions of moist air";
     output SI.SpecificInternalEnergy u "Specific internal energy";
   protected
-    SI.AbsolutePressure p_steam_sat "partial saturation pressure of steam";
+    SI.AbsolutePressure p_steam_sat "Partial saturation pressure of steam";
     SI.MassFraction X_liquid "Mass fraction of liquid water";
     SI.MassFraction X_steam "Mass fraction of steam water";
     SI.MassFraction X_air "Mass fraction of air";
@@ -974,7 +974,7 @@ Specific internal energy is determined from pressure p, temperature T and compos
     input Real dX[:](each unit="1/s") "Mass fraction derivatives";
     output Real u_der(unit="J/(kg.s)") "Specific internal energy derivative";
   protected
-    SI.AbsolutePressure p_steam_sat "partial saturation pressure of steam";
+    SI.AbsolutePressure p_steam_sat "Partial saturation pressure of steam";
     SI.MassFraction X_liquid "Mass fraction of liquid water";
     SI.MassFraction X_steam "Mass fraction of steam water";
     SI.MassFraction X_air "Mass fraction of air";

--- a/Modelica/Media/Air/ReferenceMoistAir.mo
+++ b/Modelica/Media/Air/ReferenceMoistAir.mo
@@ -61,7 +61,7 @@ package ReferenceMoistAir
       "Steam water mass fraction of saturation boundary in kg_water/kg_moistair";
     Real x_sat
       "Steam water mass content of saturation boundary in kg_water/kg_dryair";
-    AbsolutePressure p_steam_sat "partial saturation pressure of steam";
+    AbsolutePressure p_steam_sat "Partial saturation pressure of steam";
   equation
     assert(T >= 143.15 and T <= 2000,
       "Temperature T is not in the allowed range 143.15 K <= (T =" + String(T)

--- a/Modelica/Media/Air/ReferenceMoistAir.mo
+++ b/Modelica/Media/Air/ReferenceMoistAir.mo
@@ -2683,14 +2683,14 @@ for region 2.
 </html>"));
     end pds_pT;
 
-    function pd_pTX "partial pressure of steam"
+    function pd_pTX "Partial pressure of steam"
       extends Modelica.Icons.Function;
 
       input SI.AbsolutePressure p "Pressure";
       input SI.Temperature T "Temperature";
       input SI.MassFraction X[:]=Modelica.Media.Air.ReferenceMoistAir.reference_X
         "Mass fractions";
-      output SI.AbsolutePressure pd "partial pressure";
+      output SI.AbsolutePressure pd "Partial pressure";
 
     protected
       Real xw;

--- a/Modelica/Media/Water/IF97_Utilities.mo
+++ b/Modelica/Media/Water/IF97_Utilities.mo
@@ -6331,8 +6331,8 @@ of Water and Steam. ASME Journal of Engineering for Gas Turbines and Power 122 (
     aux.p := max(p, 611.657);
     aux.h := max(h, 1e3);
     aux.R_s := BaseIF97.data.RH2O;
-    aux.vt := 0.0 "initialized in case it is not needed";
-    aux.vp := 0.0 "initialized in case it is not needed";
+    aux.vt := 0.0 "Initialized in case it is not needed";
+    aux.vp := 0.0 "Initialized in case it is not needed";
     if (aux.region == 1) then
       aux.T := BaseIF97.Basic.tph1(aux.p, aux.h);
       g := BaseIF97.Basic.g1(p, aux.T);
@@ -6481,8 +6481,8 @@ of Water and Steam. ASME Journal of Engineering for Gas Turbines and Power 122 (
     aux.p := p;
     aux.s := s;
     aux.R_s := BaseIF97.data.RH2O;
-    aux.vt := 0.0 "initialized in case it is not needed";
-    aux.vp := 0.0 "initialized in case it is not needed";
+    aux.vt := 0.0 "Initialized in case it is not needed";
+    aux.vp := 0.0 "Initialized in case it is not needed";
     if (aux.region == 1) then
       aux.T := BaseIF97.Basic.tps1(p, s);
       g := BaseIF97.Basic.g1(p, aux.T);
@@ -7184,8 +7184,8 @@ of Water and Steam. ASME Journal of Engineering for Gas Turbines and Power 122 (
     aux.R_s := BaseIF97.data.RH2O;
     aux.p := p;
     aux.T := T;
-    aux.vt := 0.0 "initialized in case it is not needed";
-    aux.vp := 0.0 "initialized in case it is not needed";
+    aux.vt := 0.0 "Initialized in case it is not needed";
+    aux.vp := 0.0 "Initialized in case it is not needed";
     if (aux.region == 1) then
       g := BaseIF97.Basic.g1(p, T);
       aux.h := aux.R_s*aux.T*g.tau*g.gtau;
@@ -7618,8 +7618,8 @@ of Water and Steam. ASME Journal of Engineering for Gas Turbines and Power 122 (
     aux.R_s := BaseIF97.data.RH2O;
     aux.rho := rho;
     aux.T := T;
-    aux.vt := 0.0 "initialized in case it is not needed";
-    aux.vp := 0.0 "initialized in case it is not needed";
+    aux.vt := 0.0 "Initialized in case it is not needed";
+    aux.vp := 0.0 "Initialized in case it is not needed";
     if (aux.region == 1) then
       (aux.p,error) := BaseIF97.Inverses.pofdt125(
           d=rho,

--- a/Modelica/Media/package.mo
+++ b/Modelica/Media/package.mo
@@ -7105,7 +7105,7 @@ package Common "Data structures and fundamental functions for fluid properties"
       SI.Pressure[nspecies] compp(
         min=COMPPMIN,
         max=COMPPMAX,
-        nominal=COMPPNOM) "partial pressures of the components";
+        nominal=COMPPNOM) "Partial pressures of the components";
       SI.Velocity a(
         min=VELMIN,
         max=VELMAX,

--- a/Modelica/StateGraph.mo
+++ b/Modelica/StateGraph.mo
@@ -1438,7 +1438,7 @@ buttons:
     connector Inflow1
         "Inflow connector (this is a copy from Isolde Dressler's master thesis project)"
 
-      input SI.VolumeFlowRate Fi "inflow";
+      input SI.VolumeFlowRate Fi "Inflow";
       annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
                   -100},{100,100}}), graphics={Polygon(
                 points={{-100,-100},{0,100},{100,-100},{-100,-100}},
@@ -1450,7 +1450,7 @@ buttons:
     connector Inflow2
         "Inflow connector (this is a copy from Isolde Dressler's master thesis project)"
 
-      output SI.VolumeFlowRate Fi "inflow";
+      output SI.VolumeFlowRate Fi "Inflow";
       annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
                   -100},{100,100}}), graphics={Polygon(
                 points={{-100,-100},{0,100},{100,-100},{-100,-100}},
@@ -1462,8 +1462,8 @@ buttons:
     connector Outflow1
         "Outflow connector (this is a copy from Isolde Dressler's master thesis project)"
 
-      output SI.VolumeFlowRate Fo "outflow";
-      input Boolean open "valve open";
+      output SI.VolumeFlowRate Fo "Outflow";
+      input Boolean open "Valve open";
       annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
                   -100},{100,100}}), graphics={Polygon(
                 points={{-100,100},{0,-100},{100,100},{-100,100}},
@@ -1475,8 +1475,8 @@ buttons:
     connector Outflow2
         "Outflow connector (this is a copy from Isolde Dressler's master thesis project)"
 
-      input SI.VolumeFlowRate Fo "outflow";
-      output Boolean open "valve open";
+      input SI.VolumeFlowRate Fo "Outflow";
+      output Boolean open "Valve open";
       annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
                   -100},{100,100}}), graphics={Polygon(
                 points={{-100,100},{0,-100},{100,100},{-100,100}},

--- a/Modelica/Thermal/FluidHeatFlow/Examples/IndirectCooling.mo
+++ b/Modelica/Thermal/FluidHeatFlow/Examples/IndirectCooling.mo
@@ -12,11 +12,11 @@ model IndirectCooling "Indirect cooling circuit"
   output SI.TemperatureDifference dTtoPipe=prescribedHeatFlow.port.T-pipe1.T_q
     "Source over inner Coolant";
   output SI.TemperatureDifference dTinnerCoolant=pipe1.dT
-    "inner Coolant's temperature increase";
+    "Inner Coolant's temperature increase";
   output SI.TemperatureDifference dTCooler=innerPipe.T_q-outerPipe.T_q
     "Cooler's temperature increase between inner and outer pipes";
   output SI.TemperatureDifference dTouterCoolant=outerPipe.dT
-    "outer Coolant's temperature increase";
+    "Outer coolant's temperature increase";
   FluidHeatFlow.Sources.Ambient ambient1(
     constantAmbientTemperature=TAmb,
     medium=outerMedium,

--- a/Modelica/Thermal/FluidHeatFlow/Examples/ParallelCooling.mo
+++ b/Modelica/Thermal/FluidHeatFlow/Examples/ParallelCooling.mo
@@ -19,7 +19,7 @@ model ParallelCooling "Cooling circuit with parallel branches"
   output SI.TemperatureDifference dTCoolant2=pipe2.dT
     "Coolant2's temperature increase";
   output SI.TemperatureDifference dTmixedCoolant=ambient2.T_port-ambient1.T_port
-    "mixed Coolant's temperature increase";
+    "Mixed Coolant's temperature increase";
   FluidHeatFlow.Sources.Ambient ambient1(
     constantAmbientTemperature=TAmb,
     medium=medium,

--- a/Modelica/Thermal/FluidHeatFlow/Examples/ParallelPumpDropOut.mo
+++ b/Modelica/Thermal/FluidHeatFlow/Examples/ParallelPumpDropOut.mo
@@ -19,7 +19,7 @@ model ParallelPumpDropOut
   output SI.TemperatureDifference dTCoolant2=pipe2.dT
     "Coolant2's temperature increase";
   output SI.TemperatureDifference dTmixedCoolant=ambient2.T_port-ambient1.T_port
-    "mixed Coolant's temperature increase";
+    "Mixed Coolant's temperature increase";
   FluidHeatFlow.Sources.Ambient ambient1(
     constantAmbientTemperature=TAmb,
     medium=medium,

--- a/Modelica/Thermal/FluidHeatFlow/Examples/TwoMass.mo
+++ b/Modelica/Thermal/FluidHeatFlow/Examples/TwoMass.mo
@@ -22,7 +22,7 @@ model TwoMass "Cooling of two hot masses"
   output SI.TemperatureDifference dTCoolant2=pipe2.dT
     "Coolant2's temperature increase";
   output SI.TemperatureDifference dTmixedCoolant=ambient2.T_port-ambient1.T_port
-    "mixed Coolant's temperature increase";
+    "Mixed Coolant's temperature increase";
   FluidHeatFlow.Sources.Ambient ambient1(
     constantAmbientTemperature=TAmb,
     medium=medium,

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -1153,7 +1153,7 @@ which is only valid in the rotor-fixed coordinate system.
     operator record ComplexAdmittance =
       Complex(redeclare Conductance re "Real part of complex admittance (conductance)",
               redeclare Susceptance im "Imaginary part of complex admittance (susceptance)")
-      "Complex electrical admittance";
+      "Complex admittance";
     operator record ComplexPower =
       Complex(redeclare ActivePower re "Real part of complex power (active power)",
               redeclare ReactivePower im "Imaginary part of complex power (reactive power)")

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -1579,8 +1579,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function from_Ah "Convert from Ampere hours to Coulomb"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.ElectricCharge_Ah AmpereHour "Ampere hours";
-      output Modelica.Units.SI.ElectricCharge Coulomb "Coulomb";
+      input Modelica.Units.NonSI.ElectricCharge_Ah AmpereHour "Value in ampere hours";
+      output Modelica.Units.SI.ElectricCharge Coulomb "Value in coulomb";
     algorithm
       Coulomb := AmpereHour * 3600;
 
@@ -1593,8 +1593,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_Ah "Convert from Coulomb to Ampere hours"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.SI.ElectricCharge Coulomb "Coulomb";
-      output Modelica.Units.NonSI.ElectricCharge_Ah AmpereHour "Ampere hours";
+      input Modelica.Units.SI.ElectricCharge Coulomb "Value in coulomb";
+      output Modelica.Units.NonSI.ElectricCharge_Ah AmpereHour "Value in ampere hours";
     algorithm
       AmpereHour := Coulomb/3600;
 
@@ -1607,8 +1607,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function from_Wh "Convert from Watt hour to Joule"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.Energy_Wh WattHour "Watt hour";
-      output Modelica.Units.SI.Energy Joule "Joule";
+      input Modelica.Units.NonSI.Energy_Wh WattHour "Value in watt hour";
+      output Modelica.Units.SI.Energy Joule "Value in joule";
     algorithm
       Joule := WattHour * 3600;
 
@@ -1621,8 +1621,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_Wh "Convert from Joule to Watt hour"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.SI.Energy Joule "Joule";
-      output Modelica.Units.NonSI.Energy_Wh WattHour "Watt hour";
+      input Modelica.Units.SI.Energy Joule "Value in joule";
+      output Modelica.Units.NonSI.Energy_Wh WattHour "Value in watt hour";
     algorithm
       WattHour := Joule/3600;
 
@@ -1719,8 +1719,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function from_Hz "Convert from Hz to rad/s"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Frequency f "frequency";
-      output SI.AngularVelocity w "angular velocity";
+      input SI.Frequency f "Value in hertz";
+      output SI.AngularVelocity w "Value in radian per second";
 
     algorithm
       w := 2*Modelica.Constants.pi*f;
@@ -1734,8 +1734,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_Hz "Convert from rad/s to Hz"
       extends Modelica.Units.Icons.Conversion;
-      input SI.AngularVelocity w "angular velocity";
-      output SI.Frequency f "frequency";
+      input SI.AngularVelocity w "Value in radian per second";
+      output SI.Frequency f "Value in hertz";
     algorithm
       f := w/(2*Modelica.Constants.pi);
       annotation (Inline=true,Icon(graphics={

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -1352,10 +1352,10 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
               textString="degF")}));
     end from_degF;
 
-    function to_degRk "Convert from kelvin to degRankine"
+    function to_degRk "Convert from kelvin to degree Rankine"
       extends Modelica.Units.Icons.Conversion;
       input SI.Temperature Kelvin "Value in kelvin";
-      output Modelica.Units.NonSI.Temperature_degRk Rankine "Value in Rankine";
+      output Modelica.Units.NonSI.Temperature_degRk Rankine "Value in degree Rankine";
     algorithm
       Rankine := (9/5)*Kelvin;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1366,9 +1366,9 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
               textString="degRk")}));
     end to_degRk;
 
-    function from_degRk "Convert from degRankine to kelvin"
+    function from_degRk "Convert from degree Rankine to kelvin"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.Temperature_degRk Rankine "Value in Rankine";
+      input Modelica.Units.NonSI.Temperature_degRk Rankine "Value in degree Rankine";
       output SI.Temperature Kelvin "Value in kelvin";
     algorithm
       Kelvin := (5/9)*Rankine;

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -596,10 +596,10 @@ end UsersGuide;
     type PowerFactor = Real (final quantity="PowerFactor", final unit="1");
     type LinearTemperatureCoefficientResistance = Real (
       final quantity="LinearTemperatureCoefficientResistance",
-      final unit="Ohm/K") "First Order Temperature Coefficient";
+      final unit="Ohm/K") "First order temperature coefficient";
     type QuadraticTemperatureCoefficientResistance = Real (
       final quantity="QuadraticTemperatureCoefficientResistance",
-      final unit="Ohm/K2") "Second Order Temperature Coefficient";
+      final unit="Ohm/K2") "Second order temperature coefficient";
     // added to ISO-chapter 5
     type Transconductance = Real (final quantity="Transconductance", final unit=
             "A/V2");

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -1089,7 +1089,7 @@ end UsersGuide;
     operator record ComplexVoltage =
       Complex(redeclare Modelica.Units.SI.Voltage re "Imaginary part of complex voltage",
               redeclare Modelica.Units.SI.Voltage im "Real part of complex voltage")
-      "Complex electrical voltage";
+      "Complex electric voltage";
     operator record ComplexVoltageSlope =
       Complex(redeclare Modelica.Units.SI.VoltageSlope re "Real part of complex voltage slope",
               redeclare Modelica.Units.SI.VoltageSlope im "Imaginary part of complex voltage slope")

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -1155,9 +1155,9 @@ which is only valid in the rotor-fixed coordinate system.
               redeclare Susceptance im "Imaginary part of complex admittance (susceptance)")
       "Complex admittance";
     operator record ComplexPower =
-      Complex(redeclare ActivePower re "Real part of complex power (active power)",
-              redeclare ReactivePower im "Imaginary part of complex power (reactive power)")
-      "Complex electrical power";
+      Complex(redeclare ActivePower re "Real part of complex apparent power (active power)",
+              redeclare ReactivePower im "Imaginary part of complex apparent power (reactive power)")
+      "Complex apparent power";
     operator record ComplexPerUnit =
       Complex(redeclare PerUnit re "Real part of complex per unit quantity",
               redeclare PerUnit im "Imaginary part of complex per unit quantity")

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -1605,7 +1605,7 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
               textString="Ah")}));
     end to_Ah;
 
-    function from_Wh "Convert from Watt hour to Joule"
+    function from_Wh "Convert from watt hour to joule"
       extends Modelica.Units.Icons.Conversion;
       input Modelica.Units.NonSI.Energy_Wh WattHour "Value in watt hour";
       output Modelica.Units.SI.Energy Joule "Value in joule";
@@ -1619,7 +1619,7 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
               textString="J")}));
     end from_Wh;
 
-    function to_Wh "Convert from Joule to Watt hour"
+    function to_Wh "Convert from joule to watt hour"
       extends Modelica.Units.Icons.Conversion;
       input Modelica.Units.SI.Energy Joule "Value in joule";
       output Modelica.Units.NonSI.Energy_Wh WattHour "Value in watt hour";

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -1080,7 +1080,7 @@ end UsersGuide;
       "Complex electric current density";
     operator record ComplexElectricPotential =
       Complex(redeclare Modelica.Units.SI.ElectricPotential re "Imaginary part of complex electric potential",
-              redeclare Modelica.Units.SI.ElectricPotential im "Real part of complex electrical potential")
+              redeclare Modelica.Units.SI.ElectricPotential im "Real part of complex electric potential")
       "Complex electric potential";
     operator record ComplexPotentialDifference =
       Complex(redeclare Modelica.Units.SI.PotentialDifference re "Real part of complex potential difference",

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -1149,7 +1149,7 @@ which is only valid in the rotor-fixed coordinate system.
     operator record ComplexImpedance =
       Complex(redeclare Resistance re "Real part of complex impedance (resistance)",
               redeclare Reactance im "Imaginary part of complex impedance (reactance)")
-      "Complex electrical impedance";
+      "Complex impedance";
     operator record ComplexAdmittance =
       Complex(redeclare Conductance re "Real part of complex admittance (conductance)",
               redeclare Susceptance im "Imaginary part of complex admittance (susceptance)")

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -1294,9 +1294,9 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
           textString="1")}));
   end to_unit1;
 
-    function to_degC "Convert from Kelvin to degCelsius"
+    function to_degC "Convert from kelvin to degCelsius"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Temperature Kelvin "Value in Kelvin";
+      input SI.Temperature Kelvin "Value in kelvin";
       output Modelica.Units.NonSI.Temperature_degC Celsius "Value in Celsius";
     algorithm
       Celsius := Kelvin + Modelica.Constants.T_zero;
@@ -1308,10 +1308,10 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
               textString="degC")}));
     end to_degC;
 
-    function from_degC "Convert from degCelsius to Kelvin"
+    function from_degC "Convert from degCelsius to kelvin"
       extends Modelica.Units.Icons.Conversion;
       input Modelica.Units.NonSI.Temperature_degC Celsius "Value in Celsius";
-      output SI.Temperature Kelvin "Value in Kelvin";
+      output SI.Temperature Kelvin "Value in kelvin";
     algorithm
       Kelvin := Celsius - Modelica.Constants.T_zero;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1322,9 +1322,9 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
               textString="K")}));
     end from_degC;
 
-    function to_degF "Convert from Kelvin to degFahrenheit"
+    function to_degF "Convert from kelvin to degFahrenheit"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Temperature Kelvin "Value in Kelvin";
+      input SI.Temperature Kelvin "Value in kelvin";
       output Modelica.Units.NonSI.Temperature_degF Fahrenheit "Value in Fahrenheit";
     algorithm
       Fahrenheit := (Kelvin + Modelica.Constants.T_zero)*(9/5) + 32;
@@ -1336,10 +1336,10 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
               textString="degF")}));
     end to_degF;
 
-    function from_degF "Convert from degFahrenheit to Kelvin"
+    function from_degF "Convert from degFahrenheit to kelvin"
       extends Modelica.Units.Icons.Conversion;
       input Modelica.Units.NonSI.Temperature_degF Fahrenheit "Value in Fahrenheit";
-      output SI.Temperature Kelvin "Value in Kelvin";
+      output SI.Temperature Kelvin "Value in kelvin";
     algorithm
       Kelvin := (Fahrenheit - 32)*(5/9) - Modelica.Constants.T_zero;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1352,9 +1352,9 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
               textString="degF")}));
     end from_degF;
 
-    function to_degRk "Convert from Kelvin to degRankine"
+    function to_degRk "Convert from kelvin to degRankine"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Temperature Kelvin "Value in Kelvin";
+      input SI.Temperature Kelvin "Value in kelvin";
       output Modelica.Units.NonSI.Temperature_degRk Rankine "Value in Rankine";
     algorithm
       Rankine := (9/5)*Kelvin;
@@ -1366,10 +1366,10 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
               textString="degRk")}));
     end to_degRk;
 
-    function from_degRk "Convert from degRankine to Kelvin"
+    function from_degRk "Convert from degRankine to kelvin"
       extends Modelica.Units.Icons.Conversion;
       input Modelica.Units.NonSI.Temperature_degRk Rankine "Value in Rankine";
-      output SI.Temperature Kelvin "Value in Kelvin";
+      output SI.Temperature Kelvin "Value in kelvin";
     algorithm
       Kelvin := (5/9)*Rankine;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1784,7 +1784,7 @@ argument):</p>
 <strong>import</strong> Modelica.Units.SI;
 <strong>import</strong> Modelica.Units.Conversions.{from_degC, from_deg, from_rpm};
    ...
-<strong>parameter</strong> SI.Temperature     T   = from_degC(25);   // convert 25 degree Celsius to Kelvin
+<strong>parameter</strong> SI.Temperature     T   = from_degC(25);   // convert 25 degree Celsius to kelvin
 <strong>parameter</strong> SI.Angle           phi = from_deg(180);   // convert 180 degree to radian
 <strong>parameter</strong> SI.AngularVelocity w   = from_rpm(3600);  // convert 3600 revolutions per minutes
                                                    // to radian per seconds

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -1633,9 +1633,9 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
               textString="Wh")}));
     end to_Wh;
 
-    function to_kWh "Convert from Joule to kilo Watt hour"
+    function to_kWh "Convert from joule to kilo watt hour"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Energy J "Value in Joule";
+      input SI.Energy J "Value in joule";
       output Modelica.Units.NonSI.Energy_kWh kWh "Value in kWh";
     algorithm
       kWh := J/3.6e6;
@@ -1647,10 +1647,10 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
               textString="kWh")}));
     end to_kWh;
 
-    function from_kWh "Convert from kilo Watt hour to Joule"
+    function from_kWh "Convert from kilo watt hour to joule"
       extends Modelica.Units.Icons.Conversion;
       input Modelica.Units.NonSI.Energy_kWh kWh "Value in kWh";
-      output SI.Energy J "Value in Joule";
+      output SI.Energy J "Value in joule";
     algorithm
       J := 3.6e6*kWh;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -1294,10 +1294,10 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
           textString="1")}));
   end to_unit1;
 
-    function to_degC "Convert from kelvin to degCelsius"
+    function to_degC "Convert from kelvin to degree Celsius"
       extends Modelica.Units.Icons.Conversion;
       input SI.Temperature Kelvin "Value in kelvin";
-      output Modelica.Units.NonSI.Temperature_degC Celsius "Value in Celsius";
+      output Modelica.Units.NonSI.Temperature_degC Celsius "Value in degree Celsius";
     algorithm
       Celsius := Kelvin + Modelica.Constants.T_zero;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1308,9 +1308,9 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
               textString="degC")}));
     end to_degC;
 
-    function from_degC "Convert from degCelsius to kelvin"
+    function from_degC "Convert from degree Celsius to kelvin"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.Temperature_degC Celsius "Value in Celsius";
+      input Modelica.Units.NonSI.Temperature_degC Celsius "Value in degree Celsius";
       output SI.Temperature Kelvin "Value in kelvin";
     algorithm
       Kelvin := Celsius - Modelica.Constants.T_zero;

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -1296,8 +1296,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_degC "Convert from Kelvin to degCelsius"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Temperature Kelvin "Kelvin value";
-      output Modelica.Units.NonSI.Temperature_degC Celsius "Celsius value";
+      input SI.Temperature Kelvin "Value in Kelvin";
+      output Modelica.Units.NonSI.Temperature_degC Celsius "Value in Celsius";
     algorithm
       Celsius := Kelvin + Modelica.Constants.T_zero;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1310,8 +1310,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function from_degC "Convert from degCelsius to Kelvin"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.Temperature_degC Celsius "Celsius value";
-      output SI.Temperature Kelvin "Kelvin value";
+      input Modelica.Units.NonSI.Temperature_degC Celsius "Value in Celsius";
+      output SI.Temperature Kelvin "Value in Kelvin";
     algorithm
       Kelvin := Celsius - Modelica.Constants.T_zero;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1324,8 +1324,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_degF "Convert from Kelvin to degFahrenheit"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Temperature Kelvin "Kelvin value";
-      output Modelica.Units.NonSI.Temperature_degF Fahrenheit "Fahrenheit value";
+      input SI.Temperature Kelvin "Value in Kelvin";
+      output Modelica.Units.NonSI.Temperature_degF Fahrenheit "Value in Fahrenheit";
     algorithm
       Fahrenheit := (Kelvin + Modelica.Constants.T_zero)*(9/5) + 32;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1338,8 +1338,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function from_degF "Convert from degFahrenheit to Kelvin"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.Temperature_degF Fahrenheit "Fahrenheit value";
-      output SI.Temperature Kelvin "Kelvin value";
+      input Modelica.Units.NonSI.Temperature_degF Fahrenheit "Value in Fahrenheit";
+      output SI.Temperature Kelvin "Value in Kelvin";
     algorithm
       Kelvin := (Fahrenheit - 32)*(5/9) - Modelica.Constants.T_zero;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1354,8 +1354,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_degRk "Convert from Kelvin to degRankine"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Temperature Kelvin "Kelvin value";
-      output Modelica.Units.NonSI.Temperature_degRk Rankine "Rankine value";
+      input SI.Temperature Kelvin "Value in Kelvin";
+      output Modelica.Units.NonSI.Temperature_degRk Rankine "Value in Rankine";
     algorithm
       Rankine := (9/5)*Kelvin;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1368,8 +1368,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function from_degRk "Convert from degRankine to Kelvin"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.Temperature_degRk Rankine "Rankine value";
-      output SI.Temperature Kelvin "Kelvin value";
+      input Modelica.Units.NonSI.Temperature_degRk Rankine "Value in Rankine";
+      output SI.Temperature Kelvin "Value in Kelvin";
     algorithm
       Kelvin := (5/9)*Rankine;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1382,8 +1382,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_deg "Convert from radian to degree"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Angle radian "radian value";
-      output Modelica.Units.NonSI.Angle_deg degree "degree value";
+      input SI.Angle radian "Value in radian";
+      output Modelica.Units.NonSI.Angle_deg degree "Value in degree";
     algorithm
       degree := (180.0/Modelica.Constants.pi)*radian;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1396,8 +1396,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function from_deg "Convert from degree to radian"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.Angle_deg degree "degree value";
-      output SI.Angle radian "radian value";
+      input Modelica.Units.NonSI.Angle_deg degree "Value in degree";
+      output SI.Angle radian "Value in radian";
     algorithm
       radian := (Modelica.Constants.pi/180.0)*degree;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1410,8 +1410,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_rpm "Convert from radian per second to revolutions per minute"
       extends Modelica.Units.Icons.Conversion;
-      input SI.AngularVelocity rs "radian per second value";
-      output Modelica.Units.NonSI.AngularVelocity_rpm rpm "revolutions per minute value";
+      input SI.AngularVelocity rs "Value in radian per second";
+      output Modelica.Units.NonSI.AngularVelocity_rpm rpm "Value in revolutions per minute";
     algorithm
       rpm := (30/Modelica.Constants.pi)*rs;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1425,8 +1425,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
     function from_rpm
       "Convert from revolutions per minute to radian per second"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.AngularVelocity_rpm rpm "revolutions per minute value";
-      output SI.AngularVelocity rs "radian per second value";
+      input Modelica.Units.NonSI.AngularVelocity_rpm rpm "Value in revolutions per minute";
+      output SI.AngularVelocity rs "Value in radian per second";
     algorithm
       rs := (Modelica.Constants.pi/30)*rpm;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1439,8 +1439,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_kmh "Convert from metre per second to kilometre per hour"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Velocity ms "metre per second value";
-      output Modelica.Units.NonSI.Velocity_kmh kmh "kilometre per hour value";
+      input SI.Velocity ms "Value in metre per second";
+      output Modelica.Units.NonSI.Velocity_kmh kmh "Value in kilometre per hour";
     algorithm
       kmh := 3.6*ms;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1453,8 +1453,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function from_kmh "Convert from kilometre per hour to metre per second"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.Velocity_kmh kmh "kilometre per hour value";
-      output SI.Velocity ms "metre per second value";
+      input Modelica.Units.NonSI.Velocity_kmh kmh "Value in kilometre per hour";
+      output SI.Velocity ms "Value in metre per second";
     algorithm
       ms := kmh/3.6;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1467,8 +1467,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_day "Convert from second to day"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Time s "second value";
-      output Modelica.Units.NonSI.Time_day day "day value";
+      input SI.Time s "Value in second";
+      output Modelica.Units.NonSI.Time_day day "Value in day";
     algorithm
       day := s/86400;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1481,8 +1481,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function from_day "Convert from day to second"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.Time_day day "day value";
-      output SI.Time s "second value";
+      input Modelica.Units.NonSI.Time_day day "Value in day";
+      output SI.Time s "Value in second";
     algorithm
       s := 86400*day;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1495,8 +1495,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_hour "Convert from second to hour"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Time s "second value";
-      output Modelica.Units.NonSI.Time_hour hour "hour value";
+      input SI.Time s "Value in second";
+      output Modelica.Units.NonSI.Time_hour hour "Value in hour";
     algorithm
       hour := s/3600;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1509,8 +1509,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function from_hour "Convert from hour to second"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.Time_hour hour "hour value";
-      output SI.Time s "second value";
+      input Modelica.Units.NonSI.Time_hour hour "Value in hour";
+      output SI.Time s "Value in second";
     algorithm
       s := 3600*hour;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1523,8 +1523,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_minute "Convert from second to minute"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Time s "second value";
-      output Modelica.Units.NonSI.Time_minute minute "minute value";
+      input SI.Time s "Value in second";
+      output Modelica.Units.NonSI.Time_minute minute "Value in minute";
     algorithm
       minute := s/60;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1537,8 +1537,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function from_minute "Convert from minute to second"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.Time_minute minute "minute value";
-      output SI.Time s "second value";
+      input Modelica.Units.NonSI.Time_minute minute "Value in minute";
+      output SI.Time s "Value in second";
     algorithm
       s := 60*minute;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1551,8 +1551,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_litre "Convert from cubic metre to litre"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Volume m3 "cubic metre value";
-      output Modelica.Units.NonSI.Volume_litre litre "litre value";
+      input SI.Volume m3 "Value in cubic metre";
+      output Modelica.Units.NonSI.Volume_litre litre "Value in litre";
     algorithm
       litre := 1000*m3;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1565,8 +1565,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function from_litre "Convert from litre to cubic metre"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.Volume_litre litre "litre value";
-      output SI.Volume m3 "cubic metre value";
+      input Modelica.Units.NonSI.Volume_litre litre "Value in litre";
+      output SI.Volume m3 "Value in cubic metre";
     algorithm
       m3 := litre/1000;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1635,8 +1635,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_kWh "Convert from Joule to kilo Watt hour"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Energy J "Joule value";
-      output Modelica.Units.NonSI.Energy_kWh kWh "kWh value";
+      input SI.Energy J "Value in Joule";
+      output Modelica.Units.NonSI.Energy_kWh kWh "Value in kWh";
     algorithm
       kWh := J/3.6e6;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1649,8 +1649,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function from_kWh "Convert from kilo Watt hour to Joule"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.Energy_kWh kWh "kWh value";
-      output SI.Energy J "Joule value";
+      input Modelica.Units.NonSI.Energy_kWh kWh "Value in kWh";
+      output SI.Energy J "Value in Joule";
     algorithm
       J := 3.6e6*kWh;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1663,8 +1663,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_bar "Convert from Pascal to bar"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Pressure Pa "Pascal value";
-      output Modelica.Units.NonSI.Pressure_bar bar "bar value";
+      input SI.Pressure Pa "Value in Pascal";
+      output Modelica.Units.NonSI.Pressure_bar bar "Value in bar";
     algorithm
       bar := Pa/1e5;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1677,8 +1677,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function from_bar "Convert from bar to Pascal"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.Pressure_bar bar "bar value";
-      output SI.Pressure Pa "Pascal value";
+      input Modelica.Units.NonSI.Pressure_bar bar "Value in bar";
+      output SI.Pressure Pa "Value in Pascal";
     algorithm
       Pa := 1e5*bar;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1691,8 +1691,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_gps "Convert from kilogram per second to gram per second"
       extends Modelica.Units.Icons.Conversion;
-      input SI.MassFlowRate kgps "kg/s value";
-      output Modelica.Units.NonSI.MassFlowRate_gps gps "g/s value";
+      input SI.MassFlowRate kgps "Value in kg/s";
+      output Modelica.Units.NonSI.MassFlowRate_gps gps "Value in g/s";
     algorithm
       gps := 1000*kgps;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1705,8 +1705,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function from_gps "Convert from gram per second to kilogram per second"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.MassFlowRate_gps gps "g/s value";
-      output SI.MassFlowRate kgps "kg/s value";
+      input Modelica.Units.NonSI.MassFlowRate_gps gps "Value in g/s";
+      output SI.MassFlowRate kgps "Value in kg/s";
     algorithm
       kgps := gps/1000;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1748,8 +1748,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function to_cm2 "Convert from square metre to square centimetre"
       extends Modelica.Units.Icons.Conversion;
-      input SI.Area m2 "square metre value";
-      output Modelica.Units.NonSI.Area_cm cm2 "square centimetre value";
+      input SI.Area m2 "Value in square metre";
+      output Modelica.Units.NonSI.Area_cm cm2 "Value in square centimetre";
     algorithm
       cm2 := 10000*m2;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1762,8 +1762,8 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
 
     function from_cm2 "Convert from square centimetre to square metre"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.Area_cm cm2 "square centimetre value";
-      output SI.Area m2 "square metre value";
+      input Modelica.Units.NonSI.Area_cm cm2 "Value in square centimetre";
+      output SI.Area m2 "Value in square metre";
     algorithm
       m2 := 0.0001*cm2;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -1322,10 +1322,10 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
               textString="K")}));
     end from_degC;
 
-    function to_degF "Convert from kelvin to degFahrenheit"
+    function to_degF "Convert from kelvin to degree Fahrenheit"
       extends Modelica.Units.Icons.Conversion;
       input SI.Temperature Kelvin "Value in kelvin";
-      output Modelica.Units.NonSI.Temperature_degF Fahrenheit "Value in Fahrenheit";
+      output Modelica.Units.NonSI.Temperature_degF Fahrenheit "Value in degree Fahrenheit";
     algorithm
       Fahrenheit := (Kelvin + Modelica.Constants.T_zero)*(9/5) + 32;
       annotation (Inline=true,Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -1336,9 +1336,9 @@ Real direction[3](unit=\"1\") = to_unit1(v);   // Automatically vectorized call 
               textString="degF")}));
     end to_degF;
 
-    function from_degF "Convert from degFahrenheit to kelvin"
+    function from_degF "Convert from degree Fahrenheit to kelvin"
       extends Modelica.Units.Icons.Conversion;
-      input Modelica.Units.NonSI.Temperature_degF Fahrenheit "Value in Fahrenheit";
+      input Modelica.Units.NonSI.Temperature_degF Fahrenheit "Value in degree Fahrenheit";
       output SI.Temperature Kelvin "Value in kelvin";
     algorithm
       Kelvin := (Fahrenheit - 32)*(5/9) - Modelica.Constants.T_zero;

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -1069,7 +1069,7 @@ end UsersGuide;
     operator record ComplexCurrent =
       Complex(redeclare Modelica.Units.SI.Current re "Real part of complex current",
               redeclare Modelica.Units.SI.Current im "Imaginary part of complex current")
-      "Complex electrical current";
+      "Complex electric current";
     operator record ComplexCurrentSlope =
       Complex(redeclare Modelica.Units.SI.CurrentSlope re "Real part of complex current slope",
               redeclare Modelica.Units.SI.CurrentSlope im "Imaginary part of complex current slope")
@@ -1077,7 +1077,7 @@ end UsersGuide;
     operator record ComplexCurrentDensity =
       Complex(redeclare Modelica.Units.SI.CurrentDensity re "Real part of complex current density",
               redeclare Modelica.Units.SI.CurrentDensity im "Imaginary part of complex current density")
-      "Complex electrical current density";
+      "Complex electric current density";
     operator record ComplexElectricPotential =
       Complex(redeclare Modelica.Units.SI.ElectricPotential re "Imaginary part of complex electric potential",
               redeclare Modelica.Units.SI.ElectricPotential im "Real part of complex electrical potential")

--- a/Modelica/Utilities/Files.mo
+++ b/Modelica/Utilities/Files.mo
@@ -404,7 +404,7 @@ impure function createDirectory
       "Inquire whether directory exists; if present and not a directory, trigger an error"
      extends Modelica.Icons.Function;
      input String directoryName;
-     output Boolean exists "true if directory exists";
+     output Boolean exists "= true, if directory exists";
     protected
      Types.FileType fileType = Modelica.Utilities.Internal.FileSystem.stat(
                                              directoryName);

--- a/Modelica/Utilities/Strings.mo
+++ b/Modelica/Utilities/Strings.mo
@@ -382,7 +382,7 @@ performed replacements.
 
   function sort "Sort vector of strings in alphabetic order"
     extends Modelica.Icons.Function;
-    input String stringVector1[:] "vector of strings";
+    input String stringVector1[:] "Vector of strings";
     input Boolean caseSensitive=true
       "= false, if lower and upper case are ignored when comparing elements of stringVector1";
     output String stringVector2[size(stringVector1,1)]
@@ -644,7 +644,7 @@ import T = Modelica.Utilities.Types.TokenType;
     input String message=""
       "Message used in error message if scan is not successful";
     output Real number "Value of real number";
-    output Integer nextIndex "index of character after the found number";
+    output Integer nextIndex "Index of character after the found number";
   algorithm
     (nextIndex, number) :=Advanced.scanReal(string, startIndex, unsigned);
     if nextIndex == startIndex then

--- a/Modelica/Utilities/Strings.mo
+++ b/Modelica/Utilities/Strings.mo
@@ -315,7 +315,7 @@ If \"searchString\" is not found, a value of \"0\" is returned.
       "String that replaces 'searchString' in 'string'";
     input Integer startIndex=1 "Start search at index startIndex";
     input Boolean replaceAll=true
-      "if false, replace only the first occurrence, otherwise all occurrences";
+      "= false, if only the first occurrence is replaced, otherwise all occurrences";
     input Boolean caseSensitive=true
       "= false, if lower and upper case are ignored when searching for searchString";
     output String result "Resultant string of replacement operation";


### PR DESCRIPTION
~This change is not applied to `Units.mo` where lots of doc string start with a lower case letter.~ 

Examples:

- metre
- revolution
- angular
- radian
- cubic
- bar
- second
- minute

are spelled with a lower case letter at the beginning of the doc string. 

@MartinOtter I wonder if we shall switch to all upper case letter at the beginning of each doc string.