### PR TITLE
Add ChopperBuckBoost to PowerConverters

### DIFF
--- a/Modelica/Electrical/PowerConverters/DCDC/ChopperBuckBost.mo
+++ b/Modelica/Electrical/PowerConverters/DCDC/ChopperBuckBost.mo
@@ -38,7 +38,7 @@ model ChopperBuckBost "Bidirectional chopper"
     useHeatPort=useHeatPort,
     Ron=RonTransistor,
     Goff=GoffTransistor,
-    Vknee=VkneeTransistor) "Switching transistor hugh side" annotation (
+    Vknee=VkneeTransistor) "Switching transistor high side" annotation (
       Placement(transformation(
         origin={50,60},
         extent={{-10,-10},{10,10}},

--- a/Modelica/Electrical/PowerConverters/DCDC/ChopperBuckBost.mo
+++ b/Modelica/Electrical/PowerConverters/DCDC/ChopperBuckBost.mo
@@ -1,0 +1,120 @@
+within Modelica.Electrical.PowerConverters.DCDC;
+model ChopperBuckBost "Bidirectional chopper"
+  extends Modelica.Electrical.PowerConverters.Interfaces.DCDC.DCtwoPin1;
+  extends Modelica.Electrical.PowerConverters.Interfaces.DCDC.DCtwoPin2;
+  extends Modelica.Electrical.Analog.Interfaces.ConditionalHeatPort(final T=293.15);
+  parameter Modelica.Units.SI.Resistance RonTransistor=1e-05
+    "Transistor closed resistance";
+  parameter Modelica.Units.SI.Conductance GoffTransistor=1e-05
+    "Transistor opened conductance";
+  parameter Modelica.Units.SI.Voltage VkneeTransistor=0
+    "Transistor threshold voltage";
+  parameter Modelica.Units.SI.Resistance RonDiode=1e-05
+    "Diode closed resistance";
+  parameter Modelica.Units.SI.Conductance GoffDiode=1e-05
+    "Diode opened conductance";
+  parameter Modelica.Units.SI.Voltage VkneeDiode=0
+    "Diode threshold voltage";
+  extends Modelica.Electrical.PowerConverters.Interfaces.Enable.Enable2;
+  Modelica.Electrical.Analog.Ideal.IdealGTOThyristor transistorLS(
+    useHeatPort=useHeatPort,
+    Ron=RonTransistor,
+    Goff=GoffTransistor,
+    Vknee=VkneeTransistor) "Switching transistor low side" annotation (
+      Placement(transformation(
+        origin={-40,0},
+        extent={{-10,10},{10,-10}},
+        rotation=270)));
+  Modelica.Electrical.Analog.Ideal.IdealDiode diodeLS(
+    useHeatPort=useHeatPort,
+    Ron=RonDiode,
+    Goff=GoffDiode,
+    Vknee=VkneeDiode) "Free wheeling diode low side" annotation (Placement(
+        transformation(
+        origin={-20,0},
+        extent={{-10,-10},{10,10}},
+        rotation=90)));
+  Modelica.Electrical.Analog.Ideal.IdealGTOThyristor transistorHS(
+    useHeatPort=useHeatPort,
+    Ron=RonTransistor,
+    Goff=GoffTransistor,
+    Vknee=VkneeTransistor) "Switching transistor hugh side" annotation (
+      Placement(transformation(
+        origin={50,60},
+        extent={{-10,-10},{10,10}},
+        rotation=180)));
+  Modelica.Electrical.Analog.Ideal.IdealDiode diodeHS(
+    useHeatPort=useHeatPort,
+    Ron=RonDiode,
+    Goff=GoffDiode,
+    Vknee=VkneeDiode) "Free wheeling diode high side" annotation (Placement(
+        transformation(
+        origin={50,80},
+        extent={{-10,10},{10,-10}},
+        rotation=0)));
+equation
+  if not useHeatPort then
+    LossPower = diodeLS.LossPower + transistorLS.LossPower
+              + diodeHS.LossPower + transistorHS.LossPower;
+  end if;
+  connect(transistorLS.p, diodeLS.n)
+    annotation (Line(points={{-40,10},{-20,10}}, color={0,0,255}));
+  connect(dc_n1, transistorLS.n) annotation (Line(points={{-100,-60},{-40,-60},
+          {-40,-10}},color={0,0,255}));
+  connect(transistorLS.n, diodeLS.p)
+    annotation (Line(points={{-40,-10},{-20,-10}}, color={0,0,255}));
+  connect(diodeHS.p, transistorHS.n)
+    annotation (Line(points={{40,80},{40,60}}, color={0,0,255}));
+  connect(diodeHS.n, transistorHS.p)
+    annotation (Line(points={{60,80},{60,60}}, color={0,0,255}));
+  connect(transistorHS.p, dc_p2)
+    annotation (Line(points={{60,60},{100,60}}, color={0,0,255}));
+  connect(dc_n1, dc_n2)
+    annotation (Line(points={{-100,-60},{100,-60}}, color={0,0,255}));
+  connect(diodeLS.heatPort, heatPort) annotation (Line(points={{-10,5.55112e-16},
+          {-10,-40},{0,-40},{0,-100}},
+                             color={191,0,0}));
+  connect(transistorLS.heatPort, heatPort) annotation (Line(points={{-30,-1.77636e-15},
+          {-30,-40},{0,-40},{0,-100}},
+                                  color={191,0,0}));
+  connect(diodeHS.heatPort, heatPort)
+    annotation (Line(points={{50,90},{0,90},{0,-100}}, color={191,0,0}));
+  connect(transistorHS.heatPort, heatPort)
+    annotation (Line(points={{50,70},{0,70},{0,-100}}, color={191,0,0}));
+  connect(dc_p1, transistorLS.p)
+    annotation (Line(points={{-100,60},{-40,60},{-40,10}}, color={0,0,255}));
+  connect(transistorHS.n, dc_p1)
+    annotation (Line(points={{40,60},{-100,60}}, color={0,0,255}));
+  connect(andCondition_n.y, transistorHS.fire) annotation (Line(points={{60,-69},
+          {60,40},{40,40},{40,48}}, color={255,0,255}));
+  connect(andCondition_p.y, transistorLS.fire) annotation (Line(points={{-60,-69},
+          {-60,-10},{-52,-10}}, color={255,0,255}));
+  annotation (defaultComponentName="dcdc",
+    Icon(graphics={
+        Rectangle(
+          extent={{-100,100},{100,-100}},
+          lineColor={0,0,127},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+                   Line(points={{10,0},{0,0},{0,20},{0,-20},{0,-4},{-16,-20},{-10,
+              -8},{-4,-14},{-16,-20},{-20,-24},{-20,-60},{-20,-24},{-30,-24},{-30,
+              8},{-20,-8},{-40,-8},{-30,8},{-20,8},{-40,8},{-30,8},{-30,24},{-20,
+              24},{-20,60},{-20,24},{0,4}},
+                                   color={28,108,200}), Line(
+          points={{0,-25},{0,-15},{20,-15},{-20,-15},{-4,-15},{-20,1},{-8,-5},{-14,
+              -11},{-20,1},{-24,5},{-130,5},{-24,5},{-24,15},{8,15},{-8,5},{-8,25},
+              {8,15},{8,5},{8,25},{8,15},{24,15},{24,5},{50,5},{24,5},{4,-15}},
+          color={28,108,200},
+          origin={40,55},
+          rotation=360),
+        Line(points={{-90,-60},{90,-60}}, color={28,108,200}),
+        Text(
+          extent={{-150,148},{150,108}},
+          textString="%name",
+          textColor={0,0,255})}),
+    Documentation(info="<html>
+<p>
+This is a bidirectional buck / boost - converter with 2 transistors and 2 freewheeling diodes.
+</p>
+</html>"));
+end ChopperBuckBost;

--- a/Modelica/Electrical/PowerConverters/DCDC/package.mo
+++ b/Modelica/Electrical/PowerConverters/DCDC/package.mo
@@ -1,6 +1,7 @@
 within Modelica.Electrical.PowerConverters;
 package DCDC "DC to DC converters"
   extends Modelica.Icons.Package;
+
   annotation (Documentation(info="<html>
 <p>
 General information about DC/DC converters can be found at the

--- a/Modelica/Electrical/PowerConverters/DCDC/package.order
+++ b/Modelica/Electrical/PowerConverters/DCDC/package.order
@@ -1,4 +1,5 @@
 Control
 ChopperStepDown
 ChopperStepUp
+ChopperBuckBost
 HBridge

--- a/Modelica/Electrical/PowerConverters/Examples/DCDC/ChopperBuckBoost/ChopperBuckBoost_DutyCycle.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCDC/ChopperBuckBoost/ChopperBuckBoost_DutyCycle.mo
@@ -27,5 +27,12 @@ Changing the <code>dutyCycle &gt; idleDutyCycle</code>, the low voltage battery 
 The capacitors are precharged to the battery voltages, but the inductor leads zero current. 
 The current sensor may be used to implement current control.
 </p>
+<h4>Control</h4>
+<p>
+For hints implementing control, see:
+Stefan Norbert Matlok, 
+<a href=\"https://nbn-resolving.org/urn:nbn:de:bvb:29-opus4-146221\"><em>Digitale Regelung bidirektionaler Gleichspannungswandler</em></a> 
+(German, <em>Digital control of bidirectional DC/DC converters</em>), PhD thesis University Erlangen-Nuremberg 2020.
+</p>
 </html>"));
 end ChopperBuckBoost_DutyCycle;

--- a/Modelica/Electrical/PowerConverters/Examples/DCDC/ChopperBuckBoost/ChopperBuckBoost_DutyCycle.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCDC/ChopperBuckBoost/ChopperBuckBoost_DutyCycle.mo
@@ -1,0 +1,31 @@
+within Modelica.Electrical.PowerConverters.Examples.DCDC.ChopperBuckBoost;
+model ChopperBuckBoost_DutyCycle
+  extends DCDC.ExampleTemplates.ChopperBuckBoost(pwm(useConstantDutyCycle=false));
+  extends Modelica.Icons.Example;
+  Modelica.Blocks.Sources.Step dutyCycle(
+    height=0.2,
+    offset=idleDutyCycle - 0.1,
+    startTime=0.05)
+    annotation (Placement(transformation(extent={{-20,-50},{0,-30}})));
+equation
+  connect(dutyCycle.y, pwm.dutyCycle)
+    annotation (Line(points={{1,-40},{8,-40}},  color={0,0,127}));
+  annotation (experiment(
+      StopTime=0.1,
+      Interval=1e-05,
+      Tolerance=1e-06),
+      Documentation(info="<html>
+<p>
+This examples demonstrates bidirectional coupling of two batteries with different voltages as used in automotive. 
+For <code>idleDutyCycle = 1 - (VLV/VHV)</code>, no current is exchanged.
+</p>
+<p>
+Starting with <code>dutyCycle &lt; idleDutyCycle</code>, the high voltage battery feeds the low voltage battery. 
+Changing the <code>dutyCycle &gt; idleDutyCycle</code>, the low voltage battery feeds the high voltage battery. 
+</p>
+<p>
+The capacitors are precharged to the battery voltages, but the inductor leads zero current. 
+The current sensor may be used to implement current control.
+</p>
+</html>"));
+end ChopperBuckBoost_DutyCycle;

--- a/Modelica/Electrical/PowerConverters/Examples/DCDC/ChopperBuckBoost/ChopperBuckBoost_DutyCycle.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCDC/ChopperBuckBoost/ChopperBuckBoost_DutyCycle.mo
@@ -12,7 +12,7 @@ equation
     annotation (Line(points={{1,-40},{8,-40}},  color={0,0,127}));
   annotation (experiment(
       StopTime=0.1,
-      Interval=1e-05,
+      Interval=1e-06,
       Tolerance=1e-06),
       Documentation(info="<html>
 <p>

--- a/Modelica/Electrical/PowerConverters/Examples/DCDC/ChopperBuckBoost/package.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCDC/ChopperBuckBoost/package.mo
@@ -1,0 +1,5 @@
+within Modelica.Electrical.PowerConverters.Examples.DCDC;
+package ChopperBuckBoost "Chopper buck/boost"
+  extends Modelica.Icons.ExamplesPackage;
+
+end ChopperBuckBoost;

--- a/Modelica/Electrical/PowerConverters/Examples/DCDC/ChopperBuckBoost/package.order
+++ b/Modelica/Electrical/PowerConverters/Examples/DCDC/ChopperBuckBoost/package.order
@@ -1,0 +1,1 @@
+ChopperBuckBoost_DutyCycle

--- a/Modelica/Electrical/PowerConverters/Examples/DCDC/ExampleTemplates/ChopperBuckBoost.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCDC/ExampleTemplates/ChopperBuckBoost.mo
@@ -9,7 +9,7 @@ partial model ChopperBuckBoost "Buck/boost converter example template"
   parameter Modelica.Units.SI.Capacitance CHV=250e-6 "High voltage capacitance";
   parameter Modelica.Units.SI.Inductance L=10e-6 "Inductance";
   parameter Modelica.Units.SI.Resistance R=1e-3 "Resistance of inductor";
-  parameter Modelica.Units.SI.Frequency fS=10e3 "Switching frequency";
+  parameter Modelica.Units.SI.Frequency fS=40e3 "Switching frequency";
   parameter Real idleDutyCycle=1 - VLV/VHV "Duty cycle for idle operation";
   Modelica.Electrical.PowerConverters.DCDC.ChopperBuckBost dcdc
     annotation (Placement(transformation(extent={{10,-8},{30,12}})));

--- a/Modelica/Electrical/PowerConverters/Examples/DCDC/ExampleTemplates/ChopperBuckBoost.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCDC/ExampleTemplates/ChopperBuckBoost.mo
@@ -1,0 +1,120 @@
+within Modelica.Electrical.PowerConverters.Examples.DCDC.ExampleTemplates;
+partial model ChopperBuckBoost "Buck/boost converter example template"
+  extends Modelica.Electrical.PowerConverters.Icons.ExampleTemplate;
+  parameter Modelica.Units.SI.Voltage VLV=12 "LV voltage";
+  parameter Modelica.Units.SI.Resistance RiLV=0.01 "LV inner resistance";
+  parameter Modelica.Units.SI.Voltage VHV=24 "HV voltage";
+  parameter Modelica.Units.SI.Resistance RiHV=0.01 "HV inner resistance";
+  parameter Modelica.Units.SI.Capacitance CLV=500e-6 "Low voltage capacitance";
+  parameter Modelica.Units.SI.Capacitance CHV=250e-6 "High voltage capacitance";
+  parameter Modelica.Units.SI.Inductance L=10e-6 "Inductance";
+  parameter Modelica.Units.SI.Resistance R=1e-3 "Resistance of inductor";
+  parameter Modelica.Units.SI.Frequency fS=10e3 "Switching frequency";
+  parameter Real idleDutyCycle=1 - VLV/VHV "Duty cycle for idle operation";
+  Modelica.Electrical.PowerConverters.DCDC.ChopperBuckBost dcdc
+    annotation (Placement(transformation(extent={{10,-8},{30,12}})));
+  Modelica.Electrical.Analog.Sources.ConstantVoltage constantVoltageLV(V=VLV)
+    annotation (Placement(transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=270,
+        origin={-90,0})));
+  Modelica.Electrical.Analog.Basic.Resistor resistorLV(R=RiLV)
+    annotation (Placement(transformation(extent={{-80,10},{-60,30}})));
+  Modelica.Electrical.Analog.Basic.Ground ground
+    annotation (Placement(transformation(extent={{-100,-40},{-80,-20}})));
+  Modelica.Electrical.Analog.Basic.Capacitor capacitorLV(v(fixed=true, start=VLV), C=CLV)
+    annotation (
+      Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-50,0})));
+  Modelica.Electrical.Analog.Basic.Resistor resistor(R=R, useHeatPort=false)
+    annotation (Placement(transformation(extent={{-50,10},{-30,30}})));
+  Modelica.Electrical.Analog.Basic.Inductor inductor(i(fixed=true),  L=L)
+    annotation (Placement(transformation(extent={{-20,10},{0,30}})));
+  Modelica.Electrical.Analog.Basic.Capacitor capacitorHV(v(fixed=true, start=VHV), C=CHV)
+    annotation (
+      Placement(transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=270,
+        origin={50,0})));
+  Modelica.Electrical.Analog.Sources.ConstantVoltage constantVoltageHV(V=VHV)
+    annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={90,0})));
+  Modelica.Electrical.Analog.Basic.Resistor resistorHV(R=RiHV)
+    annotation (Placement(transformation(extent={{80,10},{60,30}})));
+  Modelica.Blocks.Sources.RealExpression vLV(y=capacitorLV.v)
+    annotation (Placement(transformation(extent={{-80,70},{-60,90}})));
+  Modelica.Blocks.Sources.RealExpression iLV(y=resistorLV.i)
+    annotation (Placement(transformation(extent={{-80,40},{-60,60}})));
+  Modelica.Blocks.Sources.RealExpression vHV(y=capacitorHV.v)
+    annotation (Placement(transformation(extent={{80,70},{60,90}})));
+  Modelica.Blocks.Sources.RealExpression iHV(y=resistorHV.i)
+    annotation (Placement(transformation(extent={{80,40},{60,60}})));
+  Modelica.Blocks.Math.Mean mean_vLV(f=fS)
+    annotation (Placement(transformation(extent={{-50,70},{-30,90}})));
+  Modelica.Blocks.Math.Mean mean_iLV(f=fS)
+    annotation (Placement(transformation(extent={{-50,40},{-30,60}})));
+  Modelica.Blocks.Math.Mean mean_vHV(f=fS)
+    annotation (Placement(transformation(extent={{50,70},{30,90}})));
+  Modelica.Blocks.Math.Mean mean_iHV(f=fS)
+    annotation (Placement(transformation(extent={{50,40},{30,60}})));
+  Modelica.Electrical.PowerConverters.DCDC.Control.SignalPWM pwm(f=fS) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=0,
+        origin={20,-40})));
+  Modelica.Electrical.Analog.Sensors.CurrentSensor currentSensor
+    annotation (Placement(transformation(extent={{-60,-30},{-80,-10}})));
+equation
+  connect(constantVoltageLV.p, resistorLV.p)
+    annotation (Line(points={{-90,10},{-90,20},{-80,20}}, color={0,0,255}));
+  connect(constantVoltageLV.n, ground.p)
+    annotation (Line(points={{-90,-10},{-90,-20}},           color={0,0,255}));
+  connect(resistorHV.p, constantVoltageHV.p)
+    annotation (Line(points={{80,20},{90,20},{90,10}}, color={0,0,255}));
+  connect(vLV.y, mean_vLV.u)
+    annotation (Line(points={{-59,80},{-52,80}}, color={0,0,127}));
+  connect(iLV.y,mean_iLV. u)
+    annotation (Line(points={{-59,50},{-52,50}}, color={0,0,127}));
+  connect(mean_iHV.u, iHV.y)
+    annotation (Line(points={{52,50},{59,50}}, color={0,0,127}));
+  connect(vHV.y, mean_vHV.u)
+    annotation (Line(points={{59,80},{52,80}}, color={0,0,127}));
+  connect(capacitorHV.n, dcdc.dc_n2) annotation (Line(points={{50,-10},{50,-20},
+          {40,-20},{40,-4},{30,-4}}, color={0,0,255}));
+  connect(dcdc.dc_p2, resistorHV.n)
+    annotation (Line(points={{30,8},{40,8},{40,20},{60,20}}, color={0,0,255}));
+  connect(capacitorHV.p, resistorHV.n)
+    annotation (Line(points={{50,10},{50,20},{60,20}},
+                                               color={0,0,255}));
+  connect(capacitorHV.n, constantVoltageHV.n) annotation (Line(points={{50,-10},
+          {50,-20},{90,-20},{90,-10}}, color={0,0,255}));
+  connect(resistorLV.n, resistor.p)
+    annotation (Line(points={{-60,20},{-50,20}}, color={0,0,255}));
+  connect(resistor.n, inductor.p)
+    annotation (Line(points={{-30,20},{-20,20}}, color={0,0,255}));
+  connect(dcdc.dc_p1, inductor.n)
+    annotation (Line(points={{10,8},{0,8},{0,20}},          color={0,0,255}));
+  connect(dcdc.fire_p, pwm.fire)
+    annotation (Line(points={{14,-10},{14,-29}}, color={255,0,255}));
+  connect(dcdc.fire_n, pwm.notFire)
+    annotation (Line(points={{26,-10},{26,-29}}, color={255,0,255}));
+  connect(resistor.p, capacitorLV.p)
+    annotation (Line(points={{-50,20},{-50,10}}, color={0,0,255}));
+  connect(ground.p, currentSensor.n)
+    annotation (Line(points={{-90,-20},{-80,-20}}, color={0,0,255}));
+  connect(currentSensor.p, capacitorLV.n)
+    annotation (Line(points={{-60,-20},{-50,-20},{-50,-10}}, color={0,0,255}));
+  connect(capacitorLV.n, dcdc.dc_n1) annotation (Line(points={{-50,-10},{-50,-20},
+          {0,-20},{0,-4},{10,-4}},   color={0,0,255}));
+  annotation (experiment(
+      StopTime=1,
+      Interval=1e-05,
+      Tolerance=1e-06), Documentation(info="<html>
+<p>
+Buck/boost chopper example template including both voltage sources; control not included yet
+</p>
+</html>"));
+end ChopperBuckBoost;

--- a/Modelica/Electrical/PowerConverters/Examples/DCDC/ExampleTemplates/ChopperBuckBoost.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCDC/ExampleTemplates/ChopperBuckBoost.mo
@@ -114,7 +114,7 @@ equation
       Interval=1e-05,
       Tolerance=1e-06), Documentation(info="<html>
 <p>
-Buck/boost chopper example template including both voltage sources; control not included yet
+Buck/boost chopper example template including both voltage sources; control not included.
 </p>
 </html>"));
 end ChopperBuckBoost;

--- a/Modelica/Electrical/PowerConverters/Examples/DCDC/ExampleTemplates/package.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCDC/ExampleTemplates/package.mo
@@ -1,6 +1,7 @@
 within Modelica.Electrical.PowerConverters.Examples.DCDC;
 package ExampleTemplates "Templates of examples"
   extends Modelica.Icons.Package;
+
   annotation (Documentation(info="<html>
 <p>This package includes templates of the used examples. The templates are partial example models.</p>
 </html>"));

--- a/Modelica/Electrical/PowerConverters/Examples/DCDC/ExampleTemplates/package.order
+++ b/Modelica/Electrical/PowerConverters/Examples/DCDC/ExampleTemplates/package.order
@@ -1,3 +1,4 @@
 ChopperStepDown
 ChopperStepUp
+ChopperBuckBoost
 HBridge

--- a/Modelica/Electrical/PowerConverters/Examples/DCDC/package.order
+++ b/Modelica/Electrical/PowerConverters/Examples/DCDC/package.order
@@ -1,4 +1,5 @@
 ChopperStepDown
 ChopperStepUp
+ChopperBuckBoost
 HBridge
 ExampleTemplates

--- a/Modelica/Resources/Reference/Modelica/Electrical/PowerConverters/Examples/DCDC/ChopperBuckBoost/ChopperBuckBoost_DutyCycle/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/PowerConverters/Examples/DCDC/ChopperBuckBoost/ChopperBuckBoost_DutyCycle/comparisonSignals.txt
@@ -1,0 +1,5 @@
+time
+vLV.y
+iLV.y
+vHV.y
+iHV.y


### PR DESCRIPTION
I know that there are lots of power converter layouts and we're presenting only basic ones, but I realized that one important topology is missing: the bidirectional two-quadrant buck/boost converter.
It is widely used in automotive to couple batteries with different voltages as well as for battery management systems. 
Furthermore, it is an important topology for teaching power electronics and its control, and its a nice example for testing performance.