### PR TITLE
Fix spelling mistakes with help of DSpellCheck

### DIFF
--- a/Modelica/Blocks/Interfaces.mo
+++ b/Modelica/Blocks/Interfaces.mo
@@ -1418,11 +1418,11 @@ of noise blocks.
   potential, 1st derivative of potential, and 2nd derivative of potential as outputs (especially useful for FMUs)"
       parameter Boolean use_pder=true "Use output for 1st derivative of potential"
         annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
-      parameter Boolean use_pder2=true "Use output for 2nd derivative of potential (only if 1st derivate is used, too)"
+      parameter Boolean use_pder2=true "Use output for 2nd derivative of potential (only if 1st derivative is used, too)"
         annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
       parameter Boolean use_fder=true "Use input for 1st derivative of flow"
         annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
-      parameter Boolean use_fder2=true "Use input for 2nd derivative of flow (only if 1st derivate is used, too)"
+      parameter Boolean use_fder2=true "Use input for 2nd derivative of flow (only if 1st derivative is used, too)"
         annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
       Modelica.Blocks.Interfaces.RealOutput p "Output for potential"
         annotation (Placement(transformation(extent={{20,70},{40,90}})));
@@ -1530,11 +1530,11 @@ Note, the input signals must be consistent to each other
   flow, 1st derivative of flow, and 2nd derivative of flow as outputs (especially useful for FMUs)"
       parameter Boolean use_pder=true "Use input for 1st derivative of potential"
         annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
-      parameter Boolean use_pder2=true "Use input for 2nd derivative of potential (only if 1st derivate is used, too)"
+      parameter Boolean use_pder2=true "Use input for 2nd derivative of potential (only if 1st derivative is used, too)"
         annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
       parameter Boolean use_fder=true "Use output for 1st derivative of flow"
         annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
-      parameter Boolean use_fder2=true "Use output for 2nd derivative of flow (only if 1st derivate is used, too)"
+      parameter Boolean use_fder2=true "Use output for 2nd derivative of flow (only if 1st derivative is used, too)"
         annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
       Modelica.Blocks.Interfaces.RealInput p "Input for potential"
         annotation (Placement(transformation(extent={{-40,70},{-20,90}})));

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1152,7 +1152,7 @@ Thus, we have to sample for a&nbsp;period of <code>n*samplePeriod&nbsp;=&nbsp;1/
 The result file &quot;rectifier6pulseFFTresult.mat&quot; can be used to plot
 amplitudes versus frequencies.
 Note that for each frequency three rows exit: one with amplitude zero,
-one with the calculated amplitude, one with apmplitude zero.
+one with the calculated amplitude, one with amplitude zero.
 Thus, the second column (amplitude) can be easily plotted versus the first column (frequency).
 As expected, one can see the 5<sup>th</sup>, 7<sup>th</sup>, 11<sup>th</sup>,
 13<sup>th</sup>, 17<sup>th</sup>, 19<sup>th</sup>, 23<sup>th</sup>, 25<sup>th</sup>,
@@ -1196,7 +1196,7 @@ Thus, we have to sample for a&nbsp;period of <code>n*samplePeriod = 1/f_res = 0.
 <p>
 The resultfile &quot;rectifier12pulseFFTresult.mat&quot; can be used to plot amplitudes versus frequencies.
 Note that for each frequency three rows exit: one with amplitude zero,
-one with the calculated amplitude, one with apmplitude zero.
+one with the calculated amplitude, one with amplitude zero.
 Thus, the second column (amplitude) can be easily plotted versus the first column (frequency).
 As expected, one can see the 11<sup>th</sup>, 13<sup>th</sup>, 23<sup>th</sup>, 25<sup>th</sup>,
 &hellip; harmonic in the result.

--- a/Modelica/Clocked/Examples/Systems/EngineThrottleControl.mo
+++ b/Modelica/Clocked/Examples/Systems/EngineThrottleControl.mo
@@ -151,7 +151,7 @@ every half-rotation and is implemented as
   src=\"modelica://Modelica/Resources/Images/Clocked/Examples/RotationalClock_Model.png\"
   alt=\"RotationalClock_Model.png\">
 <p>
