### PR TITLE
Render borders

### DIFF
--- a/Modelica/Icons.mo
+++ b/Modelica/Icons.mo
@@ -170,23 +170,22 @@ package Icons "Library of icons"
 
   partial package VariantsPackage "Icon for package containing variants"
     extends Modelica.Icons.Package;
-    annotation (Icon(coordinateSystem(preserveAspectRatio=true,  extent={{-100,-100},
-              {100,100}}), graphics={
+    annotation (Icon(coordinateSystem(preserveAspectRatio=true,  extent={{-100,-100},{100,100}}),
+        graphics={
           Ellipse(
             origin={10.0,10.0},
+            lineColor={76,76,76},
             fillColor={76,76,76},
-            pattern=LinePattern.None,
             fillPattern=FillPattern.Solid,
             extent={{-80.0,-80.0},{-20.0,-20.0}}),
           Ellipse(
             origin={10.0,10.0},
-            pattern=LinePattern.None,
             fillPattern=FillPattern.Solid,
             extent={{0.0,-80.0},{60.0,-20.0}}),
           Ellipse(
             origin={10.0,10.0},
+            lineColor={128,128,128},
             fillColor={128,128,128},
-            pattern=LinePattern.None,
             fillPattern=FillPattern.Solid,
             extent={{0.0,0.0},{60.0,60.0}}),
           Ellipse(

--- a/Modelica/Icons.mo
+++ b/Modelica/Icons.mo
@@ -173,23 +173,19 @@ package Icons "Library of icons"
     annotation (Icon(coordinateSystem(preserveAspectRatio=true,  extent={{-100,-100},{100,100}}),
         graphics={
           Ellipse(
-            origin={0.0,0.0},
             extent={{-70.0,-70.0},{-10.0,-10.0}},
             lineColor={76,76,76},
             fillColor={76,76,76},
             fillPattern=FillPattern.Solid),
           Ellipse(
-            origin={0.0,0.0},
             extent={{70.0,-70.0},{10.0,-10.0}},
             fillPattern=FillPattern.Solid),
           Ellipse(
-            origin={0.0,0.0},
             extent={{70.0,70.0},{10.0,10.0}},
             lineColor={128,128,128},
             fillColor={128,128,128},
             fillPattern=FillPattern.Solid),
           Ellipse(
-            origin={0.0,0.0},
             extent={{-70.0,70.0},{-10.0,10.0}},
             lineColor={128,128,128},
             fillColor={255,255,255},

--- a/Modelica/Icons.mo
+++ b/Modelica/Icons.mo
@@ -200,16 +200,16 @@ package Icons "Library of icons"
     annotation (
       Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}}),
         graphics={
-          Polygon(origin={20.0,0.0},
+          Polygon(
             lineColor={64,64,64},
             fillColor={255,255,255},
             fillPattern=FillPattern.Solid,
-            points={{-10.0,70.0},{10.0,70.0},{40.0,20.0},{80.0,20.0},{80.0,-20.0},{40.0,-20.0},{10.0,-70.0},{-10.0,-70.0}}),
+            points={{10,70},{30,70},{60,20},{100,20},{100,-20},{60,-20},{30,-70},{10,-70}}),
           Polygon(
             lineColor={102,102,102},
             fillColor={102,102,102},
             fillPattern=FillPattern.Solid,
-            points={{-100.0,20.0},{-60.0,20.0},{-30.0,70.0},{-10.0,70.0},{-10.0,-70.0},{-30.0,-70.0},{-60.0,-20.0},{-100.0,-20.0}})}),
+            points={{-100,20},{-60,20},{-30,70},{-10,70},{-10,-70},{-30,-70},{-60,-20},{-100,-20}})}),
       Documentation(info="<html>
 <p>This icon indicates packages containing interfaces.</p>
 </html>"));

--- a/Modelica/Icons.mo
+++ b/Modelica/Icons.mo
@@ -173,28 +173,28 @@ package Icons "Library of icons"
     annotation (Icon(coordinateSystem(preserveAspectRatio=true,  extent={{-100,-100},{100,100}}),
         graphics={
           Ellipse(
-            origin={10.0,10.0},
+            origin={0.0,0.0},
+            extent={{-70.0,-70.0},{-10.0,-10.0}},
             lineColor={76,76,76},
             fillColor={76,76,76},
-            fillPattern=FillPattern.Solid,
-            extent={{-80.0,-80.0},{-20.0,-20.0}}),
+            fillPattern=FillPattern.Solid),
           Ellipse(
-            origin={10.0,10.0},
-            fillPattern=FillPattern.Solid,
-            extent={{0.0,-80.0},{60.0,-20.0}}),
+            origin={0.0,0.0},
+            extent={{70.0,-70.0},{10.0,-10.0}},
+            fillPattern=FillPattern.Solid),
           Ellipse(
-            origin={10.0,10.0},
+            origin={0.0,0.0},
+            extent={{70.0,70.0},{10.0,10.0}},
             lineColor={128,128,128},
             fillColor={128,128,128},
-            fillPattern=FillPattern.Solid,
-            extent={{0.0,0.0},{60.0,60.0}}),
+            fillPattern=FillPattern.Solid),
           Ellipse(
-            origin={10.0,10.0},
+            origin={0.0,0.0},
+            extent={{-70.0,70.0},{-10.0,10.0}},
             lineColor={128,128,128},
             fillColor={255,255,255},
-            fillPattern=FillPattern.Solid,
-            extent={{-80.0,0.0},{-20.0,60.0}})}),
-                              Documentation(info="<html>
+            fillPattern=FillPattern.Solid)}),
+      Documentation(info="<html>
 <p>This icon shall be used for a package/library that contains several variants of one component.</p>
 </html>"));
   end VariantsPackage;

--- a/Modelica/Icons.mo
+++ b/Modelica/Icons.mo
@@ -197,18 +197,20 @@ package Icons "Library of icons"
 
   partial package InterfacesPackage "Icon for packages containing interfaces"
     extends Modelica.Icons.Package;
-    annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-              -100},{100,100}}), graphics={
+    annotation (
+      Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}}),
+        graphics={
           Polygon(origin={20.0,0.0},
             lineColor={64,64,64},
             fillColor={255,255,255},
             fillPattern=FillPattern.Solid,
             points={{-10.0,70.0},{10.0,70.0},{40.0,20.0},{80.0,20.0},{80.0,-20.0},{40.0,-20.0},{10.0,-70.0},{-10.0,-70.0}}),
-          Polygon(fillColor={102,102,102},
-            pattern=LinePattern.None,
+          Polygon(
+            lineColor={102,102,102},
+            fillColor={102,102,102},
             fillPattern=FillPattern.Solid,
             points={{-100.0,20.0},{-60.0,20.0},{-30.0,70.0},{-10.0,70.0},{-10.0,-70.0},{-30.0,-70.0},{-60.0,-20.0},{-100.0,-20.0}})}),
-                              Documentation(info="<html>
+      Documentation(info="<html>
 <p>This icon indicates packages containing interfaces.</p>
 </html>"));
   end InterfacesPackage;


### PR DESCRIPTION
Adding solid line to ellipses make appear them all of the same size. This renders better in Dymola. How about another tools?

There are some more icon candidates for similar change, e.g. `Modelica.Icons.InterfacesPackage`.