### PR TITLE
Models should be partial, not the package

### DIFF
--- a/Modelica/Utilities/Internal.mo
+++ b/Modelica/Utilities/Internal.mo
@@ -3,7 +3,7 @@ package Internal
   "Internal components that a user should usually not directly utilize"
   extends Modelica.Icons.InternalPackage;
   import Modelica.Units.SI;
-partial package PartialModelicaServices
+package PartialModelicaServices
     "Interfaces of components requiring a tool specific implementation"
     extends Modelica.Icons.InternalPackage;
   package Animation "Models and functions for 3-dim. animation"
@@ -44,7 +44,7 @@ This model is documented at
 
   end PartialShape;
 
-    model PartialVector "Interface for 3D animation of a vector quantity (force, torque etc)"
+    partial model PartialVector "Interface for 3D animation of a vector quantity (force, torque etc)"
       import Modelica.Mechanics.MultiBody.Types;
       import Modelica.Mechanics.MultiBody.Frames;
 
@@ -71,7 +71,7 @@ This model is documented at
 </html>"));
     end PartialVector;
 
-    model PartialSurface "Interface for 3D animation of surfaces"
+    partial model PartialSurface "Interface for 3D animation of surfaces"
 
       import Modelica.Mechanics.MultiBody.Frames;
       import Modelica.Mechanics.MultiBody.Types;


### PR DESCRIPTION
Closes #3615

Longer explanation:
The "PartialModelicaServices" should contain interfaces (partial classes) for ModelicaServices.
The package itself shouldn't be partial.

In theory adding partial to the classes in the package may break models, if someone created a package P extending PartialModelicaServices and then used P.PartialSurface. But that would be really really stupid.
But I can remove that part if needed.

As far as I can tell this issue has existed with PartialModelicaServices since it was created.