### PR TITLE
Do not use synchronous operators as component names.

### DIFF
--- a/Modelica/Clocked/ClockSignals/Clocks/Logical/ConjunctiveClock.mo
+++ b/Modelica/Clocked/ClockSignals/Clocks/Logical/ConjunctiveClock.mo
@@ -1,4 +1,4 @@
-﻿within Modelica.Clocked.ClockSignals.Clocks.Logical;
+within Modelica.Clocked.ClockSignals.Clocks.Logical;
 block ConjunctiveClock
   "Logical clock ticking whenever all input clocks ticked at least once, then resets and starts the next conjunctive cycle"
   extends PartialLogicalClock(

--- a/Modelica/Clocked/ClockSignals/Clocks/Logical/ConjunctiveClock.mo
+++ b/Modelica/Clocked/ClockSignals/Clocks/Logical/ConjunctiveClock.mo
@@ -1,4 +1,4 @@
-within Modelica.Clocked.ClockSignals.Clocks.Logical;
+﻿within Modelica.Clocked.ClockSignals.Clocks.Logical;
 block ConjunctiveClock
   "Logical clock ticking whenever all input clocks ticked at least once, then resets and starts the next conjunctive cycle"
   extends PartialLogicalClock(

--- a/Modelica/Clocked/ClockSignals/Clocks/Logical/DisjunctiveClock.mo
+++ b/Modelica/Clocked/ClockSignals/Clocks/Logical/DisjunctiveClock.mo
@@ -1,4 +1,4 @@
-﻿within Modelica.Clocked.ClockSignals.Clocks.Logical;
+within Modelica.Clocked.ClockSignals.Clocks.Logical;
 block DisjunctiveClock
   "Logical clock ticking whenever any of its input clock signals ticks."
   extends PartialLogicalClock(

--- a/Modelica/Clocked/ClockSignals/Clocks/Logical/DisjunctiveClock.mo
+++ b/Modelica/Clocked/ClockSignals/Clocks/Logical/DisjunctiveClock.mo
@@ -1,4 +1,4 @@
-within Modelica.Clocked.ClockSignals.Clocks.Logical;
+﻿within Modelica.Clocked.ClockSignals.Clocks.Logical;
 block DisjunctiveClock
   "Logical clock ticking whenever any of its input clock signals ticks."
   extends PartialLogicalClock(

--- a/Modelica/Clocked/Examples/Elementary/BooleanSignals/BackSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/BooleanSignals/BackSample.mo
@@ -2,8 +2,7 @@ within Modelica.Clocked.Examples.Elementary.BooleanSignals;
 model BackSample "Example of a BackSample block for Boolean signals"
    extends Modelica.Icons.Example;
 
-  Modelica.Clocked.BooleanSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.BooleanSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
@@ -19,17 +18,15 @@ Modelica.Clocked.BooleanSignals.Sampler.BackSample backSample1(
   Modelica.Blocks.Sources.BooleanTable table(table={0.05,0.15})
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(sample.u, table.y) annotation (Line(
-    points={{-47.2,30},{-59,30}},
-    color={255,0,255}));
-connect(shiftSample1.u, sample.y) annotation (Line(
-    points={{-19.2,30},{-33.4,30}},
-    color={255,0,255}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.u, table.y)
+    annotation (Line(points={{-47.2,30},{-59,30}}, color={255,0,255}));
+  connect(shiftSample1.u, sample1.y)
+    annotation (Line(points={{-19.2,30},{-33.4,30}}, color={255,0,255}));
 connect(backSample1.u, shiftSample1.y) annotation (Line(
     points={{12.8,30},{-5.4,30}},
     color={255,0,255}));

--- a/Modelica/Clocked/Examples/Elementary/BooleanSignals/Hold.mo
+++ b/Modelica/Clocked/Examples/Elementary/BooleanSignals/Hold.mo
@@ -4,32 +4,27 @@ model Hold "Example of a Hold block for Boolean signals"
 
   Modelica.Blocks.Sources.BooleanTable table(table={0.05,0.15})
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.BooleanSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.BooleanSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-52,24},{-40,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-68,-6},{-56,6}})));
-Modelica.Clocked.BooleanSignals.Sampler.Hold  hold(y_start=false)
-  annotation (Placement(transformation(extent={{-8,24},{4,36}})));
-Modelica.Clocked.BooleanSignals.Sampler.ShiftSample  shiftSample(
-    shiftCounter=2)
-  annotation (Placement(transformation(extent={{-30,24},{-18,36}})));
+Modelica.Clocked.BooleanSignals.Sampler.Hold hold1(y_start=false)
+    annotation (Placement(transformation(extent={{-8,24},{4,36}})));
+Modelica.Clocked.BooleanSignals.Sampler.ShiftSample shiftSample1(shiftCounter=2)
+    annotation (Placement(transformation(extent={{-30,24},{-18,36}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-55.4,0},{-46,0},{-46,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-  connect(table.y, sample.u) annotation (Line(
-      points={{-59,30},{-53.2,30}},
-      color={255,127,0}));
-connect(shiftSample.u, sample.y) annotation (Line(
-    points={{-31.2,30},{-39.4,30}},
-    color={255,0,255}));
-connect(hold.u, shiftSample.y) annotation (Line(
-    points={{-9.2,30},{-17.4,30}},
-    color={255,0,255}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-55.4,0},{-46,0},{-46,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(table.y, sample1.u)
+    annotation (Line(points={{-59,30},{-53.2,30}}, color={255,127,0}));
+  connect(shiftSample1.u, sample1.y)
+    annotation (Line(points={{-31.2,30},{-39.4,30}}, color={255,0,255}));
+  connect(hold1.u, shiftSample1.y)
+    annotation (Line(points={{-9.2,30},{-17.4,30}}, color={255,0,255}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/BooleanSignals/Sample1.mo
+++ b/Modelica/Clocked/Examples/Elementary/BooleanSignals/Sample1.mo
@@ -9,20 +9,18 @@ model Sample1 "Example of a Sample block for Boolean signals"
 Modelica.Blocks.Sources.BooleanStep
                              step(startTime=0.1)
   annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-Modelica.Clocked.BooleanSignals.Sampler.Sample sample
-  annotation (Placement(transformation(extent={{-48,24},{-36,36}})));
+Modelica.Clocked.BooleanSignals.Sampler.Sample sample1
+    annotation (Placement(transformation(extent={{-48,24},{-36,36}})));
 equation
   connect(periodicClock.y, assignClock.clock) annotation (Line(
       points={{-29.4,4},{-16,4},{-16,22.8}},
       color={175,175,175},
       pattern=LinePattern.Dot,
       thickness=0.5));
-connect(step.y, sample.u) annotation (Line(
-    points={{-59,30},{-49.2,30}},
-    color={255,0,255}));
-connect(sample.y, assignClock.u) annotation (Line(
-    points={{-35.4,30},{-23.2,30}},
-    color={255,0,255}));
+  connect(step.y, sample1.u)
+    annotation (Line(points={{-59,30},{-49.2,30}}, color={255,0,255}));
+  connect(sample1.y, assignClock.u)
+    annotation (Line(points={{-35.4,30},{-23.2,30}}, color={255,0,255}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/BooleanSignals/Sample2.mo
+++ b/Modelica/Clocked/Examples/Elementary/BooleanSignals/Sample2.mo
@@ -10,7 +10,7 @@ model Sample2
 Modelica.Blocks.Sources.BooleanStep
                              step(startTime=0.04)
   annotation (Placement(transformation(extent={{-96,20},{-76,40}})));
-  Modelica.Clocked.BooleanSignals.Sampler.Hold  hold
+  Modelica.Clocked.BooleanSignals.Sampler.Hold hold1
     annotation (Placement(transformation(extent={{22,24},{34,36}})));
   Modelica.Clocked.BooleanSignals.Sampler.Sample  sample2
     annotation (Placement(transformation(extent={{6,-6},{-6,6}})));
@@ -29,18 +29,16 @@ equation
 connect(step.y, sample1.u) annotation (Line(
     points={{-75,30},{-61.2,30}},
     color={255,0,255}));
-connect(hold.y, sample2.u) annotation (Line(
-    points={{34.6,30},{39,30},{39,0},{7.2,0}},
-    color={255,0,255}));
+  connect(hold1.y, sample2.u) annotation (Line(points={{34.6,30},{39,30},{39,0},
+          {7.2,0}}, color={255,0,255}));
 connect(sample2.y, xor.u2) annotation (Line(
     points={{-6.6,0},{-47,0},{-47,22},{-41,22}},
     color={255,0,255}));
 connect(xor.u1, sample1.y) annotation (Line(
     points={{-41,30},{-47.4,30}},
     color={255,0,255}));
-connect(hold.u, xor1.y) annotation (Line(
-    points={{20.8,30},{17.4,30},{17.4,31},{15,31}},
-    color={255,0,255}));
+  connect(hold1.u, xor1.y) annotation (Line(points={{20.8,30},{17.4,30},{17.4,
+          31},{15,31}}, color={255,0,255}));
 connect(xor1.u1, integerConstant.y) annotation (Line(
     points={{-8,31},{-8,45.5},{-17,45.5},{-17,61}},
     color={255,0,255}));

--- a/Modelica/Clocked/Examples/Elementary/BooleanSignals/SampleClocked.mo
+++ b/Modelica/Clocked/Examples/Elementary/BooleanSignals/SampleClocked.mo
@@ -6,21 +6,19 @@ model SampleClocked
   Modelica.Blocks.Sources.BooleanStep
                                step(startTime=0.1)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.BooleanSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.BooleanSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-62,-6},{-50,6}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(sample.u, step.y) annotation (Line(
-    points={{-47.2,30},{-59,30}},
-    color={255,0,255}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.u, step.y)
+    annotation (Line(points={{-47.2,30},{-59,30}}, color={255,0,255}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/BooleanSignals/SampleVectorizedAndClocked.mo
+++ b/Modelica/Clocked/Examples/Elementary/BooleanSignals/SampleVectorizedAndClocked.mo
@@ -6,8 +6,7 @@ model SampleVectorizedAndClocked
   Modelica.Blocks.Sources.BooleanStep
                                step2(startTime=0.04)
     annotation (Placement(transformation(extent={{-80,30},{-60,50}})));
-  Modelica.Clocked.BooleanSignals.Sampler.SampleVectorizedAndClocked
-                                                  sample(n=2)
+  Modelica.Clocked.BooleanSignals.Sampler.SampleVectorizedAndClocked sample1(n=2)
     annotation (Placement(transformation(extent={{-14,24},{-2,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
@@ -16,17 +15,15 @@ model SampleVectorizedAndClocked
                                step1(startTime=0.08)
     annotation (Placement(transformation(extent={{-80,-2},{-60,18}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-15.4,0},{-8,0},{-8,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-  connect(sample.u[1], step2.y) annotation (Line(
-      points={{-15.2,29.4},{-36,29.4},{-36,40},{-59,40}},
-      color={255,0,255}));
-  connect(step1.y, sample.u[2]) annotation (Line(
-      points={{-59,8},{-38,8},{-38,30.6},{-15.2,30.6}},
-      color={255,0,255}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-15.4,0},{-8,0},{-8,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.u[1], step2.y) annotation (Line(points={{-15.2,29.4},{-36,
+          29.4},{-36,40},{-59,40}}, color={255,0,255}));
+  connect(step1.y, sample1.u[2]) annotation (Line(points={{-59,8},{-38,8},{-38,
+          30.6},{-15.2,30.6}}, color={255,0,255}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/BooleanSignals/ShiftSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/BooleanSignals/ShiftSample.mo
@@ -2,8 +2,7 @@ within Modelica.Clocked.Examples.Elementary.BooleanSignals;
 model ShiftSample "Example of a ShiftSample block for Boolean signals"
    extends Modelica.Icons.Example;
 
-  Modelica.Clocked.BooleanSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.BooleanSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
@@ -14,17 +13,15 @@ model ShiftSample "Example of a ShiftSample block for Boolean signals"
   Modelica.Blocks.Sources.BooleanTable table(table={0.05,0.15})
     annotation (Placement(transformation(extent={{-78,20},{-58,40}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(sample.u, table.y) annotation (Line(
-    points={{-47.2,30},{-57,30}},
-    color={255,0,255}));
-connect(shiftSample1.u, sample.y) annotation (Line(
-    points={{-23.2,30},{-33.4,30}},
-    color={255,0,255}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.u, table.y)
+    annotation (Line(points={{-47.2,30},{-57,30}}, color={255,0,255}));
+  connect(shiftSample1.u, sample1.y)
+    annotation (Line(points={{-23.2,30},{-33.4,30}}, color={255,0,255}));
   annotation (experiment(StopTime=0.09),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/BooleanSignals/SubSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/BooleanSignals/SubSample.mo
@@ -2,29 +2,26 @@ within Modelica.Clocked.Examples.Elementary.BooleanSignals;
 model SubSample "Example of a SubSample block for Boolean signals"
    extends Modelica.Icons.Example;
 
-  Modelica.Clocked.BooleanSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.BooleanSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-62,-6},{-50,6}})));
-Modelica.Clocked.BooleanSignals.Sampler.SubSample  subSample(
-    inferFactor=false, factor=3)
-  annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
+Modelica.Clocked.BooleanSignals.Sampler.SubSample subSample1(inferFactor=false,
+      factor=3)
+    annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
   Modelica.Blocks.Sources.BooleanTable table(table={0.05,0.15})
     annotation (Placement(transformation(extent={{-76,20},{-56,40}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(sample.u, table.y) annotation (Line(
-    points={{-47.2,30},{-55,30}},
-    color={255,0,255}));
-connect(subSample.u, sample.y) annotation (Line(
-    points={{-23.2,30},{-33.4,30}},
-    color={255,0,255}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.u, table.y)
+    annotation (Line(points={{-47.2,30},{-55,30}}, color={255,0,255}));
+  connect(subSample1.u, sample1.y)
+    annotation (Line(points={{-23.2,30},{-33.4,30}}, color={255,0,255}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/BooleanSignals/SuperSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/BooleanSignals/SuperSample.mo
@@ -2,29 +2,26 @@ within Modelica.Clocked.Examples.Elementary.BooleanSignals;
 model SuperSample "Example of a SuperSample block for Boolean signals"
    extends Modelica.Icons.Example;
 
-  Modelica.Clocked.BooleanSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.BooleanSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-62,-6},{-50,6}})));
-Modelica.Clocked.BooleanSignals.Sampler.SuperSample superSample(inferFactor=false,
-      factor=3)
-  annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
+Modelica.Clocked.BooleanSignals.Sampler.SuperSample superSample1(inferFactor=
+        false, factor=3)
+    annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
   Modelica.Blocks.Sources.BooleanTable table(table={0.05,0.15})
     annotation (Placement(transformation(extent={{-78,20},{-58,40}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(table.y, sample.u) annotation (Line(
-    points={{-57,30},{-47.2,30}},
-    color={255,0,255}));
-connect(superSample.u, sample.y) annotation (Line(
-    points={{-23.2,30},{-33.4,30}},
-    color={255,0,255}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(table.y, sample1.u)
+    annotation (Line(points={{-57,30},{-47.2,30}}, color={255,0,255}));
+  connect(superSample1.u, sample1.y)
+    annotation (Line(points={{-23.2,30},{-33.4,30}}, color={255,0,255}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/BooleanSignals/UpSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/BooleanSignals/UpSample.mo
@@ -5,8 +5,7 @@ model UpSample "Example of an UpSample block for Boolean signals"
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-68,-6},{-56,6}})));
-  Modelica.Clocked.BooleanSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.BooleanSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-48,24},{-36,36}})));
 Modelica.Clocked.BooleanSignals.Sampler.Utilities.UpSample upSample1
   annotation (Placement(transformation(extent={{-26,34},{-14,46}})));
@@ -18,20 +17,17 @@ Modelica.Clocked.BooleanSignals.Sampler.Utilities.UpSample upSample2(
 Modelica.Blocks.Logical.And and1
   annotation (Placement(transformation(extent={{0,20},{20,40}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-55.4,0},{-42,0},{-42,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(table1.y, sample.u) annotation (Line(
-    points={{-61,30},{-49.2,30}},
-    color={255,0,255}));
-connect(upSample1.u, sample.y) annotation (Line(
-    points={{-27.2,40},{-30,40},{-30,30},{-35.4,30}},
-    color={255,0,255}));
-connect(upSample2.u, sample.y) annotation (Line(
-    points={{-27.2,20},{-30,20},{-30,30},{-35.4,30}},
-    color={255,0,255}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-55.4,0},{-42,0},{-42,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(table1.y, sample1.u)
+    annotation (Line(points={{-61,30},{-49.2,30}}, color={255,0,255}));
+  connect(upSample1.u, sample1.y) annotation (Line(points={{-27.2,40},{-30,40},
+          {-30,30},{-35.4,30}}, color={255,0,255}));
+  connect(upSample2.u, sample1.y) annotation (Line(points={{-27.2,20},{-30,20},
+          {-30,30},{-35.4,30}}, color={255,0,255}));
 connect(upSample1.y, and1.u1) annotation (Line(
     points={{-13.4,40},{-8,40},{-8,30},{-2,30}},
     color={255,0,255}));

--- a/Modelica/Clocked/Examples/Elementary/ClockSignals/ShiftSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/ClockSignals/ShiftSample.mo
@@ -5,8 +5,8 @@ model ShiftSample "Example of a ShiftSample block for Clock signals"
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-56,24},{-44,36}})));
-  Modelica.Clocked.ClockSignals.Sampler.ShiftSample shiftSample(
-    shiftCounter=4, resolution=3)
+  Modelica.Clocked.ClockSignals.Sampler.ShiftSample shiftSample1(shiftCounter=4,
+      resolution=3)
     annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
   Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{14,54},{26,66}})));
@@ -15,14 +15,14 @@ model ShiftSample "Example of a ShiftSample block for Clock signals"
     startTime=0)
     annotation (Placement(transformation(extent={{-26,50},{-6,70}})));
 equation
-connect(periodicClock.y, shiftSample.u) annotation (Line(
-    points={{-43.4,30},{-23.2,30}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
+  connect(periodicClock.y, shiftSample1.u) annotation (Line(
+      points={{-43.4,30},{-23.2,30}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
   connect(sine.y, sample1.u)
     annotation (Line(points={{-5,60},{12.8,60}}, color={0,0,127}));
-  connect(shiftSample.y, sample1.clock) annotation (Line(
+  connect(shiftSample1.y, sample1.clock) annotation (Line(
       points={{-9.4,30},{20,30},{20,52.8}},
       color={175,175,175},
       pattern=LinePattern.Dot,

--- a/Modelica/Clocked/Examples/Elementary/ClockSignals/SubSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/ClockSignals/SubSample.mo
@@ -5,9 +5,8 @@ model SubSample "Example of a SubSample block for Clock signals"
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-56,24},{-44,36}})));
-Modelica.Clocked.ClockSignals.Sampler.SubSample subSample(
-                       factor=3)
-  annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
+Modelica.Clocked.ClockSignals.Sampler.SubSample subSample1(factor=3)
+    annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
   Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{16,52},{28,64}})));
   Modelica.Blocks.Sources.Sine sine(f=2,
@@ -15,14 +14,14 @@ Modelica.Clocked.ClockSignals.Sampler.SubSample subSample(
     startTime=0)
     annotation (Placement(transformation(extent={{-24,48},{-4,68}})));
 equation
-connect(periodicClock.y, subSample.u) annotation (Line(
-    points={{-43.4,30},{-23.2,30}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
+  connect(periodicClock.y, subSample1.u) annotation (Line(
+      points={{-43.4,30},{-23.2,30}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
   connect(sine.y, sample1.u) annotation (Line(points={{-3,58},{14.8,58},{
           14.8,58}}, color={0,0,127}));
-  connect(subSample.y, sample1.clock) annotation (Line(
+  connect(subSample1.y, sample1.clock) annotation (Line(
       points={{-9.4,30},{22,30},{22,50.8}},
       color={175,175,175},
       pattern=LinePattern.Dot,

--- a/Modelica/Clocked/Examples/Elementary/ClockSignals/SuperSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/ClockSignals/SuperSample.mo
@@ -5,9 +5,8 @@ model SuperSample "Example of a SuperSample block for Clock signals"
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-56,24},{-44,36}})));
-Modelica.Clocked.ClockSignals.Sampler.SuperSample superSample(
-      factor=3)
-  annotation (Placement(transformation(extent={{-26,24},{-14,36}})));
+Modelica.Clocked.ClockSignals.Sampler.SuperSample superSample1(factor=3)
+    annotation (Placement(transformation(extent={{-26,24},{-14,36}})));
   Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{10,56},{22,68}})));
   Modelica.Blocks.Sources.Sine sine(f=2,
@@ -15,14 +14,14 @@ Modelica.Clocked.ClockSignals.Sampler.SuperSample superSample(
     startTime=0)
     annotation (Placement(transformation(extent={{-30,52},{-10,72}})));
 equation
-connect(periodicClock.y, superSample.u) annotation (Line(
-    points={{-43.4,30},{-27.2,30}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
+  connect(periodicClock.y, superSample1.u) annotation (Line(
+      points={{-43.4,30},{-27.2,30}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
   connect(sine.y, sample1.u)
     annotation (Line(points={{-9,62},{8.8,62}}, color={0,0,127}));
-  connect(superSample.y, sample1.clock) annotation (Line(
+  connect(superSample1.y, sample1.clock) annotation (Line(
       points={{-13.4,30},{2,30},{16,30},{16,54.8}},
       color={175,175,175},
       pattern=LinePattern.Dot,

--- a/Modelica/Clocked/Examples/Elementary/IntegerSignals/BackSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/IntegerSignals/BackSample.mo
@@ -2,8 +2,7 @@ within Modelica.Clocked.Examples.Elementary.IntegerSignals;
 model BackSample "Example of a BackSample block for Integer signals"
    extends Modelica.Icons.Example;
 
-  Modelica.Clocked.IntegerSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.IntegerSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
@@ -20,20 +19,18 @@ Modelica.Clocked.IntegerSignals.Sampler.BackSample backSample1(
       0; 0.075,-1; 0.1,3])
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(sample.y, shiftSample1.u) annotation (Line(
-    points={{-33.4,30},{-19.2,30}},
-    color={255,127,0}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.y, shiftSample1.u)
+    annotation (Line(points={{-33.4,30},{-19.2,30}}, color={255,127,0}));
 connect(shiftSample1.y, backSample1.u) annotation (Line(
     points={{-5.4,30},{12.8,30}},
     color={255,127,0}));
-connect(table.y, sample.u) annotation (Line(
-    points={{-59,30},{-47.2,30}},
-    color={255,127,0}));
+  connect(table.y, sample1.u)
+    annotation (Line(points={{-59,30},{-47.2,30}}, color={255,127,0}));
   annotation (experiment(StopTime=0.09),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/IntegerSignals/Hold.mo
+++ b/Modelica/Clocked/Examples/Elementary/IntegerSignals/Hold.mo
@@ -5,32 +5,28 @@ model Hold "Example of a Hold block for Integer signals"
   Modelica.Blocks.Sources.IntegerTable table(table=[0,1; 0.05,2; 0.1,0; 0.15,-1;
         0.2,3])
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.IntegerSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.IntegerSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-52,24},{-40,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-68,-6},{-56,6}})));
-Modelica.Clocked.IntegerSignals.Sampler.Hold  hold(y_start=-1)
-  annotation (Placement(transformation(extent={{-8,24},{4,36}})));
+Modelica.Clocked.IntegerSignals.Sampler.Hold hold1(y_start=-1)
+    annotation (Placement(transformation(extent={{-8,24},{4,36}})));
 Modelica.Clocked.IntegerSignals.Sampler.ShiftSample  shiftSample(
     shiftCounter=2)
   annotation (Placement(transformation(extent={{-30,24},{-18,36}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-55.4,0},{-46,0},{-46,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-  connect(table.y, sample.u) annotation (Line(
-      points={{-59,30},{-53.2,30}},
-      color={255,127,0}));
-  connect(sample.y, shiftSample.u) annotation (Line(
-      points={{-39.4,30},{-31.2,30}},
-      color={255,127,0}));
-  connect(shiftSample.y, hold.u) annotation (Line(
-      points={{-17.4,30},{-9.2,30}},
-      color={255,127,0}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-55.4,0},{-46,0},{-46,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(table.y, sample1.u)
+    annotation (Line(points={{-59,30},{-53.2,30}}, color={255,127,0}));
+  connect(sample1.y, shiftSample.u)
+    annotation (Line(points={{-39.4,30},{-31.2,30}}, color={255,127,0}));
+  connect(shiftSample.y, hold1.u)
+    annotation (Line(points={{-17.4,30},{-9.2,30}}, color={255,127,0}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/IntegerSignals/Sample1.mo
+++ b/Modelica/Clocked/Examples/Elementary/IntegerSignals/Sample1.mo
@@ -9,20 +9,18 @@ model Sample1 "Example of a Sample block for Integer signals"
 Modelica.Blocks.Sources.IntegerStep
                              step(startTime=0.1)
   annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-Modelica.Clocked.IntegerSignals.Sampler.Sample sample
-  annotation (Placement(transformation(extent={{-48,24},{-36,36}})));
+Modelica.Clocked.IntegerSignals.Sampler.Sample sample1
+    annotation (Placement(transformation(extent={{-48,24},{-36,36}})));
 equation
   connect(periodicClock.y, assignClock.clock) annotation (Line(
       points={{-29.4,4},{-16,4},{-16,22.8}},
       color={175,175,175},
       pattern=LinePattern.Dot,
       thickness=0.5));
-connect(step.y, sample.u) annotation (Line(
-    points={{-59,30},{-49.2,30}},
-    color={255,127,0}));
-connect(sample.y, assignClock.u) annotation (Line(
-    points={{-35.4,30},{-23.2,30}},
-    color={255,127,0}));
+  connect(step.y, sample1.u)
+    annotation (Line(points={{-59,30},{-49.2,30}}, color={255,127,0}));
+  connect(sample1.y, assignClock.u)
+    annotation (Line(points={{-35.4,30},{-23.2,30}}, color={255,127,0}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/IntegerSignals/Sample2.mo
+++ b/Modelica/Clocked/Examples/Elementary/IntegerSignals/Sample2.mo
@@ -10,7 +10,7 @@ model Sample2
 Modelica.Blocks.Sources.IntegerStep
                              step(startTime=0.04)
   annotation (Placement(transformation(extent={{-96,20},{-76,40}})));
-  Modelica.Clocked.IntegerSignals.Sampler.Hold  hold
+  Modelica.Clocked.IntegerSignals.Sampler.Hold hold1
     annotation (Placement(transformation(extent={{22,24},{34,36}})));
   Modelica.Clocked.IntegerSignals.Sampler.Sample  sample2
     annotation (Placement(transformation(extent={{6,-6},{-6,6}})));
@@ -40,12 +40,10 @@ equation
   connect(sum1.y, sum2.u[2]) annotation (Line(
       points={{-13.1,28},{-5.55,28},{-5.55,27.9},{2,27.9}},
       color={255,127,0}));
-  connect(hold.u, sum2.y) annotation (Line(
-      points={{20.8,30},{14.9,30}},
-      color={255,127,0}));
-  connect(hold.y, sample2.u) annotation (Line(
-      points={{34.6,30},{50,30},{50,0},{7.2,0}},
-      color={255,127,0}));
+  connect(hold1.u, sum2.y)
+    annotation (Line(points={{20.8,30},{14.9,30}}, color={255,127,0}));
+  connect(hold1.y, sample2.u) annotation (Line(points={{34.6,30},{50,30},{50,0},
+          {7.2,0}}, color={255,127,0}));
   connect(sample1.u, step.y) annotation (Line(
       points={{-61.2,30},{-75,30}},
       color={255,127,0}));

--- a/Modelica/Clocked/Examples/Elementary/IntegerSignals/SampleClocked.mo
+++ b/Modelica/Clocked/Examples/Elementary/IntegerSignals/SampleClocked.mo
@@ -6,21 +6,19 @@ model SampleClocked
   Modelica.Blocks.Sources.IntegerStep
                                step(startTime=0.1, offset=1)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.IntegerSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.IntegerSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-62,-6},{-50,6}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-  connect(step.y, sample.u) annotation (Line(
-      points={{-59,30},{-47.2,30}},
-      color={255,127,0}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(step.y, sample1.u)
+    annotation (Line(points={{-59,30},{-47.2,30}}, color={255,127,0}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/IntegerSignals/SampleVectorizedAndClocked.mo
+++ b/Modelica/Clocked/Examples/Elementary/IntegerSignals/SampleVectorizedAndClocked.mo
@@ -6,8 +6,7 @@ model SampleVectorizedAndClocked
   Modelica.Blocks.Sources.IntegerStep
                                step2(offset=1, startTime=0.04)
     annotation (Placement(transformation(extent={{-80,30},{-60,50}})));
-  Modelica.Clocked.IntegerSignals.Sampler.SampleVectorizedAndClocked
-                                                  sample(n=2)
+  Modelica.Clocked.IntegerSignals.Sampler.SampleVectorizedAndClocked sample1(n=2)
     annotation (Placement(transformation(extent={{-14,24},{-2,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
@@ -16,17 +15,15 @@ model SampleVectorizedAndClocked
                                step1(startTime=0.08)
     annotation (Placement(transformation(extent={{-80,-2},{-60,18}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-15.4,0},{-8,0},{-8,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-  connect(step1.y, sample.u[1]) annotation (Line(
-      points={{-59,8},{-38,8},{-38,29.4},{-15.2,29.4}},
-      color={255,127,0}));
-  connect(step2.y, sample.u[2]) annotation (Line(
-      points={{-59,40},{-38,40},{-38,30.6},{-15.2,30.6}},
-      color={255,127,0}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-15.4,0},{-8,0},{-8,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(step1.y, sample1.u[1]) annotation (Line(points={{-59,8},{-38,8},{-38,
+          29.4},{-15.2,29.4}}, color={255,127,0}));
+  connect(step2.y, sample1.u[2]) annotation (Line(points={{-59,40},{-38,40},{-38,
+          30.6},{-15.2,30.6}}, color={255,127,0}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/IntegerSignals/ShiftSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/IntegerSignals/ShiftSample.mo
@@ -2,8 +2,7 @@ within Modelica.Clocked.Examples.Elementary.IntegerSignals;
 model ShiftSample "Example of a ShiftSample block for Integer signals"
    extends Modelica.Icons.Example;
 
-  Modelica.Clocked.IntegerSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.IntegerSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
@@ -15,17 +14,15 @@ model ShiftSample "Example of a ShiftSample block for Integer signals"
       0; 0.075,-1; 0.1,3])
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(table.y, sample.u) annotation (Line(
-    points={{-59,30},{-47.2,30}},
-    color={255,127,0}));
-connect(sample.y, shiftSample1.u) annotation (Line(
-    points={{-33.4,30},{-23.2,30}},
-    color={255,127,0}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(table.y, sample1.u)
+    annotation (Line(points={{-59,30},{-47.2,30}}, color={255,127,0}));
+  connect(sample1.y, shiftSample1.u)
+    annotation (Line(points={{-33.4,30},{-23.2,30}}, color={255,127,0}));
   annotation (experiment(StopTime=0.09),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/IntegerSignals/SubSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/IntegerSignals/SubSample.mo
@@ -2,30 +2,27 @@ within Modelica.Clocked.Examples.Elementary.IntegerSignals;
 model SubSample "Example of a SubSample block for Integer signals"
    extends Modelica.Icons.Example;
 
-  Modelica.Clocked.IntegerSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.IntegerSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-62,-6},{-50,6}})));
-Modelica.Clocked.IntegerSignals.Sampler.SubSample  subSample(
-    inferFactor=false, factor=3)
-  annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
+Modelica.Clocked.IntegerSignals.Sampler.SubSample subSample1(inferFactor=false,
+      factor=3)
+    annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
   Modelica.Blocks.Sources.IntegerTable table(table=[0,1; 0.05,2; 0.1,0; 0.15,-1;
         0.2,3])
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-  connect(table.y, sample.u) annotation (Line(
-      points={{-59,30},{-47.2,30}},
-      color={255,127,0}));
-  connect(sample.y, subSample.u) annotation (Line(
-      points={{-33.4,30},{-23.2,30}},
-      color={255,127,0}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(table.y, sample1.u)
+    annotation (Line(points={{-59,30},{-47.2,30}}, color={255,127,0}));
+  connect(sample1.y, subSample1.u)
+    annotation (Line(points={{-33.4,30},{-23.2,30}}, color={255,127,0}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/IntegerSignals/SuperSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/IntegerSignals/SuperSample.mo
@@ -2,30 +2,27 @@ within Modelica.Clocked.Examples.Elementary.IntegerSignals;
 model SuperSample "Example of a SuperSample block for Integer signals"
    extends Modelica.Icons.Example;
 
-  Modelica.Clocked.IntegerSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.IntegerSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-62,-6},{-50,6}})));
-Modelica.Clocked.IntegerSignals.Sampler.SuperSample superSample(inferFactor=false,
-      factor=3)
-  annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
+Modelica.Clocked.IntegerSignals.Sampler.SuperSample superSample1(inferFactor=
+        false, factor=3)
+    annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
   Modelica.Blocks.Sources.IntegerTable table(table=[0,1; 0.05,2; 0.1,0; 0.15,-1;
         0.2,3])
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(table.y, sample.u) annotation (Line(
-    points={{-59,30},{-47.2,30}},
-    color={255,127,0}));
-connect(sample.y, superSample.u) annotation (Line(
-    points={{-33.4,30},{-23.2,30}},
-    color={255,127,0}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(table.y, sample1.u)
+    annotation (Line(points={{-59,30},{-47.2,30}}, color={255,127,0}));
+  connect(sample1.y, superSample1.u)
+    annotation (Line(points={{-33.4,30},{-23.2,30}}, color={255,127,0}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/IntegerSignals/UpSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/IntegerSignals/UpSample.mo
@@ -5,8 +5,7 @@ model UpSample "Example of an UpSample block for Integer signals"
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-68,-6},{-56,6}})));
-  Modelica.Clocked.IntegerSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.IntegerSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-48,24},{-36,36}})));
 Modelica.Clocked.IntegerSignals.Sampler.Utilities.UpSample upSample1
   annotation (Placement(transformation(extent={{-26,34},{-14,46}})));
@@ -19,20 +18,17 @@ Modelica.Clocked.IntegerSignals.Sampler.Utilities.UpSample upSample2(
 Modelica.Blocks.MathInteger.Sum sum(nu=2)
   annotation (Placement(transformation(extent={{2,24},{14,36}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-55.4,0},{-42,0},{-42,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(table.y, sample.u) annotation (Line(
-    points={{-59,30},{-49.2,30}},
-    color={255,127,0}));
-connect(sample.y, upSample1.u) annotation (Line(
-    points={{-35.4,30},{-32,30},{-32,40},{-27.2,40}},
-    color={255,127,0}));
-connect(sample.y, upSample2.u) annotation (Line(
-    points={{-35.4,30},{-32,30},{-32,20},{-27.2,20}},
-    color={255,127,0}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-55.4,0},{-42,0},{-42,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(table.y, sample1.u)
+    annotation (Line(points={{-59,30},{-49.2,30}}, color={255,127,0}));
+  connect(sample1.y, upSample1.u) annotation (Line(points={{-35.4,30},{-32,30},
+          {-32,40},{-27.2,40}}, color={255,127,0}));
+  connect(sample1.y, upSample2.u) annotation (Line(points={{-35.4,30},{-32,30},
+          {-32,20},{-27.2,20}}, color={255,127,0}));
 connect(upSample1.y, sum.u[1]) annotation (Line(
     points={{-13.4,40},{-6,40},{-6,32.1},{2,32.1}},
     color={255,127,0}));

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/AssignClockToSquareWaveHold.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/AssignClockToSquareWaveHold.mo
@@ -10,24 +10,21 @@ model AssignClockToSquareWaveHold
     offset=0.1,
     startTime=0)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.RealSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-48,24},{-36,36}})));
 Modelica.Clocked.RealSignals.Sampler.Utilities.AssignClockToSquareWaveHold
   clockToSquareWave
   annotation (Placement(transformation(extent={{-24,20},{-4,40}})));
 equation
-connect(sine.y, sample.u) annotation (Line(
-    points={{-59,30},{-49.2,30}},
-    color={0,0,127}));
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-55.4,0},{-42,0},{-42,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(sample.y, clockToSquareWave.u) annotation (Line(
-    points={{-35.4,30},{-26,30}},
-    color={0,0,127}));
+  connect(sine.y, sample1.u)
+    annotation (Line(points={{-59,30},{-49.2,30}}, color={0,0,127}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-55.4,0},{-42,0},{-42,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.y, clockToSquareWave.u)
+    annotation (Line(points={{-35.4,30},{-26,30}}, color={0,0,127}));
   annotation (experiment(StopTime=0.09),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/AssignClockToTriggerHold.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/AssignClockToTriggerHold.mo
@@ -10,8 +10,7 @@ model AssignClockToTriggerHold
     offset=0.1,
     startTime=0)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.RealSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-48,24},{-36,36}})));
 Modelica.Blocks.Discrete.TriggeredSampler triggeredSampler
   annotation (Placement(transformation(extent={{10,40},{30,60}})));
@@ -19,20 +18,18 @@ Modelica.Clocked.RealSignals.Sampler.Utilities.AssignClockToTriggerHold
   clockToTrigger
   annotation (Placement(transformation(extent={{-20,20},{0,40}})));
 equation
-connect(sine.y, sample.u) annotation (Line(
-    points={{-59,30},{-49.2,30}},
-    color={0,0,127}));
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-55.4,0},{-42,0},{-42,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
+  connect(sine.y, sample1.u)
+    annotation (Line(points={{-59,30},{-49.2,30}}, color={0,0,127}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-55.4,0},{-42,0},{-42,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
 connect(triggeredSampler.u, sine.y) annotation (Line(
     points={{8,50},{-54,50},{-54,30},{-59,30}},
     color={0,0,127}));
-connect(sample.y, clockToTrigger.u) annotation (Line(
-    points={{-35.4,30},{-22,30}},
-    color={0,0,127}));
+  connect(sample1.y, clockToTrigger.u)
+    annotation (Line(points={{-35.4,30},{-22,30}}, color={0,0,127}));
 connect(triggeredSampler.trigger, clockToTrigger.y) annotation (Line(
     points={{20,38.2},{20,30},{1,30}},
     color={255,0,255}));

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/BackSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/BackSample.mo
@@ -6,8 +6,7 @@ model BackSample "Example of a BackSample block for Real signals"
     offset=0.1,
     startTime=0)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.RealSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
@@ -21,17 +20,15 @@ Modelica.Clocked.RealSignals.Sampler.BackSample backSample1(
   y_start=0.5)
   annotation (Placement(transformation(extent={{-4,24},{8,36}})));
 equation
-  connect(sine.y, sample.u) annotation (Line(
-      points={{-59,30},{-47.2,30}},
-      color={0,0,127}));
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-  connect(sample.y, shiftSample1.u) annotation (Line(
-      points={{-33.4,30},{-27.2,30}},
-      color={0,0,127}));
+  connect(sine.y, sample1.u)
+    annotation (Line(points={{-59,30},{-47.2,30}}, color={0,0,127}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.y, shiftSample1.u)
+    annotation (Line(points={{-33.4,30},{-27.2,30}}, color={0,0,127}));
 connect(shiftSample1.y, backSample1.u) annotation (Line(
     points={{-13.4,30},{-5.2,30}},
     color={0,0,127}));

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/FractionalDelay.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/FractionalDelay.mo
@@ -10,24 +10,21 @@ model FractionalDelay
     offset=0.1,
     startTime=0)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.RealSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-48,24},{-36,36}})));
 Modelica.Clocked.RealSignals.NonPeriodic.FractionalDelay
   fractionalDelay(shift=3, resolution=2)
   annotation (Placement(transformation(extent={{-26,20},{-6,40}})));
 equation
-connect(sine.y, sample.u) annotation (Line(
-    points={{-59,30},{-49.2,30}},
-    color={0,0,127}));
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-55.4,0},{-42,0},{-42,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(fractionalDelay.u, sample.y) annotation (Line(
-    points={{-28,30},{-35.4,30}},
-    color={0,0,127}));
+  connect(sine.y, sample1.u)
+    annotation (Line(points={{-59,30},{-49.2,30}}, color={0,0,127}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-55.4,0},{-42,0},{-42,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(fractionalDelay.u, sample1.y)
+    annotation (Line(points={{-28,30},{-35.4,30}}, color={0,0,127}));
   annotation (experiment(StopTime=0.09),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/Hold.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/Hold.mo
@@ -6,32 +6,27 @@ model Hold "Example of a Hold block for Real signals"
     offset=0.1,
     startTime=0)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.RealSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-52,24},{-40,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-68,-6},{-56,6}})));
-Modelica.Clocked.RealSignals.Sampler.Hold hold(y_start=-1.0)
-  annotation (Placement(transformation(extent={{-8,24},{4,36}})));
-Modelica.Clocked.RealSignals.Sampler.ShiftSample shiftSample(
-    shiftCounter=2)
-  annotation (Placement(transformation(extent={{-30,24},{-18,36}})));
+Modelica.Clocked.RealSignals.Sampler.Hold hold1(y_start=-1.0)
+    annotation (Placement(transformation(extent={{-8,24},{4,36}})));
+Modelica.Clocked.RealSignals.Sampler.ShiftSample shiftSample1(shiftCounter=2)
+    annotation (Placement(transformation(extent={{-30,24},{-18,36}})));
 equation
-  connect(sine.y, sample.u) annotation (Line(
-      points={{-59,30},{-53.2,30}},
-      color={0,0,127}));
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-55.4,0},{-46,0},{-46,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(sample.y, shiftSample.u) annotation (Line(
-    points={{-39.4,30},{-31.2,30}},
-    color={0,0,127}));
-connect(shiftSample.y, hold.u) annotation (Line(
-    points={{-17.4,30},{-9.2,30}},
-    color={0,0,127}));
+  connect(sine.y, sample1.u)
+    annotation (Line(points={{-59,30},{-53.2,30}}, color={0,0,127}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-55.4,0},{-46,0},{-46,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.y, shiftSample1.u)
+    annotation (Line(points={{-39.4,30},{-31.2,30}}, color={0,0,127}));
+  connect(shiftSample1.y, hold1.u)
+    annotation (Line(points={{-17.4,30},{-9.2,30}}, color={0,0,127}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/HoldWithDAeffects1.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/HoldWithDAeffects1.mo
@@ -7,39 +7,32 @@ model HoldWithDAeffects1
     startTime=0,
   amplitude=2)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.RealSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-52,24},{-40,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-68,-6},{-56,6}})));
-Modelica.Clocked.RealSignals.Sampler.HoldWithDAeffects
-                                              hold(
-  computationalDelay=true,
-  shiftCounter=1,
-  resolution=2,
-  y_start=0.5,
-  limited=true,
-  yMax=1.9)
-  annotation (Placement(transformation(extent={{-8,24},{4,36}})));
-Modelica.Clocked.RealSignals.Sampler.ShiftSample shiftSample(
-    shiftCounter=2)
-  annotation (Placement(transformation(extent={{-30,24},{-18,36}})));
+Modelica.Clocked.RealSignals.Sampler.HoldWithDAeffects hold1(
+    computationalDelay=true,
+    shiftCounter=1,
+    resolution=2,
+    y_start=0.5,
+    limited=true,
+    yMax=1.9) annotation (Placement(transformation(extent={{-8,24},{4,36}})));
+Modelica.Clocked.RealSignals.Sampler.ShiftSample shiftSample1(shiftCounter=2)
+    annotation (Placement(transformation(extent={{-30,24},{-18,36}})));
 equation
-  connect(sine.y, sample.u) annotation (Line(
-      points={{-59,30},{-53.2,30}},
-      color={0,0,127}));
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-55.4,0},{-46,0},{-46,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(sample.y, shiftSample.u) annotation (Line(
-    points={{-39.4,30},{-31.2,30}},
-    color={0,0,127}));
-  connect(shiftSample.y, hold.u) annotation (Line(
-      points={{-17.4,30},{-9.2,30}},
-      color={0,0,127}));
+  connect(sine.y, sample1.u)
+    annotation (Line(points={{-59,30},{-53.2,30}}, color={0,0,127}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-55.4,0},{-46,0},{-46,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.y, shiftSample1.u)
+    annotation (Line(points={{-39.4,30},{-31.2,30}}, color={0,0,127}));
+  connect(shiftSample1.y, hold1.u)
+    annotation (Line(points={{-17.4,30},{-9.2,30}}, color={0,0,127}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/HoldWithDAeffects2.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/HoldWithDAeffects2.mo
@@ -7,39 +7,33 @@ model HoldWithDAeffects2
     startTime=0,
   amplitude=2)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.RealSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-52,24},{-40,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-68,-6},{-56,6}})));
-Modelica.Clocked.RealSignals.Sampler.HoldWithDAeffects
-                                              hold(
-  computationalDelay=true,
-  shiftCounter=1,
-  y_start=0.5,
-  limited=true,
-  yMax=1.9,
-  resolution=1)
-  annotation (Placement(transformation(extent={{-8,24},{4,36}})));
-Modelica.Clocked.RealSignals.Sampler.ShiftSample shiftSample(
-    shiftCounter=2)
-  annotation (Placement(transformation(extent={{-30,24},{-18,36}})));
+Modelica.Clocked.RealSignals.Sampler.HoldWithDAeffects hold1(
+    computationalDelay=true,
+    shiftCounter=1,
+    y_start=0.5,
+    limited=true,
+    yMax=1.9,
+    resolution=1)
+    annotation (Placement(transformation(extent={{-8,24},{4,36}})));
+Modelica.Clocked.RealSignals.Sampler.ShiftSample shiftSample1(shiftCounter=2)
+    annotation (Placement(transformation(extent={{-30,24},{-18,36}})));
 equation
-  connect(sine.y, sample.u) annotation (Line(
-      points={{-59,30},{-53.2,30}},
-      color={0,0,127}));
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-55.4,0},{-46,0},{-46,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(sample.y, shiftSample.u) annotation (Line(
-    points={{-39.4,30},{-31.2,30}},
-    color={0,0,127}));
-  connect(shiftSample.y, hold.u) annotation (Line(
-      points={{-17.4,30},{-9.2,30}},
-      color={0,0,127}));
+  connect(sine.y, sample1.u)
+    annotation (Line(points={{-59,30},{-53.2,30}}, color={0,0,127}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-55.4,0},{-46,0},{-46,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.y, shiftSample1.u)
+    annotation (Line(points={{-39.4,30},{-31.2,30}}, color={0,0,127}));
+  connect(shiftSample1.y, hold1.u)
+    annotation (Line(points={{-17.4,30},{-9.2,30}}, color={0,0,127}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/Sample1.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/Sample1.mo
@@ -6,7 +6,7 @@ model Sample1 "Example of a Sample block for Real signals"
     offset=0.1,
     startTime=0)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Clocked.RealSignals.Sampler.Sample sample
+  Clocked.RealSignals.Sampler.Sample sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Clocked.RealSignals.Sampler.AssignClock assignClock
     annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
@@ -14,12 +14,10 @@ model Sample1 "Example of a Sample block for Real signals"
       resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-42,-2},{-30,10}})));
 equation
-  connect(sine.y, sample.u) annotation (Line(
-      points={{-59,30},{-47.2,30}},
-      color={0,0,127}));
-  connect(sample.y, assignClock.u) annotation (Line(
-      points={{-33.4,30},{-23.2,30}},
-      color={0,0,127}));
+  connect(sine.y, sample1.u)
+    annotation (Line(points={{-59,30},{-47.2,30}}, color={0,0,127}));
+  connect(sample1.y, assignClock.u)
+    annotation (Line(points={{-33.4,30},{-23.2,30}}, color={0,0,127}));
   connect(periodicClock.y, assignClock.clock) annotation (Line(
       points={{-29.4,4},{-16,4},{-16,22.8}},
       color={175,175,175},

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/Sample2.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/Sample2.mo
@@ -2,7 +2,7 @@ within Modelica.Clocked.Examples.Elementary.RealSignals;
 model Sample2
   "Example of a Sample block with discontinuous Real input signals"
  extends Modelica.Icons.Example;
-  Clocked.RealSignals.Sampler.Sample sample
+  Clocked.RealSignals.Sampler.Sample sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Clocked.RealSignals.Sampler.AssignClock assignClock
     annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
@@ -12,17 +12,15 @@ model Sample2
 Modelica.Blocks.Sources.Step step(startTime=0.1)
   annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
 equation
-  connect(sample.y, assignClock.u) annotation (Line(
-      points={{-33.4,30},{-23.2,30}},
-      color={0,0,127}));
+  connect(sample1.y, assignClock.u)
+    annotation (Line(points={{-33.4,30},{-23.2,30}}, color={0,0,127}));
   connect(periodicClock.y, assignClock.clock) annotation (Line(
       points={{-29.4,4},{-16,4},{-16,22.8}},
       color={175,175,175},
       pattern=LinePattern.Dot,
       thickness=0.5));
-connect(step.y, sample.u) annotation (Line(
-    points={{-59,30},{-47.2,30}},
-    color={0,0,127}));
+  connect(step.y, sample1.u)
+    annotation (Line(points={{-59,30},{-47.2,30}}, color={0,0,127}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/Sample3.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/Sample3.mo
@@ -11,7 +11,7 @@ Modelica.Blocks.Sources.Step step(startTime=0.04)
   annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
   Modelica.Blocks.Math.Gain gain(k=1.2)
     annotation (Placement(transformation(extent={{-8,20},{12,40}})));
-  Modelica.Clocked.RealSignals.Sampler.Hold hold
+  Modelica.Clocked.RealSignals.Sampler.Hold hold1
     annotation (Placement(transformation(extent={{20,24},{32,36}})));
   Modelica.Blocks.Math.Feedback feedback
     annotation (Placement(transformation(extent={{-36,20},{-16,40}})));
@@ -22,9 +22,8 @@ equation
                           annotation (Line(
     points={{-59,30},{-53.2,30}},
     color={0,0,127}));
-  connect(gain.y, hold.u) annotation (Line(
-      points={{13,30},{18.8,30}},
-      color={0,0,127}));
+  connect(gain.y, hold1.u)
+    annotation (Line(points={{13,30},{18.8,30}}, color={0,0,127}));
   connect(feedback.y, gain.u) annotation (Line(
       points={{-17,30},{-10,30}},
       color={0,0,127}));
@@ -39,9 +38,8 @@ equation
   connect(sample1.y, feedback.u1) annotation (Line(
       points={{-39.4,30},{-34,30}},
       color={0,0,127}));
-  connect(hold.y, sample2.u) annotation (Line(
-      points={{32.6,30},{38,30},{38,0},{7.2,0}},
-      color={0,0,127}));
+  connect(hold1.y, sample2.u) annotation (Line(points={{32.6,30},{38,30},{38,0},
+          {7.2,0}}, color={0,0,127}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/SampleClocked.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/SampleClocked.mo
@@ -6,21 +6,19 @@ model SampleClocked "Example of a SampleClocked block for Real signals"
     offset=0.1,
     startTime=0)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.RealSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-62,-6},{-50,6}})));
 equation
-  connect(sine.y, sample.u) annotation (Line(
-      points={{-59,30},{-47.2,30}},
-      color={0,0,127}));
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
+  connect(sine.y, sample1.u)
+    annotation (Line(points={{-59,30},{-47.2,30}}, color={0,0,127}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/SampleVectorizedAndClocked.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/SampleVectorizedAndClocked.mo
@@ -8,8 +8,7 @@ model SampleVectorizedAndClocked
   offset=0.1,
   startTime=0)
     annotation (Placement(transformation(extent={{-80,30},{-60,50}})));
-  Modelica.Clocked.RealSignals.Sampler.SampleVectorizedAndClocked
-                                                  sample(n=2)
+  Modelica.Clocked.RealSignals.Sampler.SampleVectorizedAndClocked sample1(n=2)
     annotation (Placement(transformation(extent={{-14,24},{-2,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
@@ -17,17 +16,15 @@ model SampleVectorizedAndClocked
   Modelica.Blocks.Sources.Sine sine1(startTime=0, f=3)
     annotation (Placement(transformation(extent={{-80,-2},{-60,18}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-15.4,0},{-8,0},{-8,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(sine1.y, sample.u[1]) annotation (Line(
-    points={{-59,8},{-38,8},{-38,29.4},{-15.2,29.4}},
-    color={0,0,127}));
-connect(sine2.y, sample.u[2]) annotation (Line(
-    points={{-59,40},{-38,40},{-38,30.6},{-15.2,30.6}},
-    color={0,0,127}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-15.4,0},{-8,0},{-8,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sine1.y, sample1.u[1]) annotation (Line(points={{-59,8},{-38,8},{-38,
+          29.4},{-15.2,29.4}}, color={0,0,127}));
+  connect(sine2.y, sample1.u[2]) annotation (Line(points={{-59,40},{-38,40},{-38,
+          30.6},{-15.2,30.6}}, color={0,0,127}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/SampleWithADeffects.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/SampleWithADeffects.mo
@@ -7,8 +7,7 @@ model SampleWithADeffects
     startTime=0,
     amplitude=0.95)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.RealSignals.Sampler.SampleWithADeffects
-                                                  sample(
+  Modelica.Clocked.RealSignals.Sampler.SampleWithADeffects sample1(
     noisy=true,
     limited=true,
     quantized=true,
@@ -23,12 +22,10 @@ model SampleWithADeffects
       resolution=Modelica.Clocked.Types.Resolution.ms, factor=20)
     annotation (Placement(transformation(extent={{-42,-2},{-30,10}})));
 equation
-  connect(sine.y, sample.u) annotation (Line(
-      points={{-59,30},{-47.2,30}},
-      color={0,0,127}));
-  connect(sample.y, assignClock.u) annotation (Line(
-      points={{-33.4,30},{-23.2,30}},
-      color={0,0,127}));
+  connect(sine.y, sample1.u)
+    annotation (Line(points={{-59,30},{-47.2,30}}, color={0,0,127}));
+  connect(sample1.y, assignClock.u)
+    annotation (Line(points={{-33.4,30},{-23.2,30}}, color={0,0,127}));
   connect(periodicClock.y, assignClock.clock) annotation (Line(
       points={{-29.4,4},{-16,4},{-16,22.8}},
       color={175,175,175},

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/ShiftSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/ShiftSample.mo
@@ -6,8 +6,7 @@ model ShiftSample "Example of a ShiftSample block for Real signals"
     offset=0.1,
     startTime=0)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.RealSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
@@ -16,17 +15,15 @@ model ShiftSample "Example of a ShiftSample block for Real signals"
       shiftCounter=4, resolution=3)
     annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
 equation
-  connect(sine.y, sample.u) annotation (Line(
-      points={{-59,30},{-47.2,30}},
-      color={0,0,127}));
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-  connect(sample.y, shiftSample1.u) annotation (Line(
-      points={{-33.4,30},{-23.2,30}},
-      color={0,0,127}));
+  connect(sine.y, sample1.u)
+    annotation (Line(points={{-59,30},{-47.2,30}}, color={0,0,127}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.y, shiftSample1.u)
+    annotation (Line(points={{-33.4,30},{-23.2,30}}, color={0,0,127}));
   annotation (experiment(StopTime=0.09),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/SubSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/SubSample.mo
@@ -6,27 +6,24 @@ model SubSample "Example of a SubSample block for Real signals"
     offset=0.1,
     startTime=0)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.RealSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-62,-6},{-50,6}})));
-Modelica.Clocked.RealSignals.Sampler.SubSample subSample(
-    inferFactor=false, factor=3)
-  annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
+Modelica.Clocked.RealSignals.Sampler.SubSample subSample1(inferFactor=false,
+      factor=3)
+    annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
 equation
-  connect(sine.y, sample.u) annotation (Line(
-      points={{-59,30},{-47.2,30}},
-      color={0,0,127}));
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(sample.y, subSample.u) annotation (Line(
-    points={{-33.4,30},{-23.2,30}},
-    color={0,0,127}));
+  connect(sine.y, sample1.u)
+    annotation (Line(points={{-59,30},{-47.2,30}}, color={0,0,127}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.y, subSample1.u)
+    annotation (Line(points={{-33.4,30},{-23.2,30}}, color={0,0,127}));
   annotation (experiment(StopTime=0.2),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/SuperSample.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/SuperSample.mo
@@ -6,28 +6,24 @@ model SuperSample "Example of a SuperSample block for Real signals"
     offset=0.1,
     startTime=0)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.RealSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
     annotation (Placement(transformation(extent={{-62,-6},{-50,6}})));
-Modelica.Clocked.RealSignals.Sampler.SuperSample superSample(inferFactor=false,
+Modelica.Clocked.RealSignals.Sampler.SuperSample superSample1(inferFactor=false,
       factor=3)
-  annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
+    annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
 equation
-  connect(sine.y, sample.u) annotation (Line(
-      points={{-59,30},{-47.2,30}},
-      color={0,0,127}));
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-  connect(sample.y, superSample.u)
-                               annotation (Line(
-    points={{-33.4,30},{-23.2,30}},
-    color={0,0,127}));
+  connect(sine.y, sample1.u)
+    annotation (Line(points={{-59,30},{-47.2,30}}, color={0,0,127}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.y, superSample1.u)
+    annotation (Line(points={{-33.4,30},{-23.2,30}}, color={0,0,127}));
   annotation (experiment(StopTime=0.08),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/SuperSampleInterpolated.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/SuperSampleInterpolated.mo
@@ -7,8 +7,7 @@ model SuperSampleInterpolated
     offset=0.1,
     startTime=0)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.RealSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
@@ -17,18 +16,15 @@ Modelica.Clocked.RealSignals.Sampler.SuperSampleInterpolated superSampleIpo(
     inferFactor=false, factor=3)
   annotation (Placement(transformation(extent={{-22,24},{-10,36}})));
 equation
-  connect(sine.y, sample.u) annotation (Line(
-      points={{-59,30},{-47.2,30}},
-      color={0,0,127}));
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(sample.y, superSampleIpo.u)
-                               annotation (Line(
-    points={{-33.4,30},{-23.2,30}},
-    color={0,0,127}));
+  connect(sine.y, sample1.u)
+    annotation (Line(points={{-59,30},{-47.2,30}}, color={0,0,127}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.y, superSampleIpo.u)
+    annotation (Line(points={{-33.4,30},{-23.2,30}}, color={0,0,127}));
   annotation (experiment(StopTime=0.06),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/UniformNoise.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/UniformNoise.mo
@@ -2,8 +2,7 @@ within Modelica.Clocked.Examples.Elementary.RealSignals;
 model UniformNoise "Example of a UniformNoise block for Real signals"
    extends Modelica.Icons.Example;
 
-  Modelica.Clocked.RealSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
@@ -14,17 +13,15 @@ Modelica.Clocked.RealSignals.Sampler.Utilities.Internal.UniformNoise
 Modelica.Blocks.Sources.Constant const(k=0)
   annotation (Placement(transformation(extent={{-76,20},{-56,40}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(sample.y, uniformNoise.u) annotation (Line(
-    points={{-33.4,30},{-28,30}},
-    color={0,0,127}));
-connect(const.y, sample.u) annotation (Line(
-    points={{-55,30},{-47.2,30}},
-    color={0,0,127}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.y, uniformNoise.u)
+    annotation (Line(points={{-33.4,30},{-28,30}}, color={0,0,127}));
+  connect(const.y, sample1.u)
+    annotation (Line(points={{-55,30},{-47.2,30}}, color={0,0,127}));
   annotation (experiment(StopTime=1.1),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/UniformNoiseXorshift64star.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/UniformNoiseXorshift64star.mo
@@ -3,8 +3,7 @@ model UniformNoiseXorshift64star
   "Example of a UniformNoiseXorshift64star block for Real signals"
    extends Modelica.Icons.Example;
 
-  Modelica.Clocked.RealSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-46,24},{-34,36}})));
   Modelica.Clocked.ClockSignals.Clocks.PeriodicExactClock periodicClock(
       factor=20, resolution=Modelica.Clocked.Types.Resolution.ms)
@@ -15,16 +14,15 @@ Modelica.Clocked.RealSignals.Sampler.Utilities.Internal.UniformNoiseXorshift64st
 Modelica.Blocks.Sources.Constant const(k=0)
   annotation (Placement(transformation(extent={{-76,20},{-56,40}})));
 equation
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-49.4,0},{-40,0},{-40,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-  connect(sample.y, uniformNoiseXorshift64star.u)
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-49.4,0},{-40,0},{-40,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.y, uniformNoiseXorshift64star.u)
     annotation (Line(points={{-33.4,30},{-28,30}}, color={0,0,127}));
-connect(const.y, sample.u) annotation (Line(
-    points={{-55,30},{-47.2,30}},
-    color={0,0,127}));
+  connect(const.y, sample1.u)
+    annotation (Line(points={{-55,30},{-47.2,30}}, color={0,0,127}));
   annotation (experiment(StopTime=1),
   Documentation(info="<html>
 <p>

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/UpSample1.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/UpSample1.mo
@@ -9,8 +9,7 @@ model UpSample1 "Example of an UpSample block for Real signals"
     offset=0.1,
     startTime=0)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.RealSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-48,24},{-36,36}})));
 Modelica.Clocked.RealSignals.Sampler.Utilities.UpSample upSample1
   annotation (Placement(transformation(extent={{-26,34},{-14,46}})));
@@ -20,20 +19,17 @@ Modelica.Clocked.RealSignals.Sampler.Utilities.UpSample upSample2(
 Modelica.Blocks.Math.Add add
   annotation (Placement(transformation(extent={{0,20},{20,40}})));
 equation
-connect(sine.y, sample.u) annotation (Line(
-    points={{-59,30},{-49.2,30}},
-    color={0,0,127}));
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-55.4,0},{-42,0},{-42,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-connect(sample.y, upSample1.u) annotation (Line(
-    points={{-35.4,30},{-32,30},{-32,40},{-27.2,40}},
-    color={0,0,127}));
-connect(upSample2.u, sample.y) annotation (Line(
-    points={{-27.2,20},{-32,20},{-32,30},{-35.4,30}},
-    color={0,0,127}));
+  connect(sine.y, sample1.u)
+    annotation (Line(points={{-59,30},{-49.2,30}}, color={0,0,127}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-55.4,0},{-42,0},{-42,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.y, upSample1.u) annotation (Line(points={{-35.4,30},{-32,30},
+          {-32,40},{-27.2,40}}, color={0,0,127}));
+  connect(upSample2.u, sample1.y) annotation (Line(points={{-27.2,20},{-32,20},
+          {-32,30},{-35.4,30}}, color={0,0,127}));
 connect(upSample2.y, add.u2) annotation (Line(
     points={{-13.4,20},{-8,20},{-8,24},{-2,24}},
     color={0,0,127}));

--- a/Modelica/Clocked/Examples/Elementary/RealSignals/UpSample2.mo
+++ b/Modelica/Clocked/Examples/Elementary/RealSignals/UpSample2.mo
@@ -10,8 +10,7 @@ model UpSample2
     offset=0.1,
     startTime=0)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
-  Modelica.Clocked.RealSignals.Sampler.SampleClocked
-                                                  sample
+  Modelica.Clocked.RealSignals.Sampler.SampleClocked sample1
     annotation (Placement(transformation(extent={{-48,24},{-36,36}})));
 Modelica.Clocked.RealSignals.Sampler.Utilities.UpSample upSample(
       inferFactor=false, factor=3)
@@ -26,21 +25,17 @@ Modelica.Clocked.RealSignals.Sampler.Utilities.UpSample upSample(
       cBufStart={0,0})
     annotation (Placement(transformation(extent={{6,20},{26,40}})));
 equation
-connect(sine.y, sample.u) annotation (Line(
-    points={{-59,30},{-49.2,30}},
-    color={0,0,127}));
-connect(periodicClock.y, sample.clock) annotation (Line(
-    points={{-55.4,0},{-42,0},{-42,22.8}},
-    color={175,175,175},
-    pattern=LinePattern.Dot,
-    thickness=0.5));
-  connect(upSample.u, sample.y)
-                               annotation (Line(
-    points={{-25.2,30},{-35.4,30}},
-    color={0,0,127}));
-  connect(sample.y, superSampleIpo.u) annotation (Line(
-      points={{-35.4,30},{-32,30},{-32,-38},{10.8,-38}},
-      color={0,0,127}));
+  connect(sine.y, sample1.u)
+    annotation (Line(points={{-59,30},{-49.2,30}}, color={0,0,127}));
+  connect(periodicClock.y, sample1.clock) annotation (Line(
+      points={{-55.4,0},{-42,0},{-42,22.8}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(upSample.u, sample1.y)
+    annotation (Line(points={{-25.2,30},{-35.4,30}}, color={0,0,127}));
+  connect(sample1.y, superSampleIpo.u) annotation (Line(points={{-35.4,30},{-32,
+          30},{-32,-38},{10.8,-38}}, color={0,0,127}));
   connect(upSample.y, FIR2.u) annotation (Line(
       points={{-11.4,30},{-8,30},{-8,-4},{4,-4}},
       color={0,0,127}));

--- a/Modelica/Clocked/Examples/Systems/EngineThrottleControl.mo
+++ b/Modelica/Clocked/Examples/Systems/EngineThrottleControl.mo
@@ -1,4 +1,4 @@
-within Modelica.Clocked.Examples.Systems;
+﻿within Modelica.Clocked.Examples.Systems;
 model EngineThrottleControl
   "Closed-loop throttle control synchronized to the crankshaft angle of an
    internal combustion engine"
@@ -13,8 +13,8 @@ model EngineThrottleControl
     annotation (Placement(transformation(extent = {{-32,-5},{0,25}})));
   RealSignals.Sampler.Sample sample1
     annotation (Placement(transformation(extent = {{-60,9},{-46,23}})));
-  RealSignals.Sampler.Hold hold(y_start = 8.9)
-    annotation (Placement(transformation(extent = {{8,4},{20,16}})));
+  RealSignals.Sampler.Hold hold1(y_start=8.9)
+    annotation (Placement(transformation(extent={{8,4},{20,16}})));
   Utilities.ComponentsThrottleControl.Engine engine
     annotation (Placement(transformation(extent = {{32,-4},{60,24}})));
   Modelica.Blocks.Sources.Step step1(
@@ -50,14 +50,10 @@ equation
     annotation (Line(
       points = {{-45.3,16},{-35.2,16}},
       color = {0,0,127}));
-  connect(speedControl.Theta, hold.u)
-    annotation (Line(
-      points = {{1.6,10},{6.8,10}},
-      color = {0,0,127}));
-  connect(hold.y, engine.Theta)
-    annotation (Line(
-      points = {{20.6,10},{29.2,10}},
-      color = {0,0,127}));
+  connect(speedControl.Theta, hold1.u)
+    annotation (Line(points={{1.6,10},{6.8,10}}, color={0,0,127}));
+  connect(hold1.y, engine.Theta)
+    annotation (Line(points={{20.6,10},{29.2,10}}, color={0,0,127}));
   connect(torque.flange, engine.flange_b)
     annotation (Line(
       points = {{70,10},{60,10}}));

--- a/Modelica/Clocked/Examples/Systems/EngineThrottleControl.mo
+++ b/Modelica/Clocked/Examples/Systems/EngineThrottleControl.mo
@@ -1,4 +1,4 @@
-﻿within Modelica.Clocked.Examples.Systems;
+within Modelica.Clocked.Examples.Systems;
 model EngineThrottleControl
   "Closed-loop throttle control synchronized to the crankshaft angle of an
    internal combustion engine"

--- a/Modelica/Clocked/Examples/Systems/Utilities/ComponentsThrottleControl/CylinderAirCharge.mo
+++ b/Modelica/Clocked/Examples/Systems/Utilities/ComponentsThrottleControl/CylinderAirCharge.mo
@@ -17,10 +17,10 @@ block CylinderAirCharge
       origin = {0,-120})));
   Modelica.Blocks.Math.Add add(k2 = -1)
     annotation (Placement(transformation(extent = {{60,-10},{80,10}})));
-  RealSignals.Sampler.SampleClocked sample
-    annotation (Placement(transformation(extent = {{-6,-26},{6,-14}})));
-  RealSignals.Sampler.Hold hold
-    annotation (Placement(transformation(extent = {{24,-26},{36,-14}})));
+  RealSignals.Sampler.SampleClocked sample1
+    annotation (Placement(transformation(extent={{-6,-26},{6,-14}})));
+  RealSignals.Sampler.Hold hold1
+    annotation (Placement(transformation(extent={{24,-26},{36,-14}})));
   Modelica.Blocks.Continuous.Integrator integrator
     annotation (Placement(transformation(extent = {{-80,-10},{-60,10}})));
 
@@ -29,20 +29,15 @@ equation
     annotation (Line(
       points = {{81,0},{110,0}},
       color = {0,0,127}));
-  connect(clock, sample.clock)
-    annotation (Line(
-      points = {{0,-120},{0,-27.2}},
-      color = {175,175,175},
-      pattern = LinePattern.Dot,
-      thickness = 0.5));
-  connect(sample.y, hold.u)
-    annotation (Line(
-      points = {{6.6,-20},{22.8,-20}},
-      color = {0,0,127}));
-  connect(hold.y, add.u2)
-    annotation (Line(
-      points = {{36.6,-20},{50,-20},{50,-6},{58,-6}},
-      color = {0,0,127}));
+  connect(clock, sample1.clock) annotation (Line(
+      points={{0,-120},{0,-27.2}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(sample1.y, hold1.u)
+    annotation (Line(points={{6.6,-20},{22.8,-20}}, color={0,0,127}));
+  connect(hold1.y, add.u2) annotation (Line(points={{36.6,-20},{50,-20},{50,-6},
+          {58,-6}}, color={0,0,127}));
   connect(m_ao_der, integrator.u)
     annotation (Line(
       points = {{-120,0},{-82,0}},
@@ -51,8 +46,6 @@ equation
     annotation (Line(
       points = {{-59,0},{-20,0},{-20,6},{58,6}},
       color = {0,0,127}));
-  connect(integrator.y, sample.u)
-    annotation (Line(
-      points = {{-59,0},{-20,0},{-20,-20},{-7.2,-20}},
-      color = {0,0,127}));
+  connect(integrator.y, sample1.u) annotation (Line(points={{-59,0},{-20,0},{-20,
+          -20},{-7.2,-20}}, color={0,0,127}));
 end CylinderAirCharge;

--- a/Modelica/Clocked/Examples/Systems/Utilities/ComponentsThrottleControl/InductionToPowerDelay.mo
+++ b/Modelica/Clocked/Examples/Systems/Utilities/ComponentsThrottleControl/InductionToPowerDelay.mo
@@ -14,36 +14,27 @@ block InductionToPowerDelay
         extent = {{-20,-20},{20,20}},
         rotation = 90,
         origin = {0,-120})));
-  RealSignals.Sampler.SampleClocked sample
-    annotation (Placement(transformation(extent = {{-6,-6},{6,6}})));
-  RealSignals.Sampler.Hold hold(y_start = 0.152)
-    annotation (Placement(transformation(extent = {{66,-6},{78,6}})));
+  RealSignals.Sampler.SampleClocked sample1
+    annotation (Placement(transformation(extent={{-6,-6},{6,6}})));
+  RealSignals.Sampler.Hold hold1(y_start=0.152)
+    annotation (Placement(transformation(extent={{66,-6},{78,6}})));
   RealSignals.NonPeriodic.FractionalDelay delay(
     shift = 1,
     final resolution = 1 "Prepare model for usage in event-clock partitions")
     annotation (Placement(transformation(extent = {{30,-10},{50,10}})));
 
 equation
-  connect(clock, sample.clock)
-    annotation (Line(
-      points = {{0,-120},{0,-7.2}},
-      color = {175,175,175},
-      pattern = LinePattern.Dot,
-      thickness = 0.5));
-  connect(m_a, sample.u)
-    annotation (Line(
-      points = {{-120,0},{-7.2,0}},
-      color = {0,0,127}));
-  connect(hold.y, m_a_delayed)
-    annotation (Line(
-      points = {{78.6,0},{110,0}},
-      color = {0,0,127}));
-  connect(sample.y, delay.u)
-    annotation (Line(
-      points = {{6.6,0},{28,0}},
-      color = {0,0,127}));
-  connect(delay.y, hold.u)
-    annotation (Line(
-      points = {{51,0},{64.8,0}},
-      color = {0,0,127}));
+  connect(clock, sample1.clock) annotation (Line(
+      points={{0,-120},{0,-7.2}},
+      color={175,175,175},
+      pattern=LinePattern.Dot,
+      thickness=0.5));
+  connect(m_a, sample1.u)
+    annotation (Line(points={{-120,0},{-7.2,0}}, color={0,0,127}));
+  connect(hold1.y, m_a_delayed)
+    annotation (Line(points={{78.6,0},{110,0}}, color={0,0,127}));
+  connect(sample1.y, delay.u)
+    annotation (Line(points={{6.6,0},{28,0}}, color={0,0,127}));
+  connect(delay.y, hold1.u)
+    annotation (Line(points={{51,0},{64.8,0}}, color={0,0,127}));
 end InductionToPowerDelay;

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/BackSample/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/BackSample/comparisonSignals.txt
@@ -1,4 +1,4 @@
 time
-sample.y
+sample1.y
 shiftSample1.y
 backSample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/Hold/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/Hold/comparisonSignals.txt
@@ -1,4 +1,4 @@
 time
-sample.y
-shiftSample.y
-hold.y
+sample1.y
+shiftSample1.y
+hold1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/Sample1/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/Sample1/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
 assignClock.y
-sample.y
+sample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/Sample2/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/Sample2/comparisonSignals.txt
@@ -1,4 +1,4 @@
 time
 sample1.y
 sample2.y
-hold.y
+hold1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/SampleClocked/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/SampleClocked/comparisonSignals.txt
@@ -1,2 +1,2 @@
 time
-sample.y
+sample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/SampleVectorizedAndClocked/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/SampleVectorizedAndClocked/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y[1]
-sample.y[2]
+sample1.y[1]
+sample1.y[2]

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/ShiftSample/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/ShiftSample/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y
+sample1.y
 shiftSample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/SubSample/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/SubSample/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y
-subSample.y
+sample1.y
+subSample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/SuperSample/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/BooleanSignals/SuperSample/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y
-superSample.y
+sample1.y
+superSample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/BackSample/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/BackSample/comparisonSignals.txt
@@ -1,4 +1,4 @@
 time
-sample.y
+sample1.y
 shiftSample1.y
 backSample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/Hold/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/Hold/comparisonSignals.txt
@@ -1,4 +1,4 @@
 time
-sample.y
-shiftSample.y
-hold.y
+sample1.y
+shiftSample1.y
+hold1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/Sample1/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/Sample1/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
 assignClock.y
-sample.y
+sample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/Sample2/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/Sample2/comparisonSignals.txt
@@ -1,4 +1,4 @@
 time
 sample1.y
 sample2.y
-hold.y
+hold1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/SampleClocked/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/SampleClocked/comparisonSignals.txt
@@ -1,2 +1,2 @@
 time
-sample.y
+sample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/SampleVectorizedAndClocked/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/SampleVectorizedAndClocked/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y[1]
-sample.y[2]
+sample1.y[1]
+sample1.y[2]

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/ShiftSample/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/ShiftSample/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y
+sample1.y
 shiftSample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/SubSample/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/SubSample/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y
-subSample.y
+sample1.y
+subSample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/SuperSample/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/IntegerSignals/SuperSample/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y
-superSample.y
+sample1.y
+superSample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/AssignClockToSquareWaveHold/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/AssignClockToSquareWaveHold/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y
+sample1.y
 clockToSquareWave.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/AssignClockToTriggerHold/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/AssignClockToTriggerHold/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y
+sample1.y
 triggeredSampler.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/BackSample/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/BackSample/comparisonSignals.txt
@@ -1,4 +1,4 @@
 time
-sample.y
+sample1.y
 shiftSample1.y
 backSample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/FractionalDelay/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/FractionalDelay/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y
+sample1.y
 fractionalDelay.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/Hold/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/Hold/comparisonSignals.txt
@@ -1,4 +1,4 @@
 time
-sample.y
-shiftSample.y
-hold.y
+sample1.y
+shiftSample1.y
+hold1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/HoldWithDAeffects1/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/HoldWithDAeffects1/comparisonSignals.txt
@@ -1,4 +1,4 @@
 time
 sample1.y
 hold1.y
-shiftSample1.y
+// shiftSample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/HoldWithDAeffects1/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/HoldWithDAeffects1/comparisonSignals.txt
@@ -1,4 +1,4 @@
 time
-sample.y
-hold.y
-shiftSample.y
+sample1.y
+hold1.y
+shiftSample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/HoldWithDAeffects2/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/HoldWithDAeffects2/comparisonSignals.txt
@@ -1,4 +1,4 @@
 time
 sample1.y
 hold1.y
-shiftSample1.y
+// shiftSample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/HoldWithDAeffects2/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/HoldWithDAeffects2/comparisonSignals.txt
@@ -1,4 +1,4 @@
 time
-sample.y
-hold.y
-shiftSample.y
+sample1.y
+hold1.y
+shiftSample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/Sample1/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/Sample1/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
 assignClock.y
-sample.y
+sample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/Sample2/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/Sample2/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
 assignClock.y
-sample.y
+sample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/Sample3/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/Sample3/comparisonSignals.txt
@@ -1,4 +1,4 @@
 time
 sample1.y
 sample2.y
-hold.y
+hold1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/SampleClocked/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/SampleClocked/comparisonSignals.txt
@@ -1,2 +1,2 @@
 time
-sample.y
+sample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/SampleVectorizedAndClocked/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/SampleVectorizedAndClocked/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y[1]
-sample.y[2]
+sample1.y[1]
+sample1.y[2]

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/SampleWithADeffects/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/SampleWithADeffects/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
 assignClock.y
-sample.y
+sample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/ShiftSample/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/ShiftSample/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y
+sample1.y
 shiftSample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/SubSample/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/SubSample/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y
-subSample.y
+sample1.y
+subSample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/SuperSample/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/SuperSample/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y
-superSample.y
+sample1.y
+superSample1.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/SuperSampleInterpolated/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/SuperSampleInterpolated/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y
+sample1.y
 superSampleIpo.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/UniformNoise/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/UniformNoise/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y
+sample1.y
 uniformNoise.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/UniformNoiseXorshift64star/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/UniformNoiseXorshift64star/comparisonSignals.txt
@@ -1,3 +1,3 @@
 time
-sample.y
+sample1.y
 uniformNoiseXorshift64star.y

--- a/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/UpSample2/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Clocked/Examples/Elementary/RealSignals/UpSample2/comparisonSignals.txt
@@ -1,5 +1,5 @@
 time
-sample.y
+sample1.y
 upSample.y
 superSampleIpo.y
 FIR1.y


### PR DESCRIPTION
These are examples so I don't think we need conversion scripts.
Note that the models already have these as defaultComponentName, but the examples pre-date that.
Note that the BOM for EngineThrottleControl is because the file is non-ASCII due to the registered trademark symbol.

Can be pushed to a later release as well.

For an example of the reason see: https://github.com/modelica/ModelicaStandardLibrary/issues/3516#issuecomment-607870911_