### PR TITLE
Include provided header files (CI)

### DIFF
--- a/.CI/Test/FileSystem.c
+++ b/.CI/Test/FileSystem.c
@@ -1,10 +1,8 @@
-#include <string.h>
-#include <assert.h>
-
+#include "../../Modelica/Resources/C-Sources/ModelicaInternal.h"
 #include "Common.c"
 
-void ModelicaInternal_mkdir(const char* string);
-void ModelicaInternal_rmdir(const char* string);
+#include <assert.h>
+#include <string.h>
 
 int main(int argc, char **argv) {
     ModelicaInternal_mkdir("abc");

--- a/.CI/Test/ModelicaStrings.c
+++ b/.CI/Test/ModelicaStrings.c
@@ -1,10 +1,8 @@
-#include <string.h>
-#include <assert.h>
-
+#include "../../Modelica/Resources/C-Sources/ModelicaStrings.h"
 #include "Common.c"
 
-const char* ModelicaStrings_substring(const char* string,
-                                      int startIndex, int endIndex);
+#include <assert.h>
+#include <string.h>
 
 int main(int argc, char **argv) {
     assert(0 == strcmp("a", ModelicaStrings_substring("abc",-1,-1)));

--- a/.CI/Test/Tables.c
+++ b/.CI/Test/Tables.c
@@ -1,7 +1,8 @@
-#include <string.h>
-#include <assert.h>
-
+#include "../../Modelica/Resources/C-Sources/ModelicaStandardTables.h"
 #include "Common.c"
+
+#include <assert.h>
+#include <string.h>
 
 int usertab(char* tableName, int nipo, int dim[], int* colWise,
                  double** table) {
@@ -11,15 +12,6 @@ int usertab(char* tableName, int nipo, int dim[], int* colWise,
     dim[1] = 2;
     return 0; /* OK */
 }
-
-void* ModelicaStandardTables_CombiTimeTable_init(const char* tableName,
-                                                 const char* fileName,
-                                                 double* table, size_t nRow,
-                                                 size_t nColumn,
-                                                 double startTime,
-                                                 int* columns,
-                                                 size_t nCols, int smoothness,
-                                                 int extrapolation);
 
 int main(int argc, char **argv) {
     double tab[4] = {0.0, 1.0, 1.0, 2.0};

--- a/.CI/Test/TablesNoUsertab.c
+++ b/.CI/Test/TablesNoUsertab.c
@@ -1,16 +1,8 @@
-#include <string.h>
-#include <assert.h>
-
+#include "../../Modelica/Resources/C-Sources/ModelicaStandardTables.h"
 #include "Common.c"
 
-void* ModelicaStandardTables_CombiTimeTable_init(const char* tableName,
-                                                 const char* fileName,
-                                                 double* table, size_t nRow,
-                                                 size_t nColumn,
-                                                 double startTime,
-                                                 int* columns,
-                                                 size_t nCols, int smoothness,
-                                                 int extrapolation);
+#include <assert.h>
+#include <string.h>
 
 int main(int argc, char **argv) {
     double tab[4] = {0.0, 1.0, 1.0, 2.0};


### PR DESCRIPTION
There is no need to repeat the declaration if we can include the provided header files from C-Sources.

See also #3453 wehere we set Include and IncludeDirectory annotations to every external function.