### PR TITLE
Add ModelicaDuplicateString and ModelicaDuplicateStringWithErrorReturn (new in Modelica Language Specification version 3.5)

### DIFF
--- a/.CI/Test/Common.c
+++ b/.CI/Test/Common.c
@@ -6,7 +6,9 @@
 
 char* ModelicaAllocateString(size_t len) {
     void *data = malloc(len + 1); /* Never free'd in the test programs */
-    assert(data);
+    if (NULL == data) {
+        ModelicaError("Failed to allocate string");
+    }
     return data;
 }
 
@@ -16,7 +18,9 @@ char* ModelicaAllocateStringWithErrorReturn(size_t len) {
 
 char* ModelicaDuplicateString(const char* str) {
     void *data = malloc(strlen(str) + 1); /* Never free'd in the test programs */
-    assert(data);
+    if (NULL == data) {
+        ModelicaError("Failed to duplicate string");
+    }
     strcpy(data, str);
     return data;
 }

--- a/.CI/Test/Common.c
+++ b/.CI/Test/Common.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 char* ModelicaAllocateString(size_t len) {
     void *data = malloc(len + 1); /* Never free'd in the test programs */
@@ -11,6 +12,23 @@ char* ModelicaAllocateString(size_t len) {
 
 char* ModelicaAllocateStringWithErrorReturn(size_t len) {
     return malloc(len + 1); /* Never free'd in the test programs */
+}
+
+char* ModelicaDuplicateString(const char* str) {
+    void *data = malloc(strlen(str) + 1); /* Never free'd in the test programs */
+    assert(data);
+    if (NULL != data) {
+        strcpy(data, str);
+    }
+    return data;
+}
+
+char* ModelicaDuplicateStringWithErrorReturn(const char* str) {
+    void *data = malloc(strlen(str) + 1); /* Never free'd in the test programs */
+    if (NULL != data) {
+        strcpy(data, str);
+    }
+    return data;
 }
 
 void ModelicaMessage(const char *string) {

--- a/.CI/Test/Common.c
+++ b/.CI/Test/Common.c
@@ -17,9 +17,7 @@ char* ModelicaAllocateStringWithErrorReturn(size_t len) {
 char* ModelicaDuplicateString(const char* str) {
     void *data = malloc(strlen(str) + 1); /* Never free'd in the test programs */
     assert(data);
-    if (NULL != data) {
-        strcpy(data, str);
-    }
+    strcpy(data, str);
     return data;
 }
 

--- a/.CI/Test/ModelicaUtilities.h
+++ b/.CI/Test/ModelicaUtilities.h
@@ -131,12 +131,12 @@ void ModelicaMessage(const char *string);
 Output the message string (no format control).
 */
 
-void ModelicaFormatMessage(const char *string, ...) MODELICA_FORMATATTR_PRINTF;
+void ModelicaFormatMessage(const char *format, ...) MODELICA_FORMATATTR_PRINTF;
 /*
 Output the message under the same format control as the C-function printf.
 */
 
-void ModelicaVFormatMessage(const char *string, va_list args) MODELICA_FORMATATTR_VPRINTF;
+void ModelicaVFormatMessage(const char *format, va_list args) MODELICA_FORMATATTR_VPRINTF;
 /*
 Output the message under the same format control as the C-function vprintf.
 */
@@ -153,24 +153,24 @@ void ModelicaWarning(const char *string);
 Output the warning message string (no format control).
 */
 
-void ModelicaFormatWarning(const char *string, ...) MODELICA_FORMATATTR_PRINTF;
+void ModelicaFormatWarning(const char *format, ...) MODELICA_FORMATATTR_PRINTF;
 /*
 Output the warning message under the same format control as the C-function printf.
 */
 
-void ModelicaVFormatWarning(const char *string, va_list args) MODELICA_FORMATATTR_VPRINTF;
+void ModelicaVFormatWarning(const char *format, va_list args) MODELICA_FORMATATTR_VPRINTF;
 /*
 Output the warning message under the same format control as the C-function vprintf.
 */
 
-MODELICA_NORETURN void ModelicaFormatError(const char *string, ...) MODELICA_NORETURNATTR MODELICA_FORMATATTR_PRINTF;
+MODELICA_NORETURN void ModelicaFormatError(const char *format, ...) MODELICA_NORETURNATTR MODELICA_FORMATATTR_PRINTF;
 /*
 Output the error message under the same format control as the C-function
 printf. This function never returns to the calling function,
 but handles the error similarly to an assert in the Modelica code.
 */
 
-MODELICA_NORETURN void ModelicaVFormatError(const char *string, va_list args) MODELICA_NORETURNATTR MODELICA_FORMATATTR_VPRINTF;
+MODELICA_NORETURN void ModelicaVFormatError(const char *format, va_list args) MODELICA_NORETURNATTR MODELICA_FORMATATTR_VPRINTF;
 /*
 Output the error message under the same format control as the C-function
 vprintf. This function never returns to the calling function,

--- a/.CI/Test/ModelicaUtilities.h
+++ b/.CI/Test/ModelicaUtilities.h
@@ -131,18 +131,15 @@ void ModelicaMessage(const char *string);
 Output the message string (no format control).
 */
 
-
 void ModelicaFormatMessage(const char *string, ...) MODELICA_FORMATATTR_PRINTF;
 /*
 Output the message under the same format control as the C-function printf.
 */
 
-
 void ModelicaVFormatMessage(const char *string, va_list args) MODELICA_FORMATATTR_VPRINTF;
 /*
 Output the message under the same format control as the C-function vprintf.
 */
-
 
 MODELICA_NORETURN void ModelicaError(const char *string) MODELICA_NORETURNATTR;
 /*
@@ -173,14 +170,12 @@ printf. This function never returns to the calling function,
 but handles the error similarly to an assert in the Modelica code.
 */
 
-
 MODELICA_NORETURN void ModelicaVFormatError(const char *string, va_list args) MODELICA_NORETURNATTR MODELICA_FORMATATTR_VPRINTF;
 /*
 Output the error message under the same format control as the C-function
 vprintf. This function never returns to the calling function,
 but handles the error similarly to an assert in the Modelica code.
 */
-
 
 char* ModelicaAllocateString(size_t len);
 /*
@@ -191,10 +186,27 @@ calling program, as for any other array. If an error occurs, this
 function does not return, but calls "ModelicaError".
 */
 
-
 char* ModelicaAllocateStringWithErrorReturn(size_t len);
 /*
 Same as ModelicaAllocateString, except that in case of error, the
+function returns 0. This allows the external function to close files
+and free other open resources in case of error. After cleaning up
+resources use ModelicaError or ModelicaFormatError to signal
+the error.
+*/
+
+char* ModelicaDuplicateString(const char* str);
+/*
+Duplicate (= allocate memory and deep copy) a Modelica string which
+is used as return argument of an external Modelica function. Note,
+that the storage for string arrays (= pointer to string array) is still
+provided by the calling program, as for any other array. If an error
+occurs, this function does not return, but calls "ModelicaError".
+*/
+
+char* ModelicaDuplicateStringWithErrorReturn(const char* str);
+/*
+Same as ModelicaDuplicateString, except that in case of error, the
 function returns 0. This allows the external function to close files
 and free other open resources in case of error. After cleaning up
 resources use ModelicaError or ModelicaFormatError to signal

--- a/.CI/Test/ModelicaUtilities.h
+++ b/.CI/Test/ModelicaUtilities.h
@@ -209,7 +209,7 @@ char* ModelicaDuplicateStringWithErrorReturn(const char* str);
 Same as ModelicaDuplicateString, except that in case of error, the
 function returns 0. This allows the external function to close files
 and free other open resources in case of error. After cleaning up
-resources use ModelicaError or ModelicaFormatError to signal
+resources use, ModelicaError or ModelicaFormatError to signal
 the error.
 */
 

--- a/Modelica/Resources/C-Sources/ModelicaInternal.c
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.c
@@ -525,7 +525,7 @@ void ModelicaInternal_readDirectory(_In_z_ const char* directory, int nFiles,
             }
 
             /* Allocate Modelica memory for file/directory name and copy name */
-            pName = ModelicaAllocateStringWithErrorReturn(strlen(pinfo->d_name));
+            pName = ModelicaDuplicateStringWithErrorReturn(pinfo->d_name);
             if ( pName == NULL ) {
                 errnoTemp = errno;
                 closedir(pdir);
@@ -538,7 +538,6 @@ void ModelicaInternal_readDirectory(_In_z_ const char* directory, int nFiles,
                         directory, strerror(errnoTemp));
                 }
             }
-            strcpy(pName, pinfo->d_name);
 
             /* Save pointer to file */
             files[iFiles] = pName;
@@ -622,8 +621,7 @@ _Ret_z_ const char* ModelicaInternal_fullPathName(_In_z_ const char* name) {
             name, strerror(errno));
         return "";
     }
-    fullName = ModelicaAllocateString(strlen(tempName));
-    strcpy(fullName, tempName);
+    fullName = ModelicaDuplicateString(tempName);
     ModelicaConvertToUnixDirectorySeparator(fullName);
     return fullName;
 #elif (_BSD_SOURCE || _XOPEN_SOURCE >= 500 || _XOPEN_SOURCE && _XOPEN_SOURCE_EXTENDED || _POSIX_VERSION >= 200112L)
@@ -688,8 +686,7 @@ _Ret_z_ const char* ModelicaInternal_temporaryFileName(void) {
         ModelicaFormatError("Not possible to get temporary filename\n%s", strerror(errno));
         return "";
     }
-    fullName = ModelicaAllocateString(strlen(tempName));
-    strcpy(fullName, tempName);
+    fullName = ModelicaDuplicateString(tempName);
     ModelicaConvertToUnixDirectorySeparator(fullName);
 
     return fullName;
@@ -1011,12 +1008,11 @@ void ModelicaInternal_readFile(_In_z_ const char* fileName,
     while (iLines <= nLines) {
         readLine(&buf, &bufLen, fp);
 
-        line = ModelicaAllocateStringWithErrorReturn(strlen(buf));
+        line = ModelicaDuplicateStringWithErrorReturn(buf);
         if ( line == NULL ) {
             goto Modelica_OOM_ERROR1;
         }
 
-        strcpy(line, buf);
         string[iLines - 1] = line;
         iLines++;
     }
@@ -1063,12 +1059,11 @@ _Ret_z_ const char* ModelicaInternal_readLine(_In_z_ const char* fileName,
         }
     }
 
-    line = ModelicaAllocateStringWithErrorReturn(strlen(buf));
+    line = ModelicaDuplicateStringWithErrorReturn(buf);
     if (line == NULL) {
         goto Modelica_OOM_ERROR2;
     }
 
-    strcpy(line, buf);
     CacheFileForReading(fp, fileName, lineNumber, buf, bufLen);
     *endOfFile = 0;
     return line;
@@ -1134,8 +1129,7 @@ _Ret_z_ const char* ModelicaInternal_getcwd(int dummy) {
         cwd = "";
     }
 #endif
-    directory = ModelicaAllocateString(strlen(cwd));
-    strcpy(directory, cwd);
+    directory = ModelicaDuplicateString(cwd);
     ModelicaConvertToUnixDirectorySeparator(directory);
     return directory;
 }

--- a/Modelica/Resources/C-Sources/ModelicaInternal.c
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.c
@@ -1,6 +1,6 @@
 /* ModelicaInternal.c - External functions for Modelica.Utilities
 
-   Copyright (C) 2002-2023, Modelica Association and contributors
+   Copyright (C) 2002-2024, Modelica Association and contributors
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
@@ -30,6 +30,10 @@
 */
 
 /* Changelog:
+      Jan. 15, 2024: by Thomas Beutlich
+                     Utilized ModelicaDuplicateString and
+                     ModelicaDuplicateStringWithErrorReturn (ticket #3686)
+
       Nov. 17, 2020: by Thomas Beutlich
                      Fixed reading files with Unix-style line endings on Windows
                      for ModelicaInternal_readLine/_readFile (ticket #3631)
@@ -633,8 +637,7 @@ _Ret_z_ const char* ModelicaInternal_fullPathName(_In_z_ const char* name) {
     if (tempName == NULL) {
         goto FALLBACK_getcwd;
     }
-    fullName = ModelicaAllocateString(strlen(tempName) + 1);
-    strcpy(fullName, tempName);
+    fullName = ModelicaDuplicateString(tempName);
     ModelicaConvertToUnixDirectorySeparator(fullName);
     /* Retain trailing slash to match _fullpath behaviour */
     len = strlen(name);
@@ -1073,8 +1076,7 @@ END_OF_FILE:
     fclose(fp);
     CloseCachedFile(fileName);
     *endOfFile = 1;
-    line = ModelicaAllocateString(0);
-    line[0] = '\0';
+    line = ModelicaDuplicateString("");
     return line;
 
 Modelica_OOM_ERROR2:
@@ -1150,18 +1152,16 @@ void ModelicaInternal_getenv(_In_z_ const char* name, int convertToSlash,
 #endif
 
     if (value == NULL) {
-        result = ModelicaAllocateString(0);
-        result[0] = '\0';
+        result = ModelicaDuplicateString("");
         *exist = 0;
     }
     else {
 #if defined(_MSC_VER) && _MSC_VER >= 1400
-        result = ModelicaAllocateStringWithErrorReturn(len); /* (len - 1) actually is sufficient */
+        result = ModelicaDuplicateStringWithErrorReturn(value);
         if (result) {
 #else
-        result = ModelicaAllocateString(strlen(value));
+        result = ModelicaDuplicateString(value);
 #endif
-            strcpy(result, value);
             if ( convertToSlash == 1 ) {
                 ModelicaConvertToUnixDirectorySeparator(result);
             }

--- a/Modelica/Resources/C-Sources/ModelicaStrings.c
+++ b/Modelica/Resources/C-Sources/ModelicaStrings.c
@@ -1,6 +1,6 @@
 /* ModelicaStrings.c - External functions for Modelica.Utilities.Strings
 
-   Copyright (C) 2002-2020, Modelica Association and contributors
+   Copyright (C) 2002-2024, Modelica Association and contributors
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
@@ -30,6 +30,10 @@
 */
 
 /* Changelog:
+      Jan. 15, 2024: by Thomas Beutlich
+                     Utilized ModelicaDuplicateString and
+                     ModelicaDuplicateStringWithErrorReturn (ticket #3686)
+
       Mar. 15, 2020: by Thomas Beutlich
                      Improved fault-tolerance of ModelicaStrings_substring w.r.t.
                      index arguments (ticket #3503)
@@ -231,9 +235,7 @@ void ModelicaStrings_scanIdentifier(_In_z_ const char* string,
     /* Token missing or not identifier. */
     *nextIndex  = startIndex;
     {
-        char* s = ModelicaAllocateString(0);
-        s[0] = '\0';
-        *identifier = s;
+        *identifier = ModelicaDuplicateString("");
     }
     return;
 }
@@ -458,9 +460,7 @@ void ModelicaStrings_scanString(_In_z_ const char* string, int startIndex,
 
 Modelica_ERROR:
     {
-        char* s = ModelicaAllocateString(0);
-        s[0] = '\0';
-        *result = s;
+        *result = ModelicaDuplicateString("");
     }
     *nextIndex = startIndex;
     return;


### PR DESCRIPTION
Can only be merged once MSL is based on MLS 3.5.