### PR TITLE
Mark ComplexBlocks and FundamentalWave with DocumentationClass

### DIFF
--- a/Modelica/ComplexBlocks/UsersGuide/package.mo
+++ b/Modelica/ComplexBlocks/UsersGuide/package.mo
@@ -2,7 +2,7 @@ within Modelica.ComplexBlocks;
 package UsersGuide "User's Guide"
   extends Modelica.Icons.Information;
 
-  annotation (Documentation(info="<html>
+  annotation (DocumentationClass=true, Documentation(info="<html>
 <p>
 This library contains blocks for processing complex signals.
 </p>

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/UsersGuide/package.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/UsersGuide/package.mo
@@ -1,7 +1,7 @@
 within Modelica.Magnetic.QuasiStatic.FundamentalWave;
 package UsersGuide "User's Guide"
   extends Modelica.Icons.Information;
-  annotation (Documentation(info="<html>
+  annotation (DocumentationClass=true, Documentation(info="<html>
 <p>
 This is the library of quasi-static fundamental wave models for polyphase electric machines. This is complementary library with the transient machine models of
 <a href=\"modelica://Modelica.Magnetic.FundamentalWave\">FundamentalWave</a>.


### PR DESCRIPTION
Like all other UsersGuide packages.