### PR TITLE
maint/3.2.3: Add StopTime annotation to Modelica.Magnetic.QuasiStatic.FluxTubes.Examples.Leakage.GeneralLeakage

### DIFF
--- a/Modelica/Magnetic/QuasiStatic/FluxTubes.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes.mo
@@ -948,7 +948,7 @@ This model compares a transient non-linear magnetic circuit with a linearized qu
             color={255,170,85}));
         annotation (
           Diagram(coordinateSystem(preserveAspectRatio=false)),
-          experiment(StartTime=1,Interval=0.001),
+          experiment(StopTime=1,Interval=0.001),
         Documentation(info="<html>
 <p>Magnetic circuit with two reluctances, leakage reluctance,  and eddy current loss.</p>
 </html>"));


### PR DESCRIPTION
Back-port #3350 to address #2968 in maint/3.2.3.