### PR TITLE
Improve icons of joint assemblies RRR and RRP

### DIFF
--- a/Modelica/Mechanics/MultiBody/Joints/Assemblies/JointRRP.mo
+++ b/Modelica/Mechanics/MultiBody/Joints/Assemblies/JointRRP.mo
@@ -323,9 +323,11 @@ and 1 prismatic joint are connected by rigid rods.
           extent={{-50,112},{-11,90}},
           textColor={128,128,128},
           textString="im"),
-        Text(extent={{-130,-29},{130,-47}}, textString="n_a=%n_a"),
         Text(
-          extent={{-140,-55},{140,-80}},
+          extent={{-75,-27},{75,-47}},
+          textString="n_a=%n_a"),
+        Text(
+          extent={{-75,-50},{75,-70}},
           textColor={0,0,255},
           textString="%name")}));
 end JointRRP;

--- a/Modelica/Mechanics/MultiBody/Joints/Assemblies/JointRRP.mo
+++ b/Modelica/Mechanics/MultiBody/Joints/Assemblies/JointRRP.mo
@@ -244,64 +244,21 @@ and 1 prismatic joint are connected by rigid rods.
         preserveAspectRatio=true,
         extent={{-100,-100},{100,100}},
         initialScale=0.2), graphics={
-        Rectangle(
-          extent={{-90,90},{90,-90}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Text(
-          extent={{-140,-55},{140,-80}},
-          textColor={0,0,255},
-          textString="%name"),
-        Text(
-          extent={{26,124},{68,93}},
-          textColor={128,128,128},
-          textString="ib"),
-        Text(
-          extent={{-134,128},{-94,94}},
-          textColor={128,128,128},
-          textString="ia"),
-        Ellipse(
-          extent={{-100,25},{-50,-25}},
-          fillColor={192,192,192},
-          fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{-85,10},{-65,-10}},
-          fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{-26,80},{24,30}},
-          fillColor={192,192,192},
-          fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{-10,66},{10,46}},
-          fillPattern=FillPattern.Solid),
-        Polygon(
-          points={{-71,9},{-24,45},{-19,39},{-66,3},{-71,9}},
-          fillPattern=FillPattern.Solid),
-        Polygon(
-          points={{54,5},{5,47},{8,53},{58,11},{54,5}},
-          fillPattern=FillPattern.Solid),
-        Text(
-          extent={{-130,-30},{130,-50}},
-          textString="n_a=%n_a"),
         Line(
-          points={{0,57},{0,86},{0,86},{0,100}},
+          points={{0,74},{0,100}},
           color={95,95,95},
           thickness=0.5),
-        Text(
-          extent={{-55,126},{-15,92}},
-          textColor={128,128,128},
-          textString="im"),
-        Line(
-          points={{-80,100},{-80,8}},
-          color={95,95,95},
-          thickness=0.5),
+        Polygon(
+          points={{0,50},{54,-14},{54,6},{0,70},{0,50}},
+          fillPattern=FillPattern.Solid,
+          lineColor={95,95,95},
+          fillColor={192,192,192}),
         Line(
           points={{80,80},{101,80}},
           color={95,95,95},
           thickness=0.5),
         Line(
-          points={{100,40},{93,40},{93,3}},
+          points={{100,40},{90,40},{90,0}},
           color={95,95,95},
           thickness=0.5),
         Rectangle(
@@ -325,5 +282,50 @@ and 1 prismatic joint are connected by rigid rods.
         Line(
           points={{80,100},{80,80},{57,11}},
           color={95,95,95},
-          thickness=0.5)}));
+          thickness=0.5),
+        Ellipse(
+          extent={{-100,20},{-60,-20}},
+          fillColor={192,192,192},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-20,80},{20,40}},
+          fillColor={192,192,192},
+          fillPattern=FillPattern.Solid,
+          lineColor={95,95,95}),
+        Polygon(
+          points={{-82,2},{-2,62},{2,58},{-78,-2},{-82,2}},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0},
+          fillColor={0,0,0}),
+        Ellipse(
+          extent={{-90,10},{-70,-10}},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0},
+          fillColor={0,0,0}),
+        Ellipse(
+          extent={{-10,70},{10,50}},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0},
+          fillColor={0,0,0}),
+        Line(
+          points={{-80,100},{-80,0}},
+          color={95,95,95},
+          thickness=0.5),
+        Text(
+          extent={{34,112},{69,90}},
+          textColor={128,128,128},
+          textString="ib"),
+        Text(
+          extent={{-130,112},{-91,90}},
+          textColor={128,128,128},
+          textString="ia"),
+        Text(
+          extent={{-50,112},{-11,90}},
+          textColor={128,128,128},
+          textString="im"),
+        Text(extent={{-130,-29},{130,-47}}, textString="n_a=%n_a"),
+        Text(
+          extent={{-140,-55},{140,-80}},
+          textColor={0,0,255},
+          textString="%name")}));
 end JointRRP;

