### PR TITLE
Refs #3593: Fix documentation of quasi-static machine examples

### DIFF
--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Characteristics.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Characteristics.mo
@@ -121,7 +121,7 @@ Simulate for 1 second and plot (versus <code>imcQS.wMechanical</code> or <code>s
 </p>
 
 <ul>
-<li><code>currentSensorQS.abs_i[1]</code>: (equivalent) RMS stator current</li>
+<li><code>iSensorQS.I</code>: (equivalent) RMS stator current</li>
 <li><code>imcQS.tauElectrical</code>: machine torque</li>
 <li><code>imcQS.powerBalance.powerStator</code>: stator power</li>
 <li><code>imcQS.powerBalance.powerMechanical</code>: mechanical power</li>

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Conveyor.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Conveyor.mo
@@ -201,9 +201,9 @@ The mechanical load is a constant torque like a conveyor (with regularization ar
 </p>
 <p>Simulate for 20 seconds and plot (versus time):</p>
 <ul>
-<li>currentQuasiRMSSensor|currentQuasiRMSSensorQS.I: stator current RMS</li>
-<li>imc|imcQS.wMechanical: machine speed</li>
-<li>imc|imcQS.tauElectrical: machine torque</li>
+<li><code>currentQuasiRMSSensor|currentQuasiRMSSensorQS.I</code>: (equivalent) stator current RMS</li>
+<li><code>imc|imcQS.wMechanical</code>: machine speed</li>
+<li><code>imc|imcQS.tauElectrical</code>: machine torque</li>
 </ul>
 <p>Default machine parameters are used.</p>
 </html>"),

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_DOL.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_DOL.mo
@@ -273,7 +273,7 @@ Simulate for 1 second and plot (versus time):
 </p>
 
 <ul>
-<li><code>currentRMSsensor.I|currentSensorQS.abs_i[1]</code>: (equivalent) RMS stator current</li>
+<li><code>currentQuasiRMSSensor|currentQuasiRMSSensorQS.I</code>: (equivalent) RMS stator current</li>
 <li><code>imc|imcQS.wMechanical</code>: machine speed</li>
 <li><code>imc|imcQS.tauElectrical</code>: machine torque</li>
 </ul>

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Initialize.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Initialize.mo
@@ -176,9 +176,9 @@ The induction machine with squirrel cage is initialized in steady-state at no-lo
 at time tStart a load torque step is applied.<br>
 Simulate for 1.5 seconds and plot (versus time):
 <ul>
-<li>currentQuasiRMSSensor.I: stator current RMS</li>
-<li>aimc.wMechanical: motor's speed</li>
-<li>aimc.tauElectrical: motor's torque</li>
+<li><code>currentQuasiRMSSensor|currentQuasiRMSSensorQS.I</code>: (equivalent) RMS stator current</li>
+<li><code>imc|imcQS.wMechanical</code>: machine speed</li>
+<li><code>imc|imcQS.tauElectrical</code>: machine torque</li>
 </ul>
 Default machine parameters of model <em>IM_SquirrelCage</em> are used.
 </html>"),

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Transformer.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Transformer.mo
@@ -254,9 +254,9 @@ at start time tStart2 the machine is fed directly from the voltage source, final
 Simulate for 2.5 seconds and plot (versus time):</p>
 
 <ul>
-<li>currentQuasiRMSSensor.I: stator current RMS</li>
-<li>aimc.wMechanical: motor's speed</li>
-<li>aimc.tauElectrical: motor's torque</li>
+<li><code>currentQuasiRMSSensor|currentQuasiRMSSensorQS.I</code>: (equivalent) stator current RMS</li>
+<li><code>imc|imcQS.wMechanical</code>: machine speed</li>
+<li><code>imc|imcQS.tauElectrical</code>: machine torque</li>
 </ul>
 <p>Default machine parameters are used.</p>
 </html>"),

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_YD.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_YD.mo
@@ -183,9 +183,9 @@ At start time tStart three-phase voltage is supplied to the induction machine wi
 <p>Simulate for 2.5 seconds and plot (versus time):</p>
 
 <ul>
-<li>currentQuasiRMSSensor.I: stator current RMS</li>
-<li>aimc.wMechanical: motor's speed</li>
-<li>aimc.tauElectrical: motor's torque</li>
+<li><code>currentQuasiRMSSensor|currentQuasiRMSSensorQS.I</code>: (equivalent) stator current RMS</li>
+<li><code>imc|imcQS.wMechanical</code>: machine speed</li>
+<li><code>imc|imcQS.tauElectrical</code>: machine torque</li>
 </ul>
 <p>
 Default machine parameters are used.</p>

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMS_Characteristics.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMS_Characteristics.mo
@@ -138,9 +138,9 @@ Simulate for 1 second and plot (versus <code>imsQS.wMechanical</code> or <code>s
 </p>
 
 <ul>
-<li><code>currentSensorQS.abs_i[1]</code>: (equivalent) RMS stator current</li>
+<li><code>iSensorQS.I</code>: (equivalent) RMS stator current</li>
 <li><code>imsQS.tauElectrical</code>: machine torque</li>
-<li><code>imscQS.powerBalance.powerStator</code>: stator power</li>
+<li><code>imsQS.powerBalance.powerStator</code>: stator power</li>
 <li><code>imsQS.powerBalance.powerMechanical</code>: mechanical power</li>
 </ul>
 <p>Default machine parameters are used. The rotor resistance may be varied to demonstrate the impact on the characteristic curves</p>

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_Mains.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_Mains.mo
@@ -259,7 +259,7 @@ Simulate for 1 second and plot (versus time):
 </p>
 
 <ul>
-<li><code>currentRMSsensor.I|currentSensorQS.abs_i[1]</code>: (equivalent) RMS stator current</li>
+<li><code>currentQuasiRMSSensor|currentQuasiRMSSensorQS.I</code>: (equivalent) RMS stator current</li>
 <li><code>smpm|smpmQS.wMechanical</code>: machine speed</li>
 <li><code>smpm|smpmQS.tauElectrical</code>: machine torque</li>
 </ul>


### PR DESCRIPTION
I checked the quasi static induction machine examples and updated the documentation to match the actual variables.