### PR TITLE
Use ellipses instead of arcs by lines

### DIFF
--- a/Modelica/Mechanics/Rotational/Interfaces/PartialTorque.mo
+++ b/Modelica/Mechanics/Rotational/Interfaces/PartialTorque.mo
@@ -7,23 +7,40 @@ partial model PartialTorque
 
 equation
   phi = flange.phi - phi_support;
-  annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-            -100},{100,100}}), graphics={
+  annotation (
+    Icon(
+      coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,100}}),
+      graphics={
         Rectangle(
-          extent={{-96,96},{96,-96}},
+          extent={{-80,64},{80,-56}},
           lineColor={255,255,255},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid),
-        Line(points={{0,-62},{0,-100}}),
+        Ellipse(
+          extent={{-100,-100},{100,100}},
+          lineColor={0,0,0},
+          startAngle=40,
+          endAngle=150,
+          closure=EllipseClosure.None,
+          origin={0,0}),
+        Polygon(
+          points={{90,50},{66,100},{40,74},{90,50}},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-60,-60},{60,60}},
+          lineColor={0,0,0},
+          startAngle=40,
+          endAngle=140,
+          closure=EllipseClosure.None,
+          origin={0,-120}),
+        Line(
+          points={{0,-60},{0,-100}}),
         Text(
           extent={{-150,150},{150,110}},
           textColor={0,0,255},
           textString="%name"),
         Polygon(
-          points={{94,26},{80,84},{50,62},{94,26}},
-          fillPattern=FillPattern.Solid),
-        Polygon(
-          points={{-50,-98},{-30,-80},{-42,-72},{-50,-98}},
+          points={{-54,-94},{-30,-78},{-44,-66},{-54,-94}},
           fillPattern=FillPattern.Solid),
         Line(
           visible=not useSupport,
@@ -39,13 +56,7 @@ equation
           points={{10,-120},{30,-100}}),
         Line(
           visible=not useSupport,
-          points={{-30,-100},{30,-100}}),
-    Line(
-      points={{-48,-92},{-38,-76},{-18,-64},{0,-60},{18,-64},{38,-76},{48,-92}},
-      smooth=Smooth.Bezier),
-    Line(
-      points={{-86,40},{-74,66},{-56,86},{-20,100},{20,100},{60,80},{82,48}},
-      smooth=Smooth.Bezier)}),
+          points={{-30,-100},{30,-100}})}),
     Documentation(info="<html>
 <p>
 Partial model of torque that accelerates the flange.

--- a/Modelica/Mechanics/Rotational/Sources/ConstantSpeed.mo
+++ b/Modelica/Mechanics/Rotational/Sources/ConstantSpeed.mo
@@ -12,7 +12,7 @@ equation
             100,100}}), graphics={
           Line(points={{-60,60},{-60,-10}}, color={192,192,192}),
           Line(points={{-75,0},{75,0}}, color={192,192,192}),
-          Line(points={{10,-15},{10,70}}, color={0,0,127}),
+          Line(points={{10,60},{10,-10}}, color={0,0,127}),
           Text(extent={{-120,-50},{120,-20}}, textString="%w_fixed")}),
     Documentation(info="<html>
 <p>

--- a/Modelica/Mechanics/Rotational/Sources/SignTorque.mo
+++ b/Modelica/Mechanics/Rotational/Sources/SignTorque.mo
@@ -36,7 +36,9 @@ equation
           Line(points={{-75,24},{75,24}},
                                         color={192,192,192}),
           Line(points={{0,66},{0,-20}}, color={192,192,192}),
-        Line(points={{-74,-12},{-8,-12},{-6,-10},{6,58},{8,60},{48,60}})}), Documentation(info="<html>
+        Line(points={{-74,-12},{-8,-12},{-6,-10},{6,58},{8,60},{48,60}},
+          color={0,0,127})}),
+    Documentation(info="<html>
 <p>Model of constant torque which changes sign with direction of rotation.</p>
 <p>Please note:<br>
 Positive torque accelerates in both directions of rotation.<br>

--- a/Modelica/Mechanics/Rotational/Sources/Torque.mo
+++ b/Modelica/Mechanics/Rotational/Sources/Torque.mo
@@ -20,24 +20,36 @@ blocks of Modelica.Blocks.Sources.
 </p>
 </html>"),
     Icon(
-    coordinateSystem(preserveAspectRatio=true,
-      extent={{-100,-100},{100,100}}),
+      coordinateSystem(preserveAspectRatio=true,
+        extent={{-100,-100},{100,100}}),
       graphics={
-    Text(extent={{-150,110},{150,70}},
-      textString="%name",
-      textColor={0,0,255}),
-    Text(extent={{-62,-29},{-141,-70}},
-      textString="tau"),
-    Polygon(points={{86,0},{66,58},{37,27},{86,0}},
-      fillPattern=FillPattern.Solid),
-    Line(points={{0,-10},{0,-101}}),
-    Polygon(points={{-53,-54},{-36,-30},{-50,-24},{-53,-54}},
-      fillPattern=FillPattern.Solid),
-    Line(
-      points={{-84,0},{-78,18},{-56,46},{-20,60},{20,60},{60,40},{82,8}},
-      smooth=Smooth.Bezier,
-      thickness=0.5),
-    Line(
-      points={{-50,-40},{-38,-24},{-18,-12},{0,-10},{18,-12},{38,-24},{50,-40}},
-      smooth=Smooth.Bezier)}));
+        Ellipse(
+          extent={{-100,-100},{100,100}},
+          lineColor={0,0,0},
+          startAngle=40,
+          endAngle=150,
+          closure=EllipseClosure.None,
+          origin={0,-40}),
+        Ellipse(
+          extent={{-60,-60},{60,60}},
+          lineColor={0,0,0},
+          startAngle=40,
+          endAngle=140,
+          closure=EllipseClosure.None,
+          origin={0,-80}),
+        Text(
+          extent={{-62,-29},{-141,-70}},
+          textString="tau"),
+        Polygon(
+          points={{90,10},{66,60},{40,34},{90,10}},
+          fillPattern=FillPattern.Solid),
+        Line(
+          points={{0,-20},{0,-101}}),
+        Polygon(
+          points={{-54,-54},{-30,-38},{-44,-26},{-54,-54}},
+          fillPattern=FillPattern.Solid),
+        Text(
+          extent={{-150,110},{150,70}},
+          textString="%name",
+          textColor={0,0,255})}));
 end Torque;

