### PR TITLE
Correct illegal annotations.

### DIFF
--- a/Modelica/Fluid/Valves.mo
+++ b/Modelica/Fluid/Valves.mo
@@ -451,13 +451,7 @@ it is open.
     port_b.h_outflow = inStream(port_a.h_outflow);
     connect(open, openingGenerator.u) annotation (Line(points={{0,80},{0,42},{2.22045e-15,
             42}}, color={255,0,255}));
-    annotation (Placement(transformation(
-          origin={0,90},
-          extent={{-20,-20},{20,20}},
-          rotation=270), iconTransformation(
-          extent={{-20,-20},{20,20}},
-          rotation=270,
-          origin={0,80})),
+    annotation (
     Icon(coordinateSystem(
           preserveAspectRatio=false,
           extent={{-100,-100},{100,100}}), graphics={

--- a/Modelica/Thermal/HeatTransfer/Examples/Utilities/DirectCapacity.mo
+++ b/Modelica/Thermal/HeatTransfer/Examples/Utilities/DirectCapacity.mo
@@ -22,14 +22,14 @@ model DirectCapacity
     "Heat flow to the heat capacity"
     annotation (Placement(transformation(extent={{140,-100},{100,-60}})));
 equation
-  connect(heatFlowToTemperature.f, Q_flow) annotation (Line(points={{22,4,-8},{60,-8},{60,-80},{120,-80}},
+  connect(heatFlowToTemperature.f, Q_flow) annotation (Line(points={{22.4,-8},{60,-8},{60,-80},{120,-80}},
                                    color={0,0,127}));
-  connect(heatFlowToTemperature.p, T) annotation (Line(points={{22,4,8},{60,8},{60,80},{110,80}},
+  connect(heatFlowToTemperature.p, T) annotation (Line(points={{22.4,8},{60,8},{60,80},{110,80}},
                             color={0,0,127}));
-  connect(heatFlowToTemperature.pder, derT) annotation (Line(points={{22,4,5},{80,5},{80,30},{110,30}},
+  connect(heatFlowToTemperature.pder, derT) annotation (Line(points={{22.4,5},{80,5},{80,30},{110,30}},
                                 color={0,0,127}));
   connect(heatCapacitor.port,heatFlowToTemperature. heatPort)
-    annotation (Line(points={{-10,0},{18,4,0}}, color={191,0,0}));
+    annotation (Line(points={{-10,0},{18.4,0}}, color={191,0,0}));
   connect(Q_flowDrive, forceSource.Q_flow)
     annotation (Line(points={{-120,0},{-50,0}}, color={0,0,127}));
   connect(heatCapacitor.port, forceSource.port)


### PR DESCRIPTION
Closes #3539
I checked all of MSL for illegal annotations that's why I got one more. Note: the check is not yet complete so I cannot guarantee that there are no additional issues.

In Valves I believe the Placement is leftover from some component, possibly opening_min that was transformed into a parameter, and thus no longer needs a Placement-annotation.
