### PR TITLE
Update 3rd-party header uthash to v2.2.0

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaInternal.c
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.c
@@ -207,6 +207,32 @@ void ModelicaInternal_setenv(_In_z_ const char* name,
   #define _POSIX_ 1
 #endif
 
+/* Have the <stdint.h> header file */
+#if defined(_WIN32)
+#if defined(_MSC_VER) && _MSC_VER >= 1600
+#define HAVE_STDINT_H 1
+#elif defined(__WATCOMC__) || defined(__MINGW32__) || defined(__CYGWIN__)
+#define HAVE_STDINT_H 1
+#else
+#undef HAVE_STDINT_H
+#endif
+#elif defined(__GNUC__) && !defined(__VXWORKS__)
+#define HAVE_STDINT_H 1
+#else
+#undef HAVE_STDINT_H
+#endif
+
+/* Replacement for integer type header */
+#if !defined(HAVE_STDINT_H)
+#define HASH_NO_STDINT 1
+#if defined(_MSC_VER)
+#include "stdint_msvc.h"
+#else
+#define uint32_t unsigned int
+#define uint8_t unsigned char
+#endif
+#endif
+
 #define HASH_NONFATAL_OOM 1
 #include "uthash.h"
 #include "gconstructor.h"

--- a/Modelica/Resources/C-Sources/ModelicaInternal.c
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.c
@@ -207,32 +207,8 @@ void ModelicaInternal_setenv(_In_z_ const char* name,
   #define _POSIX_ 1
 #endif
 
-/* Have the <stdint.h> header file */
-#if defined(_WIN32)
-#if defined(_MSC_VER) && _MSC_VER >= 1600
-#define HAVE_STDINT_H 1
-#elif defined(__WATCOMC__) || defined(__MINGW32__) || defined(__CYGWIN__)
-#define HAVE_STDINT_H 1
-#else
-#undef HAVE_STDINT_H
-#endif
-#elif defined(__GNUC__) && !defined(__VXWORKS__)
-#define HAVE_STDINT_H 1
-#else
-#undef HAVE_STDINT_H
-#endif
-
-/* Replacement for integer type header */
-#if !defined(HAVE_STDINT_H)
+#include "stdint_wrap.h"
 #define HASH_NO_STDINT 1
-#if defined(_MSC_VER)
-#include "stdint_msvc.h"
-#else
-#define uint32_t unsigned int
-#define uint8_t unsigned char
-#endif
-#endif
-
 #define HASH_NONFATAL_OOM 1
 #include "uthash.h"
 #include "gconstructor.h"

--- a/Modelica/Resources/C-Sources/ModelicaRandom.c
+++ b/Modelica/Resources/C-Sources/ModelicaRandom.c
@@ -41,58 +41,7 @@
 */
 
 #include "ModelicaRandom.h"
-
-/* Have RANDOM int64 / uint64 */
-#if defined (_WIN32)
-#if defined(_MSC_VER) || defined(__WATCOMC__) || defined(__MINGW32__) || defined(__CYGWIN__) || defined(__BORLANDC__)
-#define HAVE_RANDOM_INT64_T 1
-#define HAVE_RANDOM_UINT64_T 1
-#else
-#undef HAVE_RANDOM_INT64_T
-#undef HAVE_RANDOM_UINT64_T
-#endif
-#else
-#define HAVE_RANDOM_INT64_T 1
-#define HAVE_RANDOM_UINT64_T 1
-#endif
-
-/* Define to 1 if you have the <stdint.h> header file. */
-#if defined(_WIN32)
-#if defined(_MSC_VER) && _MSC_VER >= 1600
-#define HAVE_RANDOM_STDINT_H 1
-#elif defined(__WATCOMC__) || defined(__MINGW32__) || defined(__CYGWIN__)
-#define HAVE_RANDOM_STDINT_H 1
-#else
-#undef HAVE_RANDOM_STDINT_H
-#endif
-#elif defined(__GNUC__) && !defined(__VXWORKS__)
-#define HAVE_RANDOM_STDINT_H 1
-#else
-#undef HAVE_RANDOM_STDINT_H
-#endif
-
-/* Include integer type header */
-#if defined(HAVE_RANDOM_STDINT_H)
-#include <stdint.h>
-#else
-#define int32_t  int
-#define uint32_t unsigned int
-#if defined(HAVE_RANDOM_INT64_T)
-#if defined(__BORLANDC__) || (defined(_MSC_VER) && _MSC_VER < 1300)
-#define int64_t __int64
-#else
-#define int64_t long long
-#endif
-#endif
-#if defined(HAVE_RANDOM_UINT64_T)
-#if defined(__BORLANDC__) || (defined(_MSC_VER) && _MSC_VER < 1300)
-#define uint64_t unsigned __int64
-#else
-#define uint64_t unsigned long long
-#endif
-#endif
-#endif
-
+#include "stdint_wrap.h"
 #include <stdlib.h>
 #include <limits.h>
 #include <math.h>

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -165,6 +165,32 @@
 #include "ModelicaIO.h"
 #include "ModelicaUtilities.h"
 #if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
+/* Have the <stdint.h> header file */
+#if defined(_WIN32)
+#if defined(_MSC_VER) && _MSC_VER >= 1600
+#define HAVE_STDINT_H 1
+#elif defined(__WATCOMC__) || defined(__MINGW32__) || defined(__CYGWIN__)
+#define HAVE_STDINT_H 1
+#else
+#undef HAVE_STDINT_H
+#endif
+#elif defined(__GNUC__) && !defined(__VXWORKS__)
+#define HAVE_STDINT_H 1
+#else
+#undef HAVE_STDINT_H
+#endif
+
+/* Replacement for integer type header */
+#if !defined(HAVE_STDINT_H)
+#define HASH_NO_STDINT 1
+#if defined(_MSC_VER)
+#include "stdint_msvc.h"
+#else
+#define uint32_t unsigned int
+#define uint8_t unsigned char
+#endif
+#endif
+
 #define uthash_strlen(s) key_strlen(s)
 #define HASH_NONFATAL_OOM 1
 #include "uthash.h"

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -165,32 +165,8 @@
 #include "ModelicaIO.h"
 #include "ModelicaUtilities.h"
 #if defined(TABLE_SHARE) && !defined(NO_FILE_SYSTEM)
-/* Have the <stdint.h> header file */
-#if defined(_WIN32)
-#if defined(_MSC_VER) && _MSC_VER >= 1600
-#define HAVE_STDINT_H 1
-#elif defined(__WATCOMC__) || defined(__MINGW32__) || defined(__CYGWIN__)
-#define HAVE_STDINT_H 1
-#else
-#undef HAVE_STDINT_H
-#endif
-#elif defined(__GNUC__) && !defined(__VXWORKS__)
-#define HAVE_STDINT_H 1
-#else
-#undef HAVE_STDINT_H
-#endif
-
-/* Replacement for integer type header */
-#if !defined(HAVE_STDINT_H)
+#include "stdint_wrap.h"
 #define HASH_NO_STDINT 1
-#if defined(_MSC_VER)
-#include "stdint_msvc.h"
-#else
-#define uint32_t unsigned int
-#define uint8_t unsigned char
-#endif
-#endif
-
 #define uthash_strlen(s) key_strlen(s)
 #define HASH_NONFATAL_OOM 1
 #include "uthash.h"

--- a/Modelica/Resources/C-Sources/ModelicaStrings.c
+++ b/Modelica/Resources/C-Sources/ModelicaStrings.c
@@ -91,33 +91,8 @@
 #endif
 
 #include "ModelicaUtilities.h"
-
-/* Have the <stdint.h> header file */
-#if defined(_WIN32)
-#if defined(_MSC_VER) && _MSC_VER >= 1600
-#define HAVE_STDINT_H 1
-#elif defined(__WATCOMC__) || defined(__MINGW32__) || defined(__CYGWIN__)
-#define HAVE_STDINT_H 1
-#else
-#undef HAVE_STDINT_H
-#endif
-#elif defined(__GNUC__) && !defined(__VXWORKS__)
-#define HAVE_STDINT_H 1
-#else
-#undef HAVE_STDINT_H
-#endif
-
-/* Replacement for integer type header */
-#if !defined(HAVE_STDINT_H)
+#include "stdint_wrap.h"
 #define HASH_NO_STDINT 1
-#if defined(_MSC_VER)
-#include "stdint_msvc.h"
-#else
-#define uint32_t unsigned int
-#define uint8_t unsigned char
-#endif
-#endif
-
 #if !defined(HASH_FUNCTION)
 #define HASH_FUNCTION HASH_AP
 #endif

--- a/Modelica/Resources/C-Sources/ModelicaStrings.c
+++ b/Modelica/Resources/C-Sources/ModelicaStrings.c
@@ -91,6 +91,33 @@
 #endif
 
 #include "ModelicaUtilities.h"
+
+/* Have the <stdint.h> header file */
+#if defined(_WIN32)
+#if defined(_MSC_VER) && _MSC_VER >= 1600
+#define HAVE_STDINT_H 1
+#elif defined(__WATCOMC__) || defined(__MINGW32__) || defined(__CYGWIN__)
+#define HAVE_STDINT_H 1
+#else
+#undef HAVE_STDINT_H
+#endif
+#elif defined(__GNUC__) && !defined(__VXWORKS__)
+#define HAVE_STDINT_H 1
+#else
+#undef HAVE_STDINT_H
+#endif
+
+/* Replacement for integer type header */
+#if !defined(HAVE_STDINT_H)
+#define HASH_NO_STDINT 1
+#if defined(_MSC_VER)
+#include "stdint_msvc.h"
+#else
+#define uint32_t unsigned int
+#define uint8_t unsigned char
+#endif
+#endif
+
 #if !defined(HASH_FUNCTION)
 #define HASH_FUNCTION HASH_AP
 #endif

--- a/Modelica/Resources/C-Sources/stdint_wrap.h
+++ b/Modelica/Resources/C-Sources/stdint_wrap.h
@@ -1,0 +1,98 @@
+/* stdint_wrap.h - Wrapper for stdint.h not being available with C89
+
+   Copyright (C) 2020, Modelica Association and contributors
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   3. Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef MODELICA_STDINT_WRAP_H_
+#define MODELICA_STDINT_WRAP_H_
+
+/* Have 64 bit integral types */
+#if defined(_WIN32)
+#if defined(__WATCOMC__) || defined(__MINGW32__) || defined(__CYGWIN__) || defined(__BORLANDC__)
+#define HAVE_MODELICA_INT64_T 1
+#define HAVE_MODELICA_UINT64_T 1
+#elif defined(_MSC_VER) && _MSC_VER > 1300
+#define HAVE_MODELICA_INT64_T 1
+#define HAVE_MODELICA_UINT64_T 1
+#elif defined(_MSC_VER)
+#define HAVE_MODELICA_INT64_T 1
+#undef HAVE_MODELICA_UINT64_T
+#else
+#undef HAVE_MODELICA_INT64_T
+#undef HAVE_MODELICA_UINT64_T
+#endif
+#else
+#define HAVE_MODELICA_INT64_T 1
+#define HAVE_MODELICA_UINT64_T 1
+#endif
+
+/* Have the <stdint.h> header file */
+#if defined(_WIN32)
+#if defined(_MSC_VER) && _MSC_VER >= 1600
+#define HAVE_MODELICA_STDINT_H 1
+#elif defined(__WATCOMC__) || defined(__MINGW32__) || defined(__CYGWIN__)
+#define HAVE_MODELICA_STDINT_H 1
+#else
+#undef HAVE_MODELICA_STDINT_H
+#endif
+#elif defined(__GNUC__) && !defined(__VXWORKS__)
+#define HAVE_MODELICA_STDINT_H 1
+#else
+#undef HAVE_MODELICA_STDINT_H
+#endif
+
+/* Include integer type header */
+#if defined(HAVE_MODELICA_STDINT_H)
+#include <stdint.h>
+#elif defined(_MSC_VER)
+#include "stdint_msvc.h"
+#else
+#define int8_t signed char
+#define uint8_t unsigned char
+#define int16_t short
+#define uint16_t unsigned short
+#define int32_t int
+#define uint32_t unsigned int
+#if defined(HAVE_MODELICA_INT64_T)
+#if defined(__BORLANDC__) || (defined(_MSC_VER) && _MSC_VER < 1300)
+#define int64_t __int64
+#else
+#define int64_t long long
+#endif
+#endif
+#if defined(HAVE_MODELICA_UINT64_T)
+#if defined(__BORLANDC__) || (defined(_MSC_VER) && _MSC_VER < 1300)
+#define uint64_t unsigned __int64
+#else
+#define uint64_t unsigned long long
+#endif
+#endif
+#endif
+
+#endif

--- a/Modelica/Resources/C-Sources/uthash.h
+++ b/Modelica/Resources/C-Sources/uthash.h
@@ -30,6 +30,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stddef.h>   /* ptrdiff_t */
 #include <stdlib.h>   /* exit */
 
+#if defined(HASH_DEFINE_OWN_STDINT) && HASH_DEFINE_OWN_STDINT
+/* This codepath is provided for backward compatibility, but I plan to remove it. */
+#warning "HASH_DEFINE_OWN_STDINT is deprecated; please use HASH_NO_STDINT instead"
+typedef unsigned int uint32_t;
+typedef unsigned char uint8_t;
+#elif defined(HASH_NO_STDINT) && HASH_NO_STDINT
+#else
+#include <stdint.h>   /* uint8_t, uint32_t */
+#endif
+
 /* These macros use decltype or the earlier __typeof GNU extension.
    As decltype is only available in newer compilers (VS2010 or gcc 4.3+
    when compiling c++ source) this code uses whatever method is needed
@@ -60,23 +70,6 @@ do {                                                                            
 do {                                                                             \
   (dst) = DECLTYPE(dst)(src);                                                    \
 } while (0)
-#endif
-
-/* a number of the hash function use uint32_t which isn't defined on Pre VS2010 */
-#if defined(_WIN32)
-#if defined(_MSC_VER) && _MSC_VER >= 1600
-#include <stdint.h>
-#elif defined(__WATCOMC__) || defined(__MINGW32__) || defined(__CYGWIN__)
-#include <stdint.h>
-#else
-typedef unsigned int uint32_t;
-typedef unsigned char uint8_t;
-#endif
-#elif defined(__GNUC__) && !defined(__VXWORKS__)
-#include <stdint.h>
-#else
-typedef unsigned int uint32_t;
-typedef unsigned char uint8_t;
 #endif
 
 #ifndef uthash_malloc
@@ -144,7 +137,7 @@ typedef unsigned char uint8_t;
 /* calculate the element whose hash handle address is hhp */
 #define ELMT_FROM_HH(tbl,hhp) ((void*)(((char*)(hhp)) - ((tbl)->hho)))
 /* calculate the hash handle from element address elp */
-#define HH_FROM_ELMT(tbl,elp) ((UT_hash_handle *)(((char*)(elp)) + ((tbl)->hho)))
+#define HH_FROM_ELMT(tbl,elp) ((UT_hash_handle*)(void*)(((char*)(elp)) + ((tbl)->hho)))
 
 #define HASH_ROLLBACK_BKT(hh, head, itemptrhh)                                   \
 do {                                                                             \
@@ -175,9 +168,12 @@ do {                                                                            
 
 #define HASH_FIND(hh,head,keyptr,keylen,out)                                     \
 do {                                                                             \
-  unsigned _hf_hashv;                                                            \
-  HASH_VALUE(keyptr, keylen, _hf_hashv);                                         \
-  HASH_FIND_BYHASHVALUE(hh, head, keyptr, keylen, _hf_hashv, out);               \
+  (out) = NULL;                                                                  \
+  if (head) {                                                                    \
+    unsigned _hf_hashv;                                                          \
+    HASH_VALUE(keyptr, keylen, _hf_hashv);                                       \
+    HASH_FIND_BYHASHVALUE(hh, head, keyptr, keylen, _hf_hashv, out);             \
+  }                                                                              \
 } while (0)
 
 #ifdef HASH_BLOOM
@@ -405,7 +401,7 @@ do {                                                                            
 do {                                                                             \
   IF_HASH_NONFATAL_OOM( int _ha_oomed = 0; )                                     \
   (add)->hh.hashv = (hashval);                                                   \
-  (add)->hh.key = (char*) (keyptr);                                              \
+  (add)->hh.key = (const void*) (keyptr);                                        \
   (add)->hh.keylen = (unsigned) (keylen_in);                                     \
   if (!(head)) {                                                                 \
     (add)->hh.next = NULL;                                                       \
@@ -519,7 +515,8 @@ do {                                                                            
  * This is for uthash developer only; it compiles away if HASH_DEBUG isn't defined.
  */
 #ifdef HASH_DEBUG
-#define HASH_OOPS(...) do { fprintf(stderr,__VA_ARGS__); exit(-1); } while (0)
+#include <stdio.h>   /* fprintf, stderr */
+#define HASH_OOPS(...) do { fprintf(stderr, __VA_ARGS__); exit(-1); } while (0)
 #define HASH_FSCK(hh,head,where)                                                 \
 do {                                                                             \
   struct UT_hash_handle *_thh;                                                   \
@@ -750,87 +747,6 @@ do {                                                                            
   hashv += hashv >> 6;                                                           \
 } while (0)
 
-#ifdef HASH_USING_NO_STRICT_ALIASING
-/* The MurmurHash exploits some CPU's (x86,x86_64) tolerance for unaligned reads.
- * For other types of CPU's (e.g. Sparc) an unaligned read causes a bus error.
- * MurmurHash uses the faster approach only on CPU's where we know it's safe.
- *
- * Note the preprocessor built-in defines can be emitted using:
- *
- *   gcc -m64 -dM -E - < /dev/null                  (on gcc)
- *   cc -## a.c (where a.c is a simple test file)   (Sun Studio)
- */
-#if (defined(__i386__) || defined(__x86_64__)  || defined(_M_IX86))
-#define MUR_GETBLOCK(p,i) p[i]
-#else /* non intel */
-#define MUR_PLUS0_ALIGNED(p) (((unsigned long)p & 3UL) == 0UL)
-#define MUR_PLUS1_ALIGNED(p) (((unsigned long)p & 3UL) == 1UL)
-#define MUR_PLUS2_ALIGNED(p) (((unsigned long)p & 3UL) == 2UL)
-#define MUR_PLUS3_ALIGNED(p) (((unsigned long)p & 3UL) == 3UL)
-#define WP(p) ((uint32_t*)((unsigned long)(p) & ~3UL))
-#if (defined(__BIG_ENDIAN__) || defined(SPARC) || defined(__ppc__) || defined(__ppc64__))
-#define MUR_THREE_ONE(p) ((((*WP(p))&0x00ffffff) << 8) | (((*(WP(p)+1))&0xff000000) >> 24))
-#define MUR_TWO_TWO(p)   ((((*WP(p))&0x0000ffff) <<16) | (((*(WP(p)+1))&0xffff0000) >> 16))
-#define MUR_ONE_THREE(p) ((((*WP(p))&0x000000ff) <<24) | (((*(WP(p)+1))&0xffffff00) >>  8))
-#else /* assume little endian non-intel */
-#define MUR_THREE_ONE(p) ((((*WP(p))&0xffffff00) >> 8) | (((*(WP(p)+1))&0x000000ff) << 24))
-#define MUR_TWO_TWO(p)   ((((*WP(p))&0xffff0000) >>16) | (((*(WP(p)+1))&0x0000ffff) << 16))
-#define MUR_ONE_THREE(p) ((((*WP(p))&0xff000000) >>24) | (((*(WP(p)+1))&0x00ffffff) <<  8))
-#endif
-#define MUR_GETBLOCK(p,i) (MUR_PLUS0_ALIGNED(p) ? ((p)[i]) :           \
-                            (MUR_PLUS1_ALIGNED(p) ? MUR_THREE_ONE(p) : \
-                             (MUR_PLUS2_ALIGNED(p) ? MUR_TWO_TWO(p) :  \
-                                                      MUR_ONE_THREE(p))))
-#endif
-#define MUR_ROTL32(x,r) (((x) << (r)) | ((x) >> (32 - (r))))
-#define MUR_FMIX(_h) \
-do {                 \
-  _h ^= _h >> 16;    \
-  _h *= 0x85ebca6bu; \
-  _h ^= _h >> 13;    \
-  _h *= 0xc2b2ae35u; \
-  _h ^= _h >> 16;    \
-} while (0)
-
-#define HASH_MUR(key,keylen,hashv)                                     \
-do {                                                                   \
-  const uint8_t *_mur_data = (const uint8_t*)(key);                    \
-  const int _mur_nblocks = (int)(keylen) / 4;                          \
-  uint32_t _mur_h1 = 0xf88D5353u;                                      \
-  uint32_t _mur_c1 = 0xcc9e2d51u;                                      \
-  uint32_t _mur_c2 = 0x1b873593u;                                      \
-  uint32_t _mur_k1 = 0;                                                \
-  const uint8_t *_mur_tail;                                            \
-  const uint32_t *_mur_blocks = (const uint32_t*)(_mur_data+(_mur_nblocks*4)); \
-  int _mur_i;                                                          \
-  for (_mur_i = -_mur_nblocks; _mur_i != 0; _mur_i++) {                \
-    _mur_k1 = MUR_GETBLOCK(_mur_blocks,_mur_i);                        \
-    _mur_k1 *= _mur_c1;                                                \
-    _mur_k1 = MUR_ROTL32(_mur_k1,15);                                  \
-    _mur_k1 *= _mur_c2;                                                \
-                                                                       \
-    _mur_h1 ^= _mur_k1;                                                \
-    _mur_h1 = MUR_ROTL32(_mur_h1,13);                                  \
-    _mur_h1 = (_mur_h1*5U) + 0xe6546b64u;                              \
-  }                                                                    \
-  _mur_tail = (const uint8_t*)(_mur_data + (_mur_nblocks*4));          \
-  _mur_k1=0;                                                           \
-  switch ((keylen) & 3U) {                                             \
-    case 0: break;                                                     \
-    case 3: _mur_k1 ^= (uint32_t)_mur_tail[2] << 16; /* FALLTHROUGH */ \
-    case 2: _mur_k1 ^= (uint32_t)_mur_tail[1] << 8;  /* FALLTHROUGH */ \
-    case 1: _mur_k1 ^= (uint32_t)_mur_tail[0];                         \
-    _mur_k1 *= _mur_c1;                                                \
-    _mur_k1 = MUR_ROTL32(_mur_k1,15);                                  \
-    _mur_k1 *= _mur_c2;                                                \
-    _mur_h1 ^= _mur_k1;                                                \
-  }                                                                    \
-  _mur_h1 ^= (uint32_t)(keylen);                                       \
-  MUR_FMIX(_mur_h1);                                                   \
-  hashv = _mur_h1;                                                     \
-} while (0)
-#endif  /* HASH_USING_NO_STRICT_ALIASING */
-
 /* iterate over items in a known bucket to find desired item */
 #define HASH_FIND_IN_BKT(tbl,hh,head,keyptr,keylen_in,hashval,out)               \
 do {                                                                             \
@@ -841,7 +757,7 @@ do {                                                                            
   }                                                                              \
   while ((out) != NULL) {                                                        \
     if ((out)->hh.hashv == (hashval) && (out)->hh.keylen == (keylen_in)) {       \
-      if (HASH_KEYCMP((out)->hh.key, keyptr, keylen_in) == 0) {              \
+      if (HASH_KEYCMP((out)->hh.key, keyptr, keylen_in) == 0) {                  \
         break;                                                                   \
       }                                                                          \
     }                                                                            \
@@ -927,12 +843,12 @@ do {                                                                            
   struct UT_hash_handle *_he_thh, *_he_hh_nxt;                                   \
   UT_hash_bucket *_he_new_buckets, *_he_newbkt;                                  \
   _he_new_buckets = (UT_hash_bucket*)uthash_malloc(                              \
-           2UL * (tbl)->num_buckets * sizeof(struct UT_hash_bucket));            \
+           sizeof(struct UT_hash_bucket) * (tbl)->num_buckets * 2U);             \
   if (!_he_new_buckets) {                                                        \
     HASH_RECORD_OOM(oomed);                                                      \
   } else {                                                                       \
     uthash_bzero(_he_new_buckets,                                                \
-        2UL * (tbl)->num_buckets * sizeof(struct UT_hash_bucket));               \
+        sizeof(struct UT_hash_bucket) * (tbl)->num_buckets * 2U);                \
     (tbl)->ideal_chain_maxlen =                                                  \
        ((tbl)->num_items >> ((tbl)->log2_num_buckets+1U)) +                      \
        ((((tbl)->num_items & (((tbl)->num_buckets*2U)-1U)) != 0U) ? 1U : 0U);    \
@@ -1080,7 +996,7 @@ do {                                                                            
         _elt = ELMT_FROM_HH((src)->hh_src.tbl, _src_hh);                         \
         if (cond(_elt)) {                                                        \
           IF_HASH_NONFATAL_OOM( int _hs_oomed = 0; )                             \
-          _dst_hh = (UT_hash_handle*)(((char*)_elt) + _dst_hho);                 \
+          _dst_hh = (UT_hash_handle*)(void*)(((char*)_elt) + _dst_hho);          \
           _dst_hh->key = _src_hh->key;                                           \
           _dst_hh->keylen = _src_hh->keylen;                                     \
           _dst_hh->hashv = _src_hh->hashv;                                       \
@@ -1219,7 +1135,7 @@ typedef struct UT_hash_handle {
    void *next;                       /* next element in app order      */
    struct UT_hash_handle *hh_prev;   /* previous hh in bucket order    */
    struct UT_hash_handle *hh_next;   /* next hh in bucket order        */
-   void *key;                        /* ptr to enclosing struct's key  */
+   const void *key;                  /* ptr to enclosing struct's key  */
    unsigned keylen;                  /* enclosing struct's key len     */
    unsigned hashv;                   /* result of hash-fcn(key)        */
 } UT_hash_handle;

--- a/Modelica/Resources/C-Sources/uthash.h
+++ b/Modelica/Resources/C-Sources/uthash.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2003-2018, Troy D. Hanson     http://troydhanson.github.com/uthash/
+Copyright (c) 2003-2020, Troy D. Hanson     http://troydhanson.github.com/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,7 +24,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UTHASH_H
 #define UTHASH_H
 
-#define UTHASH_VERSION 2.1.0
+#define UTHASH_VERSION 2.2.0
 
 #include <string.h>   /* memcmp, memset, strlen */
 #include <stddef.h>   /* ptrdiff_t */

--- a/Modelica/Resources/Licenses/LICENSE_uthash.txt
+++ b/Modelica/Resources/Licenses/LICENSE_uthash.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2003-2018, Troy D. Hanson     http://troydhanson.github.com/uthash/
+Copyright (c) 2005-2020, Troy D. Hanson    http://troydhanson.github.com/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This updates to uthash v2.2.0 and does some refactoring on inclusion of stdint.h.