### PR TITLE
Corrected homotopy operator to be consistent with provided reference

### DIFF
--- a/Modelica/Electrical/Analog/Examples/OpAmps.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps.mo
@@ -783,7 +783,7 @@ package OpAmps "Examples with operational amplifiers"
       Vps=Vps,
       Vns=Vns,
       strict=false,
-      homotopyType=Modelica.Blocks.Types.LimiterHomotopy.UpperLimit)
+      homotopyType=Modelica.Blocks.Types.LimiterHomotopy.LowerLimit)
       annotation (Placement(transformation(extent={{-60,10},{-40,-10}})));
     Modelica.Electrical.Analog.Basic.Resistor r2(R=R2, i(start=Vps/R2))
       annotation (Placement(transformation(


### PR DESCRIPTION
The OpAmps.SignalGenerator example has an initial output of opAmp1 which is -15 V in the provided reference results. 

This commit updates the homtopy parameter of opAmp1 to obtain a simulation which starts at the lower saturation limit and is thus consistent with the provided reference.