### PR TITLE
Add defaults for old modifiers for conversion of LinearDependency

### DIFF
--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -412,7 +412,6 @@ convertModifiers("Modelica.StateGraph.Temporary.NumericValue",
 
 convertModifiers({"Modelica.StateGraph.Interfaces.PartialStep",
                   "Modelica.StateGraph.InitialStep",
-                  "Modelica.StateGraph.InitialStep",
                   "Modelica.StateGraph.InitialStepWithSignal",
                   "Modelica.StateGraph.Step",
                   "Modelica.StateGraph.StepWithSignal"},

--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -412,6 +412,7 @@ convertModifiers("Modelica.StateGraph.Temporary.NumericValue",
 
 convertModifiers({"Modelica.StateGraph.Interfaces.PartialStep",
                   "Modelica.StateGraph.InitialStep",
+                  "Modelica.StateGraph.InitialStep",
                   "Modelica.StateGraph.InitialStepWithSignal",
                   "Modelica.StateGraph.Step",
                   "Modelica.StateGraph.StepWithSignal"},
@@ -1710,7 +1711,7 @@ convertElement({"Modelica.Media.Interfaces.PartialMedium.BaseProperties",
                 "R", "R_s")
 
 convertModifiers("Modelica.Blocks.Math.LinearDependency",
-                 {"y0", "k1", "k2"}, {"y0=%y0%", "k1=%y0%*%k1%", "k2=%y0%*%k2%"}, true)
+                 {"y0=0", "k1=0", "k2=0"}, {"y0=%y0%", "k1=%y0%*%k1%", "k2=%y0%*%k2%"}, true)
 convertModifiers({"Modelica.Mechanics.MultiBody.Joints.Prismatic"},
                   {"s_offset"}, fill("", 0), true)
 convertModifiers({"Modelica.Mechanics.MultiBody.Joints.Revolute"},


### PR DESCRIPTION
For Modelica.Blocks.Math.LinearDependency add defaults for old modifiers in case someone used it and didn't specify all parameters.