### PR TITLE
More clearly specify damper cage in synchronous machine models

### DIFF
--- a/Modelica/Magnetic/FundamentalWave/BasicMachines/SynchronousMachines/SM_ElectricalExcited.mo
+++ b/Modelica/Magnetic/FundamentalWave/BasicMachines/SynchronousMachines/SM_ElectricalExcited.mo
@@ -41,24 +41,24 @@ model SM_ElectricalExcited
           "Nominal resistances and inductances", group="Damper cage"));
   parameter SI.Inductance Lrsigmad(start=0.05/(2*pi*
         fsNominal))
-    "Rotor leakage inductance, d-axis, w.r.t. stator side" annotation (
+    "Rotor damper cage leakage inductance, d-axis, w.r.t. stator side" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Inductance Lrsigmaq=Lrsigmad
-    "Rotor leakage inductance, q-axis, w.r.t. stator side" annotation (
+    "Rotor damper cage leakage inductance, q-axis, w.r.t. stator side" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Resistance Rrd(start=0.04)
-    "Rotor resistance, d-axis, w.r.t. stator side" annotation (Dialog(
+    "Rotor damper cage resistance, d-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Resistance Rrq=Rrd
-    "Rotor resistance , q-axis, w.r.t. stator side" annotation (Dialog(
+    "Rotor damper cage resistance, q-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));

--- a/Modelica/Magnetic/FundamentalWave/BasicMachines/SynchronousMachines/SM_PermanentMagnet.mo
+++ b/Modelica/Magnetic/FundamentalWave/BasicMachines/SynchronousMachines/SM_PermanentMagnet.mo
@@ -39,24 +39,24 @@ model SM_PermanentMagnet
           "Nominal resistances and inductances", group="Damper cage"));
   parameter SI.Inductance Lrsigmad(start=0.05/(2*pi*
         fsNominal))
-    "Rotor leakage inductance, d-axis, w.r.t. stator side" annotation (
+    "Rotor damper cage leakage inductance, d-axis, w.r.t. stator side" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Inductance Lrsigmaq=Lrsigmad
-    "Rotor leakage inductance, q-axis, w.r.t. stator side" annotation (
+    "Rotor damper cage leakage inductance, q-axis, w.r.t. stator side" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Resistance Rrd(start=0.04)
-    "Rotor resistance, d-axis, w.r.t. stator side" annotation (Dialog(
+    "Rotor damper cage resistance, d-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Resistance Rrq=Rrd
-    "Rotor resistance , q-axis, w.r.t. stator side" annotation (Dialog(
+    "Rotor damper cage resistance, q-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));

--- a/Modelica/Magnetic/FundamentalWave/BasicMachines/SynchronousMachines/SM_ReluctanceRotor.mo
+++ b/Modelica/Magnetic/FundamentalWave/BasicMachines/SynchronousMachines/SM_ReluctanceRotor.mo
@@ -9,7 +9,6 @@ model SM_ReluctanceRotor "Reluctance machine with optional damper cage"
     redeclare final
       Modelica.Electrical.Machines.Thermal.SynchronousMachines.ThermalAmbientSMR
       thermalAmbient(final useDamperCage=useDamperCage, final Tr=TrOperational),
-
     redeclare final
       Modelica.Electrical.Machines.Interfaces.InductionMachines.ThermalPortSMR
       thermalPort(final useDamperCage=useDamperCage),
@@ -39,24 +38,24 @@ model SM_ReluctanceRotor "Reluctance machine with optional damper cage"
           "Nominal resistances and inductances", group="Damper cage"));
   parameter SI.Inductance Lrsigmad(start=0.05/(2*pi*
         fsNominal))
-    "Rotor leakage inductance, d-axis, w.r.t. stator side" annotation (
+    "Rotor damper cage leakage inductance, d-axis, w.r.t. stator side" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Inductance Lrsigmaq=Lrsigmad
-    "Rotor leakage inductance, q-axis, w.r.t. stator side" annotation (
+    "Rotor damper cage leakage inductance, q-axis, w.r.t. stator side" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Resistance Rrd(start=0.04)
-    "Rotor resistance, d-axis, w.r.t. stator side" annotation (Dialog(
+    "Rotor damper cage resistance, d-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Resistance Rrq=Rrd
-    "Rotor resistance , q-axis, w.r.t. stator side" annotation (Dialog(
+    "Rotor damper cage resistance, q-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));

--- a/Modelica/Magnetic/FundamentalWave/BasicMachines/SynchronousMachines/package.mo
+++ b/Modelica/Magnetic/FundamentalWave/BasicMachines/SynchronousMachines/package.mo
@@ -1,6 +1,7 @@
 within Modelica.Magnetic.FundamentalWave.BasicMachines;
 package SynchronousMachines "Synchronous machines"
   extends Modelica.Icons.VariantsPackage;
+
   annotation (Documentation(info="<html>
 <p>This package contains various synchronous machine models.</p>
 

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/SynchronousMachines/SM_ElectricalExcited.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/SynchronousMachines/SM_ElectricalExcited.mo
@@ -40,24 +40,24 @@ model SM_ElectricalExcited
           "Nominal resistances and inductances", group="Damper cage"));
   parameter SI.Inductance Lrsigmad(start=0.05/(2*pi*
         fsNominal))
-    "Rotor leakage inductance, d-axis, w.r.t. stator side" annotation (
+    "Rotor damper cage leakage inductance, d-axis, w.r.t. stator side" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Inductance Lrsigmaq=Lrsigmad
-    "Rotor leakage inductance, q-axis, w.r.t. stator side" annotation (
+    "Rotor damper cage leakage inductance, q-axis, w.r.t. stator side" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Resistance Rrd(start=0.04)
-    "Rotor resistance, d-axis, w.r.t. stator side" annotation (Dialog(
+    "Rotor damper cage resistance, d-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Resistance Rrq=Rrd
-    "Rotor resistance , q-axis, w.r.t. stator side" annotation (Dialog(
+    "Rotor damper cage resistance, q-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/SynchronousMachines/SM_PermanentMagnet.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/SynchronousMachines/SM_PermanentMagnet.mo
@@ -38,24 +38,24 @@ model SM_PermanentMagnet
           "Nominal resistances and inductances", group="Damper cage"));
   parameter SI.Inductance Lrsigmad(start=0.05/(2*pi*
         fsNominal))
-    "Rotor leakage inductance, d-axis, w.r.t. stator side" annotation (
+    "Rotor damper cage leakage inductance, d-axis, w.r.t. stator side" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Inductance Lrsigmaq=Lrsigmad
-    "Rotor leakage inductance, q-axis, w.r.t. stator side" annotation (
+    "Rotor damper cage leakage inductance, q-axis, w.r.t. stator side" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Resistance Rrd(start=0.04)
-    "Rotor resistance, d-axis, w.r.t. stator side" annotation (Dialog(
+    "Rotor damper cage resistance, d-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Resistance Rrq=Rrd
-    "Rotor resistance , q-axis, w.r.t. stator side" annotation (Dialog(
+    "Rotor damper cage resistance, q-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/SynchronousMachines/SM_ReluctanceRotor.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/SynchronousMachines/SM_ReluctanceRotor.mo
@@ -34,24 +34,24 @@ model SM_ReluctanceRotor
           "Nominal resistances and inductances", group="Damper cage"));
   parameter SI.Inductance Lrsigmad(start=0.05/(2*pi*
         fsNominal))
-    "Rotor leakage inductance, d-axis, w.r.t. stator side" annotation (
+    "Rotor damper cage leakage inductance, d-axis, w.r.t. stator side" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Inductance Lrsigmaq=Lrsigmad
-    "Rotor leakage inductance, q-axis, w.r.t. stator side" annotation (
+    "Rotor damper cage leakage inductance, q-axis, w.r.t. stator side" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Resistance Rrd(start=0.04)
-    "Rotor resistance, d-axis, w.r.t. stator side" annotation (Dialog(
+    "Rotor damper cage resistance, d-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
   parameter SI.Resistance Rrq=Rrd
-    "Rotor resistance , q-axis, w.r.t. stator side" annotation (Dialog(
+    "Rotor damper cage resistance , q-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));


### PR DESCRIPTION
In the Electrical.Machines package the rotor leakage inductances and rotor resistances clearly refer to the damper cage. The damper cage shall also be clearly indicated in the cage parameters of the fundamental wave synchronous machine models. 