### PR TITLE
Addresses #3412 (OpAmp-examples regression)

### DIFF
--- a/Modelica/Electrical/Analog/Examples/OpAmps/Differentiator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Differentiator.mo
@@ -5,7 +5,7 @@ model Differentiator "Differentiating amplifier"
   parameter SI.Frequency f=10 "Frequency of input voltage";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
-  Sources.TrapezoidVoltage                            vIn(
+  Sources.TrapezoidVoltage vIn(
     V=2*Vin,
     rising=0.2/f,
     width=0.3/f,
@@ -14,7 +14,7 @@ model Differentiator "Differentiating amplifier"
     nperiod=-1,
     offset=-Vin,
     startTime=-(vIn.rising + vIn.width/2))
-                                      annotation (Placement(
+    annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
@@ -25,7 +25,8 @@ model Differentiator "Differentiating amplifier"
         rotation=270,
         origin={40,0})));
   OpAmpCircuits.Der der_(
-    k=2,                 f=f,
+    k=2,
+    f=f,
     v(fixed=true))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
 equation

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Differentiator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Differentiator.mo
@@ -26,7 +26,7 @@ model Differentiator "Differentiating amplifier"
         origin={40,0})));
   OpAmpCircuits.Der der_(
     k=2,                 f=f,
-    c(v(start=0, fixed=true)))
+    v(fixed=true))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
 equation
   connect(vIn.p, der_.p1)

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Differentiator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Differentiator.mo
@@ -5,18 +5,28 @@ model Differentiator "Differentiating amplifier"
   parameter SI.Frequency f=10 "Frequency of input voltage";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
-  Sources.SineVoltage                                 vIn(V=Vin,
-             f=f)                     annotation (Placement(
+  Sources.TrapezoidVoltage                            vIn(
+    V=2*Vin,
+    rising=0.2/f,
+    width=0.3/f,
+    falling=0.2/f,
+    period=1/f,
+    nperiod=-1,
+    offset=-Vin,
+    startTime=-(vIn.rising + vIn.width/2))
+                                      annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-40,0})));
   Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(
         transformation(
-        extent={{10,10},{-10,-10}},
+        extent={{-10,10},{10,-10}},
         rotation=270,
         origin={40,0})));
-  OpAmpCircuits.Der der_(f=f, v(fixed=true))
+  OpAmpCircuits.Der der_(
+    k=2,                 f=f,
+    c(v(start=0, fixed=true)))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
 equation
   connect(vIn.p, der_.p1)
@@ -25,9 +35,9 @@ equation
     annotation (Line(points={{-40,-10},{-10,-10}}, color={0,0,255}));
   connect(der_.n1, ground.p)
     annotation (Line(points={{-10,-10},{-10,-20}}, color={0,0,255}));
-  connect(der_.p2, vOut.n)
+  connect(der_.p2, vOut.p)
     annotation (Line(points={{10,10},{40,10}}, color={0,0,255}));
