### PR TITLE
Adds a block to calculate the extrema of  a signal

### DIFF
--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2424,15 +2424,15 @@ Note: The output is updated after each period defined by 1/f.
               u "Connector of Real input signal" annotation (Placement(
           transformation(extent={{-140,-20},{-100,20}})));
     Modelica.Blocks.Interfaces.RealOutput
-              y_min "Max of input signal" annotation (Placement(
+              y_min "Min of input signal" annotation (Placement(
           transformation(extent={{100,-70},{120,-50}})));
     Modelica.Blocks.Interfaces.RealOutput
-              y_max "Min of input signal" annotation (Placement(
+              y_max "Max of input signal" annotation (Placement(
           transformation(extent={{100,50},{120,70}})));
   protected
     parameter SI.Time t0(fixed=false) "Start time of simulation";
     discrete Real y_min_last "Last sampled min value";
-    discrete Real y_max_last "Last sampled min value";
+    discrete Real y_max_last "Last sampled max value";
   initial equation
     t0 = time;
     y_min_last = u;

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2498,7 +2498,7 @@ Note: The output is updated after each sample period defined by <code>Ts</code>.
       <td>1.0.0</td>
       <td>2021-02-25</td>
       <td><a href=\"https://github.com/dietmarw\">dietmarw</a>,
-          <a href=\"https://github.com/tinrabuzin\">tinrabuzin</a>
+          <a href=\"https://github.com/tinrabuzin\">tinrabuzin</a></td>
       <td>Initial version</td>
     </tr>
 </table> 

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2431,19 +2431,17 @@ Note: The output is updated after each period defined by 1/f.
           transformation(extent={{100,50},{120,70}})));
   protected
     parameter SI.Time t0(fixed=false) "Start time of simulation";
-    discrete Real y_min_last "Last sampled min value";
-    discrete Real y_max_last "Last sampled max value";
+
   initial equation
     t0 = time;
-    y_min_last = u;
-    y_max_last = u;
+    y_min = u;
+    y_max = u;
+
   equation
     when sample(t0 + Ts, Ts) then
-      y_min_last = min(u, pre(y_min_last));
-      y_max_last = max(u, pre(y_max_last));
+      y_min = min(u, pre(y_min));
+      y_max = max(u, pre(y_max));
     end when;
-    y_min = y_min_last;
-    y_max = y_max_last;
     annotation (Icon(graphics={
           Line(points={{-80,68},{-80,-80}}, color={192,192,192}),
           Polygon(

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2416,6 +2416,95 @@ Note: The output is updated after each period defined by 1/f.
             textString="f=%f")}));
   end RootMeanSquare;
 
+  block SignalExtrema "Calculate min and max of a signal"
+    extends Modelica.Blocks.Icons.Block;
+
+    parameter SI.Time Ts(start=0.01) "Sample time";
+    Modelica.Blocks.Interfaces.RealInput
+              u "Connector of Real input signal" annotation (Placement(
+          transformation(extent={{-140,-20},{-100,20}})));
+    Modelica.Blocks.Interfaces.RealOutput
+              y_min "Max of input signal" annotation (Placement(
+          transformation(extent={{100,-70},{120,-50}})));
+    Modelica.Blocks.Interfaces.RealOutput
+              y_max "Min of input signal" annotation (Placement(
+          transformation(extent={{100,50},{120,70}})));
+  protected
+    parameter SI.Time t0(fixed=false) "Start time of simulation";
+    discrete Real y_min_last "Last sampled min value";
+    discrete Real y_max_last "Last sampled min value";
+  initial equation
+    t0 = time;
+    y_min_last = u;
+    y_max_last = u;
+  equation
+    when sample(t0 + Ts, Ts) then
+      y_min_last = min(u, pre(y_min_last));
+      y_max_last = max(u, pre(y_max_last));
+    end when;
+    y_min = y_min_last;
+    y_max = y_max_last;
+    annotation (Icon(graphics={
+          Line(points={{-80,68},{-80,-80}}, color={192,192,192}),
+          Polygon(
+            points={{-80,90},{-88,68},{-72,68},{-80,90}},
+            lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Line(points={{-90,0},{68,0}}, color={192,192,192}),
+          Polygon(
+            points={{90,0},{68,8},{68,-8},{90,0}},
+            lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Line(
+            points={{-80,0},{-75.2,32.3},{-72,50.3},{-68.7,64.5},{-65.5,74.2},{-62.3,79.3},{-59.1,79.6},{-55.9,75.3},{-52.7,67.1},{-48.6,52.2},{-43,25.8},{-35,-13.9},{-30.2,-33.7},{-26.1,-45.9},{-22.1,-53.2},{-18,-56},{-14.1,-52.5},{-10.1,-45.3},{-5.23,-32.1},{8.44,13.7},{13.3,26.4},{18.1,34.8},{22.1,38},{26.9,37.2},{31.8,31.8},{38.2,19.4},{51.1,-10.5},{57.5,-21.2},{63.1,-25.9},{68.7,-25.9},{75.2,-20.5},{80,-13.8}},
+            smooth=Smooth.Bezier,
+            color={192,192,192}),
+          Text(extent={{-150,-110},{150,-150}},
+            textString="Ts=%Ts", lineColor={0,0,0}),
+          Line(
+            points={{-60,80},{52,80}},
+            color={0,0,0},
+            pattern=LinePattern.Dash),    Text(
+          extent={{-150,150},{150,110}},
+          textString="%name",
+          lineColor={0,0,255}),
+          Text(extent={{60,70},{92,50}},
+                                 lineColor={0,0,0},
+            textString="max"),
+          Text(extent={{60,-50},{92,-70}},
+                                 lineColor={0,0,0},
+            textString="min"),
+          Line(
+            points={{-18,-56},{50,-56}},
+            color={0,0,0},
+            pattern=LinePattern.Dash)}), Documentation(info="<html>
+<p>
+This block calculates the max and the min of input signal <code>u</code>.
+</p>
+<p>
+Note: The output is updated after each sample period defined by <code>Ts</code>.
+</p>
+</html>",   revisions="<html>
+<table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
+    <tr>
+      <th>Version</th>
+      <th>Date</th>
+      <th>Author</th>
+      <th>Comment</th>
+    </tr>
+    <tr>
+      <td>1.0.0</td>
+      <td>2021-02-25</td>
+      <td><a href=\"https://github.com/dietmarw\">dietmarw</a>,
+          <a href=\"https://github.com/tinrabuzin\">tinrabuzin</a>
+      <td>Initial version</td>
+    </tr>
+</table> 
+</html>"));
+  end SignalExtrema;
+
   block Variance "Calculates the empirical variance of its input signal"
     extends Modelica.Blocks.Icons.Block;
     parameter SI.Time t_eps(min=100*Modelica.Constants.eps)=1e-7

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2439,6 +2439,8 @@ Note: The output is updated after each period defined by 1/f.
     t0 = time;
     y_min = u;
     y_max = u;
+    t_min = time;
+    t_max = time;
 
   equation
     when sample(t0 + Ts, Ts) then

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2483,9 +2483,14 @@ Note: The output is updated after each period defined by 1/f.
 <p>
 This block calculates the max and the min of input signal <code>u</code>.
 </p>
-<p>
-Note: The output is updated after each sample period defined by <code>Ts</code>.
-</p>
+<h5>Note:</h5>
+<p>The output is updated after each sample period defined by <code>Ts</code>.
+This means that:</p>
+<ul>
+<li>The extrema will be approximate as it only return the extremas at the sampling points.</li>
+<li>The sampling will generate many events which may slow down the simulation.</li>
+</ul>
+
 </html>",   revisions="<html>
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
     <tr>

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2429,6 +2429,9 @@ Note: The output is updated after each period defined by 1/f.
     Modelica.Blocks.Interfaces.RealOutput
               y_max "Max of input signal" annotation (Placement(
           transformation(extent={{100,50},{120,70}})));
+    discrete Real t_min "Sample time of last found minimum";
+    discrete Real t_max "Sample time of last found maximum";
+
   protected
     parameter SI.Time t0(fixed=false) "Start time of simulation";
 
@@ -2441,6 +2444,16 @@ Note: The output is updated after each period defined by 1/f.
     when sample(t0 + Ts, Ts) then
       y_min = min(u, pre(y_min));
       y_max = max(u, pre(y_max));
+      if y_min<pre(y_min) then
+        t_min = time;
+        t_max=pre(t_max);
+      elseif y_max>pre(y_max) then
+        t_max = time;
+        t_min=pre(t_min);
+      else
+        t_min=pre(t_min);
+        t_max=pre(t_max);
+      end if;
     end when;
     annotation (Icon(graphics={
           Line(points={{-80,68},{-80,-80}}, color={192,192,192}),
@@ -2479,7 +2492,9 @@ Note: The output is updated after each period defined by 1/f.
             color={0,0,0},
             pattern=LinePattern.Dash)}), Documentation(info="<html>
 <p>
-This block calculates the max and the min of input signal <code>u</code>.
+This block calculates the min and the max of the input signal <code>u</code>
+and stores the time at which the last min or max was reached in the 
+variables <code>t_min</code> and <code>t_max</code> respectively.
 </p>
 <h5>Note:</h5>
 <p>The output is updated after each sample period defined by <code>Ts</code>.

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2495,7 +2495,7 @@ Note: The output is updated after each period defined by 1/f.
             pattern=LinePattern.Dash)}), Documentation(info="<html>
 <p>
 This block calculates the min and the max of the input signal <code>u</code>
-and stores the time at which the last min or max was reached in the 
+and stores the time at which the last min or max was reached in the
 variables <code>t_min</code> and <code>t_max</code> respectively.
 </p>
 <h5>Note:</h5>
@@ -2521,7 +2521,7 @@ This means that:</p>
           <a href=\"https://github.com/tinrabuzin\">tinrabuzin</a></td>
       <td>Initial version</td>
     </tr>
-</table> 
+</table>
 </html>"));
   end SignalExtrema;
 

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1449,16 +1449,15 @@ Compare the sinc signal and an exponentially damped sine.
 
   model DemonstrateSignalExtrema "Test detection of signal extrema"
     extends Modelica.Icons.Example;
-    inner Modelica.Blocks.Noise.GlobalSeed globalSeed(useAutomaticSeed=true)
-      annotation (Placement(transformation(extent={{-80,60},{-60,80}})));
-    Modelica.Blocks.Noise.UniformNoise uniformNoiseAmplitude(
-      samplePeriod=1e-2,
-      y_min=1,
-      y_max=5) annotation (Placement(transformation(extent={{-80,10},{-60,30}})));
-    Modelica.Blocks.Noise.UniformNoise uniformNoiseFrequency(
-      samplePeriod=1e-2,
-      y_min=10,
-      y_max=100)
+    Sources.Sine amplitude(
+      amplitude=2,
+      f=63,
+      offset=3)
+      annotation (Placement(transformation(extent={{-80,10},{-60,30}})));
+    Sources.Cosine frequency(
+      amplitude=45,
+      f=77,
+      offset=55)
       annotation (Placement(transformation(extent={{-80,-30},{-60,-10}})));
     Modelica.Blocks.Sources.SineVariableFrequencyAndAmplitude sine(
         useConstantFrequency=false, phi(fixed=true))
@@ -1472,17 +1471,17 @@ Compare the sinc signal and an exponentially damped sine.
       annotation (Line(points={{1,0},{20,0},{20,20},{38,20}}, color={0,0,127}));
     connect(sine.y, signalExtrema2.u) annotation (Line(points={{1,0},{20,0},{20,-20},
             {38,-20}}, color={0,0,127}));
-    connect(uniformNoiseAmplitude.y, sine.amplitude) annotation (Line(points={{-59,
-            20},{-40,20},{-40,6},{-22,6}}, color={0,0,127}));
-    connect(uniformNoiseFrequency.y, sine.f) annotation (Line(points={{-59,-20},{-40,
-            -20},{-40,-6},{-22,-6}}, color={0,0,127}));
+    connect(amplitude.y, sine.amplitude) annotation (Line(points={{-59,20},{-40,
+            20},{-40,6},{-22,6}}, color={0,0,127}));
+    connect(frequency.y, sine.f) annotation (Line(points={{-59,-20},{-40,-20},{
+            -40,-6},{-22,-6}}, color={0,0,127}));
     annotation (experiment(
         StopTime=1.5,
         Interval=1e-05,
         Tolerance=1e-06), Documentation(info="<html>
 <p>
-This example uses a sinusoidal signal with amplitude and frequency randomly set every 10 ms. 
-Amplitude varies in the range of [1,5] and frequency varies in the range of [10, 100] Hz. 
+This example uses a sinusoidal signal with amplitude varying sinusoidally in the range of [1,5] with a frequency of 63 Hz, 
+and frequency varying according to a cosine function in the range of [10, 100] Hz with a frqeuncy of 77 Hz.
 </p>
 <p>
 Note that signalExtrema1 doesn't find the extrema exactly since sampling frequency 100 Hz is too small compared to maximum frequency of the input signal, 

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1,4 +1,4 @@
-within Modelica;
+﻿within Modelica;
 package Blocks "Library of basic input/output control blocks (continuous, discrete, logical, table blocks)"
 
   extends Modelica.Icons.Package;
@@ -1446,6 +1446,51 @@ Compare the sinc signal and an exponentially damped sine.
 </p>
 </html>"));
   end CompareSincExpSine;
+
+  model DemonstrateSignalExtrema "Test detection of signal extrema"
+    extends Modelica.Icons.Example;
+    inner Modelica.Blocks.Noise.GlobalSeed globalSeed(useAutomaticSeed=true)
+      annotation (Placement(transformation(extent={{-80,60},{-60,80}})));
+    Modelica.Blocks.Noise.UniformNoise uniformNoiseAmplitude(
+      samplePeriod=1e-2,
+      y_min=1,
+      y_max=5) annotation (Placement(transformation(extent={{-80,10},{-60,30}})));
+    Modelica.Blocks.Noise.UniformNoise uniformNoiseFrequency(
+      samplePeriod=1e-2,
+      y_min=10,
+      y_max=100)
+      annotation (Placement(transformation(extent={{-80,-30},{-60,-10}})));
+    Modelica.Blocks.Sources.SineVariableFrequencyAndAmplitude sine(
+        useConstantFrequency=false, phi(fixed=true))
+      annotation (Placement(transformation(extent={{-20,-10},{0,10}})));
+    Modelica.Blocks.Math.SignalExtrema signalExtrema1(Ts=1e-2)
+      annotation (Placement(transformation(extent={{40,10},{60,30}})));
+    Modelica.Blocks.Math.SignalExtrema signalExtrema2(Ts=1e-4)
+      annotation (Placement(transformation(extent={{40,-30},{60,-10}})));
+  equation
+    connect(sine.y, signalExtrema1.u)
+      annotation (Line(points={{1,0},{20,0},{20,20},{38,20}}, color={0,0,127}));
+    connect(sine.y, signalExtrema2.u) annotation (Line(points={{1,0},{20,0},{20,-20},
+            {38,-20}}, color={0,0,127}));
+    connect(uniformNoiseAmplitude.y, sine.amplitude) annotation (Line(points={{-59,
+            20},{-40,20},{-40,6},{-22,6}}, color={0,0,127}));
+    connect(uniformNoiseFrequency.y, sine.f) annotation (Line(points={{-59,-20},{-40,
+            -20},{-40,-6},{-22,-6}}, color={0,0,127}));
+    annotation (                                 experiment(
+        StopTime=1.5,
+        Interval=1e-05,
+        Tolerance=1e-06,
+        __Dymola_Algorithm="Dassl"), Documentation(info="<html>
+<p>
+This example uses a sinusoidal signal with amplitude and frequency randomly set every 10 ms. 
+Amplitude varies in the range of [1,5] and frequency varies in the range of [10, 100] Hz. 
+</p>
+<p>
+Note that signalExtrema1 doesn't find the extrema exactly since sampling frequency 100 Hz is too small compared to maximum frequency of the input signal, 
+whereas signalExtrema2 catches the extrema rather good due to the fact that sampling frequency 10 kHz is high enough.
+</p>
+</html>"));
+  end DemonstrateSignalExtrema;
 
   package Noise "Library of examples to demonstrate the usage of package Blocks.Noise"
     extends Modelica.Icons.ExamplesPackage;

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1,4 +1,4 @@
-﻿within Modelica;
+within Modelica;
 package Blocks "Library of basic input/output control blocks (continuous, discrete, logical, table blocks)"
 
   extends Modelica.Icons.Package;
@@ -1480,11 +1480,11 @@ Compare the sinc signal and an exponentially damped sine.
         Interval=1e-05,
         Tolerance=1e-06), Documentation(info="<html>
 <p>
-This example uses a sinusoidal signal with amplitude varying sinusoidally in the range of [1,5] with a frequency of 63 Hz, 
+This example uses a sinusoidal signal with amplitude varying sinusoidally in the range of [1,5] with a frequency of 63 Hz,
 and frequency varying according to a cosine function in the range of [10, 100] Hz with a frqeuncy of 77 Hz.
 </p>
 <p>
-Note that signalExtrema1 doesn't find the extrema exactly since sampling frequency 100 Hz is too small compared to maximum frequency of the input signal, 
+Note that signalExtrema1 doesn't find the extrema exactly since sampling frequency 100 Hz is too small compared to maximum frequency of the input signal,
 whereas signalExtrema2 catches the extrema rather good due to the fact that sampling frequency 10 kHz is high enough.
 </p>
 </html>"));

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1476,11 +1476,10 @@ Compare the sinc signal and an exponentially damped sine.
             20},{-40,20},{-40,6},{-22,6}}, color={0,0,127}));
     connect(uniformNoiseFrequency.y, sine.f) annotation (Line(points={{-59,-20},{-40,
             -20},{-40,-6},{-22,-6}}, color={0,0,127}));
-    annotation (                                 experiment(
+    annotation (experiment(
         StopTime=1.5,
         Interval=1e-05,
-        Tolerance=1e-06,
-        __Dymola_Algorithm="Dassl"), Documentation(info="<html>
+        Tolerance=1e-06), Documentation(info="<html>
 <p>
 This example uses a sinusoidal signal with amplitude and frequency randomly set every 10 ms. 
 Amplitude varies in the range of [1,5] and frequency varies in the range of [10, 100] Hz. 

--- a/Modelica/Resources/Reference/Modelica/Blocks/Examples/DemonstrateSignalExtrema/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Blocks/Examples/DemonstrateSignalExtrema/comparisonSignals.txt
@@ -1,0 +1,10 @@
+time
+signalExtrema1.y_min
+signalExtrema1.y_max
+signalExtrema1.t_min
+signalExtrema1.t_max
+signalExtrema2.y_min
+signalExtrema2.y_max
+signalExtrema2.t_min
+signalExtrema2.t_max
+

--- a/ModelicaTest/Blocks.mo
+++ b/ModelicaTest/Blocks.mo
@@ -2038,12 +2038,4 @@ the whole homotopy transformation.</p>
 </html>"));
   end LimPID;
 
-  model SignalExtrema "Test of determining the extrema (min and max) of a signal"
-    extends Modelica.Icons.Example;
-    Modelica.Blocks.Math.SignalExtrema signalExtrema(Ts(displayUnit="ms") = 0.001) annotation (Placement(transformation(extent={{12,-10},{32,10}})));
-    Modelica.Blocks.Sources.ExpSine expSine(f=10, damping=-1) annotation (Placement(transformation(extent={{-32,-10},{-12,10}})));
-  equation
-    connect(expSine.y, signalExtrema.u) annotation (Line(points={{-11,0},{10,0}}, color={0,0,127}));
-    annotation (experiment(StopTime=1));
-  end SignalExtrema;
 end Blocks;

--- a/ModelicaTest/Blocks.mo
+++ b/ModelicaTest/Blocks.mo
@@ -2038,4 +2038,12 @@ the whole homotopy transformation.</p>
 </html>"));
   end LimPID;
 
+  model SignalExtrema "Test of determining the extrema (min and max) of a signal"
+    extends Modelica.Icons.Example;
+    Modelica.Blocks.Math.SignalExtrema signalExtrema(Ts(displayUnit="ms") = 0.001) annotation (Placement(transformation(extent={{12,-10},{32,10}})));
+    Modelica.Blocks.Sources.ExpSine expSine(f=10, damping=-1) annotation (Placement(transformation(extent={{-32,-10},{-12,10}})));
+  equation
+    connect(expSine.y, signalExtrema.u) annotation (Line(points={{-11,0},{10,0}}, color={0,0,127}));
+    annotation (experiment(StopTime=1));
+  end SignalExtrema;
 end Blocks;


### PR DESCRIPTION
Based on an old discussion MO#109 and now triggered again via @tinrabuzin.
The implementation is based on `Modelica.Blocks.Math.Mean`

I specifically put this into draft mode and like to discuss this first. 

Some notes:
 - I'm aware that there are some performance drawbacks, but these are the same as present in other block like `Mean`
 - I'm not 100% happy with the name yet. Ideally I would have called it `MinMax` but that one is taken although one could argue that that block really should be placed under `Blocks.Routing` 
