### PR TITLE
Implement choice between sawtooth and triangle reference signal in PowerConverters/DCDC/Control/SignalPWM

### DIFF
--- a/Modelica/Electrical/PowerConverters/DCDC/Control/SignalPWM.mo
+++ b/Modelica/Electrical/PowerConverters/DCDC/Control/SignalPWM.mo
@@ -2,11 +2,14 @@ within Modelica.Electrical.PowerConverters.DCDC.Control;
 model SignalPWM
   "Generates a pulse width modulated (PWM) boolean fire signal"
   extends Icons.Control;
+  import Modelica.Electrical.PowerConverters.Types.SingleReferenceType;
   parameter Boolean useConstantDutyCycle=true
     "Enables constant duty cycle";
   parameter Real constantDutyCycle=0 "Constant duty cycle"
     annotation (Dialog(enable=useConstantDutyCycle));
   parameter SI.Frequency f=1000 "Switching frequency";
+  parameter SingleReferenceType refType=Modelica.Electrical.PowerConverters.Types.SingleReferenceType.Sawtooth
+    "Type of reference signal";
   parameter SI.Time startTime=0 "Start time";
   Modelica.Blocks.Interfaces.RealInput dutyCycle if not
     useConstantDutyCycle "Duty cycle"
@@ -38,9 +41,18 @@ model SignalPWM
     final amplitude=1,
     final nperiod=-1,
     final offset=0,
-    final startTime=startTime) annotation (Placement(transformation(
-        origin={-50,-50},
-        extent={{-10,-10},{10,10}})));
+    final startTime=startTime) if refType==SingleReferenceType.Sawtooth
+    annotation (Placement(transformation(origin={-50,-50}, extent={{-10,-10},{10,10}})));
+  Modelica.Blocks.Sources.Trapezoid triangle(
+    rising=0.5/f,
+    width=0,
+    falling=0.5/f,
+    final period=1/f,
+    final amplitude=1,
+    final nperiod=-1,
+    final offset=0,
+    final startTime=startTime) if refType==SingleReferenceType.Triangle
+    annotation (Placement(transformation(origin={-50,-80}, extent={{-10,-10},{10,10}})));
   Modelica.Blocks.Logical.Not inverse annotation (Placement(
         transformation(
         extent={{-10,10},{10,-10}},
@@ -63,6 +75,8 @@ equation
       points={{33,-8},{36,-8},{36,80},{-60,80},{-60,110}}, color={255,0,255}));
   connect(inverse.y, notFire) annotation (Line(
       points={{52,31},{52,80},{60,80},{60,110}}, color={255,0,255}));
+  connect(greaterEqual.u1, triangle.y) annotation (Line(points={{10,-8},{0,-8},{
+          0,-80},{-39,-80}}, color={0,0,127}));
   annotation (defaultComponentName="pwm",
     Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
             {100,100}}),graphics={Line(

--- a/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_TrianglePWM_RL.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_TrianglePWM_RL.mo
@@ -1,0 +1,42 @@
+within Modelica.Electrical.PowerConverters.Examples.DCDC.HBridge;
+model HBridge_TrianglePWM_RL "H bridge DC/DC converter with R-L load"
+  extends ExampleTemplates.HBridge(signalPWM(refType=Modelica.Electrical.PowerConverters.Types.SingleReferenceType.Triangle));
+  extends Modelica.Icons.Example;
+  parameter SI.Resistance R=100 "Resistance";
+  parameter SI.Inductance L=1 "Inductance";
+  Modelica.Electrical.Analog.Basic.Resistor resistor(R=R) annotation (
+      Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={20,50})));
+  Modelica.Electrical.Analog.Basic.Inductor inductor(i(fixed=true,
+        start=0), L=L) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={20,10})));
+  Blocks.Discrete.ZeroOrderHold zeroOrderHold(samplePeriod=1/f, startTime=0.5/f)
+    annotation (Placement(transformation(extent={{12,-30},{32,-10}})));
+equation
+  connect(resistor.n, inductor.p) annotation (Line(
+      points={{20,40},{20,20}}, color={0,0,255}));
+  connect(inductor.n, currentSensor.p) annotation (Line(
+      points={{20,0},{20,-6},{0,-6}}, color={0,0,255}));
+  connect(resistor.p, hbridge.dc_p2) annotation (Line(
+      points={{20,60},{20,70},{-30,70},{-30,6},{-40,6}}, color={0,0,255}));
+  connect(currentSensor.i, zeroOrderHold.u)
+    annotation (Line(points={{-10,-17},{-10,-20},{10,-20}}, color={0,0,127}));
+  annotation (
+    Documentation(info="<html>
+<p>
+This is the same example as <a href=\"modelica://Modelica.Electrical.PowerConverters.Examples.DCDC.HBridge.HBridge_RL\">HBridge_RL</a> 
+but using a triangle (instead of a sawtooth) as pwm reference signal. 
+This enables an easy sampling of the current in the middle of the pwm period, which delivers with good approximation the mean current: 
+Compare <code>meanCurrent.y</code> and <code>zeroOrderHold.y</code>. 
+For discrete or quasi-continuous control it is essential to sample the correct mean current with low effort once during the pwm period.
+</p>
+</html>"),
+    experiment(
+      StopTime=0.1,
+      Interval=0.0002,
+      Tolerance=1e-06));
+end HBridge_TrianglePWM_RL;

--- a/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/package.order
+++ b/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/package.order
@@ -1,3 +1,4 @@
 HBridge_R
 HBridge_RL
+HBridge_TrianglePWM_RL
 HBridge_DC_Drive

--- a/Modelica/Electrical/PowerConverters/Types/SingleReferenceType.mo
+++ b/Modelica/Electrical/PowerConverters/Types/SingleReferenceType.mo
@@ -1,0 +1,5 @@
+within Modelica.Electrical.PowerConverters.Types;
+type SingleReferenceType = enumeration(
+    Sawtooth "Sawtooth",
+    Triangle "Triangle")
+  "Enumeration defining the type of reference signal";

--- a/Modelica/Electrical/PowerConverters/Types/package.order
+++ b/Modelica/Electrical/PowerConverters/Types/package.order
@@ -1,4 +1,5 @@
 PWMType
 ReferenceType
+SingleReferenceType
 Voltage2AngleType
 SoftStarterModeOfOperation


### PR DESCRIPTION
This is a backwards compatible enhancement:
For discrete and quasi-continuous control it is essential to sample the current at the right time instant during the pwm period to catch the mean current. Using triangle reference signal, it is easy to sample exactly in the middle of the pwm period.
