### PR TITLE
Do not include intsafe.h on MinGW

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaMatIO.c
+++ b/Modelica/Resources/C-Sources/ModelicaMatIO.c
@@ -68,9 +68,6 @@
 
 #if !defined(__BORLANDC__) && !defined(__LCC__) && !(defined(_MSC_VER) && _MSC_VER < 1400)
 #define HAVE_SAFE_MATH 1
-#if !defined(PSNIP_SAFE_FORCE_PORTABLE) && defined(_MSC_VER) && _MSC_VER < 1600
-#define PSNIP_SAFE_FORCE_PORTABLE
-#endif
 #include "safe-math.h"
 #else
 #undef HAVE_SAFE_MATH

--- a/Modelica/Resources/C-Sources/safe-math.h
+++ b/Modelica/Resources/C-Sources/safe-math.h
@@ -23,7 +23,9 @@
 #    if __has_include(<intsafe.h>)
 #      define PSNIP_SAFE_HAVE_INTSAFE_H
 #    endif
-#  elif defined(_WIN32)
+#  elif defined(_MSC_VER) && _MSC_VER >= 1600
+#    define PSNIP_SAFE_HAVE_INTSAFE_H
+#  elif defined(__CYGWIN__) && defined(__GNUC__) && __GNUC__ >= 5
 #    define PSNIP_SAFE_HAVE_INTSAFE_H
 #  endif
 #endif /* !defined(PSNIP_SAFE_FORCE_PORTABLE) */


### PR DESCRIPTION
Back-port #3568 to fix #3556 in maint/4.0.1.