### PR TITLE
Fix Modelica.Utilities.Strings.hashString to always use provided HASH_AP

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaStrings.c
+++ b/Modelica/Resources/C-Sources/ModelicaStrings.c
@@ -93,9 +93,6 @@
 #include "ModelicaUtilities.h"
 #include "stdint_wrap.h"
 #define HASH_NO_STDINT 1
-#if !defined(HASH_FUNCTION)
-#define HASH_FUNCTION HASH_AP
-#endif
 #include "uthash.h"
 #undef uthash_fatal /* Ensure that nowhere in this file uses uthash_fatal by accident */
 
@@ -547,6 +544,9 @@ do { \
     } \
 } while (0)
 
+#undef HASH_FUNCTION
+#define HASH_FUNCTION HASH_AP
+
 int ModelicaStrings_hashString(_In_z_ const char* str) {
     /* Compute an unsigned int hash code from a character string */
     size_t len = strlen(str);
@@ -559,6 +559,9 @@ int ModelicaStrings_hashString(_In_z_ const char* str) {
 
     return h.is;
 }
+
+#undef HASH_FUNCTION
+#define HASH_FUNCTION HASH_JEN
 
 #if defined(__clang__)
 #pragma clang diagnostic pop

--- a/Modelica/Resources/C-Sources/uthash.h
+++ b/Modelica/Resources/C-Sources/uthash.h
@@ -85,15 +85,12 @@ do {                                                                            
 #define uthash_strlen(s) strlen(s)
 #endif
 
-#ifdef uthash_memcmp
-/* This warning will not catch programs that define uthash_memcmp AFTER including uthash.h. */
-#warning "uthash_memcmp is deprecated; please use HASH_KEYCMP instead"
-#else
-#define uthash_memcmp(a,b,n) memcmp(a,b,n)
+#ifndef HASH_FUNCTION
+#define HASH_FUNCTION(keyptr,keylen,hashv) HASH_JEN(keyptr, keylen, hashv)
 #endif
 
 #ifndef HASH_KEYCMP
-#define HASH_KEYCMP(a,b,n) uthash_memcmp(a,b,n)
+#define HASH_KEYCMP(a,b,n) memcmp(a,b,n)
 #endif
 
 #ifndef uthash_noexpand_fyi
@@ -151,7 +148,7 @@ do {                                                                            
 
 #define HASH_VALUE(keyptr,keylen,hashv)                                          \
 do {                                                                             \
-  HASH_FCN(keyptr, keylen, hashv);                                               \
+  HASH_FUNCTION(keyptr, keylen, hashv);                                          \
 } while (0)
 
 #define HASH_FIND_BYHASHVALUE(hh,head,keyptr,keylen,hashval,out)                 \
@@ -581,13 +578,6 @@ do {                                                                            
 } while (0)
 #else
 #define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)
-#endif
-
-/* default to Jenkin's hash unless overridden e.g. DHASH_FUNCTION=HASH_SAX */
-#ifdef HASH_FUNCTION
-#define HASH_FCN HASH_FUNCTION
-#else
-#define HASH_FCN HASH_JEN
 #endif
 
 /* The Bernstein hash function, used in Perl prior to v5.6. Note (x<<5+x)=x*33. */

--- a/Modelica/Resources/C-Sources/uthash.h
+++ b/Modelica/Resources/C-Sources/uthash.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2003-2020, Troy D. Hanson     http://troydhanson.github.com/uthash/
+Copyright (c) 2003-2021, Troy D. Hanson     http://troydhanson.github.com/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,7 +24,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UTHASH_H
 #define UTHASH_H
 
-#define UTHASH_VERSION 2.2.0
+#define UTHASH_VERSION 2.3.0
 
 #include <string.h>   /* memcmp, memset, strlen */
 #include <stddef.h>   /* ptrdiff_t */
@@ -678,7 +678,8 @@ do {                                                                            
     case 4:  _hj_i += ( (unsigned)_hj_key[3] << 24 );  /* FALLTHROUGH */         \
     case 3:  _hj_i += ( (unsigned)_hj_key[2] << 16 );  /* FALLTHROUGH */         \
     case 2:  _hj_i += ( (unsigned)_hj_key[1] << 8 );   /* FALLTHROUGH */         \
-    case 1:  _hj_i += _hj_key[0];                                                \
+    case 1:  _hj_i += _hj_key[0];                      /* FALLTHROUGH */         \
+    default: ;                                                                   \
   }                                                                              \
   HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                             \
 } while (0)
@@ -726,6 +727,8 @@ do {                                                                            
     case 1: hashv += *_sfh_key;                                                  \
             hashv ^= hashv << 10;                                                \
             hashv += hashv >> 1;                                                 \
+            break;                                                               \
+    default: ;                                                                   \
   }                                                                              \
                                                                                  \
   /* Force "avalanching" of final 127 bits */                                    \

--- a/ModelicaTest/Utilities.mo
+++ b/ModelicaTest/Utilities.mo
@@ -207,11 +207,10 @@ extends Modelica.Icons.ExamplesPackage;
 
     Strings.scanNoToken("  abc = 3;   ", 11);
 
-    // The hash-function can now be redefined, so we don't know what it is.
     hash1 := Strings.hashString("this is a test");
-    assert(hash1 == Strings.hashString("this is a test"), "Strings.hashString 1 failed");
+    assert(hash1 == 1827717433, "Strings.hashString 1 failed");
     hash2 := Strings.hashString("Controller.noise1");
-    assert(hash2 == Strings.hashString("Controller.noise1"), "Strings.hashString 2 failed");
+    assert(hash2 == -1025762750, "Strings.hashString 2 failed");
     // Check that hashString actually produces different values
     assert(hash1 <> Strings.hashString("this is a tes1"), "Strings.hashString 1 failed");
     assert(hash1 <> Strings.hashString("this is a tes2"), "Strings.hashString 1 failed");


### PR DESCRIPTION
This closes #3727 by making ModelicaStrings.c independent of the inclusion order. It also reverts #3442 by reintroducing the test for exact values.

This PR uses a non-released version of uthash. I will update to uthash v2.3.0 whenever it is available.

@Quuxplusone FYI