### PR TITLE
Improve fault-tolerance of Modelica.Utilities.Strings.substring w.r.t. index arguments and remove undocumented case with endIndex=-999

### DIFF
--- a/.CI/Test/ModelicaStrings.c
+++ b/.CI/Test/ModelicaStrings.c
@@ -7,5 +7,12 @@ const char* ModelicaStrings_substring(const char* string,
                                       int startIndex, int endIndex);
 
 int main(int argc, char **argv) {
-    assert(0 == strcmp("bcd", ModelicaStrings_substring("abcdef",2,4)));
+    assert(0 == strcmp("a", ModelicaStrings_substring("abc",-1,-1)));
+    assert(0 == strcmp("b", ModelicaStrings_substring("abc",2,-1)));
+    assert(0 == strcmp("", ModelicaStrings_substring("abc",2,0)));
+    assert(0 == strcmp("", ModelicaStrings_substring("abc",2,1)));
+    assert(0 == strcmp("b", ModelicaStrings_substring("abc",2,2)));
+    assert(0 == strcmp("bc", ModelicaStrings_substring("abc",2,3)));
+    assert(0 == strcmp("bc", ModelicaStrings_substring("abc",2,4)));
+    assert(0 == strcmp("", ModelicaStrings_substring("abc",4,4)));
 }

--- a/Modelica/Resources/C-Sources/ModelicaStrings.c
+++ b/Modelica/Resources/C-Sources/ModelicaStrings.c
@@ -30,6 +30,10 @@
 */
 
 /* Changelog:
+      Mar. 15, 2020: by Thomas Beutlich
+                     Improved fault-tolerance of ModelicaStrings_substring w.r.t.
+                     index arguments (ticket #3503)
+
       Jun. 16, 2017: by Thomas Beutlich, ESI ITI GmbH
                      Utilized hash macros of uthash.h for ModelicaStrings_hashString
                      (ticket #2250)
@@ -105,28 +109,28 @@ _Ret_z_ const char* ModelicaStrings_substring(_In_z_ const char* string,
        An assert is triggered, if startIndex/endIndex are not valid.
      */
     char* substring;
-    int len1 = (int) strlen(string);
+    int len1 = ModelicaStrings_length(string);
     int len2;
 
     /* Check arguments */