-  connect(der_.n2, vOut.p)
+  connect(der_.n2, vOut.n)
     annotation (Line(points={{10,-10},{40,-10}}, color={0,0,255}));
   annotation (Documentation(info="<html>
 <p>This is a (inverting) differentiating amplifier. Resistance R can be chosen, capacitance C is defined by the desired time constant resp. frequency.</p>

--- a/Modelica/Electrical/Analog/Examples/OpAmps/HighPass.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/HighPass.mo
@@ -13,9 +13,9 @@ model HighPass "High-pass filter"
         rotation=270,
         origin={40,0})));
   OpAmpCircuits.Derivative derivative(T=1/(2*pi*fG),
-                                               v(fixed=true))
+    v(fixed=true))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
-  Sources.TrapezoidVoltage                            vIn(
+  Sources.TrapezoidVoltage vIn(
     V=Vin,
     rising=0.2/f,
     width=0.3/f,
@@ -24,7 +24,7 @@ model HighPass "High-pass filter"
     nperiod=-1,
     offset=0,
     startTime=-(vIn.rising + vIn.width/2))
-                                      annotation (Placement(
+    annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/HighPass.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/HighPass.mo
@@ -1,37 +1,45 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model HighPass "High-pass filter"
   extends Modelica.Icons.Example;
+  import Modelica.Constants.pi;
   parameter SI.Voltage Vin=5 "Amplitude of input voltage";
   parameter SI.Frequency f=10 "Frequency of input voltage";
+  parameter SI.Frequency fG=f/10 "Limiting frequency";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
-  Sources.PulseVoltage  vIn(
-    width=50,
+  Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(
+        transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=270,
+        origin={40,0})));
+  OpAmpCircuits.Derivative derivative(T=1/(2*pi*fG),
+                                               v(fixed=true))
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+  Sources.TrapezoidVoltage                            vIn(
+    V=Vin,
+    rising=0.2/f,
+    width=0.3/f,
+    falling=0.2/f,
     period=1/f,
-    V=2*Vin,
-    offset=-Vin)
-    annotation (Placement(transformation(
+    nperiod=-1,
+    offset=0,
+    startTime=-(vIn.rising + vIn.width/2))
+                                      annotation (Placement(
+        transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-40,0})));
-  Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(
-        transformation(
-        extent={{10,10},{-10,-10}},
-        rotation=270,
-        origin={40,0})));
-  OpAmpCircuits.Derivative derivative(T=0.1/f, v(fixed=true))
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
 equation
-  connect(vIn.p, derivative.p1) annotation (Line(points={{-40,10},{-26,10},{-26,
-          10},{-10,10}}, color={0,0,255}));
-  connect(vIn.n, derivative.n1)
-    annotation (Line(points={{-40,-10},{-10,-10}}, color={0,0,255}));
-  connect(derivative.p2, vOut.n)
-    annotation (Line(points={{10,10},{40,10}}, color={0,0,255}));
-  connect(derivative.n2, vOut.p)
-    annotation (Line(points={{10,-10},{40,-10}}, color={0,0,255}));
   connect(derivative.n1, ground.p)
     annotation (Line(points={{-10,-10},{-10,-20},{-10,-20}}, color={0,0,255}));
+  connect(derivative.p2, vOut.p)
+    annotation (Line(points={{10,10},{40,10}}, color={0,0,255}));
+  connect(derivative.n2, vOut.n)
+    annotation (Line(points={{10,-10},{40,-10}}, color={0,0,255}));
+  connect(vIn.p, derivative.p1)
+    annotation (Line(points={{-40,10},{-10,10}}, color={0,0,255}));
+  connect(vIn.n, derivative.n1)
+    annotation (Line(points={{-40,-10},{-10,-10}}, color={0,0,255}));
   annotation (Documentation(info="<html>
 <p>This is a (inverting) high pass filter. Resistance R1 can be chosen, resistance R2 is defined by the desired amplification k, capacitance C is defined by the desired cut-off frequency.</p>
 <p>The example is taken from: U. Tietze and C. Schenk, Halbleiter-Schaltungstechnik (German), 11th edition, Springer 1999, Chapter 13.3</p>

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Integrator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Integrator.mo
@@ -5,32 +5,41 @@ model Integrator "Integrating amplifier"
   parameter SI.Frequency f=10 "Frequency of input voltage";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
-  Sources.SineVoltage vIn(V=Vin, f=f)
-    annotation (Placement(
+  Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(
+        transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=270,
+        origin={40,0})));
+  OpAmpCircuits.Integrator integrator(
+    k=2,                              f=f,
+    opAmp(v_in(start=0)),
+    c(v(start=0, fixed=true)))
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+  Sources.TrapezoidVoltage                            vIn(
+    V=2*Vin,
+    rising=0.2/f,
+    width=0.3/f,
+    falling=0.2/f,
+    period=1/f,
+    nperiod=-1,
+    offset=-Vin,
+    startTime=-(vIn.rising + vIn.width/2))
+                                      annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-40,0})));
-  Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(
-        transformation(
-        extent={{10,10},{-10,-10}},
-        rotation=270,
-        origin={40,0})));
-  OpAmpCircuits.Integrator integrator(
-    v2(fixed=true, start=Vin),        f=f,
-    opAmp(v_in(start=0)))
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
 equation
