### PR TITLE
Remove combiTimeTable.nextTimeEvent from the list of comparison signals.

### DIFF
--- a/ModelicaTest/Resources/Reference/ModelicaTest/MultiBody/PlanarLoopWithMove/comparisonSignals.txt
+++ b/ModelicaTest/Resources/Reference/ModelicaTest/MultiBody/PlanarLoopWithMove/comparisonSignals.txt
@@ -1,5 +1,4 @@
 time
-combiTimeTable.nextTimeEvent
 rh1[1]
 rh1[2]
 rh1[3]


### PR DESCRIPTION
The signal is problematic, since it jumps to Modelica.Constants.inf at the end of the simulation. This value is not well defined across tools.
The outputs from the combiTimeTable component are already tested which should be enough.