### PR TITLE
Fix invalid memory access in isValidCombiTimeTable and isValidCombiTable1D

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -39,6 +39,10 @@
       Modelica.Blocks.Tables.CombiTable2Dv
 
    Changelog:
+      May 27, 2020:  by Thomas Beutlich
+                     Fixed invalid memory access in error messages of
+                     isValidCombiTimeTable and isValidCombiTable1D (ticket #3562)
+
       Nov. 01, 2019: by Thomas Beutlich
                      Added univariate Makima-spline interpolation (ticket #1039)
 
@@ -6176,8 +6180,8 @@ static int isValidCombiTimeTable(CombiTimeTable* tableID,
                 if (DO_CLEANUP == cleanUp) {
                     ModelicaStandardTables_CombiTimeTable_close(tableID);
                 }
-                ModelicaFormatError("The column index %d is out of range "
-                    "for table matrix \"%s(%lu,%lu)\".\n", tableID->cols[iCol],
+                ModelicaFormatError("The column index %lu is out of range "
+                    "for table matrix \"%s(%lu,%lu)\".\n", (unsigned long)col,
                     tableName, (unsigned long)nRow, (unsigned long)nCol);
             }
         }
@@ -6284,8 +6288,8 @@ static int isValidCombiTable1D(CombiTable1D* tableID,
                 if (DO_CLEANUP == cleanUp) {
                     ModelicaStandardTables_CombiTable1D_close(tableID);
                 }
-                ModelicaFormatError("The column index %d is out of range "
-                    "for table matrix \"%s(%lu,%lu)\".\n", tableID->cols[iCol],
+                ModelicaFormatError("The column index %lu is out of range "
+                    "for table matrix \"%s(%lu,%lu)\".\n", (unsigned long)col,
                     tableName, (unsigned long)nRow, (unsigned long)nCol);
             }
         }


### PR DESCRIPTION
The external object tableID must not be accessed after destruction when assembling the error message.

closes #3562