### PR TITLE
Use ellipses instead of arcs by lines in Mechanics.MultiBody.Forces

### DIFF
--- a/Modelica/Mechanics/MultiBody/Forces/Force.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/Force.mo
@@ -82,13 +82,8 @@ equation
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=true,  extent={{-100,-100},{100,
             100}}), graphics={
-        Rectangle(
-          extent={{-98,99},{99,-98}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
         Text(
-          extent={{-92,61},{87,35}},
+          extent={{-80,70},{100,40}},
           textColor={192,192,192},
           textString="resolve"),
         Text(

--- a/Modelica/Mechanics/MultiBody/Forces/ForceAndTorque.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/ForceAndTorque.mo
@@ -129,17 +129,26 @@ equation
           lineColor={255,255,255},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-100,-130},{100,70}},
+          lineColor={0,0,0},
+          startAngle=100,
+          endAngle=140,
+          closure=EllipseClosure.None),
+        Ellipse(
+          extent={{-100,-130},{100,70}},
+          lineColor={0,0,0},
+          startAngle=40,
+          endAngle=80,
+          closure=EllipseClosure.None),
         Text(
-          extent={{-59,55},{72,30}},
+          extent={{-80,100},{100,70}},
           textColor={192,192,192},
           textString="resolve"),
         Text(
           extent={{-150,-55},{150,-95}},
           textString="%name",
           textColor={0,0,255}),
-        Polygon(
-          points={{100,21},{84,55},{69,39},{100,21}},
-          fillPattern=FillPattern.Solid),
         Line(
           points={{80,100},{80,0}},
           color={95,95,95},
@@ -148,7 +157,10 @@ equation
           points={{-95,1},{-64,11},{-64,-10},{-95,1}},
           fillPattern=FillPattern.Solid),
         Polygon(
-          points={{-100,20},{-86,53},{-70,42},{-100,20}},
+          points={{-92,10},{-82,46},{-60,32},{-92,10}},
+          fillPattern=FillPattern.Solid),
+        Polygon(
+          points={{92,10},{82,46},{60,32},{92,10}},
           fillPattern=FillPattern.Solid),
         Line(
           points={{-80,100},{80,100}},
@@ -159,8 +171,6 @@ equation
           fillPattern=FillPattern.Solid),
         Line(points={{-64,0},{-20,0}}),
         Line(points={{20,0},{65,0}}),
-        Line(points={{-79,47},{-70,61},{-59,72},{-45,81},{-32,84},{-20,85}}),
-        Line(points={{76,47},{66,60},{55,69},{49,74},{41,80},{31,84},{20,85}}),
         Text(
           extent={{-144,124},{-106,102}},
           textString="f"),

--- a/Modelica/Mechanics/MultiBody/Forces/ForceAndTorque.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/ForceAndTorque.mo
@@ -124,11 +124,6 @@ equation
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,
             100}}), graphics={
-        Rectangle(
-          extent={{-98,99},{99,-98}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
         Ellipse(
           extent={{-100,-130},{100,70}},
           lineColor={0,0,0},

--- a/Modelica/Mechanics/MultiBody/Forces/Internal/BasicForce.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/Internal/BasicForce.mo
@@ -55,17 +55,12 @@ equation
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=true,  extent={{-100,-100},{
             100,100}}), graphics={
-        Rectangle(
-          extent={{-98,99},{99,-98}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
         Text(
-          extent={{-92,61},{87,35}},
+          extent={{-80,70},{100,40}},
           textColor={192,192,192},
           textString="resolve"),
         Text(
-          extent={{-136,-52},{149,-113}},
+          extent={{-150,-55},{150,-95}},
           textString="%name",
           textColor={0,0,255}),
         Line(

--- a/Modelica/Mechanics/MultiBody/Forces/Internal/BasicTorque.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/Internal/BasicTorque.mo
@@ -62,8 +62,14 @@ equation
           lineColor={255,255,255},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-100,-140},{100,60}},
+          lineColor={0,0,0},
+          startAngle=100,
+          endAngle=140,
+          closure=EllipseClosure.None),
         Text(
-          extent={{-59,55},{72,30}},
+          extent={{-80,90},{100,60}},
           textColor={192,192,192},
           textString="resolve"),
         Text(
@@ -71,21 +77,25 @@ equation
           textString="%name",
           textColor={0,0,255}),
         Polygon(
-          points={{100,20},{84,52},{69,39},{100,20}},
+          points={{92,0},{82,36},{60,22},{92,0}},
           fillPattern=FillPattern.Solid),
         Line(
-          points={{40,100},{76,46}},
+          points={{40,100},{80,20}},
           color={95,95,95},
           pattern=LinePattern.Dot),
         Polygon(
-          points={{-99,20},{-86,53},{-70,42},{-99,20}},
+          points={{-92,0},{-82,36},{-60,22},{-92,0}},
           fillPattern=FillPattern.Solid),
         Line(
           points={{-60,100},{40,100}},
           color={95,95,95},
           pattern=LinePattern.Dot),
-        Line(points={{-79,47},{-70,61},{-59,72},{-45,81},{-32,84},{-20,85}}),
-        Line(points={{77,45},{66,60},{55,69},{49,74},{41,80},{31,84},{20,85}})}),
+        Ellipse(
+          extent={{-100,-140},{100,60}},
+          lineColor={0,0,0},
+          startAngle=40,
+          endAngle=80,
+          closure=EllipseClosure.None)}),
     Documentation(info="<html>
 <p>
 The <strong>3</strong> signals of the <strong>torque</strong> connector are interpreted

--- a/Modelica/Mechanics/MultiBody/Forces/Internal/BasicTorque.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/Internal/BasicTorque.mo
@@ -57,23 +57,24 @@ equation
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{
             100,100}}), graphics={
-        Rectangle(
-          extent={{-98,99},{99,-98}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
         Ellipse(
           extent={{-100,-140},{100,60}},
           lineColor={0,0,0},
           startAngle=100,
           endAngle=140,
           closure=EllipseClosure.None),
+        Ellipse(
+          extent={{-100,-140},{100,60}},
+          lineColor={0,0,0},
+          startAngle=40,
+          endAngle=80,
+          closure=EllipseClosure.None),
         Text(
           extent={{-80,90},{100,60}},
           textColor={192,192,192},
           textString="resolve"),
         Text(
-          extent={{-139,-27},{146,-88}},
+          extent={{-150,-30},{150,-70}},
           textString="%name",
           textColor={0,0,255}),
         Polygon(
@@ -89,13 +90,7 @@ equation
         Line(
           points={{-60,100},{40,100}},
           color={95,95,95},
-          pattern=LinePattern.Dot),
-        Ellipse(
-          extent={{-100,-140},{100,60}},
-          lineColor={0,0,0},
-          startAngle=40,
-          endAngle=80,
-          closure=EllipseClosure.None)}),
+          pattern=LinePattern.Dot)}),
     Documentation(info="<html>
 <p>
 The <strong>3</strong> signals of the <strong>torque</strong> connector are interpreted

--- a/Modelica/Mechanics/MultiBody/Forces/Internal/BasicWorldTorque.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/Internal/BasicWorldTorque.mo
@@ -37,8 +37,14 @@ equation
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{
             100,100}}), graphics={
+        Ellipse(
+          extent={{-100,-110},{100,50}},
+          lineColor={0,0,0},
+          startAngle=40,
+          endAngle=160,
+          closure=EllipseClosure.None),
         Text(
-          extent={{-61,64},{46,27}},
+          extent={{-100,90},{100,60}},
           textColor={192,192,192},
           textString="resolve"),
         Text(
@@ -46,16 +52,11 @@ equation
           textString="%name",
           textColor={0,0,255}),
         Line(
-          points={{0,95},{0,82}},
+          points={{0,95},{0,50}},
           color={95,95,95},
           pattern=LinePattern.Dot),
-        Line(
-          points={{-100,0},{-94,13},{-86,28},{-74,48},{-65,60},{-52,72},{-35,
-              81},{-22,84},{-8,84},{7,80},{19,73},{32,65},{44,55},{52,47},{
-              58,40}},
-          thickness=0.5),
         Polygon(
-          points={{94,10},{75,59},{41,24},{94,10}},
+          points={{91,1},{64,56},{36,28},{91,1}},
           fillPattern=FillPattern.Solid)}),
     Documentation(info="<html>
 <p>

--- a/Modelica/Mechanics/MultiBody/Forces/Torque.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/Torque.mo
@@ -84,11 +84,6 @@ equation
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,
             100}}), graphics={
-        Rectangle(
-          extent={{-98,99},{99,-98}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
         Ellipse(
           extent={{-100,-140},{100,60}},
           lineColor={0,0,0},

--- a/Modelica/Mechanics/MultiBody/Forces/Torque.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/Torque.mo
@@ -89,30 +89,40 @@ equation
           lineColor={255,255,255},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid),
-        Text(
-          extent={{-59,55},{72,30}},
-          textColor={192,192,192},
-          textString="resolve"),
+        Ellipse(
+          extent={{-100,-140},{100,60}},
+          lineColor={0,0,0},
+          startAngle=100,
+          endAngle=140,
+          closure=EllipseClosure.None),
+        Ellipse(
+          extent={{-100,-140},{100,60}},
+          lineColor={0,0,0},
+          startAngle=40,
+          endAngle=80,
+          closure=EllipseClosure.None),
         Text(
           extent={{-150,-30},{150,-70}},
           textString="%name",
           textColor={0,0,255}),
-        Polygon(
-          points={{100,20},{84,52},{69,39},{100,20}},
-          fillPattern=FillPattern.Solid),
         Line(
-          points={{40,100},{76,46}},
+          points={{40,100},{80,20}},
           color={95,95,95},
           pattern=LinePattern.Dot),
         Polygon(
-          points={{-99,20},{-86,53},{-70,42},{-99,20}},
+          points={{-92,0},{-82,36},{-60,22},{-92,0}},
           fillPattern=FillPattern.Solid),
         Line(
           points={{-60,100},{40,100}},
           color={95,95,95},
           pattern=LinePattern.Dot),
-        Line(points={{-79,47},{-70,61},{-59,72},{-45,81},{-32,84},{-20,85}}),
-        Line(points={{77,45},{66,60},{55,69},{49,74},{41,80},{31,84},{20,85}})}),
+        Polygon(
+          points={{92,0},{82,36},{60,22},{92,0}},
+          fillPattern=FillPattern.Solid),
+        Text(
+          extent={{-80,90},{100,60}},
+          textColor={192,192,192},
+          textString="resolve")}),
     Documentation(info="<html>
 <p>
 The <strong>3</strong> signals of the <strong>torque</strong> connector are interpreted

--- a/Modelica/Mechanics/MultiBody/Forces/WorldForceAndTorque.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/WorldForceAndTorque.mo
@@ -96,24 +96,25 @@ equation
   annotation (defaultComponentName="forceAndTorque",
     Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,
             100}}), graphics={
+        Ellipse(
+          extent={{-108,-80},{82,80}},
+          lineColor={0,0,0},
+          startAngle=40,
+          endAngle=150,
+          closure=EllipseClosure.None),
         Text(
-          extent={{-63,56},{44,19}},
+          extent={{-100,50},{80,20}},
           textColor={192,192,192},
           textString="resolve"),
         Text(
           extent={{-150,-75},{150,-115}},
           textString="%name",
           textColor={0,0,255}),
-        Line(
-          points={{-100,60},{-86,68},{-80,72},{-70,78},{-64,82},{-46,86},{-34,
-              88},{-16,88},{-2,86},{12,80},{24,74},{34,68},{46,58},{52,54},{
-              58,48}},
-          thickness=0.5),
         Polygon(
-          points={{89,17},{64,76},{30,41},{89,17}},
+          points={{91,21},{64,76},{36,48},{91,21}},
           fillPattern=FillPattern.Solid),
         Line(
-          points={{0,95},{0,-26}},
+          points={{0,101},{0,-20}},
           color={95,95,95},
           pattern=LinePattern.Dot),
         Line(

--- a/Modelica/Mechanics/MultiBody/Forces/WorldTorque.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/WorldTorque.mo
@@ -128,8 +128,14 @@ This leads to the following animation
          Icon(coordinateSystem(
         preserveAspectRatio=true,
         extent={{-100,-100},{100,100}}), graphics={
+        Ellipse(
+          extent={{-100,-110},{100,50}},
+          lineColor={0,0,0},
+          startAngle=40,
+          endAngle=160,
+          closure=EllipseClosure.None),
         Text(
-          extent={{-61,64},{46,27}},
+          extent={{-100,90},{100,60}},
           textColor={192,192,192},
           textString="resolve"),
         Text(
@@ -137,15 +143,10 @@ This leads to the following animation
           textString="%name",
           textColor={0,0,255}),
         Line(
-          points={{0,95},{0,82}},
+          points={{0,95},{0,50}},
           color={95,95,95},
           pattern=LinePattern.Dot),
-        Line(
-          points={{-100,0},{-94,13},{-86,28},{-74,48},{-65,60},{-52,72},{-35,
-              81},{-22,84},{-8,84},{7,80},{19,73},{32,65},{44,55},{52,47},{58,
-              40}},
-          thickness=0.5),
         Polygon(
-          points={{94,10},{75,59},{41,24},{94,10}},
+          points={{91,1},{64,56},{36,28},{91,1}},
           fillPattern=FillPattern.Solid)}));
 end WorldTorque;


### PR DESCRIPTION
This is a free continuation of #3634. In the figure below are shown the four elements being touched at most.

![iconsMBSforces0](https://user-images.githubusercontent.com/9588978/105512975-1202e800-5cd2-11eb-9ef8-2856c90b8a70.png)

