### PR TITLE
Avoid deprecated "builtin" external language for common mathematical functions

### DIFF
--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -11030,7 +11030,7 @@ function sin "Sine"
   output Real y "Dependent variable y=sin(u)";
 algorithm
   y := .sin(u);
-  annotation (
+  annotation (Inline=true,
     Icon(coordinateSystem(
         preserveAspectRatio=true,
         extent={{-100,-100},{100,100}}), graphics={
@@ -11066,7 +11066,7 @@ function cos "Cosine"
   output Real y "Dependent variable y=cos(u)";
 algorithm
   y := .cos(u);
-  annotation (
+  annotation (Inline=true,
     Icon(coordinateSystem(
         preserveAspectRatio=true,
         extent={{-100,-100},{100,100}}), graphics={
@@ -11102,7 +11102,7 @@ function tan "Tangent (u shall not be -pi/2, pi/2, 3*pi/2, ...)"
   output Real y "Dependent variable y=tan(u)";
 algorithm
   y := .tan(u);
-  annotation (
+  annotation (Inline=true,
     Icon(coordinateSystem(
         preserveAspectRatio=true,
         extent={{-100,-100},{100,100}}), graphics={
@@ -11138,7 +11138,7 @@ function asin "Inverse sine (-1 <= u <= 1)"
   output Modelica.Units.SI.Angle y "Dependent variable y=asin(u)";
 algorithm
   y := .asin(u);
-  annotation (
+  annotation (Inline=true,
     Icon(coordinateSystem(
         preserveAspectRatio=true,
         extent={{-100,-100},{100,100}}), graphics={
@@ -11172,7 +11172,7 @@ function acos "Inverse cosine (-1 <= u <= 1)"
   output Modelica.Units.SI.Angle y "Dependent variable y=acos(u)";
 algorithm
   y := .acos(u);
-  annotation (
+  annotation (Inline=true,
     Icon(coordinateSystem(
         preserveAspectRatio=true,
         extent={{-100,-100},{100,100}}), graphics={
@@ -11206,7 +11206,7 @@ function atan "Inverse tangent"
   output Modelica.Units.SI.Angle y "Dependent variable y=atan(u)";
 algorithm
   y := .atan(u);
-  annotation (
+  annotation (Inline=true,
     Icon(coordinateSystem(
         preserveAspectRatio=true,
         extent={{-100,-100},{100,100}}), graphics={
@@ -11242,7 +11242,7 @@ function atan2 "Four quadrant inverse tangent"
   output Modelica.Units.SI.Angle y "Dependent variable y=atan2(u1, u2)=atan(u1/u2)";
 algorithm
   y := .atan2(u1, u2);
-  annotation (
+  annotation (Inline=true,
     Icon(coordinateSystem(
         preserveAspectRatio=true,
         extent={{-100,-100},{100,100}}), graphics={
@@ -11352,7 +11352,7 @@ function sinh "Hyperbolic sine"
   output Real y "Dependent variable y=sinh(u)";
 algorithm
   y := .sinh(u);
-  annotation (
+  annotation (Inline=true,
     Icon(coordinateSystem(
         preserveAspectRatio=true,
         extent={{-100,-100},{100,100}}), graphics={
@@ -11387,7 +11387,7 @@ function cosh "Hyperbolic cosine"
   output Real y "Dependent variable y=cosh(u)";
 algorithm
   y := .cosh(u);
-  annotation (
+  annotation (Inline=true,
     Icon(coordinateSystem(
         preserveAspectRatio=true,
         extent={{-100,-100},{100,100}}), graphics={
@@ -11424,7 +11424,7 @@ function tanh "Hyperbolic tangent"
   output Real y "Dependent variable y=tanh(u)";
 algorithm
   y := .tanh(u);
-  annotation (
+  annotation (Inline=true,
     Icon(coordinateSystem(
         preserveAspectRatio=true,
         extent={{-100,-100},{100,100}}), graphics={
@@ -11546,7 +11546,7 @@ function exp "Exponential, base e"
   output Real y "Dependent variable y=exp(u)";
 algorithm
   y := .exp(u);
-  annotation (
+  annotation (Inline=true,
     Icon(coordinateSystem(
         preserveAspectRatio=true,
         extent={{-100,-100},{100,100}}), graphics={
@@ -11580,7 +11580,7 @@ function log "Natural (base e) logarithm (u shall be > 0)"
   output Real y "Dependent variable y=ln(u)";
 algorithm
   y := .log(u);
-  annotation (
+  annotation (Inline=true,
     Icon(coordinateSystem(
         preserveAspectRatio=true,
         extent={{-100,-100},{100,100}}), graphics={
@@ -11615,7 +11615,7 @@ function log10 "Base 10 logarithm (u shall be > 0)"
   output Real y "Dependent variable y=lg(u)";
 algorithm
   y := .log10(u);
-  annotation (
+  annotation (Inline=true,
     Icon(coordinateSystem(
         preserveAspectRatio=true,
         extent={{-100,-100},{100,100}}), graphics={

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -11028,8 +11028,8 @@ function sin "Sine"
   extends Modelica.Math.Icons.AxisLeft;
   input Modelica.Units.SI.Angle u "Independent variable";
   output Real y "Dependent variable y=sin(u)";
-
-external "C" y = sin(u) annotation (Include="#include <math.h>");
+algorithm
+  y := .sin(u);
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11064,8 +11064,8 @@ function cos "Cosine"
   extends Modelica.Math.Icons.AxisLeft;
   input Modelica.Units.SI.Angle u "Independent variable";
   output Real y "Dependent variable y=cos(u)";
-
-external "C" y = cos(u) annotation (Include="#include <math.h>");
+algorithm
+  y := .cos(u);
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11100,8 +11100,8 @@ function tan "Tangent (u shall not be -pi/2, pi/2, 3*pi/2, ...)"
   extends Modelica.Math.Icons.AxisCenter;
   input Modelica.Units.SI.Angle u "Independent variable";
   output Real y "Dependent variable y=tan(u)";
-
-external "C" y = tan(u) annotation (Include="#include <math.h>");
+algorithm
+  y := .tan(u);
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11136,8 +11136,8 @@ function asin "Inverse sine (-1 <= u <= 1)"
   extends Modelica.Math.Icons.AxisCenter;
   input Real u "Independent variable";
   output Modelica.Units.SI.Angle y "Dependent variable y=asin(u)";
-
-external "C" y = asin(u) annotation (Include="#include <math.h>");
+algorithm
+  y := .asin(u);
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11170,8 +11170,8 @@ function acos "Inverse cosine (-1 <= u <= 1)"
   extends Modelica.Math.Icons.AxisCenter;
   input Real u "Independent variable";
   output Modelica.Units.SI.Angle y "Dependent variable y=acos(u)";
-
-external "C" y = acos(u) annotation (Include="#include <math.h>");
+algorithm
+  y := .acos(u);
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11204,8 +11204,8 @@ function atan "Inverse tangent"
   extends Modelica.Math.Icons.AxisCenter;
   input Real u "Independent variable";
   output Modelica.Units.SI.Angle y "Dependent variable y=atan(u)";
-
-external "C" y = atan(u) annotation (Include="#include <math.h>");
+algorithm
+  y := .atan(u);
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11240,8 +11240,8 @@ function atan2 "Four quadrant inverse tangent"
   input Real u1 "First independent variable";
   input Real u2 "Second independent variable";
   output Modelica.Units.SI.Angle y "Dependent variable y=atan2(u1, u2)=atan(u1/u2)";
-
-external "C" y = atan2(u1, u2) annotation (Include="#include <math.h>");
+algorithm
+  y := .atan2(u1, u2);
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11350,8 +11350,8 @@ function sinh "Hyperbolic sine"
   extends Modelica.Math.Icons.AxisCenter;
   input Real u "Independent variable";
   output Real y "Dependent variable y=sinh(u)";
-
-external "C" y = sinh(u) annotation (Include="#include <math.h>");
+algorithm
+  y := .sinh(u);
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11385,8 +11385,8 @@ function cosh "Hyperbolic cosine"
   extends Modelica.Math.Icons.AxisCenter;
   input Real u "Independent variable";
   output Real y "Dependent variable y=cosh(u)";
-
-external "C" y = cosh(u) annotation (Include="#include <math.h>");
+algorithm
+  y := .cosh(u);
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11422,8 +11422,8 @@ function tanh "Hyperbolic tangent"
   extends Modelica.Math.Icons.AxisCenter;
   input Real u "Independent variable";
   output Real y "Dependent variable y=tanh(u)";
-
-external "C" y = tanh(u) annotation (Include="#include <math.h>");
+algorithm
+  y := .tanh(u);
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11544,8 +11544,8 @@ function exp "Exponential, base e"
   extends Modelica.Math.Icons.AxisCenter;
   input Real u "Independent variable";
   output Real y "Dependent variable y=exp(u)";
-
-external "C" y = exp(u) annotation (Include="#include <math.h>");
+algorithm
+  y := .exp(u);
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11578,8 +11578,8 @@ function log "Natural (base e) logarithm (u shall be > 0)"
   extends Modelica.Math.Icons.AxisLeft;
   input Real u "Independent variable";
   output Real y "Dependent variable y=ln(u)";
-
-external "C" y = log(u) annotation (Include="#include <math.h>");
+algorithm
+  y := .log(u);
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11613,8 +11613,8 @@ function log10 "Base 10 logarithm (u shall be > 0)"
   extends Modelica.Math.Icons.AxisLeft;
   input Real u "Independent variable";
   output Real y "Dependent variable y=lg(u)";
-
-external "C" y = log10(u) annotation (Include="#include <math.h>");
+algorithm
+  y := .log10(u);
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -11029,7 +11029,7 @@ function sin "Sine"
   input Modelica.Units.SI.Angle u "Independent variable";
   output Real y "Dependent variable y=sin(u)";
 
-external "builtin" y = sin(u);
+external "C" y = sin(u) annotation (Include="#include <math.h>");
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11065,7 +11065,7 @@ function cos "Cosine"
   input Modelica.Units.SI.Angle u "Independent variable";
   output Real y "Dependent variable y=cos(u)";
 
-external "builtin" y = cos(u);
+external "C" y = cos(u) annotation (Include="#include <math.h>");
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11101,7 +11101,7 @@ function tan "Tangent (u shall not be -pi/2, pi/2, 3*pi/2, ...)"
   input Modelica.Units.SI.Angle u "Independent variable";
   output Real y "Dependent variable y=tan(u)";
 
-external "builtin" y = tan(u);
+external "C" y = tan(u) annotation (Include="#include <math.h>");
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11137,7 +11137,7 @@ function asin "Inverse sine (-1 <= u <= 1)"
   input Real u "Independent variable";
   output Modelica.Units.SI.Angle y "Dependent variable y=asin(u)";
 
-external "builtin" y = asin(u);
+external "C" y = asin(u) annotation (Include="#include <math.h>");
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11171,7 +11171,7 @@ function acos "Inverse cosine (-1 <= u <= 1)"
   input Real u "Independent variable";
   output Modelica.Units.SI.Angle y "Dependent variable y=acos(u)";
 
-external "builtin" y = acos(u);
+external "C" y = acos(u) annotation (Include="#include <math.h>");
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11205,7 +11205,7 @@ function atan "Inverse tangent"
   input Real u "Independent variable";
   output Modelica.Units.SI.Angle y "Dependent variable y=atan(u)";
 
-external "builtin" y = atan(u);
+external "C" y = atan(u) annotation (Include="#include <math.h>");
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11241,7 +11241,7 @@ function atan2 "Four quadrant inverse tangent"
   input Real u2 "Second independent variable";
   output Modelica.Units.SI.Angle y "Dependent variable y=atan2(u1, u2)=atan(u1/u2)";
 
-external "builtin" y = atan2(u1, u2);
+external "C" y = atan2(u1, u2) annotation (Include="#include <math.h>");
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11351,7 +11351,7 @@ function sinh "Hyperbolic sine"
   input Real u "Independent variable";
   output Real y "Dependent variable y=sinh(u)";
 
-external "builtin" y = sinh(u);
+external "C" y = sinh(u) annotation (Include="#include <math.h>");
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11386,7 +11386,7 @@ function cosh "Hyperbolic cosine"
   input Real u "Independent variable";
   output Real y "Dependent variable y=cosh(u)";
 
-external "builtin" y = cosh(u);
+external "C" y = cosh(u) annotation (Include="#include <math.h>");
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11423,7 +11423,7 @@ function tanh "Hyperbolic tangent"
   input Real u "Independent variable";
   output Real y "Dependent variable y=tanh(u)";
 
-external "builtin" y = tanh(u);
+external "C" y = tanh(u) annotation (Include="#include <math.h>");
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11545,7 +11545,7 @@ function exp "Exponential, base e"
   input Real u "Independent variable";
   output Real y "Dependent variable y=exp(u)";
 
-external "builtin" y = exp(u);
+external "C" y = exp(u) annotation (Include="#include <math.h>");
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11579,7 +11579,7 @@ function log "Natural (base e) logarithm (u shall be > 0)"
   input Real u "Independent variable";
   output Real y "Dependent variable y=ln(u)";
 
-external "builtin" y = log(u);
+external "C" y = log(u) annotation (Include="#include <math.h>");
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,
@@ -11614,7 +11614,7 @@ function log10 "Base 10 logarithm (u shall be > 0)"
   input Real u "Independent variable";
   output Real y "Dependent variable y=lg(u)";
 
-external "builtin" y = log10(u);
+external "C" y = log10(u) annotation (Include="#include <math.h>");
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=true,


### PR DESCRIPTION
Modelica Language Specification 3.5 deprecates the usage of the "builtin" external language.