--- a/Modelica/Mechanics/MultiBody/Joints/Assemblies/JointRRP.mo
+++ b/Modelica/Mechanics/MultiBody/Joints/Assemblies/JointRRP.mo
@@ -251,7 +251,7 @@ and 1 prismatic joint are connected by rigid rods.
         Polygon(
           points={{0,50},{54,-14},{54,6},{0,70},{0,50}},
           fillPattern=FillPattern.Solid,
-          lineColor={95,95,95},
+          lineColor={0,0,0},
           fillColor={192,192,192}),
         Line(
           points={{80,80},{101,80}},
@@ -291,7 +291,7 @@ and 1 prismatic joint are connected by rigid rods.
           extent={{-20,80},{20,40}},
           fillColor={192,192,192},
           fillPattern=FillPattern.Solid,
-          lineColor={95,95,95}),
+          lineColor={0,0,0}),
         Polygon(
           points={{-82,2},{-2,62},{2,58},{-78,-2},{-82,2}},
           fillPattern=FillPattern.Solid,

--- a/Modelica/Mechanics/MultiBody/Joints/Assemblies/JointRRR.mo
+++ b/Modelica/Mechanics/MultiBody/Joints/Assemblies/JointRRR.mo
@@ -232,78 +232,81 @@ are connected by rigid rods.
         preserveAspectRatio=true,
         extent={{-100,-100},{100,100}},
         initialScale=0.2), graphics={
-        Rectangle(
-          extent={{-90,90},{90,-90}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Text(
-          extent={{-140,-55},{140,-80}},
-          textColor={0,0,255},
-          textString="%name"),
-        Text(
-          extent={{36,114},{71,92}},
-          textColor={128,128,128},
-          textString="ib"),
-        Text(
-          extent={{-126,115},{-87,90}},
-          textColor={128,128,128},
-          textString="ia"),
         Ellipse(
-          extent={{-100,25},{-50,-25}},
+          extent={{-100,20},{-60,-20}},
           fillColor={192,192,192},
           fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{-85,10},{-65,-10}},
-          fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{50,25},{100,-25}},
-          fillColor={192,192,192},
-          fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{65,10},{85,-10}},
-          fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{-26,80},{24,30}},
-          fillColor={192,192,192},
-          fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{-10,66},{10,46}},
-          fillPattern=FillPattern.Solid),
         Polygon(
-          points={{-71,9},{-24,45},{-19,39},{-66,3},{-71,9}},
-          fillPattern=FillPattern.Solid),
-        Polygon(
-          points={{54,12},{5,47},{10,52},{59,18},{54,12}},
-          fillPattern=FillPattern.Solid),
-        Polygon(
-          points={{100,-4},{83,-4},{84,3},{100,3},{100,-4}},
-          fillPattern=FillPattern.Solid),
+          points={{-4,56},{72,-4},{80,4},{4,64},{-4,56}},
+          fillPattern=FillPattern.Solid,
+          lineColor={95,95,95},
+          fillColor={192,192,192}),
         Line(
-          points={{80,24},{80,80},{80,80},{80,100}},
+          points={{0,74},{0,100}},
           color={95,95,95},
           thickness=0.5),
-        Text(
-          extent={{-130,-30},{130,-50}},
-          textString="n_a=%n_a"),
+        Ellipse(
+          extent={{-20,80},{20,40}},
+          fillColor={192,192,192},
+          fillPattern=FillPattern.Solid,
+          lineColor={95,95,95}),
+        Polygon(
+          points={{-82,2},{-2,62},{2,58},{-78,-2},{-82,2}},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0},
+          fillColor={0,0,0}),
+        Ellipse(
+          extent={{-90,10},{-70,-10}},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0},
+          fillColor={0,0,0}),
+        Ellipse(
+          extent={{-10,70},{10,50}},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0},
+          fillColor={0,0,0}),
         Line(
-          points={{0,57},{0,86},{0,86},{0,100}},
+          points={{80,14},{80,80},{80,80},{80,100}},
           color={95,95,95},
           thickness=0.5),
-        Text(
-          extent={{-46,114},{-7,91}},
-          textColor={128,128,128},
-          textString="im"),
         Line(
-          points={{-80,100},{-80,8}},
+          points={{-80,100},{-80,0}},
           color={95,95,95},
           thickness=0.5),
         Line(
           points={{80,80},{101,80}},
           color={95,95,95},
           thickness=0.5),
