### PR TITLE
Fix initial condition of Modelica.Blocks.Examples.PID_Controller (MSL 3.2.3)

### DIFF
--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -24,6 +24,7 @@ package Examples
       initType=Modelica.Blocks.Types.InitPID.SteadyState,
       limitsAtInit=false,
       controllerType=Modelica.Blocks.Types.SimpleController.PI,
+      limiter(u(start = 0)),
       Td=0.1) annotation (Placement(transformation(extent={{-56,-20},{-36,0}})));
     Modelica.Mechanics.Rotational.Components.Inertia inertia1(
       phi(fixed=true, start=0),


### PR DESCRIPTION
Refs #3435 

- This PR refers to MSL 3.2.3
- Equivalent PR for MSL 4.0.0 is provided by #3505