### PR TITLE
Changed homotopy parameter to be consistent

### DIFF
--- a/Modelica/Electrical/Analog/Examples/OpAmps/SignalGenerator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/SignalGenerator.mo
@@ -14,7 +14,7 @@ model SignalGenerator "Rectangle-Triangle generator"
     Vps=Vps,
     Vns=Vns,
     strict=false,
-    homotopyType=Modelica.Blocks.Types.LimiterHomotopy.UpperLimit)
+    homotopyType=Modelica.Blocks.Types.LimiterHomotopy.LowerLimit)
     annotation (Placement(transformation(extent={{-60,10},{-40,-10}})));
   Modelica.Electrical.Analog.Basic.Resistor r2(R=R2, i(start=Vps/R2))
     annotation (Placement(transformation(


### PR DESCRIPTION
with provided reference results, where the opAmp1 output voltage starts at lower limit, not upper limit. 

See OpenModelica [test report](https://libraries.openmodelica.org/branches/newInst/Modelica_4.0.0/files/Modelica_4.0.0_Modelica.Electrical.Analog.Examples.OpAmps.SignalGenerator.diff.opAmp1.out.v.html)