### PR TITLE
Spelling: Rename "release notes" to "changelog" in C-Sources

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaFFT.c
+++ b/Modelica/Resources/C-Sources/ModelicaFFT.c
@@ -32,7 +32,7 @@
 
 /* Adapted to the needs of the Modelica Standard Library:
 
-   Release Notes:
+   Changelog:
       Dec. 02, 2015: by Martin Otter, DLR
                      Combined the C- and Header files of Kiss-FFT as needed for MSL
                      Adapted the memory allocation scheme so that for exponents of 2,3,5

--- a/Modelica/Resources/C-Sources/ModelicaIO.c
+++ b/Modelica/Resources/C-Sources/ModelicaIO.c
@@ -36,7 +36,7 @@
       Modelica.Utilities.Streams.readRealMatrix
       Modelica.Utilities.Streams.writeRealMatrix
 
-   Release Notes:
+   Changelog:
       Jan. 15, 2018: by Thomas Beutlich, ESI ITI GmbH
                      Added support to ignore UTF-8 BOM if reading text file
                      (ticket #2404)

--- a/Modelica/Resources/C-Sources/ModelicaIO.h
+++ b/Modelica/Resources/C-Sources/ModelicaIO.h
@@ -38,7 +38,7 @@
                     - "__declspec(dllexport)" if included in a DLL and the
                       functions shall be visible outside of the DLL
 
-   Release Notes:
+   Changelog:
       Mar. 08, 2017: by Thomas Beutlich, ESI ITI GmbH
                      Added ModelicaIO_readRealTable from ModelicaStandardTables
                      (ticket #2192)

--- a/Modelica/Resources/C-Sources/ModelicaInternal.c
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.c
@@ -29,7 +29,7 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-/* Release Notes:
+/* Changelog:
       Nov. 13, 2019: by Thomas Beutlich
                      Utilized blockwise I/O in ModelicaInternal_copyFile
                      (ticket #3229)

--- a/Modelica/Resources/C-Sources/ModelicaRandom.c
+++ b/Modelica/Resources/C-Sources/ModelicaRandom.c
@@ -29,7 +29,7 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-/* Release Notes:
+/* Changelog:
       Sep. 23, 2016: by Thomas Beutlich, ESI ITI GmbH
                      Fixed resource leak (ticket #2069)
 

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -38,7 +38,7 @@
       Modelica.Blocks.Tables.CombiTable2Ds
       Modelica.Blocks.Tables.CombiTable2Dv
 
-   Release Notes:
+   Changelog:
       Nov. 01, 2019: by Thomas Beutlich
                      Added univariate Makima-spline interpolation (ticket #1039)
 

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.h
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.h
@@ -42,7 +42,7 @@
    DEBUG_TIME_EVENTS     : Trace time events of CombiTimeTable
    DUMMY_FUNCTION_USERTAB: Use a dummy function "usertab"
 
-   Release Notes:
+   Changelog:
       Aug. 03, 2019: by Thomas Beutlich
                      Added second derivatives (ticket #2901)
 

--- a/Modelica/Resources/C-Sources/ModelicaStrings.c
+++ b/Modelica/Resources/C-Sources/ModelicaStrings.c
@@ -29,7 +29,7 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-/* Release Notes:
+/* Changelog:
       Jun. 16, 2017: by Thomas Beutlich, ESI ITI GmbH
                      Utilized hash macros of uthash.h for ModelicaStrings_hashString
                      (ticket #2250)


### PR DESCRIPTION
I believe it should be called "Changelog".