### PR TITLE
Back-port of #3291 for the pump model into MSL 3.2.3 maintenance

### DIFF
--- a/Modelica/Fluid/Examples/PumpingSystem.mo
+++ b/Modelica/Fluid/Examples/PumpingSystem.mo
@@ -28,6 +28,7 @@ model PumpingSystem "Model of a pumping system for drinking water"
 
   Machines.PrescribedPump pumps(
     checkValve=true,
+    checkValveHomotopy = Modelica.Fluid.Types.CheckValveHomotopyType.Closed,
     N_nominal=1200,
     redeclare function flowCharacteristic =
         Modelica.Fluid.Machines.BaseClasses.PumpCharacteristics.quadraticFlow (

--- a/Modelica/Fluid/Machines.mo
+++ b/Modelica/Fluid/Machines.mo
@@ -311,6 +311,8 @@ Then the model can be replaced with a Pump with rotational shaft or with a Presc
     parameter Medium.MassFlowRate m_flow_start = system.m_flow_start
         "Guess value of m_flow = port_a.m_flow"
       annotation(Dialog(tab = "Initialization"));
+    parameter Types.CheckValveHomotopyType checkValveHomotopy = Types.CheckValveHomotopyType.NoHomotopy "= whether the valve is Closed, Open, or unknown at initialization"
+      annotation(Dialog(tab = "Initialization"));
     final parameter SI.VolumeFlowRate V_flow_single_init = m_flow_start/rho_nominal/nParallel
         "Used for simplified initialization model";
     final parameter SI.Position delta_head_init = flowCharacteristic(V_flow_single_init*1.1)-flowCharacteristic(V_flow_single_init)
@@ -434,11 +436,21 @@ Then the model can be replaced with a Pump with rotational shaft or with a Presc
     else
       // Flow characteristics when check valve is open
       // The simplified model uses an approximation of the tangent to the head curve in the initialization point
-      head = homotopy(if s > 0 then (N/N_nominal)^2*flowCharacteristic(V_flow_single*N_nominal/N)
+      // or the zero-flow vertical axis in case the system is initialized with the check valve closed
+      if checkValveHomotopy == Types.CheckValveHomotopyType.NoHomotopy then
+        head = if s > 0 then (N/N_nominal)^2*flowCharacteristic(V_flow_single*N_nominal/N)
+                               else (N/N_nominal)^2*flowCharacteristic(0) - s*unitHead;
+        V_flow_single = if s > 0 then s*unitMassFlowRate/rho else 0;
+      else
+        head = homotopy(if s > 0 then (N/N_nominal)^2*flowCharacteristic(V_flow_single*N_nominal/N)
                                else (N/N_nominal)^2*flowCharacteristic(0) - s*unitHead,
-                      N/N_nominal*(flowCharacteristic(V_flow_single_init)+(V_flow_single-V_flow_single_init)*noEvent(if abs(V_flow_single_init)>0 then delta_head_init/(0.1*V_flow_single_init) else 0)));
-      V_flow_single = homotopy(if s > 0 then s*unitMassFlowRate/rho else 0,
-                               s*unitMassFlowRate/rho_nominal);
+                      if checkValveHomotopy == Types.CheckValveHomotopyType.Open then
+                        N/N_nominal*(flowCharacteristic(V_flow_single_init)+(V_flow_single-V_flow_single_init)*noEvent(if abs(V_flow_single_init)>0 then delta_head_init/(0.1*V_flow_single_init) else 0))
+                      else
+                        N/N_nominal*flowCharacteristic(0) - s*unitHead);
+        V_flow_single = homotopy(if s > 0 then s*unitMassFlowRate/rho else 0,
+                               if checkValveHomotopy == Types.CheckValveHomotopyType.Open then s*unitMassFlowRate/rho_nominal else 0);
+      end if;
     end if;
     // Power consumption
     if use_powerCharacteristic then

--- a/Modelica/Fluid/Types.mo
+++ b/Modelica/Fluid/Types.mo
@@ -318,6 +318,13 @@ ModelStructure.a_vb).
 
 </html>"));
 
+  type CheckValveHomotopyType = enumeration(Open, Closed, NoHomotopy)
+   "Enumeration with choices for check valve homotopy"
+    annotation (Documentation(info="<html>
+    <p>If it is know whether the check valve will start open or closed this can simplify the initialization.</p>
+    <p>The choice <strong>NoHomotopy</strong> is useful if nothing is known for the check valve.</p>
+    </html>"));
+
   annotation (preferredView="info",
               Documentation(info="<html>
 

--- a/Modelica/Fluid/Types.mo
+++ b/Modelica/Fluid/Types.mo
@@ -321,7 +321,7 @@ ModelStructure.a_vb).
   type CheckValveHomotopyType = enumeration(Open, Closed, NoHomotopy)
    "Enumeration with choices for check valve homotopy"
     annotation (Documentation(info="<html>
-    <p>If it is know whether the check valve will start open or closed this can simplify the initialization.</p>
+    <p>If it is known whether the check valve will start open or closed this can simplify the initialization.</p>
     <p>The choice <strong>NoHomotopy</strong> is useful if nothing is known for the check valve.</p>
     </html>"));
 


### PR DESCRIPTION
This PR back-ports into MSL 3.2.3 maintenance some of the changes that were made to MSL 4.0.0 in #3291, to make sure that the `PumpingSystem` example can be reliably initialized.

A homotopy expression and a parameter `checkValveClosedInit` was introduced used to manage the `CheckValve=true` case in the pump model. The code of the pump model is now exactly the same as in MSL 4.0.0 (check [here](https://github.com/modelica/ModelicaStandardLibrary/blob/e2983375f27cda0a2ca91d3add1ce8d9bf20e2ee/Modelica/Fluid/Machines.mo#L324) and  [here](https://github.com/modelica/ModelicaStandardLibrary/blob/e2983375f27cda0a2ca91d3add1ce8d9bf20e2ee/Modelica/Fluid/Machines.mo#L443)), which is the combined result of applying 1d9e75ee followed by 94fea03a. 

The new parameter `checkValveClosedInit` defaults to `noHomotopy` as suggested by @HansOlsson in #3291, hence the default behaviour is exactly the same as in released MSL 3.2.3, making the fix fully backwards compatible.

Then, in order to ensure the convergence in OpenModelica of the `PumpingSystem` example, which starts with the pump having the check valve closed, d72f405 was also applied, changing the set up of the homotopy parameter for this specific test case.

Checked with OpenModelica 1.16.0 and Dymola 2020x. The best performance is obtained when also #3599 is included.