--- a/Modelica/Mechanics/Rotational/Sources/Torque2.mo
+++ b/Modelica/Mechanics/Rotational/Sources/Torque2.mo
@@ -23,19 +23,32 @@ blocks of Modelica.Blocks.Sources.
 </p>
 </html>"),
     Icon(
-    coordinateSystem(preserveAspectRatio=true,
+      coordinateSystem(preserveAspectRatio=true,
       extent={{-100,-100},{100,100}}),
       graphics={
-    Text(extent={{-150,-40},{150,-80}},
-      textString="%name",
-      textColor={0,0,255}),
-    Polygon(points={{-78,24},{-69,17},{-89,0},{-78,24}},
-      lineThickness=0.5,
-      fillPattern=FillPattern.Solid),
-    Line(points={{-74,20},{-70,23},{-65,26},{-60,28},{-56,29},{-50,30},{-41,30},{-35,29},{-31,28},{-26,26},{-21,23},{-17,20},{-13,15},{-10,9}},
-      thickness=0.5, smooth=Smooth.Bezier),
-    Line(points={{74,20},{70,23},{65,26},{60,28},{56,29},{50,30},{41,30},{35,29},{31,28},{26,26},{21,23},{17,20},{13,15},{10,9}},
-      thickness=0.5, smooth=Smooth.Bezier),
-    Polygon(points={{89,0},{78,24},{69,17},{89,0}},
-      fillPattern=FillPattern.Solid)}));
+        Ellipse(
+          extent={{-50,-50},{50,50}},
+          lineColor={0,0,0},
+          startAngle=40,
+          endAngle=140,
+          closure=EllipseClosure.None,
+          origin={50,-20}),
+        Ellipse(
+          extent={{-50,-50},{50,50}},
+          lineColor={0,0,0},
+          startAngle=40,
+          endAngle=140,
+          closure=EllipseClosure.None,
+          origin={-50,-20}),
+        Text(
+          extent={{-150,-40},{150,-80}},
+          textString="%name",
+          textColor={0,0,255}),
+        Polygon(
+          points={{-80,28},{-72,18},{-92,8},{-80,28}},
+          lineThickness=0.5,
+          fillPattern=FillPattern.Solid),
+        Polygon(
+          points={{80,28},{72,18},{92,8},{80,28}},
+          fillPattern=FillPattern.Solid)}));
 end Torque2;

