### PR TITLE
Fix missing include in Common.c (CI)

### DIFF
--- a/.CI/Test/Common.c
+++ b/.CI/Test/Common.c
@@ -1,4 +1,5 @@
 #include "../../Modelica/Resources/C-Sources/ModelicaUtilities.h"
+#include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
 


### PR DESCRIPTION
I got a compile error when using Common.c in MSVC environment otherwise.