### PR TITLE
Update Valves.mo

### DIFF
--- a/Modelica/Fluid/Valves.mo
+++ b/Modelica/Fluid/Valves.mo
@@ -6,6 +6,7 @@ package Valves "Components for the regulation and control of fluid flow"
       extends BaseClasses.PartialValve;
       import Modelica.Fluid.Types.CvTypes;
       import Modelica.Constants.pi;
+      import Modelica.Fluid.Utilities;
 
       constant SI.ReynoldsNumber Re_turbulent = 4000
       "cf. straight pipe for fully open valve -- dp_turbulent increases for closing valve";


### PR DESCRIPTION
OpenModelica 1.14.1 apparently needs specific import to find Modelica.Fluids.Utilities.{regRoot, regRoot2} in ValveIncompressible class. I am not sure this is a general problem and not specific  problem of OpenModelica. A review from expert is required.

Please see see [this post](https://stackoverflow.com/questions/60900784/broken-modelica-fluid-valves-valveincompressible-model-receiving-error-functio/60917796#60917796) on StackOverflow for additional info.

Where I wrong in posting on StackOverflow? What is the most useful channel to report bugs in the OpenModelica environment and the standard library?