+  connect(integrator.n1, ground.p)
+    annotation (Line(points={{-10,-10},{-10,-20}}, color={0,0,255}));
+  connect(integrator.p2, vOut.p)
+    annotation (Line(points={{10,10},{40,10}}, color={0,0,255}));
+  connect(integrator.n2, vOut.n)
+    annotation (Line(points={{10,-10},{40,-10}}, color={0,0,255}));
   connect(vIn.p, integrator.p1)
     annotation (Line(points={{-40,10},{-10,10}}, color={0,0,255}));
   connect(vIn.n, integrator.n1)
     annotation (Line(points={{-40,-10},{-10,-10}}, color={0,0,255}));
-  connect(integrator.n1, ground.p)
-    annotation (Line(points={{-10,-10},{-10,-20}}, color={0,0,255}));
-  connect(integrator.p2, vOut.n)
-    annotation (Line(points={{10,10},{40,10}}, color={0,0,255}));
-  connect(integrator.n2, vOut.p)
-    annotation (Line(points={{10,-10},{40,-10}}, color={0,0,255}));
   annotation (Documentation(info="<html>
 <p>This is an (inverting) integrating amplifier. Resistance R can be chosen, capacitance C is defined by the desired time constant resp. frequency.</p>
 <p>Note: <code>vOut</code> measure the negative output voltage.</p>

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Integrator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Integrator.mo
@@ -12,8 +12,7 @@ model Integrator "Integrating amplifier"
         origin={40,0})));
   OpAmpCircuits.Integrator integrator(
     k=2,                              f=f,
-    opAmp(v_in(start=0)),
-    c(v(start=0, fixed=true)))
+    v(fixed=true))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   Sources.TrapezoidVoltage                            vIn(
     V=2*Vin,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Integrator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Integrator.mo
@@ -11,10 +11,11 @@ model Integrator "Integrating amplifier"
         rotation=270,
         origin={40,0})));
   OpAmpCircuits.Integrator integrator(
-    k=2,                              f=f,
+    k=2,
+    f=f,
     v(fixed=true))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
-  Sources.TrapezoidVoltage                            vIn(
+  Sources.TrapezoidVoltage vIn(
     V=2*Vin,
     rising=0.2/f,
     width=0.3/f,
@@ -23,7 +24,7 @@ model Integrator "Integrating amplifier"
     nperiod=-1,
     offset=-Vin,
     startTime=-(vIn.rising + vIn.width/2))
-                                      annotation (Placement(
+    annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/LowPass.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/LowPass.mo
@@ -13,9 +13,7 @@ model LowPass "Low-pass filter"
         rotation=270,
         origin={40,0})));
   OpAmpCircuits.FirstOrder firstOrder(
-    T=1/(2*pi*fG),
-    opAmp(v_in(start=0)),
-    c(v(start=0, fixed=true)))
+    T=1/(2*pi*fG), v(fixed=true))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   Sources.TrapezoidVoltage                            vIn(
     V=Vin,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/LowPass.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/LowPass.mo
@@ -15,7 +15,7 @@ model LowPass "Low-pass filter"
   OpAmpCircuits.FirstOrder firstOrder(
     T=1/(2*pi*fG), v(fixed=true))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
-  Sources.TrapezoidVoltage                            vIn(
+  Sources.TrapezoidVoltage vIn(
     V=Vin,
     rising=0.2/f,
     width=0.3/f,
@@ -24,7 +24,7 @@ model LowPass "Low-pass filter"
     nperiod=-1,
     offset=0,
     startTime=-(vIn.rising + vIn.width/2))
-                                      annotation (Placement(
+    annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/LowPass.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/LowPass.mo
@@ -1,40 +1,47 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model LowPass "Low-pass filter"
   extends Modelica.Icons.Example;
+  import Modelica.Constants.pi;
   parameter SI.Voltage Vin=5 "Amplitude of input voltage";
   parameter SI.Frequency f=10 "Frequency of input voltage";
+  parameter SI.Frequency fG=f/10 "Limiting frequency";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
-  Sources.PulseVoltage vIn(
-    width=50,
-    period=1/f,
-    V=2*Vin,
-    offset=-Vin)
-              annotation (Placement(transformation(
-        extent={{-10,-10},{10,10}},
-        rotation=270,
-        origin={-40,0})));
   Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(
         transformation(
-        extent={{10,10},{-10,-10}},
+        extent={{-10,10},{10,-10}},
         rotation=270,
         origin={40,0})));
   OpAmpCircuits.FirstOrder firstOrder(
-    v2(fixed=true),
-    T=0.1/f,
-    opAmp(v_in(start=0)))
+    T=1/(2*pi*fG),
+    opAmp(v_in(start=0)),
+    c(v(start=0, fixed=true)))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+  Sources.TrapezoidVoltage                            vIn(
+    V=Vin,
+    rising=0.2/f,
+    width=0.3/f,
+    falling=0.2/f,
+    period=1/f,
+    nperiod=-1,
+    offset=0,
+    startTime=-(vIn.rising + vIn.width/2))
+                                      annotation (Placement(
+        transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-40,0})));
 equation
