### PR TITLE
maint/3.2.3: Add missing redeclaration of SaturationProperties for WaterIF97

### DIFF
--- a/Modelica/Media/Water/package.mo
+++ b/Modelica/Media/Water/package.mo
@@ -139,6 +139,9 @@ partial package WaterIF97_base
     onePhase=false,
     fluidConstants=waterConstants);
 
+  redeclare record extends SaturationProperties
+  end SaturationProperties;
+
   redeclare record extends ThermodynamicState "Thermodynamic state"
     SpecificEnthalpy h "Specific enthalpy";
     Density d "Density";


### PR DESCRIPTION
Back-port #3494 to fix #3493 in maint/3.2.3.