### PR TITLE
Make array inputs of external C functions const (introduced in Modelica 3.5)

### DIFF
--- a/Modelica/Blocks/Tables.mo
+++ b/Modelica/Blocks/Tables.mo
@@ -1330,7 +1330,7 @@ protected
     external \"C\" dummy_y = mydummyfunc(dummy_u);
     annotation(IncludeDirectory=\"modelica://Modelica/Resources/Data/Tables\",
            Include = \"#include \"usertab.c\"
-double mydummyfunc(double* dummy_in) {
+double mydummyfunc(const double* dummy_in) {
    return 0;
 }
 \");

--- a/Modelica/Resources/C-Sources/ModelicaFFT.c
+++ b/Modelica/Resources/C-Sources/ModelicaFFT.c
@@ -518,7 +518,7 @@ static void mrkiss_fftr(mrkiss_fftr_cfg st, const mrkiss_fft_scalar *timedata, m
     }
 }
 
-int ModelicaFFT_kiss_fftr(_In_ double* u, size_t nu, _In_ double* work, size_t nwork,
+int ModelicaFFT_kiss_fftr(_In_ const double* u, size_t nu, _In_ double* work, size_t nwork,
                           _Out_ double *amplitudes, _Out_ double *phases) {
 
     /* Compute real FFT with mrkiss_fftr

--- a/Modelica/Resources/C-Sources/ModelicaFFT.h
+++ b/Modelica/Resources/C-Sources/ModelicaFFT.h
@@ -69,7 +69,7 @@
 #define _Out_
 #endif
 
-MODELICA_EXPORT int ModelicaFFT_kiss_fftr(_In_ double* u, size_t nu, _In_ double* work, size_t nwork,
+MODELICA_EXPORT int ModelicaFFT_kiss_fftr(_In_ const double* u, size_t nu, _In_ double* work, size_t nwork,
     _Out_ double *amplitudes, _Out_ double *phases) MODELICA_NONNULLATTR;
 
 #endif

--- a/Modelica/Resources/C-Sources/ModelicaIO.c
+++ b/Modelica/Resources/C-Sources/ModelicaIO.c
@@ -112,7 +112,7 @@ void ModelicaIO_readRealMatrix(_In_z_ const char* fileName,
     int verbose) {
     ModelicaNotExistError("ModelicaIO_readRealMatrix"); }
 int ModelicaIO_writeRealMatrix(_In_z_ const char* fileName,
-    _In_z_ const char* matrixName, _In_ double* matrix, size_t m, size_t n,
+    _In_z_ const char* matrixName, _In_ const double* matrix, size_t m, size_t n,
     int append, _In_z_ const char* version) {
     ModelicaNotExistError("ModelicaIO_writeRealMatrix"); return 0; }
 double* ModelicaIO_readRealTable(_In_z_ const char* fileName,
@@ -290,7 +290,7 @@ void ModelicaIO_readRealMatrix(_In_z_ const char* fileName,
 
 int ModelicaIO_writeRealMatrix(_In_z_ const char* fileName,
                                _In_z_ const char* matrixName,
-                               _In_ double* matrix, size_t m, size_t n,
+                               _In_ const double* matrix, size_t m, size_t n,
                                int append,
                                _In_z_ const char* version) {
     int status;

--- a/Modelica/Resources/C-Sources/ModelicaIO.h
+++ b/Modelica/Resources/C-Sources/ModelicaIO.h
@@ -112,7 +112,7 @@ MODELICA_EXPORT void ModelicaIO_readRealMatrix(_In_z_ const char* fileName,
 
 MODELICA_EXPORT int ModelicaIO_writeRealMatrix(_In_z_ const char* fileName,
                                _In_z_ const char* matrixName,
-                               _In_ double* matrix, size_t m, size_t n,
+                               _In_ const double* matrix, size_t m, size_t n,
                                int append,
                                _In_z_ const char* version) MODELICA_NONNULLATTR;
   /* Write matrix to file

--- a/Modelica/Resources/C-Sources/ModelicaRandom.c
+++ b/Modelica/Resources/C-Sources/ModelicaRandom.c
@@ -122,7 +122,7 @@ static void ModelicaRandom_deleteCS(void) {
 #define ModelicaRandom_INVM64 5.42101086242752217004e-20 /* = 2^(-64) */
 #define ModelicaRandom_RAND(INT64) ( (int64_t)(INT64) * ModelicaRandom_INVM64 + 0.5 )
 
-void ModelicaRandom_xorshift64star(_In_ int* state_in,
+void ModelicaRandom_xorshift64star(_In_ const int* state_in,
                                    _Out_ int* state_out, _Out_ double* y) {
     /*  xorshift64* random number generator.
         For details see http://xorshift.di.unimi.it/
@@ -172,7 +172,7 @@ void ModelicaRandom_xorshift64star(_In_ int* state_in,
     *y = ModelicaRandom_RAND(x);
 }
 
-void ModelicaRandom_xorshift128plus(_In_ int* state_in,
+void ModelicaRandom_xorshift128plus(_In_ const int* state_in,
                                     _Out_ int* state_out, _Out_ double* y) {
     /*  xorshift128+ random number generator.
         For details see http://xorshift.di.unimi.it
@@ -274,7 +274,7 @@ static void ModelicaRandom_xorshift1024star_internal(uint64_t s[], int* p, doubl
 #endif
 }
 
-void ModelicaRandom_xorshift1024star(_In_ int* state_in,
+void ModelicaRandom_xorshift1024star(_In_ const int* state_in,
                                      _Out_ int* state_out, _Out_ double* y) {
     /*  xorshift1024* random number generator.
         For details see http://xorshift.di.unimi.it
@@ -334,7 +334,7 @@ static uint64_t ModelicaRandom_s[ 16 ];
 static int ModelicaRandom_p;
 static int ModelicaRandom_id = 0;
 
-void ModelicaRandom_setInternalState_xorshift1024star(_In_ int* state,
+void ModelicaRandom_setInternalState_xorshift1024star(_In_ const int* state,
                                                       size_t nState, int id) {
     /* Receive the external states from Modelica */
     union s_tag {

--- a/Modelica/Resources/C-Sources/ModelicaRandom.h
+++ b/Modelica/Resources/C-Sources/ModelicaRandom.h
@@ -69,14 +69,14 @@
 #define _Out_
 #endif
 
-MODELICA_EXPORT void ModelicaRandom_xorshift64star(_In_ int* state_in,
+MODELICA_EXPORT void ModelicaRandom_xorshift64star(_In_ const int* state_in,
     _Out_ int* state_out, _Out_ double* y) MODELICA_NONNULLATTR;
-MODELICA_EXPORT void ModelicaRandom_xorshift128plus(_In_ int* state_in,
+MODELICA_EXPORT void ModelicaRandom_xorshift128plus(_In_ const int* state_in,
     _Out_ int* state_out, _Out_ double* y) MODELICA_NONNULLATTR;
-MODELICA_EXPORT void ModelicaRandom_xorshift1024star(_In_ int* state_in,
+MODELICA_EXPORT void ModelicaRandom_xorshift1024star(_In_ const int* state_in,
     _Out_ int* state_out, _Out_ double* y) MODELICA_NONNULLATTR;
 MODELICA_EXPORT void ModelicaRandom_setInternalState_xorshift1024star(
-    _In_ int* state, size_t nState, int id) MODELICA_NONNULLATTR;
+    _In_ const int* state, size_t nState, int id) MODELICA_NONNULLATTR;
 MODELICA_EXPORT double ModelicaRandom_impureRandom_xorshift1024star(int id);
 MODELICA_EXPORT int ModelicaRandom_automaticGlobalSeed(double dummy);
 MODELICA_EXPORT void ModelicaRandom_convertRealToIntegers(double d,

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -1,6 +1,6 @@
 /* ModelicaStandardTables.c - External table functions
 
-   Copyright (C) 2013-2022, Modelica Association and contributors
+   Copyright (C) 2013-2024, Modelica Association and contributors
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
@@ -653,10 +653,10 @@ void* ModelicaStandardTables_CombiTimeTable_init2(_In_z_ const char* fileName,
 
 void* ModelicaStandardTables_CombiTimeTable_init3(_In_z_ const char* fileName,
                                                   _In_z_ const char* tableName,
-                                                  _In_ double* table, size_t nRow,
+                                                  _In_ const double* table, size_t nRow,
                                                   size_t nColumn,
                                                   double startTime,
-                                                  _In_ int* columns,
+                                                  _In_ const int* columns,
                                                   size_t nCols, int smoothness,
                                                   int extrapolation,
                                                   double shiftTime,
@@ -2114,9 +2114,9 @@ void* ModelicaStandardTables_CombiTable1D_init2(_In_z_ const char* fileName,
 
 void* ModelicaStandardTables_CombiTable1D_init3(_In_z_ const char* fileName,
                                                 _In_z_ const char* tableName,
-                                                _In_ double* table, size_t nRow,
+                                                _In_ const double* table, size_t nRow,
                                                 size_t nColumn,
-                                                _In_ int* columns,
+                                                _In_ const int* columns,
                                                 size_t nCols, int smoothness,
                                                 int extrapolation,
                                                 int verbose,
@@ -2920,7 +2920,7 @@ void* ModelicaStandardTables_CombiTable2D_init2(_In_z_ const char* fileName,
 
 void* ModelicaStandardTables_CombiTable2D_init3(_In_z_ const char* fileName,
                                                 _In_z_ const char* tableName,
-                                                _In_ double* table, size_t nRow,
+                                                _In_ const double* table, size_t nRow,
                                                 size_t nColumn, int smoothness,
                                                 int extrapolation,
                                                 int verbose,

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -624,10 +624,10 @@ static void spline2DClose(CubicHermite2D** spline);
 
 void* ModelicaStandardTables_CombiTimeTable_init(_In_z_ const char* tableName,
                                                  _In_z_ const char* fileName,
-                                                 _In_ double* table, size_t nRow,
+                                                 _In_ const double* table, size_t nRow,
                                                  size_t nColumn,
                                                  double startTime,
-                                                 _In_ int* columns,
+                                                 _In_ const int* columns,
                                                  size_t nCols, int smoothness,
                                                  int extrapolation) {
     return ModelicaStandardTables_CombiTimeTable_init2(fileName,
@@ -637,10 +637,10 @@ void* ModelicaStandardTables_CombiTimeTable_init(_In_z_ const char* tableName,
 
 void* ModelicaStandardTables_CombiTimeTable_init2(_In_z_ const char* fileName,
                                                   _In_z_ const char* tableName,
-                                                  _In_ double* table, size_t nRow,
+                                                  _In_ const double* table, size_t nRow,
                                                   size_t nColumn,
                                                   double startTime,
-                                                  _In_ int* columns,
+                                                  _In_ const int* columns,
                                                   size_t nCols, int smoothness,
                                                   int extrapolation,
                                                   double shiftTime,
@@ -2090,9 +2090,9 @@ double ModelicaStandardTables_CombiTimeTable_read(void* _tableID, int force,
 
 void* ModelicaStandardTables_CombiTable1D_init(_In_z_ const char* tableName,
                                                _In_z_ const char* fileName,
-                                               _In_ double* table, size_t nRow,
+                                               _In_ const double* table, size_t nRow,
                                                size_t nColumn,
-                                               _In_ int* columns,
+                                               _In_ const int* columns,
                                                size_t nCols, int smoothness) {
     return ModelicaStandardTables_CombiTable1D_init2(fileName, tableName,
         table, nRow, nColumn, columns, nCols, smoothness, LAST_TWO_POINTS,
@@ -2101,9 +2101,9 @@ void* ModelicaStandardTables_CombiTable1D_init(_In_z_ const char* tableName,
 
 void* ModelicaStandardTables_CombiTable1D_init2(_In_z_ const char* fileName,
                                                 _In_z_ const char* tableName,
-                                                _In_ double* table, size_t nRow,
+                                                _In_ const double* table, size_t nRow,
                                                 size_t nColumn,
-                                                _In_ int* columns,
+                                                _In_ const int* columns,
                                                 size_t nCols, int smoothness,
                                                 int extrapolation,
                                                 int verbose) {
@@ -2902,7 +2902,7 @@ double ModelicaStandardTables_CombiTable1D_read(void* _tableID, int force,
 
 void* ModelicaStandardTables_CombiTable2D_init(_In_z_ const char* tableName,
                                                _In_z_ const char* fileName,
-                                               _In_ double* table, size_t nRow,
+                                               _In_ const double* table, size_t nRow,
                                                size_t nColumn, int smoothness) {
     return ModelicaStandardTables_CombiTable2D_init2(fileName, tableName,
         table, nRow, nColumn, smoothness, LAST_TWO_POINTS, 1 /* verbose */);
@@ -2910,7 +2910,7 @@ void* ModelicaStandardTables_CombiTable2D_init(_In_z_ const char* tableName,
 
 void* ModelicaStandardTables_CombiTable2D_init2(_In_z_ const char* fileName,
                                                 _In_z_ const char* tableName,
-                                                _In_ double* table, size_t nRow,
+                                                _In_ const double* table, size_t nRow,
                                                 size_t nColumn, int smoothness,
                                                 int extrapolation,
                                                 int verbose) {

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.h
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.h
@@ -1,6 +1,6 @@
 /* ModelicaStandardTables.h - External table functions header
 
-   Copyright (C) 2008-2020, Modelica Association and contributors
+   Copyright (C) 2008-2024, Modelica Association and contributors
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
@@ -159,10 +159,10 @@ MODELICA_EXPORT void* ModelicaStandardTables_CombiTimeTable_init2(_In_z_ const c
 
 MODELICA_EXPORT void* ModelicaStandardTables_CombiTimeTable_init3(_In_z_ const char* fileName,
                                                   _In_z_ const char* tableName,
-                                                  _In_ double* table, size_t nRow,
+                                                  _In_ const double* table, size_t nRow,
                                                   size_t nColumn,
                                                   double startTime,
-                                                  _In_ int* columns,
+                                                  _In_ const int* columns,
                                                   size_t nCols, int smoothness,
                                                   int extrapolation,
                                                   double shiftTime,
@@ -302,9 +302,9 @@ MODELICA_EXPORT void* ModelicaStandardTables_CombiTable1D_init2(_In_z_ const cha
 
 MODELICA_EXPORT void* ModelicaStandardTables_CombiTable1D_init3(_In_z_ const char* fileName,
                                                 _In_z_ const char* tableName,
-                                                _In_ double* table, size_t nRow,
+                                                _In_ const double* table, size_t nRow,
                                                 size_t nColumn,
-                                                _In_ int* columns,
+                                                _In_ const int* columns,
                                                 size_t nCols, int smoothness,
                                                 int extrapolation,
                                                 int verbose,
@@ -406,7 +406,7 @@ MODELICA_EXPORT void* ModelicaStandardTables_CombiTable2D_init2(_In_z_ const cha
 
 MODELICA_EXPORT void* ModelicaStandardTables_CombiTable2D_init3(_In_z_ const char* fileName,
                                                 _In_z_ const char* tableName,
-                                                _In_ double* table, size_t nRow,
+                                                _In_ const double* table, size_t nRow,
                                                 size_t nColumn, int smoothness,
                                                 int extrapolation,
                                                 int verbose,

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.h
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.h
@@ -132,10 +132,10 @@
 
 MODELICA_EXPORT void* ModelicaStandardTables_CombiTimeTable_init(_In_z_ const char* tableName,
                                                  _In_z_ const char* fileName,
-                                                 _In_ double* table, size_t nRow,
+                                                 _In_ const double* table, size_t nRow,
                                                  size_t nColumn,
                                                  double startTime,
-                                                 _In_ int* columns,
+                                                 _In_ const int* columns,
                                                  size_t nCols, int smoothness,
                                                  int extrapolation) MODELICA_NONNULLATTR;
   /* Same as ModelicaStandardTables_CombiTimeTable_init2, but without shiftTime, timeEvents and
@@ -144,10 +144,10 @@ MODELICA_EXPORT void* ModelicaStandardTables_CombiTimeTable_init(_In_z_ const ch
 
 MODELICA_EXPORT void* ModelicaStandardTables_CombiTimeTable_init2(_In_z_ const char* fileName,
                                                   _In_z_ const char* tableName,
-                                                  _In_ double* table, size_t nRow,
+                                                  _In_ const double* table, size_t nRow,
                                                   size_t nColumn,
                                                   double startTime,
-                                                  _In_ int* columns,
+                                                  _In_ const int* columns,
                                                   size_t nCols, int smoothness,
                                                   int extrapolation,
                                                   double shiftTime,
@@ -280,9 +280,9 @@ MODELICA_EXPORT double ModelicaStandardTables_CombiTimeTable_read(void* tableID,
 
 MODELICA_EXPORT void* ModelicaStandardTables_CombiTable1D_init(_In_z_ const char* tableName,
                                                _In_z_ const char* fileName,
-                                               _In_ double* table, size_t nRow,
+                                               _In_ const double* table, size_t nRow,
                                                size_t nColumn,
-                                               _In_ int* columns,
+                                               _In_ const int* columns,
                                                size_t nCols, int smoothness) MODELICA_NONNULLATTR;
   /* Same as ModelicaStandardTables_CombiTable1D_init2, but without extrapolation and
      verbose arguments
@@ -290,9 +290,9 @@ MODELICA_EXPORT void* ModelicaStandardTables_CombiTable1D_init(_In_z_ const char
 
 MODELICA_EXPORT void* ModelicaStandardTables_CombiTable1D_init2(_In_z_ const char* fileName,
                                                 _In_z_ const char* tableName,
-                                                _In_ double* table, size_t nRow,
+                                                _In_ const double* table, size_t nRow,
                                                 size_t nColumn,
-                                                _In_ int* columns,
+                                                _In_ const int* columns,
                                                 size_t nCols, int smoothness,
                                                 int extrapolation,
                                                 int verbose) MODELICA_NONNULLATTR;
@@ -390,13 +390,13 @@ MODELICA_EXPORT double ModelicaStandardTables_CombiTable1D_read(void* tableID, i
 
 MODELICA_EXPORT void* ModelicaStandardTables_CombiTable2D_init(_In_z_ const char* tableName,
                                                _In_z_ const char* fileName,
-                                               _In_ double* table, size_t nRow,
+                                               _In_ const double* table, size_t nRow,
                                                size_t nColumn, int smoothness) MODELICA_NONNULLATTR;
   /* Same as ModelicaStandardTables_CombiTable2D_init2, but without verbose argument */
 
 MODELICA_EXPORT void* ModelicaStandardTables_CombiTable2D_init2(_In_z_ const char* fileName,
                                                 _In_z_ const char* tableName,
-                                                _In_ double* table, size_t nRow,
+                                                _In_ const double* table, size_t nRow,
                                                 size_t nColumn, int smoothness,
                                                 int extrapolation,
                                                 int verbose) MODELICA_NONNULLATTR;

--- a/ModelicaTest/Tables/CombiTable1Ds.mo
+++ b/ModelicaTest/Tables/CombiTable1Ds.mo
@@ -235,7 +235,7 @@ package CombiTable1Ds "Test models for Modelica.Blocks.Tables.CombiTable1Ds"
       external "C" dummy_y = mydummyfunc(dummy_u)
       annotation(IncludeDirectory="modelica://Modelica/Resources/Data/Tables",
              Include = "#include \"usertab.c\"
-double mydummyfunc(double* dummy_in) {
+double mydummyfunc(const double* dummy_in) {
     return 0.;
 }
 ");

--- a/ModelicaTest/Tables/CombiTable1Dv.mo
+++ b/ModelicaTest/Tables/CombiTable1Dv.mo
@@ -235,7 +235,7 @@ package CombiTable1Dv "Test models for Modelica.Blocks.Tables.CombiTable1Dv"
       external "C" dummy_y = mydummyfunc(dummy_u)
       annotation(IncludeDirectory="modelica://Modelica/Resources/Data/Tables",
              Include = "#include \"usertab.c\"
-double mydummyfunc(double* dummy_in) {
+double mydummyfunc(const double* dummy_in) {
     return 0.;
 }
 ");

--- a/ModelicaTest/Tables/CombiTimeTable.mo
+++ b/ModelicaTest/Tables/CombiTimeTable.mo
@@ -752,7 +752,7 @@ package CombiTimeTable "Test models for Modelica.Blocks.Sources.CombiTimeTable"
       external "C" dummy_y = mydummyfunc(dummy_u)
       annotation(IncludeDirectory="modelica://Modelica/Resources/Data/Tables",
              Include = "#include \"usertab.c\"
-double mydummyfunc(double* dummy_in) {
+double mydummyfunc(const double* dummy_in) {
     return 0.;
 }
 ");


### PR DESCRIPTION
Can only be merged once MSL is based on MLS 3.5.

Resolves #3839.