-It bookeeps the angular of the last time a rotation has been
+It accounts the angular of the last time a rotation has been
 recognized (<code>angular_offset</code>). Given
 <code>angular_offset</code>, the event-condition for rotations is:
 </p><p>
@@ -159,10 +159,10 @@ recognized (<code>angular_offset</code>). Given
 </p><p>
 In our case, <code>angle</code> is the position of the crankshaft of the engine and
 <code>trigger_interval</code> is 180°. In the end,
-<code>crankshaftPositionEvent</code> samples it's own input angle to bookeep
+<code>crankshaftPositionEvent</code> samples it's own input angle to account
 an offset used to decide when to tick; the clock's event condition depends on
-the state present when the condition changed last time from beeing non-satisfied
-to beeing satisfied, i.e., the state when the clock last ticked.
+the state present when the condition changed last time from being non-satisfied
+to being satisfied, i.e., the state when the clock last ticked.
 </p><p>
 <em>This example model is based on the following references:</em>
 </p>

--- a/Modelica/Electrical/Analog/Examples/ShowSaturatingInductor.mo
+++ b/Modelica/Electrical/Analog/Examples/ShowSaturatingInductor.mo
@@ -59,7 +59,7 @@ equation
           textString="Show Saturating Inductor")}),
     experiment(StopTime=6.2832, Interval=0.01),
     Documentation(info="<html>
-<p>This simple circuit uses the saturating inductor which has a changing inductivity.</p>
+<p>This simple circuit uses the saturating inductor which has a changing inductance.</p>
 <p>This circuit should be simulated until 1 s. Compare <code>SaturatingInductance1.p.i</code> with <code>Inductance1.p.i</code> to see the difference between saturating and ideal inductor.</p>
 </html>"));
 end ShowSaturatingInductor;

--- a/Modelica/Electrical/Analog/Ideal/IdealizedOpAmpLimited.mo
+++ b/Modelica/Electrical/Analog/Ideal/IdealizedOpAmpLimited.mo
@@ -94,7 +94,7 @@ equation
 </ul>
 <p>Supply voltage is either defined by parameter Vps and Vns or by (optional) pins s_p and s_n.</p>
 <p>In the first case the necessary power is drawn from an implicit internal supply, in the second case from the external supply.</p>
-<p>If initializion is problematic for a model containing this as a component you can set the <strong>homotopyType</strong> parameter.
+<p>If initialization is problematic for a model containing this as a component you can set the <strong>homotopyType</strong> parameter.
 Using <strong>Linear</strong> ignores the saturation initially which simplifies the initialization, and may help if the component
 is connected with negative feedback; but generally fails if the feedback is positive.
 Using <strong>LowerLimit</strong> (or <strong>UpperLimit</strong>) gives a fixed value within the saturation bounds, which works with positive feedback.

--- a/Modelica/Electrical/Batteries/UsersGuide/References.mo
+++ b/Modelica/Electrical/Batteries/UsersGuide/References.mo
@@ -17,12 +17,12 @@ class References "References"
       <td>[Keil2012]</td>
       <td>Peter Keil and Andreas Jossen,
         <em>Aufbau und Parametrierung von Batteriemodellen</em>,
-        19. Design&amp;Eelektronik-Entwicklerforum Batterien &amp; Ladekonzepte 2012, M&uuml;nchen, Germany</td>
+        19. Design&amp;Elektronik-Entwicklerforum Batterien &amp; Ladekonzepte 2012, M&uuml;nchen, Germany</td>
     </tr>
 
     <tr>
       <td>[Einhorn11a]</td>
-      <td>M. Einhorn, V. Conte, C, Kral, C. Niklas, H. Popp and J. Fleig,
+      <td>M. Einhorn, V. Conte, C. Kral, C. Niklas, H. Popp and J. Fleig,
         <a href=\"https://2011.international.conference.modelica.org/proceedings/pages/papers/17_4_ID_105_a_fv.pdf\">
         <em>A Modelica Library for Simulation of Electric Energy Storages</em></a>,
         8th International Modelica Conference 2011, Dresden, Germany</td>

--- a/Modelica/Electrical/Machines/Interfaces/DCMachines/PartialThermalAmbientDCMachines.mo
+++ b/Modelica/Electrical/Machines/Interfaces/DCMachines/PartialThermalAmbientDCMachines.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Machines.Interfaces.DCMachines;
 model PartialThermalAmbientDCMachines
-  "Partial thermal ambient for DC machines"
+  "Partial thermal ambience for DC machines"
   parameter Boolean useTemperatureInputs=false
     "If true, temperature inputs are used; else, temperatures are constant"
     annotation (Evaluate=true);
@@ -99,6 +99,6 @@ equation
                 fillPattern=FillPattern.Solid,
                 origin={0,68},
                 rotation=90)}), Documentation(info="<html>
-Partial thermal ambient for induction machines
+Partial thermal ambience for induction machines
 </html>"));
 end PartialThermalAmbientDCMachines;

--- a/Modelica/Electrical/Machines/Interfaces/InductionMachines/PartialThermalAmbientInductionMachines.mo
+++ b/Modelica/Electrical/Machines/Interfaces/InductionMachines/PartialThermalAmbientInductionMachines.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Machines.Interfaces.InductionMachines;
 model PartialThermalAmbientInductionMachines
-  "Partial thermal ambient for induction machines"
+  "Partial thermal ambience for induction machines"
   parameter Integer m=3 "Number of stator phases" annotation(Evaluate=true);
   parameter Boolean useTemperatureInputs=false
     "If true, temperature inputs are used; else, temperatures are constant"
@@ -116,6 +116,6 @@ equation
           fillPattern=FillPattern.Solid,
           origin={0,68},
           rotation=90)}), Documentation(info="<html>
-Partial thermal ambient for induction machines
+Partial thermal ambience for induction machines
 </html>"));
 end PartialThermalAmbientInductionMachines;

--- a/Modelica/Electrical/Machines/Thermal/package.mo
+++ b/Modelica/Electrical/Machines/Thermal/package.mo
@@ -10,16 +10,16 @@ package Thermal "Library with models for connecting thermal models"
 <h4>Thermal concept</h4>
 <p>
 Each machine model is equipped with a machine-specific conditional <code>thermalPort</code>.
-If <code>useThermalPort == false</code>, a machine-specific thermal ambient prescribing constant temperatures is used inside the machine.
-If <code>useThermalPort == true</code>, a thermal model or machine-specific thermal ambient prescribing the temperatures has to be connected from outside.
-On the other hand, all losses are dissipated to this internal or external thermal ambient.
+If <code>useThermalPort == false</code>, a machine-specific thermal ambience prescribing constant temperatures is used inside the machine.
+If <code>useThermalPort == true</code>, a thermal model or machine-specific thermal ambience prescribing the temperatures has to be connected from outside.
+On the other hand, all losses are dissipated to this internal or external thermal ambience.
 </p>
 <p>
 The machine specific thermal connector contains <a href=\"modelica://Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a\">heatPort</a>s
 for all relevant loss sources of the machine type, although some of the loss sources are not yet implemented;
 these heatPorts are left unconnected inside the machine, i.e., the HeatFlowRate is zero,
-but they have to be connected to a constant temperature source in the internal or external thermal ambient.
-Simple machine-specific thermal ambients for constant temperatures (<code>useTemperatureInputs == false</code>)
+but they have to be connected to a constant temperature source in the internal or external thermal ambience.
+Simple machine-specific thermal ambience for constant temperatures (<code>useTemperatureInputs == false</code>)
 or temperatures prescribed via signal inputs (<code>useTemperatureInputs == true</code>) are provided in this package.
 </p>
 <h4>Loss sources</h4>

--- a/Modelica/Electrical/Polyphase/Examples/PolyphaseRectifier.mo
+++ b/Modelica/Electrical/Polyphase/Examples/PolyphaseRectifier.mo
@@ -150,9 +150,9 @@ You may try different number of phases 2 &le; <code>m</code>, as well as connect
 </p>
 <ul>
 <li>AC power <code>analysatorAC.pTotal</code> (sum of all phases)</li>
-<li>AC current <code>analysatorAC.iFeed[m]</code> (1st harmonice rms)</li>
-<li>AC voltage <code>analysatorAC.vLN[m]</code> (1st harmonice rms, line to neutral)</li>
-<li>AC voltage <code>analysatorAC.vLL[m]</code> (1st harmonice rms, line to line)</li>
+<li>AC current <code>analysatorAC.iFeed[m]</code> (1st harmonic rms)</li>
+<li>AC voltage <code>analysatorAC.vLN[m]</code> (1st harmonic rms, line to neutral)</li>
+<li>AC voltage <code>analysatorAC.vLL[m]</code> (1st harmonic rms, line to line)</li>
 </ul>
 <p>
 as well as DC values per subsystem (rectifier) and total (load):

--- a/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/HysteresisModelComparison.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/HysteresisModelComparison.mo
@@ -118,7 +118,7 @@ Compared to the complex Preisach hysteresis model the Tellinen model is very sim
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 1: </strong>Simulated magnetic flux densities B of different hysteresis models (b) due to an applied mangetic field strength shown in (a). Corresponding B(H) loops of the hysteresis models GenericHystTellinenSoft (c), GenericHystTellinenTable (d) and GenericHystPreisachEverett (e).</caption>
+  <caption align=\"bottom\"><strong>Fig. 1: </strong>Simulated magnetic flux densities B of different hysteresis models (b) due to an applied magnetic field strength shown in (a). Corresponding B(H) loops of the hysteresis models GenericHystTellinenSoft (c), GenericHystTellinenTable (d) and GenericHystPreisachEverett (e).</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Examples/Hysteresis/HysteresisModelComparison/plot1.png\">

--- a/Modelica/Magnetic/FluxTubes/Interfaces/TwoPort.mo
+++ b/Modelica/Magnetic/FluxTubes/Interfaces/TwoPort.mo
@@ -1,5 +1,5 @@
 within Modelica.Magnetic.FluxTubes.Interfaces;
-partial model TwoPort "Interface component including flux balance euqation"
+partial model TwoPort "Interface component including flux balance equation"
 
   extends TwoPortExtended;
 

--- a/Modelica/Magnetic/FluxTubes/Shapes/FixedShape/Toroid.mo
+++ b/Modelica/Magnetic/FluxTubes/Shapes/FixedShape/Toroid.mo
@@ -22,7 +22,7 @@ Please refer to the enclosing sub-package <a href=\"modelica://Modelica.Magnetic
 </p>
 
 <p>
-For toroidal flux tubes with a circumferental magnetic flux, the flux density is a function of the radius.
+For toroidal flux tubes with a circumferential magnetic flux, the flux density is a function of the radius.
 For that reason, the characteristic <code>mu_r(B)</code> is evaluated for the flux density at the flux tube's mean radius.
 </p>
 

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/Toroid.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/Toroid.mo
@@ -21,7 +21,7 @@ Please refer to the enclosing sub-package <a href=\"modelica://Modelica.Magnetic
 </p>
 
 <p>
-For toroidal flux tubes with a circumferental magnetic flux, the flux density is a function of the radius.
+For toroidal flux tubes with a circumferential magnetic flux, the flux density is a function of the radius.
 For that reason, the characteristic <code>mu_r(B)</code> is evaluated for the flux density at the flux tube's mean radius.
 </p>
 

--- a/Modelica/Math/FastFourierTransform.mo
+++ b/Modelica/Math/FastFourierTransform.mo
@@ -19,7 +19,7 @@ package FastFourierTransform
       parameter SI.Frequency f1 = 2 "Frequency of sine";
       parameter SI.Frequency f2 = 3 "Frequency of cosine";
       parameter String FFT_resultFileName = "RealFFT1_resultFFT.mat"
-        "File where FFT will be stored as [f,A,Phi], with f in {Hz] and A the amplitudes and Phi the phases in [rad]";
+        "File where FFT will be stored as [f,A,Phi], with f in [Hz] and A the amplitudes and Phi the phases in [rad]";
       final parameter Integer nfi = max(1,min(integer(ceil(f_max/f_resolution))+1,nf))
         "Number of frequency points of the interested frequency range (only up to f_max)";
       final parameter SI.Frequency fi[nfi](each fixed=false)
@@ -123,7 +123,7 @@ Furthermore, note that the FFT phases are with respect to a cos(..) signal.
       parameter SI.Frequency f1 = 2 "Frequency of sine";
       parameter SI.Frequency f2 = 3 "Frequency of cosine";
       parameter String FFT_resultFileName = "RealFFT2_resultFFT.mat"
-        "File where FFT will be stored as [f,A,Phi], with f in {Hz] and A the amplitues and Phi the phases in [rad]";
+        "File where FFT will be stored as [f,A,Phi], with f in [Hz] and A the amplitudes and Phi the phases in [rad]";
       final parameter Integer nfi = max(1,min(integer(ceil(f_max/f_resolution))+1,nf))
         "Number of frequency points of the interested frequency range (only up to f_max)";
       final parameter SI.Frequency fi[nfi](each fixed=false)

--- a/Modelica/Mechanics/MultiBody/Joints/Assemblies/package.mo
+++ b/Modelica/Mechanics/MultiBody/Joints/Assemblies/package.mo
@@ -104,7 +104,7 @@ pair of joints\" from Woernle and Hiller is described in:
     Schliessbedingungen in kinematischen Schleifen mit Anwendung
     bei der R&uuml;ckw&auml;rtstransformation f&uuml;r
     Industrieroboter.</strong><br>
-    Fortschritt-Berichte VDI, Reihe 18, Nr. 59, Duesseldorf: VDI-Verlag 1988,
+    Fortschritt-Berichte VDI, Reihe 18, Nr. 59, D&uuml;sseldorf: VDI-Verlag 1988,
     ISBN 3-18-145918-6.<br>&nbsp;</dd>
 <dt>Hiller M., and Woernle C.:</dt>
 <dd><strong>A Systematic Approach for Solving the Inverse Kinematic

--- a/Modelica/Mechanics/MultiBody/UsersGuide/Literature.mo
+++ b/Modelica/Mechanics/MultiBody/UsersGuide/Literature.mo
@@ -36,7 +36,7 @@ dynamical effects is described in:
     Schliessbedingungen in kinematischen Schleifen mit Anwendung
     bei der R&uuml;ckw&auml;rtstransformation f&uuml;r
     Industrieroboter.</strong><br>
-    Fortschritt-Berichte VDI, Reihe 18, Nr. 59, Duesseldorf: VDI-Verlag 1988,
+    Fortschritt-Berichte VDI, Reihe 18, Nr. 59, D&uuml;sseldorf: VDI-Verlag 1988,
     ISBN 3-18-145918-6.<br>&nbsp;</dd>
 <dt>Hiller M., and Woernle C.:</dt>
 <dd><strong>A Systematic Approach for Solving the Inverse Kinematic

--- a/Modelica/Mechanics/Translational/Components/RollingResistance.mo
+++ b/Modelica/Mechanics/Translational/Components/RollingResistance.mo
@@ -104,7 +104,7 @@ flange.f = Cr * fWeight * cos(alpha)
 </blockquote>
 
 <p>
-The rolling resistance coeffcient&nbsp;<var>C<sub>r</sub></var> is either constant
+The rolling resistance coefficient&nbsp;<var>C<sub>r</sub></var> is either constant
 (given by the parameter <code>CrConstant</code>)
 or prescribed by the input <code>cr</code>.
 </p>

--- a/Modelica/Mechanics/Translational/Components/Vehicle.mo
+++ b/Modelica/Mechanics/Translational/Components/Vehicle.mo
@@ -220,7 +220,7 @@ fRoll = Cr*m*g*cos(alpha)
 </pre>
 </blockquote>
 <p>
-Rolling resistance coeffcient&nbsp;<var>Cr</var> is either constant
+Rolling resistance coefficient&nbsp;<var>Cr</var> is either constant
 or prescribed by the input <code>cr</code>.
 Rolling resistance has a&nbsp;crossover from positive to negative velocity within <code>[-vReg,&nbsp;vReg]</code>.
 </p>

--- a/Modelica/Media/Air/ReferenceMoistAir.mo
+++ b/Modelica/Media/Air/ReferenceMoistAir.mo
@@ -205,7 +205,7 @@ package ReferenceMoistAir
   end setSmoothState;
 
   function Xsaturation
-    "Return absolute humitity per unit mass of moist air at saturation as a function of the thermodynamic state record"
+    "Return absolute humidity per unit mass of moist air at saturation as a function of the thermodynamic state record"
     extends Modelica.Icons.Function;
     input ThermodynamicState state "Thermodynamic state record";
     output MassFraction X_sat "Steam mass fraction of sat. boundary";
@@ -217,7 +217,7 @@ package ReferenceMoistAir
   end Xsaturation;
 
   function xsaturation
-    "Return absolute humitity per unit mass of dry air at saturation as a function of the thermodynamic state record"
+    "Return absolute humidity per unit mass of dry air at saturation as a function of the thermodynamic state record"
     extends Modelica.Icons.Function;
     input ThermodynamicState state "Thermodynamic state record";
     output MassFraction x_sat "Absolute humidity per unit mass of dry air";
@@ -4004,11 +4004,11 @@ The package MoistAir can be used as any other medium model (see <a href=\"modeli
 </tr>
 <tr>
 <td>x<sub>w</sub></td>
-<td>Absolutue humidity in kg(water)/kg(dry air)</td>
+<td>Absolute humidity in kg(water)/kg(dry air)</td>
 </tr>
 <tr>
 <td>x<sub>ws</sub></td>
-<td>Absolutue humidity on saturation boundary in kg(water)/kg(dry air)</td>
+<td>Absolute humidity on saturation boundary in kg(water)/kg(dry air)</td>
 </tr>
 <tr>
 <td>&phi;</td>

--- a/Modelica/Media/R134a.mo
+++ b/Modelica/Media/R134a.mo
@@ -191,7 +191,7 @@ package R134a "R134a: Medium model for R134a"
     extends Modelica.Media.Interfaces.PartialTwoPhaseMedium(
       ThermoStates=Modelica.Media.Interfaces.Choices.IndependentVariables.ph,
       mediumName="R134a_ph",
-      substanceNames={"tetrafluoroethan"},
+      substanceNames={"tetrafluoroethane"},
       singleState=false,
       SpecificEnthalpy(start=h_default, nominal=5.0e5),
       Density(start=4, nominal=500),
@@ -220,7 +220,7 @@ package R134a "R134a: Medium model for R134a"
       r134aConstants(
       each chemicalFormula="CF3CH2F",
       each structureFormula="1,1,1,2-tetrafluoroethane",
-      each iupacName="tetrafluoroethan",
+      each iupacName="tetrafluoroethane",
       each casRegistryNumber="811-97-2",
       each molarMass=R134aData.data.MM,
       each criticalMolarVolume=R134aData.data.MM/R134aData.data.DCRIT,

--- a/Modelica/Resources/C-Sources/zlib/inftrees.h
+++ b/Modelica/Resources/C-Sources/zlib/inftrees.h
@@ -38,7 +38,7 @@ typedef struct {
 /* Maximum size of the dynamic table.  The maximum number of code structures is
    1444, which is the sum of 852 for literal/length codes and 592 for distance
    codes.  These values were found by exhaustive searches using the program
-   examples/enough.c found in the zlib distribtution.  The arguments to that
+   examples/enough.c found in the zlib distributions.  The arguments to that
    program are the number of symbols, the initial root table size, and the
    maximum bit length of a code.  "enough 286 9 15" for literal/length codes
    returns returns 852, and "enough 30 6 15" for distance codes returns 592.

--- a/Modelica/Resources/C-Sources/zlib/zlib.h
+++ b/Modelica/Resources/C-Sources/zlib/zlib.h
@@ -276,7 +276,7 @@ ZEXTERN int ZEXPORT deflate OF((z_streamp strm, int flush));
   == 0), or after each call of deflate().  If deflate returns Z_OK and with
   zero avail_out, it must be called again after making room in the output
   buffer because there might be more output pending. See deflatePending(),
-  which can be used if desired to determine whether or not there is more ouput
+  which can be used if desired to determine whether or not there is more output
   in that case.
 
     Normally the parameter flush is set to Z_NO_FLUSH, which allows deflate to
@@ -661,7 +661,7 @@ ZEXTERN int ZEXPORT deflateGetDictionary OF((z_streamp strm,
    to dictionary.  dictionary must have enough space, where 32768 bytes is
    always enough.  If deflateGetDictionary() is called with dictionary equal to
    Z_NULL, then only the dictionary length is returned, and nothing is copied.
-   Similary, if dictLength is Z_NULL, then it is not set.
+   Similarly, if dictLength is Z_NULL, then it is not set.
 
      deflateGetDictionary() may return a length less than the window size, even
    when more than the window size in input has been provided. It may return up
@@ -913,7 +913,7 @@ ZEXTERN int ZEXPORT inflateGetDictionary OF((z_streamp strm,
    to dictionary.  dictionary must have enough space, where 32768 bytes is
    always enough.  If inflateGetDictionary() is called with dictionary equal to
    Z_NULL, then only the dictionary length is returned, and nothing is copied.
-   Similary, if dictLength is Z_NULL, then it is not set.
+   Similarly, if dictLength is Z_NULL, then it is not set.
 
      inflateGetDictionary returns Z_OK on success, or Z_STREAM_ERROR if the
    stream state is inconsistent.

--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -1898,6 +1898,8 @@ convertClass("Modelica.SIunits.LoundnessLevel",
               "Modelica.Units.SI.LoudnessLevel")
 convertClass("Modelica.SIunits.Loundness",
               "Modelica.Units.SI.Loudness")
+convertClass("Modelica.SIunits.Wavelenght",
+              "Modelica.Units.SI.Wavelength")
 convertClass("Modelica.SIunits.Conversions.NonSIunits.FirstOrderTemperaturCoefficient",
               "Modelica.Units.SI.LinearTemperatureCoefficientResistance")
 convertClass("Modelica.SIunits.Conversions.NonSIunits.SecondOrderTemperaturCoefficient",

--- a/Modelica/Thermal/FluidHeatFlow/Sources/IdealPump.mo
+++ b/Modelica/Thermal/FluidHeatFlow/Sources/IdealPump.mo
@@ -46,7 +46,7 @@ The axis intersections vary with speed as follows:
 <p>
 Coolant's temperature and enthalpy flow are not affected.<br>
 Setting parameter m (mass of medium within fan/pump) to zero
-leads to neglection of temperature transient cv*m*der(T).<br>
+leads to negligence of temperature transient cv*m*der(T).<br>
 Thermodynamic equations are defined by BaseClasses.TwoPort.
 </p>
 </html>"),

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -271,8 +271,6 @@ end UsersGuide;
     type AngularFrequency = Real (final quantity="AngularFrequency", final unit=
             "rad/s");
     type Wavelength = Real (final quantity="Wavelength", final unit="m");
-    type Wavelenght = Wavelength;
-    // For compatibility reasons only
     type WaveNumber = Real (final quantity="WaveNumber", final unit="m-1");
     type CircularWaveNumber = Real (final quantity="CircularWaveNumber", final unit=
                "rad/m");

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -3931,7 +3931,7 @@ to <font color=\"blue\"><strong>existing</strong></font> libraries:
                       Stray Load losses<br>
                       Core losses (only eddy current losses but no hysteresis losses; not for transformers) </td></tr>
 <tr><td> Thermal.* </td>
-    <td> Simple thermal ambients, to be connected to the thermal ports of machines,<br>
+    <td> Simple thermal ambience, to be connected to the thermal ports of machines,<br>
                       as well as material constants and utility functions.</td></tr>
 <tr><td> Icons.* </td>
     <td> Icons for transient and quasi-static electrical machines and transformers.</td></tr>
@@ -5990,7 +5990,7 @@ have been <font color=\"blue\"><strong>improved</strong></font> in a
 
 <tr><td colspan=\"2\"><strong>Math.Vectors.</strong></td></tr>
 <tr><td> normalize</td>
-          <td> Implementation changed, so that the result is awalys continuous<br>
+          <td> Implementation changed, so that the result is always continuous<br>
                                                 (previously, this was not the case for small vectors: normalize(eps,eps)).
                                                 </td></tr>
 


### PR DESCRIPTION
There are some question marks here:
* "ambient" does not seem to be used as noun
* "inductivity" seems to be a Germanism

I also removed the forgotten `Modelica.SIunits.Wavelenght` on the fly.