--- a/Modelica/Mechanics/Translational/Sources/SignForce.mo
+++ b/Modelica/Mechanics/Translational/Sources/SignForce.mo
@@ -27,7 +27,9 @@ equation
           Line(points={{0,66},{0,-20}}, color={192,192,192}),
           Line(points={{-75,24},{75,24}},
                                         color={192,192,192}),
-        Line(points={{-74,-12},{-8,-12},{-6,-10},{6,58},{8,60},{74,60}})}), Documentation(info="<html>
+        Line(points={{-74,-12},{-8,-12},{-6,-10},{6,58},{8,60},{74,60}},
+          color={0,0,127})}),
+    Documentation(info="<html>
 <p>Model of constant force which changes sign with direction of movement.</p>
 <p>Please note:<br>
 Positive force accelerates in both directions of movement.<br>


### PR DESCRIPTION
Free continuation of #3730 for `Rotational.Sources`.

Test model:
```
model UseEllipsesRotational
  Modelica.Mechanics.Rotational.Sources.Torque torque annotation (Placement(transformation(extent={{-80,60},{-60,80}})));
  Modelica.Mechanics.Rotational.Sources.Torque2 torque1 annotation (Placement(transformation(extent={{-40,60},{-20,80}})));
  Modelica.Mechanics.Rotational.Sources.InverseSpeedDependentTorque inverseSpeedDependentTorque annotation (Placement(transformation(extent={{-80,0},{-60,20}})));
  Modelica.Mechanics.Rotational.Sources.LinearSpeedDependentTorque linearSpeedDependentTorque annotation (Placement(transformation(extent={{-80,-30},{-60,-10}})));
  Modelica.Mechanics.Rotational.Sources.QuadraticSpeedDependentTorque quadraticSpeedDependentTorque annotation (Placement(transformation(extent={{-80,-60},{-60,-40}})));
  Modelica.Mechanics.Rotational.Sources.ConstantTorque constantTorque annotation (Placement(transformation(extent={{-80,-90},{-60,-70}})));
  Modelica.Mechanics.Rotational.Sources.SignTorque signTorque annotation (Placement(transformation(extent={{-40,0},{-20,20}})));
  Modelica.Mechanics.Rotational.Sources.ConstantSpeed constantSpeed annotation (Placement(transformation(extent={{-40,-30},{-20,-10}})));
  Modelica.Mechanics.Rotational.Sources.TorqueStep torqueStep annotation (Placement(transformation(extent={{-40,-60},{-20,-40}})));
  Modelica.Mechanics.Rotational.Sources.EddyCurrentTorque eddyCurrentTorque annotation (Placement(transformation(extent={{-40,-90},{-20,-70}})));
  Modelica.Mechanics.Rotational.Interfaces.PartialTorque partialTorque annotation (Placement(transformation(extent={{-40,30},{-20,50}})));
end UseEllipsesRotational;
```

This is how the changes render in Dymola 2021x. (Previously: arcs by lines; now: by ellipses)

![iconsSources](https://user-images.githubusercontent.com/9588978/105861169-b6e13600-5fee-11eb-8c8d-f45274a7f735.png)

__Note:__ There is still a white rectangle in the `partialTorque` for it is considered being a background of "diagrams" of torques by functions (such as `constantTorque`, etc.). I have nevertheless reduced its size.