+        Ellipse(
+          extent={{54,20},{94,-20}},
+          fillColor={192,192,192},
+          fillPattern=FillPattern.Solid,
+          lineColor={95,95,95}),
         Line(
-          points={{100,40},{93,40},{93,3}},
+          points={{100,40},{90,40},{90,0}},
           color={95,95,95},
-          thickness=0.5)}));
+          thickness=0.5),
+        Ellipse(
+          extent={{64,10},{84,-10}},
+          fillPattern=FillPattern.Solid),
+        Polygon(
+          points={{100,-4},{72,-4},{72,4},{100,4},{100,-4}},
+          fillPattern=FillPattern.Solid),
+        Text(
+          extent={{34,112},{69,90}},
+          textColor={128,128,128},
+          textString="ib"),
+        Text(
+          extent={{-130,112},{-91,90}},
+          textColor={128,128,128},
+          textString="ia"),
+        Text(
+          extent={{-50,112},{-11,90}},
+          textColor={128,128,128},
+          textString="im"),
+        Text(extent={{-130,-29},{130,-47}}, textString="n_a=%n_a"),
+        Text(
+          extent={{-140,-55},{140,-80}},
+          textColor={0,0,255},
+          textString="%name")}));
 end JointRRR;

--- a/Modelica/Mechanics/MultiBody/Joints/Assemblies/JointRRR.mo
+++ b/Modelica/Mechanics/MultiBody/Joints/Assemblies/JointRRR.mo
@@ -304,9 +304,11 @@ are connected by rigid rods.
           extent={{-50,112},{-11,90}},
           textColor={128,128,128},
           textString="im"),
-        Text(extent={{-130,-29},{130,-47}}, textString="n_a=%n_a"),
         Text(
-          extent={{-140,-55},{140,-80}},
+          extent={{-75,-27},{75,-47}},
+          textString="n_a=%n_a"),
+        Text(
+          extent={{-75,-50},{75,-70}},
           textColor={0,0,255},
           textString="%name")}));
 end JointRRR;

--- a/Modelica/Mechanics/MultiBody/Joints/Assemblies/JointRRR.mo
+++ b/Modelica/Mechanics/MultiBody/Joints/Assemblies/JointRRR.mo
@@ -235,11 +235,21 @@ are connected by rigid rods.
         Ellipse(
           extent={{-100,20},{-60,-20}},
           fillColor={192,192,192},
-          fillPattern=FillPattern.Solid),
-        Polygon(
-          points={{-4,56},{72,-4},{80,4},{4,64},{-4,56}},
           fillPattern=FillPattern.Solid,
-          lineColor={95,95,95},
+          lineColor={0,0,0}),
+        Line(
+          points={{100,40},{90,40},{90,0}},
+          color={95,95,95},
+          thickness=0.5),
+        Ellipse(
+          extent={{60,20},{100,-20}},
+          fillColor={128,128,128},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Polygon(
+          points={{-2,56},{78,-4},{82,4},{2,64},{-2,56}},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0},
           fillColor={192,192,192}),
         Line(
           points={{0,74},{0,100}},
@@ -249,7 +259,7 @@ are connected by rigid rods.
           extent={{-20,80},{20,40}},
           fillColor={192,192,192},
           fillPattern=FillPattern.Solid,
-          lineColor={95,95,95}),
+          lineColor={0,0,0}),
         Polygon(
           points={{-82,2},{-2,62},{2,58},{-78,-2},{-82,2}},
           fillPattern=FillPattern.Solid,
@@ -266,10 +276,6 @@ are connected by rigid rods.
           lineColor={0,0,0},
           fillColor={0,0,0}),
         Line(
-          points={{80,14},{80,80},{80,80},{80,100}},
-          color={95,95,95},
-          thickness=0.5),
-        Line(
           points={{-80,100},{-80,0}},
           color={95,95,95},
           thickness=0.5),
@@ -278,20 +284,14 @@ are connected by rigid rods.
           color={95,95,95},
           thickness=0.5),
         Ellipse(
-          extent={{54,20},{94,-20}},
-          fillColor={192,192,192},
+          extent={{70,10},{90,-10}},
           fillPattern=FillPattern.Solid,
-          lineColor={95,95,95}),
+          lineColor={0,0,0},
+          fillColor={192,192,192}),
         Line(
-          points={{100,40},{90,40},{90,0}},
+          points={{80,0},{80,80},{80,80},{80,100}},
           color={95,95,95},
           thickness=0.5),
-        Ellipse(
-          extent={{64,10},{84,-10}},
-          fillPattern=FillPattern.Solid),
-        Polygon(
-          points={{100,-4},{72,-4},{72,4},{100,4},{100,-4}},
-          fillPattern=FillPattern.Solid),
         Text(
           extent={{34,112},{69,90}},
           textColor={128,128,128},


### PR DESCRIPTION
Icons redesign in order to better reflect assembly's functionality - objects representing one body have the same attributes (color). Deleted white background as well.

![grafik](https://user-images.githubusercontent.com/9588978/104564679-80e59e80-564b-11eb-92c8-3e147df5b1dc.png)

![grafik](https://user-images.githubusercontent.com/9588978/104565330-6cee6c80-564c-11eb-80fb-b881c8850010.png)