-  connect(vIn.n, firstOrder.n1)
-    annotation (Line(points={{-40,-10},{-10,-10}}, color={0,0,255}));
-  connect(vIn.p, firstOrder.p1)
-    annotation (Line(points={{-40,10},{-10,10}}, color={0,0,255}));
-  connect(firstOrder.p2, vOut.n)
-    annotation (Line(points={{10,10},{40,10}}, color={0,0,255}));
-  connect(firstOrder.n2, vOut.p)
-    annotation (Line(points={{10,-10},{40,-10}}, color={0,0,255}));
   connect(firstOrder.n1, ground.p)
     annotation (Line(points={{-10,-10},{-10,-20},{-10,-20}}, color={0,0,255}));
+  connect(firstOrder.p2, vOut.p)
+    annotation (Line(points={{10,10},{40,10}}, color={0,0,255}));
+  connect(firstOrder.n2, vOut.n)
+    annotation (Line(points={{10,-10},{40,-10}}, color={0,0,255}));
+  connect(vIn.p, firstOrder.p1)
+    annotation (Line(points={{-40,10},{-10,10}}, color={0,0,255}));
+  connect(vIn.n, firstOrder.n1)
+    annotation (Line(points={{-40,-10},{-10,-10}}, color={0,0,255}));
   annotation (Documentation(info="<html>
 <p>This is a (inverting) low pass filter. Resistance R1 can be chosen, resistance R2 is defined by the desired amplification k, capacitance C is defined by the desired cut-off frequency.</p>
 <p>The example is taken from: U. Tietze and C. Schenk, Halbleiter-Schaltungstechnik (German), 11th edition, Springer 1999, Chapter 13.3</p>

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/FirstOrder.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/FirstOrder.mo
@@ -7,6 +7,7 @@ model FirstOrder "Lowpass filter operational amplifier circuit"
   parameter SI.Resistance R2=k*R1 "Calculated resistance to reach k";
   parameter SI.Time T "Time constant";
   parameter SI.Capacitance C=T/R2 "Calculated capacitance to reach T";
+  SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
   Basic.Resistor                            r1(R=R1)
     annotation (Placement(transformation(extent={{-50,20},{-30,40}})));
   Basic.Resistor                            r2(R=R2)

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Integrator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Integrator.mo
@@ -6,6 +6,7 @@ model Integrator "Integrating operational amplifier circuit"
   parameter SI.Frequency f "Frequency";
   parameter SI.Resistance R=1000 "Resistance at negative input of OpAmp";
   parameter SI.Capacitance C=1/k/(2*pi*f*R) "Calculated capacitance to reach desired amplification k";
+  SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
   Basic.Capacitor  c(final C=C)
     annotation (Placement(transformation(extent={{30,20},{10,40}})));
   Basic.Resistor r(final R=R)


### PR DESCRIPTION
If desired, this PR changes the 4 OpAmp-examples so that the original reference results are met.
The alternative would be (as mentioned in #3412): Eccaept the changes in the examples and store new reference results.