### PR TITLE
Remove unused type Modelica.Mechanics.MultiBody.Types.Init

### DIFF
--- a/Modelica/Mechanics/MultiBody/Types/Init.mo
+++ b/Modelica/Mechanics/MultiBody/Types/Init.mo
@@ -1,9 +1,0 @@
-within Modelica.Mechanics.MultiBody.Types;
-type Init = enumeration(
-    Free,
-    PositionVelocity,
-    SteadyState,
-    Position,
-    Velocity,
-    VelocityAcceleration,
-    PositionVelocityAcceleration);

--- a/Modelica/Mechanics/MultiBody/Types/package.order
+++ b/Modelica/Mechanics/MultiBody/Types/package.order
@@ -11,6 +11,5 @@ ResolveInFrameB
 ResolveInFrameAB
 RotationTypes
 GravityTypes
-Init
 VectorQuantity
 Defaults

--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -159,6 +159,8 @@ convertClass("Modelica.Mechanics.MultiBody.Sensors.TansformRelativeVector",
               "Modelica.Mechanics.MultiBody.Sensors.TransformRelativeVector")
 convertClass("Modelica.Mechanics.MultiBody.Visualizers.Ground",
               "ObsoleteModelica4.Mechanics.MultiBody.Visualizers.Ground")
+convertClass("Modelica.Mechanics.MultiBody.Types.Init",
+              "ObsoleteModelica4.Mechanics.MultiBody.Types.Init")
 convertClass("Modelica.ComplexBlocks.Sources.LogFrequencySweep",
               "Modelica.Blocks.Sources.LogFrequencySweep")
 convertClass("Modelica.Electrical.Machines.BasicMachines.AsynchronousInductionMachines.AIM_SquirrelCage",

--- a/ModelicaTestConversion4.mo
+++ b/ModelicaTestConversion4.mo
@@ -2553,6 +2553,17 @@ Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrar
 </p>
 </html>"));
       end Issue3382;
+
+      model Issue3534 "Conversion test for #3534"
+        extends Modelica.Icons.Example;
+        import Modelica.Mechanics.MultiBody.Types;
+        parameter Types.Init initType = Types.Init.PositionVelocityAcceleration;
+      annotation(experiment(StopTime=1), Documentation(info="<html>
+<p>
+Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/3534\">#3534</a>.
+</p>
+</html>"));
+      end Issue3534;
     end MultiBody;
 
     package Rotational

--- a/ObsoleteModelica4.mo
+++ b/ObsoleteModelica4.mo
@@ -1005,6 +1005,45 @@ This shape visualizes the x-y plane by a box.
 </html>"));
         end Ground;
       end Visualizers;
+      package Types "Constants and types with choices, especially to build menus"
+        extends Modelica.Icons.TypesPackage;
+        type Init = enumeration(
+          Free "Free (no initialization)",
+          PositionVelocity "Initialize generalized position and velocity variables",
+          SteadyState "Initialize in steady state (velocity and acceleration are zero)",
+          Position "Initialize only generalized position variable(s)",
+          Velocity "Initialize only generalized velocity variable(s)",
+          VelocityAcceleration "Initialize generalized velocity and acceleration variables",
+          PositionVelocityAcceleration "Initialize generalized position, velocity and acceleration variables")
+        "Enumeration defining initialization for MultiBody components"
+        annotation (
+          obsolete = "Obsolete type - use start/fixed attributes instead",
+          Documentation(info="<html>
+<table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
+<tr><th><strong>Types.Init.</strong></th><th><strong>Meaning</strong></th></tr>
+<tr><td>Free</td>
+    <td>No initialization</td></tr>
+
+<tr><td>PositionVelocity</td>
+    <td>Initialize generalized position and velocity variables</td></tr>
+
+<tr><td>SteadyState</td>
+    <td>Initialize in steady state (velocity and acceleration are zero)</td></tr>
+
+<tr><td>Position </td>
+    <td>Initialize only generalized position variable(s)</td></tr>
+
+<tr><td>Velocity</td>
+    <td>Initialize only generalized velocity variable(s)</td></tr>
+
+<tr><td>VelocityAcceleration</td>
+    <td>Initialize generalized velocity and acceleration variables</td></tr>
+
+<tr><td>PositionVelocityAcceleration</td>
+    <td>Initialize generalized position, velocity and acceleration variables</td></tr>
+</table>
+</html>"));
+      end Types;
     end MultiBody;
 
     package Rotational "Library to model 1-dimensional, rotational mechanical systems"


### PR DESCRIPTION
In 901dd3068dcc071cb2b4a1e1261e4aa0556977fb for MSL v3.0.1 (more than 10 years ago) all references of Modelica.Mechanics.MultiBody.Types.Init were removed. Also the documentation of Modelica.Mechanics.MultiBody.Types.Init was removed. However, the type itself could neither be deleted nor be marked as obsolete since the obsolete annotation was only invented /back-ported to Modelica Specification 3.2rev2 in 2013. Hence, this superfluous type was an undocumented leftover since 2007.

This PR moves the unused type to ObsoleteModelica4, reintroduces the documentation, adds conversion and a conversion test model.

See #1539.