### PR TITLE
Modified homotopy parameter to ensure correct initialization

### DIFF
--- a/Modelica/Electrical/Analog/Examples/OpAmps.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps.mo
@@ -712,7 +712,8 @@ package OpAmps "Examples with operational amplifiers"
     Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimted opAmp(
       Vps=Vps,
       Vns=Vns,
-      homotopyType = Modelica.Blocks.Types.LimiterHomotopy.LowerLimit) annotation (Placement(transformation(extent={{0,-10},{20,10}})));
+      homotopyType = Modelica.Blocks.Types.LimiterHomotopy.LowerLimit,
+      strict = true) annotation (Placement(transformation(extent={{0,-10},{20,10}})));
     Modelica.Electrical.Analog.Basic.Ground ground
       annotation (Placement(transformation(extent={{-20,-80},{0,-60}})));
     Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(

--- a/Modelica/Electrical/Analog/Examples/OpAmps.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps.mo
@@ -711,7 +711,8 @@ package OpAmps "Examples with operational amplifiers"
     parameter SI.Capacitance C=1/f/(2*R*log(1 + 2*R1/R2)) "Calculated capacitance to reach the desired frequency f";
     Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimted opAmp(
       Vps=Vps,
-      Vns=Vns) annotation (Placement(transformation(extent={{0,-10},{20,10}})));
+      Vns=Vns,
+      homotopyType = Modelica.Blocks.Types.LimiterHomotopy.LowerLimit) annotation (Placement(transformation(extent={{0,-10},{20,10}})));
     Modelica.Electrical.Analog.Basic.Ground ground
       annotation (Placement(transformation(extent={{-20,-80},{0,-60}})));
     Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(

--- a/Modelica/Electrical/Analog/Ideal.mo
+++ b/Modelica/Electrical/Analog/Ideal.mo
@@ -762,6 +762,12 @@ If the input voltage is vin larger than 0, the output voltage is out.v = VMax.
 </ul>
 <p>Supply voltage is either defined by parameter Vps and Vns or by (optional) pins s_p and s_n.</p>
 <p>In the first case the necessary power is drawn from an implicit internal supply, in the second case from the external supply.</p>
+<p>If initializion is problematic for a model containing this as a component you can set the <strong>homotopyType</strong> parameter.
+Using <strong>Linear</strong> ignores the saturation initially which simplifies the initialization, and may help if the component
+is connected with negative feedback; but generally fails if the feedback is positive.
+Using <strong>LowerLimit</strong> (or <strong>UpperLimit</strong>) gives a fixed value within the saturation bounds, which works with positive feedback.
+However, it does not work if the intent is to initialize the input to give a specific output.
+</p>
 </html>"));
   end IdealizedOpAmpLimted;
 


### PR DESCRIPTION
The default value for homotopy is Linear, which leads OpenModelica to select an initial condition in the linear regime which is physically valid (although unstable) but not the desired one. This commit changes the homotopy parameter in specific instance of opAmp of this example to ensure the desired initialization of the opAmp output at the lower saturation limit of -15 V.