### PR TITLE
Removed potentially singular homotopy operator

### DIFF
--- a/Modelica/Fluid/Vessels.mo
+++ b/Modelica/Fluid/Vessels.mo
@@ -354,10 +354,9 @@ of the modeller. Increase nPorts to add an additional port.
                               * noEvent(if ports[i].m_flow>0 then zeta_in[i]/portInDensities[i] else -zeta_out[i]/medium.d);
               */
 
-              ports[i].p = homotopy(vessel_ps_static[i] + (0.5/portAreas[i]^2*Utilities.regSquare2(ports[i].m_flow, m_flow_turbulent[i],
-                                           (portsData_zeta_in[i] - 1 + portAreas[i]^2/vesselArea^2)/portInDensities[i]*ports_penetration[i],
-                                           (portsData_zeta_out[i] + 1 - portAreas[i]^2/vesselArea^2)/medium.d/ports_penetration[i])),
-                                    vessel_ps_static[i]);
+              ports[i].p = vessel_ps_static[i] + (0.5/portAreas[i]^2*Utilities.regSquare2(ports[i].m_flow, m_flow_turbulent[i],
+                                (portsData_zeta_in[i] - 1 + portAreas[i]^2/vesselArea^2)/portInDensities[i]*ports_penetration[i],
+                                (portsData_zeta_out[i] + 1 - portAreas[i]^2/vesselArea^2)/medium.d/ports_penetration[i]));
               /*
                 // alternative formulation m_flow=f(dp); not allowing the ideal portsData_zeta_in[i]=1 though
                 ports[i].m_flow = smooth(2, portAreas[i]*Utilities.regRoot2(ports[i].p - vessel_ps_static[i], dp_small,


### PR DESCRIPTION
The simplified expression for the vessel port pressure loss always assumped zero pressure loss. This homotopy can lead to singular behaviour in some cases, which were not detected by Dymola that doesn't use homotopy by default, but could affect other tools that do. It was hence removed from MSL master in #3291 with commit 30e8c54

This PR back-ports commit 30e8c54 into maint/3.2.3. Tested successfully in OpenModelica 1.16.0 and Dymola 2020x on `Modelica.Fluid.Examples.Explanatory.MeasuringTemperature`, that was previously failing in OpenModelica because of singular simplified model.

