### PR TITLE
Improve conversion of initialization of Modelica.Blocks.Continuous.{PID, LimPID}

### DIFF
--- a/Modelica/Blocks/Continuous.mo
+++ b/Modelica/Blocks/Continuous.mo
@@ -793,7 +793,7 @@ to compute u by an algebraic equation.
       annotation(Evaluate=true, choices(checkBox=true));
     parameter Real kFF=1 "Gain of feed-forward input"
       annotation(Dialog(enable=withFeedForward));
-    parameter Init initType = Init.NoInit
+    parameter Init initType = Init.InitialState
       "Type of initialization (1: no init, 2: steady state, 3: initial state, 4: initial output)"
       annotation(Evaluate=true, Dialog(group="Initialization"));
     parameter Real xi_start=0

--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -130,9 +130,9 @@ convertClass("Modelica.Blocks.Interfaces.Adaptors.ReceiveBoolean",
 convertClass("Modelica.Blocks.Interfaces.Adaptors.ReceiveInteger",
               "ObsoleteModelica4.Blocks.Interfaces.Adaptors.ReceiveInteger")
 convertClass("Modelica.Blocks.Types.Init.DoNotUse_InitialIntegratorState",
-              "Modelica.Blocks.Types.Init.NoInit")
+              "Modelica.Blocks.Types.Init.InitialState")
 convertClass("Modelica.Blocks.Types.InitPID.DoNotUse_InitialIntegratorState",
-              "Modelica.Blocks.Types.Init.NoInit")
+              "Modelica.Blocks.Types.Init.InitialState")
 convertClass("Modelica.Blocks.Types.InitPID",
               "Modelica.Blocks.Types.Init")
 convertClass("Modelica.Icons.RotationalSensor",

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -2592,12 +2592,18 @@ The following <font color=\"blue\"><strong>existing components</strong></font> h
 
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\" style=\"border-collapse:collapse;\">
 <tr><td colspan=\"2\"><strong>Modelica.Blocks</strong></td></tr>
-<tr><td>Nonlinear.Limiter<br>Nonlinear.VariableLimiter<br>Continuous.LimPID</td>
+<tr><td>Nonlinear.Limiter<br>Nonlinear.VariableLimiter</td>
     <td>The superfluous parameter <code>limitsAtInit</code> has been removed.</td></tr>
+<tr><td>Continuous.PID</td>
+    <td>The initialization option <code>initType</code>&nbsp;=&nbsp;<code>InitPID.DoNotUse_InitialIntegratorState</code> to only initialize the integrator state has been removed. This option has been converted to both initialize the integrator state and the derivative state, i.e., <code>initType</code>&nbsp;=&nbsp;<code>Init.InitialState</code>.</td></tr>
+<tr><td>Continuous.LimPID</td>
+    <td>The superfluous parameter <code>limitsAtInit</code> has been removed.<br>The initialization option <code>initType</code>&nbsp;=&nbsp;<code>InitPID.DoNotUse_InitialIntegratorState</code> to only initialize the integrator state has been removed. This option has been converted to both initialize the integrator state and the derivative state, i.e., <code>initType</code>&nbsp;=&nbsp;<code>Init.InitialState</code>.</td></tr>
 <tr><td>Nonlinear.DeadZone</td>
     <td>The superfluous parameter <code>deadZoneAtInit</code> has been removed.</td></tr>
 <tr><td>Interfaces.PartialNoise<br>Noise.UniformNoise<br>Noise.NormalNoise<br>Noise.TruncatedNormalNoise<br>Noise.BandLimitedWhiteNoise</td>
     <td>As a side-effect of the updated computation in Modelica.Math.Random.Utilities.automaticLocalSeed the <code>localSeed</code> parameter is computed differently if <code>useAutomaticLocalSeed</code> is set to true.</td></tr>
+<tr><td>Types.InitPID</td>
+    <td>The enumeration type has been converted to <code>Types.Init</code> with exception of the alternative <code>InitPID.DoNotUse_InitialIntegratorState</code>, that was converted to <code>Init.InitialState</code> leading to a different initialization behaviour.</td></tr>
 <tr><td colspan=\"2\"><strong>Modelica.Electrical.Machines.Utilities</strong></td></tr>
 <tr><td>SwitchYD</td>
     <td>The <a href=\"modelica://Modelica.Electrical.Polyphase.Ideal.IdealCommutingSwitch\">IdealCommutingSwitch</a> is replaced by an <a href=\"modelica://Modelica.Electrical.Polyphase.Ideal.IdealOpeningSwitch\">IdealOpeningSwitch</a> and an <a href=\"modelica://Modelica.Electrical.Polyphase.Ideal.IdealClosingSwitch\">IdealClosingSwitch</a> to allow a time delay between the two switching actions.</td></tr>

--- a/ModelicaTestConversion4.mo
+++ b/ModelicaTestConversion4.mo
@@ -135,9 +135,11 @@ Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrar
       Modelica.Blocks.Continuous.LimPID pid1(initType=InitPID(3), yMax=1);
       Modelica.Blocks.Continuous.LimPID pid2(initType=InitPID.DoNotUse_InitialIntegratorState, yMax=1);
       Modelica.Blocks.Continuous.LimPID pid3(initType=InitPID.SteadyState, yMax=1);
-      Modelica.Blocks.Continuous.PID pid4(initType=Modelica.Blocks.Types.InitPID(3), Td=0.5, Ti=0.5);
-      Modelica.Blocks.Continuous.PID pid5(initType=Modelica.Blocks.Types.InitPID.DoNotUse_InitialIntegratorState, Td=0.5, Ti=0.5);
-      Modelica.Blocks.Continuous.PID pid6(initType=Modelica.Blocks.Types.InitPID.NoInit, Td=0.5, Ti=0.5);
+      Modelica.Blocks.Continuous.LimPID pid4(yMax=1);
+      Modelica.Blocks.Continuous.PID pid5(initType=Modelica.Blocks.Types.InitPID(3), Td=0.5, Ti=0.5);
+      Modelica.Blocks.Continuous.PID pid6(initType=Modelica.Blocks.Types.InitPID.DoNotUse_InitialIntegratorState, Td=0.5, Ti=0.5);
+      Modelica.Blocks.Continuous.PID pid7(initType=Modelica.Blocks.Types.InitPID.NoInit, Td=0.5, Ti=0.5);
+      Modelica.Blocks.Continuous.PID pid8(Td=0.5, Ti=0.5);
       Modelica.Blocks.Sources.Clock clock;
     equation
       connect(clock.y, pid1.u_s);
@@ -146,9 +148,12 @@ Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrar
       connect(clock.y, pid2.u_m);
       connect(clock.y, pid3.u_s);
       connect(clock.y, pid3.u_m);
-      connect(clock.y, pid4.u);
+      connect(clock.y, pid4.u_s);
+      connect(clock.y, pid4.u_m);
       connect(clock.y, pid5.u);
       connect(clock.y, pid6.u);
+      connect(clock.y, pid7.u);
+      connect(clock.y, pid8.u);
       annotation(experiment(StopTime=1), Documentation(info="<html>
 <p>
 Conversion test for <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/2892\">#2892</a>.


### PR DESCRIPTION
In 49460b0 for #2898 the default initType of PID was converted from InitPID.DoNotUse_InitialIntegratorState to Init.InitialState. For LimPID it was different, that is from InitPID.DoNotUse_InitialIntegratorState to Init.NoInit. The conversion rule was added to convert from InitPID.DoNotUse_InitialIntegratorState to Init.NoInit, matching the LimPID manual conversion.

@mdempse1 reported that the conversion to Init.NoInit breaks the initialization and model structure of user models containing LimPID components. Despite Init.NoInit being the default initType for PI, the default initialization for PID and LimPID should better be converted to Init.InitialState. No matter if Init.NoInit or Init.InitialState, the initialization of the converted PID or LimPID component behaves differently since there is no compatibility preserving conversion possible (see #2892 and #1215).