### PR TITLE
Add tableOnFile parameter to icon of CombiTable blocks

### DIFF
--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -1899,7 +1899,8 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         fillColor={255,215,136},
         fillPattern=FillPattern.Solid,
         extent={{-48.0,-50.0},{2.0,70.0}}),
-      Line(points={{-48.0,-50.0},{-48.0,70.0},{52.0,70.0},{52.0,-50.0},{-48.0,-50.0},{-48.0,-20.0},{52.0,-20.0},{52.0,10.0},{-48.0,10.0},{-48.0,40.0},{52.0,40.0},{52.0,70.0},{2.0,70.0},{2.0,-51.0}})}));
+      Line(points={{-48.0,-50.0},{-48.0,70.0},{52.0,70.0},{52.0,-50.0},{-48.0,-50.0},{-48.0,-20.0},{52.0,-20.0},{52.0,10.0},{-48.0,10.0},{-48.0,40.0},{52.0,40.0},{52.0,70.0},{2.0,70.0},{2.0,-51.0}}),
+      Text(extent={{-150,-150},{150,-110}}, textString="tableOnFile=%tableOnFile")}));
   end CombiTimeTable;
 
   block BooleanConstant "Generate constant signal of type Boolean"

--- a/Modelica/Blocks/Tables.mo
+++ b/Modelica/Blocks/Tables.mo
@@ -250,7 +250,8 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         extent={{-60.0,-20.0},{-30.0,0.0}}),
       Rectangle(fillColor={255,215,136},
         fillPattern=FillPattern.Solid,
-        extent={{-60.0,-40.0},{-30.0,-20.0}})}));
+        extent={{-60.0,-40.0},{-30.0,-20.0}}),
+      Text(extent={{-150,-150},{150,-110}}, textString="tableOnFile=%tableOnFile")}));
   end CombiTable1Ds;
 
   block CombiTable1Dv
@@ -503,7 +504,8 @@ MATLAB is a registered trademark of The MathWorks, Inc.
         extent={{-60.0,-20.0},{-30.0,0.0}}),
       Rectangle(fillColor={255,215,136},
         fillPattern=FillPattern.Solid,
-        extent={{-60.0,-40.0},{-30.0,-20.0}})}));
+        extent={{-60.0,-40.0},{-30.0,-20.0}}),
+      Text(extent={{-150,-150},{150,-110}}, textString="tableOnFile=%tableOnFile")}));
   end CombiTable1Dv;
 
   block CombiTable2Ds "Table look-up in two dimensions (matrix/file)"
@@ -961,7 +963,8 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       Rectangle(origin={-2.3077,-0.0},
         fillColor={255,215,136},
         fillPattern=FillPattern.Solid,
-        extent={{32.3077,20.0},{62.3077,40.0}})}));
+        extent={{32.3077,20.0},{62.3077,40.0}}),
+      Text(extent={{-150,-150},{150,-110}}, textString="tableOnFile=%tableOnFile")}));
     end CombiTable2DBase;
 
     pure function getTimeTableValue


### PR DESCRIPTION
This PR adds tableOnFile as the primary parameter to the icons of the table blocks.