### PR TITLE
Handle Unix-style line endings on Windows for readFile/readLine

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaInternal.c
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.c
@@ -978,14 +978,16 @@ void ModelicaInternal_readFile(_In_z_ const char* fileName,
     if (mismatchedEnding) {
 		 fp = ModelicaStreams_openFileForReading(fileName, 0);
 		 for(iLines = 1;iLines <= nLines;iLines++) {
-			 line = (char*)(string[iLines - 1]);
+			 size_t lineLen;
+       int c;
+       line = (char*)(string[iLines - 1]);
 			 c = fgetc(fp);
 			 lineLen = 0;
 			 while (c != '\n' && c != EOF) {
 				 if (line[lineLen] != '\0') line[lineLen] = c; else {
 					 fclose(fp);
-					 ModelicaFormatError("Error when reading line %i from file\n\"%s\":\n"
-						 "%s\n", iLines, fileName, strerror(errno));
+					 ModelicaFormatError("Error when reading line %lu from file\n\"%s\":\n"
+						 "%s\n", (unsigned long)iLines, fileName, strerror(errno));
 				 }
 				 c = fgetc(fp);
 				 lineLen++;


### PR DESCRIPTION
The issue occurs in readLine/readFile when:
* Using Windows
* Using Visual C++
* Using text-files with Unix-style line endings.
* And the files have lines with 200 characters (or more).
And the results are a mess.

See https://stackoverflow.com/questions/15649089/fgetpos-behaviour-depends-on-newline-character for background.

Draft since the following is not yet complete:

- [ ] Testing, including adding a test-case.
- [ ] The cache-handling seems a bit messy.
- [ ] And might as well increase max-length from 200.