### PR TITLE
Update description strings of Modelica.Blocks.Types.Smoothness

### DIFF
--- a/Modelica/Blocks/Types.mo
+++ b/Modelica/Blocks/Types.mo
@@ -4,17 +4,17 @@ package Types
   extends Modelica.Icons.TypesPackage;
 
   type Smoothness = enumeration(
-      LinearSegments "Table points are linearly interpolated",
+      LinearSegments "Linear interpolation of table points",
       ContinuousDerivative
-        "Table points are interpolated (by Akima splines) such that the first derivative is continuous",
+        "Akima spline interpolation of table points (such that the first derivative is continuous)",
       ConstantSegments
-        "Table points are not interpolated, but the value from the previous abscissa point is returned",
+        "Piecewise constant interpolation of table points (the value from the previous abscissa point is returned)",
       MonotoneContinuousDerivative1
-        "Table points are interpolated (by Fritsch-Butland splines) such that the monotonicity is preserved and the first derivative is continuous",
+        "Fritsch-Butland spline interpolation (such that the monotonicity is preserved and the first derivative is continuous)",
       MonotoneContinuousDerivative2
-        "Table points are interpolated (by Steffen splines) such that the monotonicity is preserved and the first derivative is continuous",
+        "Steffen spline interpolation of table points (such that the monotonicity is preserved and the first derivative is continuous)",
       ModifiedContinuousDerivative
-        "Table points are interpolated (by modified Akima splines) such that the first derivative is continuous and shortcomings of the original Akima method are avoided")
+        "Modified Akima spline interpolation of table points (such that the first derivative is continuous and shortcomings of the original Akima method are avoided)")
     "Enumeration defining the smoothness of table interpolation";
 
     type Extrapolation = enumeration(


### PR DESCRIPTION
Description strings of the alternatives of Modelica.Blocks.Types.Smoothness are rather long which make the interpolation kind hard to grasp at first sight.

![grafik](https://user-images.githubusercontent.com/14896695/76140524-bdc02c80-605b-11ea-81de-41e17f5de2bc.png)

These strings are changed to put the relevant interpolation type first. This is how it looks:

Dymola:
![grafik](https://user-images.githubusercontent.com/14896695/76140542-f3651580-605b-11ea-8b74-a8127c4fd32b.png)

SimulationX:
![grafik](https://user-images.githubusercontent.com/14896695/76140656-13e19f80-605d-11ea-965a-b634ad648aeb.png)

WSM:
![grafik](https://user-images.githubusercontent.com/14896695/76140612-a46bb000-605c-11ea-90be-50f7442ea2c2.png)