-    if ( startIndex < 1 ) {
-        ModelicaFormatError("Wrong call of Utilities.Strings.substring:\n"
-                            "  startIndex = %d (has to be > 0).\n"
-                            "  string     = \"%s\"\n", startIndex, string);
+    if (startIndex < 1) {
+        ModelicaFormatWarning("Negative startIndex (= %d) of Utilities.Strings.substring "
+                              "was set to 1.", startIndex);
+        startIndex = 1;
     }
-    else if ( endIndex == -999 ) {
+    else if (endIndex == -999) {
+        ModelicaFormatWarning("Negative endIndex (= -999) of Utilities.Strings.substring "
+                              "was set to %d.", startIndex);
         endIndex = startIndex;
     }
-    else if ( endIndex < startIndex ) {
-        ModelicaFormatError("Wrong call of  Utilities.Strings.substring:\n"
-                            "  startIndex = %d\n"
-                            "  endIndex   = %d (>= startIndex required)\n"
-                            "  string     = \"%s\"\n", startIndex, endIndex, string);
+    else if (endIndex < startIndex ) {
+        return "";
     }
-    else if ( endIndex > len1 ) {
-        ModelicaFormatError("Wrong call of Utilities.Strings.substring:\n"
-                            "  endIndex = %d (<= %d required (=length(string)).\n"
-                            "  string   = \"%s\"\n", endIndex, len1, string);
+    else if (endIndex > len1) {
+        ModelicaFormatWarning("Argument endIndex (= %d) of Utilities.Strings.substring exceeds "
+                              "the string length (= %d) for string \"%s\" "
+                              "and was set to %d.", endIndex, len1, string, len1);
+        endIndex = len1;
     }
 
     /* Allocate memory and copy string */

--- a/Modelica/Resources/C-Sources/ModelicaStrings.c
+++ b/Modelica/Resources/C-Sources/ModelicaStrings.c
@@ -104,40 +104,39 @@
 
 _Ret_z_ const char* ModelicaStrings_substring(_In_z_ const char* string,
                                       int startIndex, int endIndex) {
-    /* Return string1(startIndex:endIndex) if endIndex >= startIndex,
-       or return string1(startIndex:startIndex), if endIndex = 0.
-       An assert is triggered, if startIndex/endIndex are not valid.
+    /* Return string(startIndex:endIndex) if endIndex >= startIndex,
+       or return string(startIndex:startIndex), if endIndex < 0.
+       Warnings are triggered, if startIndex/endIndex are not valid.
      */
     char* substring;
-    int len1 = ModelicaStrings_length(string);
-    int len2;
+    int len = ModelicaStrings_length(string);
 
     /* Check arguments */
     if (startIndex < 1) {
-        ModelicaFormatWarning("Negative startIndex (= %d) of Utilities.Strings.substring "
+        ModelicaFormatWarning("Non-positive startIndex (= %d) of Utilities.Strings.substring "
                               "was set to 1.", startIndex);
         startIndex = 1;
     }
-    else if (endIndex == -999) {
-        ModelicaFormatWarning("Negative endIndex (= -999) of Utilities.Strings.substring "
-                              "was set to %d.", startIndex);
-        endIndex = startIndex;
-    }
-    else if (endIndex < startIndex ) {
+    else if (startIndex > len) {
         return "";
     }
-    else if (endIndex > len1) {
-        ModelicaFormatWarning("Argument endIndex (= %d) of Utilities.Strings.substring exceeds "
-                              "the string length (= %d) for string \"%s\" "
-                              "and was set to %d.", endIndex, len1, string, len1);
-        endIndex = len1;
+    if (endIndex < 0) {
+        ModelicaFormatWarning("Negative endIndex (= %d) of Utilities.Strings.substring "
+                              "was set to %d.", endIndex, startIndex);
+        endIndex = startIndex;
+    }
+    else if (endIndex < startIndex) {
+        return "";
+    }
+    else if (endIndex > len) {
+        endIndex = len;
     }
 
     /* Allocate memory and copy string */
-    len2 = endIndex - startIndex + 1;
-    substring = ModelicaAllocateString((size_t)len2);
-    strncpy(substring, &string[startIndex-1], (size_t)len2);
-    substring[len2] = '\0';
+    len = endIndex - startIndex + 1;
+    substring = ModelicaAllocateString((size_t)len);
+    strncpy(substring, &string[startIndex-1], (size_t)len);
+    substring[len] = '\0';
     return substring;
 }
 
@@ -164,10 +163,10 @@ int ModelicaStrings_compare(_In_z_ const char* string1, _In_z_ const char* strin
         result = (int)(tolower((unsigned char)*string1)) - (int)(tolower((unsigned char)*string2));
     }
 
-    if ( result < 0 ) {
+    if (result < 0) {
         result = 1;
     }
-    else if ( result == 0 ) {
+    else if (result == 0) {
         result = 2;
     }
     else {

--- a/Modelica/Utilities/Strings.mo
+++ b/Modelica/Utilities/Strings.mo
@@ -24,7 +24,7 @@ Returns the number of characters of \"string\".
     input String string "String from which a substring is inquired";
     input Integer startIndex(min=1)
       "Character position of substring begin (index=1 is first character in string)";
-    input Integer endIndex(min=1) "Character position of substring end";
+    input Integer endIndex(min=0) "Character position of substring end";
     output String result
       "String containing substring string[startIndex:endIndex]";
   external "C" result = ModelicaStrings_substring(string,startIndex,endIndex) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC");
@@ -40,13 +40,14 @@ the substring from position startIndex
 up to and including position endIndex of \"string\" .
 </p>
 <p>
-If index, startIndex, or endIndex are not correct, e.g.,
-if endIndex &gt; length(string), an assert is triggered.
+If startIndex or endIndex are not correct, e.g.,
+if endIndex &gt; length(string), a warning is raised.
 </p>
 <h4>Example</h4>
 <blockquote><pre>
 string1 := \"This is line 111\";
 string2 := Strings.substring(string1,9,12); // string2 = \"line\"
+string3 := Strings.substring(string1,9,0); // string3 = \"\"
 </pre></blockquote>
 </html>"));
   end substring;

--- a/Modelica/Utilities/Strings.mo
+++ b/Modelica/Utilities/Strings.mo
@@ -24,7 +24,7 @@ Returns the number of characters of \"string\".
     input String string "String from which a substring is inquired";
     input Integer startIndex(min=1)
       "Character position of substring begin (index=1 is first character in string)";
-    input Integer endIndex(min=0) "Character position of substring end";
+    input Integer endIndex "Character position of substring end";
     output String result
       "String containing substring string[startIndex:endIndex]";
   external "C" result = ModelicaStrings_substring(string,startIndex,endIndex) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC");
@@ -38,11 +38,15 @@ string2 = Strings.<strong>substring</strong>(string, startIndex, endIndex);
 This function returns
 the substring from position startIndex
 up to and including position endIndex of \"string\" .
+The substring computation has the following properties:
 </p>
-<p>
-If startIndex or endIndex are not correct, e.g.,
-if endIndex &gt; length(string), a warning is raised.
-</p>
+<ul>
+<li>If the <code>startIndex</code> is non-positive, it is set to 1 and a warning is raised.</li>
+<li>If the <code>startIndex</code> exceeds the string length, the returned substring is empty.</li>
+<li>If the <code>endIndex</code> is negative, it is set to the <code>startIndex</code> and a warning is raised. The returned substring is the single character at position <code>startIndex</code> of <code>string</code>.</li>
+<li>If the <code>endIndex</code> is non-negative and less than the <code>startIndex</code>, the returned substring is empty.</li>
+<li>If the <code>endIndex</code> exceeds the string length, it is set to the string length.</li>
+</ul>
 <h4>Example</h4>
 <blockquote><pre>
 string1 := \"This is line 111\";


### PR DESCRIPTION
I missed the feature of Modelica.Utilities.Strings.substring to return an empty string. This is why I started this PR.

* Do not assert on incorrect arguments of substring, but try to correct them and raise a warning instead.
* substring was also improved to return an empty string, in case endIndex is less than startIndex.