### PR TITLE
Do not fail for w<=0 in Complex TransferFunction

### DIFF
--- a/Complex.mo
+++ b/Complex.mo
@@ -191,7 +191,7 @@ operator record Complex "Complex number with overloaded operators"
     algorithm
       c3 := if c2==0 then Complex(1,0) else Complex.'^'.complexPower(c1,Complex(c2,0));
       annotation(Inline=true, smoothOrder=100, Documentation(info="<html>
-<p>This function returns the given Complex numbers c1 to the power of the Integer number c2.</p>
+<p>This function returns the given Complex number c1 to the power of the Integer number c2.</p>
 <p>This also works for zero exponent.</p>
 </html>"));
     end integerPower;

--- a/Complex.mo
+++ b/Complex.mo
@@ -180,7 +180,7 @@ operator record Complex "Complex number with overloaded operators"
     algorithm
       c3 := Complex(exp(re)*cos(im), exp(re)*sin(im));
       annotation(Inline=true, smoothOrder=100, Documentation(info="<html>
-<p>This function returns the given Complex numbers c1 to the power of the Complex number c2.</p>
+<p>This function returns the given Complex number c1 to the power of the Complex number c2.</p>
 </html>"));
     end complexPower;
     function integerPower "Integer power of complex number"
@@ -189,7 +189,7 @@ operator record Complex "Complex number with overloaded operators"
       input Integer c2 "Integer exponent";
       output Complex c3 "= c1^c2";
     algorithm
-      c3 := if c2==0 then Complex(1,0) else Complex.'^'.complexPower(c1,Complex(c2,0));
+      c3 := if c2==0 then Complex(1) else Complex.'^'.complexPower(c1,Complex(c2));
       annotation(Inline=true, smoothOrder=100, Documentation(info="<html>
 <p>This function returns the given Complex number c1 to the power of the Integer number c2.</p>
 <p>This also works for zero exponent.</p>

--- a/Complex.mo
+++ b/Complex.mo
@@ -166,21 +166,35 @@ operator record Complex "Complex number with overloaded operators"
 </html>"));
   end '/';
 
-  encapsulated operator function '^' "Complex power of complex number"
-    import Complex;
-    input Complex c1 "Complex number";
-    input Complex c2 "Complex exponent";
-    output Complex c3 "= c1^c2";
-  protected
-    Real lnz=0.5*log(c1.re*c1.re + c1.im*c1.im);
-    Real phi=atan2(c1.im, c1.re);
-    Real re=lnz*c2.re - phi*c2.im;
-    Real im=lnz*c2.im + phi*c2.re;
-  algorithm
-    c3 := Complex(exp(re)*cos(im), exp(re)*sin(im));
-    annotation(Inline=true, smoothOrder=100, Documentation(info="<html>
+  encapsulated operator '^' "Power"
+    function complexPower "Complex power of complex number"
+      import Complex;
+      input Complex c1 "Complex number";
+      input Complex c2 "Complex exponent";
+      output Complex c3 "= c1^c2";
+    protected
+      Real lnz=0.5*log(c1.re*c1.re + c1.im*c1.im);
+      Real phi=atan2(c1.im, c1.re);
+      Real re=lnz*c2.re - phi*c2.im;
+      Real im=lnz*c2.im + phi*c2.re;
+    algorithm
+      c3 := Complex(exp(re)*cos(im), exp(re)*sin(im));
+      annotation(Inline=true, smoothOrder=100, Documentation(info="<html>
 <p>This function returns the given Complex numbers c1 to the power of the Complex number c2.</p>
 </html>"));
+    end complexPower;
+    function integerPower "Integer power of complex number"
+      import Complex;
+      input Complex c1 "Complex number";
+      input Integer c2 "Integer exponent";
+      output Complex c3 "= c1^c2";
+    algorithm
+      c3 := if c2==0 then Complex(1,0) else Complex.'^'.complexPower(c1,Complex(c2,0));
+      annotation(Inline=true, smoothOrder=100, Documentation(info="<html>
+<p>This function returns the given Complex numbers c1 to the power of the Integer number c2.</p>
+<p>This also works for zero exponent.</p>
+</html>"));
+    end integerPower;
   end '^';
 
   encapsulated operator function '=='

--- a/Modelica/ComplexBlocks/ComplexMath/TransferFunction.mo
+++ b/Modelica/ComplexBlocks/ComplexMath/TransferFunction.mo
@@ -15,7 +15,7 @@ protected
   Complex aw[size(a,1)];
   Complex bSum;
   Complex aSum;
-  function powerOfI "Internal function to compute j^k for any integer"
+  function powerOfJ "Internal function to compute j^k for any integer"
     input Integer k;
     output Complex x;
   protected
@@ -23,11 +23,11 @@ protected
   algorithm
    x:=if m==0 then Complex(1) elseif m==1 then j elseif m==2 then Complex(-1) else -j;
    annotation(Inline=true);
-  end powerOfI;
+  end powerOfJ;
 equation
   // Avoid computing power of Complex numbers - since it fails for w==0
-  bw = {b[i]*(w)^(i-1)*powerOfI(i-1) for i in 1:size(b,1)};
-  aw = {a[i]*(w)^(i-1)*powerOfI(i-1) for i in 1:size(a,1)};
+  bw = {b[i]*(w)^(i-1)*powerOfJ(i-1) for i in 1:size(b,1)};
+  aw = {a[i]*(w)^(i-1)*powerOfJ(i-1) for i in 1:size(a,1)};
   bSum = Complex(sum(bw.re), sum(bw.im));
   aSum = Complex(sum(aw.re), sum(aw.im));
   y = u*bSum/aSum;

--- a/Modelica/ComplexBlocks/ComplexMath/TransferFunction.mo
+++ b/Modelica/ComplexBlocks/ComplexMath/TransferFunction.mo
@@ -15,16 +15,19 @@ protected
   Complex aw[size(a,1)];
   Complex bSum;
   Complex aSum;
-  function PowerOfI "Internal function to compute j^k for any integer"
+  function powerOfI "Internal function to compute j^k for any integer"
     input Integer k;
     output Complex x;
+  protected
+     Integer m=mod(k,4);
   algorithm
-   x:=if mod(k,4)==1 then Complex(1,0) elseif mod(k,4)==2 then j elseif mod(k,4)==3 then Complex(-1,0) else -j;
-  end PowerOfI;
+   x:=if m==0 then Complex(1) elseif m==1 then j elseif m==2 then Complex(-1) else -j;
+   annotation(Inline=true);
+  end powerOfI;
 equation
   // Avoid computing power of Complex numbers - since it fails for w==0
-  bw = {b[i]*(w)^(i-1)*PowerOfI(i-1) for i in 1:size(b,1)};
-  aw = {a[i]*(w)^(i-1)*PowerOfI(i-1) for i in 1:size(a,1)};
+  bw = {b[i]*(w)^(i-1)*powerOfI(i-1) for i in 1:size(b,1)};
+  aw = {a[i]*(w)^(i-1)*powerOfI(i-1) for i in 1:size(a,1)};
   bSum = Complex(sum(bw.re), sum(bw.im));
   aSum = Complex(sum(aw.re), sum(aw.im));
   y = u*bSum/aSum;

--- a/Modelica/ComplexBlocks/ComplexMath/TransferFunction.mo
+++ b/Modelica/ComplexBlocks/ComplexMath/TransferFunction.mo
@@ -15,9 +15,16 @@ protected
   Complex aw[size(a,1)];
   Complex bSum;
   Complex aSum;
+  function PowerOfI "Internal function to compute j^k for any integer"
+    input Integer k;
+    output Complex x;
+  algorithm
+   x:=if mod(k,4)==1 then Complex(1,0) elseif mod(k,4)==2 then j elseif mod(k,4)==3 then Complex(-1,0) else -j;
+  end PowerOfI;
 equation
-  bw = {b[i]*(j*w)^(i-1) for i in 1:size(b,1)};
-  aw = {a[i]*(j*w)^(i-1) for i in 1:size(a,1)};
+  // Avoid computing power of Complex numbers - since it fails for w==0
+  bw = {b[i]*(w)^(i-1)*PowerOfI(i-1) for i in 1:size(b,1)};
+  aw = {a[i]*(w)^(i-1)*PowerOfI(i-1) for i in 1:size(a,1)};
   bSum = Complex(sum(bw.re), sum(bw.im));
   aSum = Complex(sum(aw.re), sum(aw.im));
   y = u*bSum/aSum;


### PR DESCRIPTION
Trying to simulate TransferFunction for w=0 fails because (j*w)^(i-1) tries to compute a complex power which fails for zero exponent.
This change corrects that in two different ways - we could decide to do just one of them.
1. By handling it in TransferFunction - There is an extra protected function, but it could be removed by some loss of readability.
2. By introducing Complex ^Integer in the complex class; note that by using the type of the exponent we avoid the odd cases in a safe way.


