### PR TITLE
Reduce number of signals for Modelica.Electrical.PowerConverters.Examples.ACAC.SoftStarter

### DIFF
--- a/Modelica/Resources/Reference/Modelica/Electrical/PowerConverters/Examples/ACAC/SoftStarter/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/PowerConverters/Examples/ACAC/SoftStarter/comparisonSignals.txt
@@ -19,11 +19,11 @@ rootMeanSquare.y
 rootMeanSquare.mean.x
 harmonic.mean1.x
 harmonic.mean2.x
-imc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
-imc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
-imc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
-imc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
-imc.stator.zeroInductor.i0
+// imc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
+// imc.rotorCage.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
+// imc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[1].Phi.re
+// imc.stator.electroMagneticConverter.singlePhaseElectroMagneticConverter[2].Phi.im
+// imc.stator.zeroInductor.i0
 loadInertia.phi
 loadInertia.w
 softStartControl.vRef


### PR DESCRIPTION
Modelica.Electrical.PowerConverters.Examples.ACAC.SoftStarter is the only example (and test) model of the MSL, where the simulation result data (stored as CSV) exceeds the 100MB file size limit (for files in GitHub repositories).

```
git.exe push --thin --progress "origin" v4.0.0-beta.2

Counting objects: 4233, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (4118/4118), done.
Writing objects: 100% (4233/4233), 608.18 MiB | 117.00 KiB/s, done.
Total 4233 (delta 2639), reused 0 (delta 0)
remote: Resolving deltas: 100% (2639/2639), completed with 367 local objects.
remote: warning: File Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Cooling/DCPM_Cooling.csv is 53.02 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: warning: File Modelica/Electrical/Machines/Examples/InductionMachines/IMC_Conveyor/IMC_Conveyor.csv is 60.53 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: warning: File Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierBridge2mPulse/ThyristorBridge2mPulse_DC_Drive/ThyristorBridge2mPulse_DC_Drive.csv is 97.81 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: warning: File Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_DC_Drive/HBridge_DC_Drive.csv is 79.70 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: warning: File Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Conveyor/IMC_Conveyor.csv is 62.77 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: warning: File Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Conveyor/IMC_Conveyor.csv is 94.66 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: warning: File Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Initialize/IMC_Initialize.csv is 96.69 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: warning: File Modelica/Thermal/HeatTransfer/Examples/Motor/Motor.csv is 75.02 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: error: GH001: Large files detected. You may want to try Git Large File Storage - https://git-lfs.github.com.
remote: error: Trace: b1b06fbc7f9d3d5e23c220f1a975a169
remote: error: See http://git.io/iEPt8g for more information.
remote: error: File Modelica/Electrical/PowerConverters/Examples/ACAC/SoftStarter/SoftStarter.csv is 121.52 MB; this exceeds GitHub's file size limit of 100.00 MB
To https://github.com/modelica/MAP-LIB_ReferenceResults
! [remote rejected] v4.0.0-beta.2 -> v4.0.0-beta.2 (pre-receive hook declined)
error: failed to push some refs to 'https://github.com/modelica/MAP-LIB_ReferenceResults'


git did not exit cleanly (exit code 1) (5381063 ms @ 12.03.2020 07:55:13)
````

This pull request removes five variables from the comparison signals such that no more error shows up during upload.

```
git.exe push --thin --progress "origin" v4.0.0-beta.2

Counting objects: 4233, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (4117/4117), done.
Writing objects: 100% (4233/4233), 598.26 MiB | 111.00 KiB/s, done.
Total 4233 (delta 2635), reused 0 (delta 0)
remote: Resolving deltas: 100% (2635/2635), completed with 366 local objects.
remote: warning: GH001: Large files detected. You may want to try Git Large File Storage - https://git-lfs.github.com.
remote: warning: See http://git.io/iEPt8g for more information.
remote: warning: File Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Cooling/DCPM_Cooling.csv is 53.02 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: warning: File Modelica/Electrical/Machines/Examples/InductionMachines/IMC_Conveyor/IMC_Conveyor.csv is 60.53 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: warning: File Modelica/Electrical/PowerConverters/Examples/ACAC/SoftStarter/SoftStarter.csv is 98.92 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: warning: File Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierBridge2mPulse/ThyristorBridge2mPulse_DC_Drive/ThyristorBridge2mPulse_DC_Drive.csv is 97.81 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: warning: File Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_DC_Drive/HBridge_DC_Drive.csv is 79.70 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: warning: File Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Conveyor/IMC_Conveyor.csv is 62.77 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: warning: File Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Conveyor/IMC_Conveyor.csv is 94.66 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: warning: File Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Initialize/IMC_Initialize.csv is 96.69 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: warning: File Modelica/Thermal/HeatTransfer/Examples/Motor/Motor.csv is 75.02 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote:
remote: Create a pull request for 'v4.0.0-beta.2' on GitHub by visiting:
remote:      https://github.com/modelica/MAP-LIB_ReferenceResults/pull/new/v4.0.0-beta.2
remote:
To https://github.com/modelica/MAP-LIB_ReferenceResults
* [new branch]      v4.0.0-beta.2 -> v4.0.0-beta.2

Success (5582235 ms @ 12.03.2020 20:33:46)
```