### PR TITLE
Update matio library to 1.5.21

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaMatIO.c
+++ b/Modelica/Resources/C-Sources/ModelicaMatIO.c
@@ -1,6 +1,6 @@
 /* ModelicaMatIO.c - MAT file I/O functions
 
-   Copyright (C) 2013-2020, Modelica Association and contributors
+   Copyright (C) 2013-2021, Modelica Association and contributors
    Copyright (C) 2005-2013, Christopher C. Hulbert
    All rights reserved.
 
@@ -117,7 +117,7 @@
 #endif
 
 /* Define to 1 if the system has the type `long double'. */
-#if defined (_WIN32)
+#if defined(_WIN32)
 #if defined(__WATCOMC__) || (defined(_MSC_VER) && _MSC_VER >= 1300)
 #define HAVE_LONG_DOUBLE 1
 #endif
@@ -127,7 +127,7 @@
 #endif
 
 /* Define to 1 if the system has the type `long long int'. */
-#if defined (_WIN32)
+#if defined(_WIN32)
 #if defined(__WATCOMC__) || (defined(_MSC_VER) && _MSC_VER >= 1300)
 #define HAVE_LONG_LONG_INT 1
 #endif
@@ -174,7 +174,7 @@
 #define HAVE_STRUCT_LCONV_THOUSANDS_SEP 1
 
 /* Define to 1 if the system has the type `unsigned long long int'. */
-#if defined (_WIN32)
+#if defined(_WIN32)
 #if defined(__WATCOMC__) || (defined(_MSC_VER) && _MSC_VER >= 1300)
 #define HAVE_UNSIGNED_LONG_LONG_INT 1
 #endif
@@ -213,7 +213,7 @@
 #endif
 
 /* Fixed types in safe-math.h disabled */
-#define PSNIP_SAFE_NO_FIXED 1 
+#define PSNIP_SAFE_NO_FIXED 1
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
@@ -254,7 +254,7 @@
 #include <hdf5.h>
 #endif
 
-#if (defined(_WIN64) || defined(_WIN32)) && !defined(__CYGWIN__)
+#if ( defined(_WIN64) || defined(_WIN32) ) && !defined(__CYGWIN__)
 #include <io.h>
 #endif
 
@@ -280,8 +280,8 @@
 #define READ_BLOCK_SIZE (256)
 #endif
 
-#define _CAT(X, Y) X ## Y
-#define CAT(X, Y) _CAT(X, Y) 
+#define _CAT(X, Y) X##Y
+#define CAT(X, Y) _CAT(X, Y)
 
 /** @if mat_devman
  * @brief Matlab MAT File information
@@ -290,21 +290,22 @@
  * @ingroup mat_internal
  * @endif
  */
-struct _mat_t {
-    void  *fp;              /**< File pointer for the MAT file */
-    char  *header;          /**< MAT file header string */
-    char  *subsys_offset;   /**< Offset */
-    char  *filename;        /**< Filename of the MAT file */
-    int    version;         /**< MAT file version */
-    int    byteswap;        /**< 1 if byte swapping is required, 0 otherwise */
-    int    mode;            /**< Access mode */
-    long   bof;             /**< Beginning of file not including any header */
-    size_t next_index;      /**< Index/File position of next variable to read */
-    size_t num_datasets;    /**< Number of datasets in the file */
+struct _mat_t
+{
+    void *fp;            /**< File pointer for the MAT file */
+    char *header;        /**< MAT file header string */
+    char *subsys_offset; /**< Offset */
+    char *filename;      /**< Filename of the MAT file */
+    int version;         /**< MAT file version */
+    int byteswap;        /**< 1 if byte swapping is required, 0 otherwise */
+    int mode;            /**< Access mode */
+    long bof;            /**< Beginning of file not including any header */
+    size_t next_index;   /**< Index/File position of next variable to read */
+    size_t num_datasets; /**< Number of datasets in the file */
 #if HAVE_HDF5
-    hid_t  refs_id;         /**< Id of the /#refs# group in HDF5 */
+    hid_t refs_id; /**< Id of the /#refs# group in HDF5 */
 #endif
-    char **dir;             /**< Names of the datasets in the file */
+    char **dir; /**< Names of the datasets in the file */
 };
 
 /** @if mat_devman
@@ -312,18 +313,19 @@ struct _mat_t {
  * @ingroup mat_internal
  * @endif
  */
-struct matvar_internal {
+struct matvar_internal
+{
 #if HAVE_HDF5
-    char      *hdf5_name;   /**< Name */
-    hobj_ref_t hdf5_ref;    /**< Reference */
-    hid_t      id;          /**< Id */
+    char *hdf5_name;     /**< Name */
+    hobj_ref_t hdf5_ref; /**< Reference */
+    hid_t id;            /**< Id */
 #endif
-    long       datapos;     /**< Offset from the beginning of the MAT file to the data */
-    unsigned   num_fields;  /**< Number of fields */
-    char     **fieldnames;  /**< Pointer to fieldnames */
+    long datapos;        /**< Offset from the beginning of the MAT file to the data */
+    unsigned num_fields; /**< Number of fields */
+    char **fieldnames;   /**< Pointer to fieldnames */
 #if HAVE_ZLIB
-    z_streamp  z;           /**< zlib compression state */
-    void      *data;        /**< Inflated data array */
+    z_streamp z; /**< zlib compression state */
+    void *data;  /**< Inflated data array */
 #endif
 };
 
@@ -336,111 +338,105 @@ int rpl_snprintf(char *, size_t, const char *, ...);
 #endif /* !HAVE_SNPRINTF */
 
 /* endian.c */
-static double        Mat_doubleSwap(double  *a);
-static float         Mat_floatSwap(float   *a);
+static double Mat_doubleSwap(double *a);
+static float Mat_floatSwap(float *a);
 #ifdef HAVE_MATIO_INT64_T
-static mat_int64_t   Mat_int64Swap(mat_int64_t  *a);
+static mat_int64_t Mat_int64Swap(mat_int64_t *a);
 #endif /* HAVE_MATIO_INT64_T */
 #ifdef HAVE_MATIO_UINT64_T
-static mat_uint64_t  Mat_uint64Swap(mat_uint64_t *a);
+static mat_uint64_t Mat_uint64Swap(mat_uint64_t *a);
 #endif /* HAVE_MATIO_UINT64_T */
-static mat_int32_t   Mat_int32Swap(mat_int32_t  *a);
-static mat_uint32_t  Mat_uint32Swap(mat_uint32_t *a);
-static mat_int16_t   Mat_int16Swap(mat_int16_t  *a);
-static mat_uint16_t  Mat_uint16Swap(mat_uint16_t *a);
+static mat_int32_t Mat_int32Swap(mat_int32_t *a);
+static mat_uint32_t Mat_uint32Swap(mat_uint32_t *a);
+static mat_int16_t Mat_int16Swap(mat_int16_t *a);
+static mat_uint16_t Mat_uint16Swap(mat_uint16_t *a);
 
 /* read_data.c */
-static size_t ReadDoubleData(mat_t *mat,double *data,enum matio_types data_type,
-               size_t len);
-static size_t ReadSingleData(mat_t *mat,float  *data,enum matio_types data_type,
-               size_t len);
+static size_t ReadDoubleData(mat_t *mat, double *data, enum matio_types data_type, size_t len);
+static size_t ReadSingleData(mat_t *mat, float *data, enum matio_types data_type, size_t len);
 #ifdef HAVE_MATIO_INT64_T
-static size_t ReadInt64Data (mat_t *mat,mat_int64_t *data,
-               enum matio_types data_type,size_t len);
+static size_t ReadInt64Data(mat_t *mat, mat_int64_t *data, enum matio_types data_type, size_t len);
 #endif /* HAVE_MATIO_INT64_T */
 #ifdef HAVE_MATIO_UINT64_T
-static size_t ReadUInt64Data(mat_t *mat,mat_uint64_t *data,
-               enum matio_types data_type,size_t len);
+static size_t ReadUInt64Data(mat_t *mat, mat_uint64_t *data, enum matio_types data_type,
+                             size_t len);
 #endif /* HAVE_MATIO_UINT64_T */
-static size_t ReadInt32Data (mat_t *mat,mat_int32_t *data,
-               enum matio_types data_type,size_t len);
-static size_t ReadUInt32Data(mat_t *mat,mat_uint32_t *data,
-               enum matio_types data_type,size_t len);
-static size_t ReadInt16Data (mat_t *mat,mat_int16_t *data,
-               enum matio_types data_type,size_t len);
-static size_t ReadUInt16Data(mat_t *mat,mat_uint16_t *data,
-               enum matio_types data_type,size_t len);
-static size_t ReadInt8Data  (mat_t *mat,mat_int8_t  *data,
-               enum matio_types data_type,size_t len);
-static size_t ReadUInt8Data (mat_t *mat,mat_uint8_t  *data,
-               enum matio_types data_type,size_t len);
-static size_t ReadCharData  (mat_t *mat,char  *data,enum matio_types data_type,
-               size_t len);
-static int ReadDataSlab1(mat_t *mat,void *data,enum matio_classes class_type,
-               enum matio_types data_type,int start,int stride,int edge);
-static int ReadDataSlab2(mat_t *mat,void *data,enum matio_classes class_type,
-               enum matio_types data_type,size_t *dims,int *start,int *stride,
-               int *edge);
-static int ReadDataSlabN(mat_t *mat,void *data,enum matio_classes class_type,
-               enum matio_types data_type,int rank,size_t *dims,int *start,
-               int *stride,int *edge);
+static size_t ReadInt32Data(mat_t *mat, mat_int32_t *data, enum matio_types data_type, size_t len);
+static size_t ReadUInt32Data(mat_t *mat, mat_uint32_t *data, enum matio_types data_type,
+                             size_t len);
+static size_t ReadInt16Data(mat_t *mat, mat_int16_t *data, enum matio_types data_type, size_t len);
+static size_t ReadUInt16Data(mat_t *mat, mat_uint16_t *data, enum matio_types data_type,
+                             size_t len);
+static size_t ReadInt8Data(mat_t *mat, mat_int8_t *data, enum matio_types data_type, size_t len);
+static size_t ReadUInt8Data(mat_t *mat, mat_uint8_t *data, enum matio_types data_type, size_t len);
+static size_t ReadCharData(mat_t *mat, void *data, enum matio_types data_type, size_t len);
+static int ReadDataSlab1(mat_t *mat, void *data, enum matio_classes class_type,
+                         enum matio_types data_type, int start, int stride, int edge);
+static int ReadDataSlab2(mat_t *mat, void *data, enum matio_classes class_type,
+                         enum matio_types data_type, size_t *dims, int *start, int *stride,
+                         int *edge);
+static int ReadDataSlabN(mat_t *mat, void *data, enum matio_classes class_type,
+                         enum matio_types data_type, int rank, size_t *dims, int *start,
+                         int *stride, int *edge);
 #if HAVE_ZLIB
-static int ReadCompressedDoubleData(mat_t *mat,z_streamp z,double  *data,
-               enum matio_types data_type,int len);
-static int ReadCompressedSingleData(mat_t *mat,z_streamp z,float   *data,
-               enum matio_types data_type,int len);
+static int ReadCompressedDoubleData(mat_t *mat, z_streamp z, double *data,
+                                    enum matio_types data_type, int len);
+static int ReadCompressedSingleData(mat_t *mat, z_streamp z, float *data,
+                                    enum matio_types data_type, int len);
 #ifdef HAVE_MATIO_INT64_T
-static int ReadCompressedInt64Data(mat_t *mat,z_streamp z,mat_int64_t *data,
-               enum matio_types data_type,int len);
+static int ReadCompressedInt64Data(mat_t *mat, z_streamp z, mat_int64_t *data,
+                                   enum matio_types data_type, int len);
 #endif /* HAVE_MATIO_INT64_T */
 #ifdef HAVE_MATIO_UINT64_T
-static int ReadCompressedUInt64Data(mat_t *mat,z_streamp z,mat_uint64_t *data,
-               enum matio_types data_type,int len);
+static int ReadCompressedUInt64Data(mat_t *mat, z_streamp z, mat_uint64_t *data,
+                                    enum matio_types data_type, int len);
 #endif /* HAVE_MATIO_UINT64_T */
-static int ReadCompressedInt32Data(mat_t *mat,z_streamp z,mat_int32_t *data,
-               enum matio_types data_type,int len);
-static int ReadCompressedUInt32Data(mat_t *mat,z_streamp z,mat_uint32_t *data,
-               enum matio_types data_type,int len);
-static int ReadCompressedInt16Data(mat_t *mat,z_streamp z,mat_int16_t *data,
-               enum matio_types data_type,int len);
-static int ReadCompressedUInt16Data(mat_t *mat,z_streamp z,mat_uint16_t *data,
-               enum matio_types data_type,int len);
-static int ReadCompressedInt8Data(mat_t *mat,z_streamp z,mat_int8_t  *data,
-               enum matio_types data_type,int len);
-static int ReadCompressedUInt8Data(mat_t *mat,z_streamp z,mat_uint8_t  *data,
-               enum matio_types data_type,int len);
-static int ReadCompressedCharData(mat_t *mat,z_streamp z,char *data,
-               enum matio_types data_type,int len);
-static int ReadCompressedDataSlab1(mat_t *mat,z_streamp z,void *data,
-               enum matio_classes class_type,enum matio_types data_type,
-               int start,int stride,int edge);
-static int ReadCompressedDataSlab2(mat_t *mat,z_streamp z,void *data,
-               enum matio_classes class_type,enum matio_types data_type,
-               size_t *dims,int *start,int *stride,int *edge);
-static int ReadCompressedDataSlabN(mat_t *mat,z_streamp z,void *data,
-               enum matio_classes class_type,enum matio_types data_type,
-               int rank,size_t *dims,int *start,int *stride,int *edge);
+static int ReadCompressedInt32Data(mat_t *mat, z_streamp z, mat_int32_t *data,
+                                   enum matio_types data_type, int len);
+static int ReadCompressedUInt32Data(mat_t *mat, z_streamp z, mat_uint32_t *data,
+                                    enum matio_types data_type, int len);
+static int ReadCompressedInt16Data(mat_t *mat, z_streamp z, mat_int16_t *data,
+                                   enum matio_types data_type, int len);
+static int ReadCompressedUInt16Data(mat_t *mat, z_streamp z, mat_uint16_t *data,
+                                    enum matio_types data_type, int len);
+static int ReadCompressedInt8Data(mat_t *mat, z_streamp z, mat_int8_t *data,
+                                  enum matio_types data_type, int len);
+static int ReadCompressedUInt8Data(mat_t *mat, z_streamp z, mat_uint8_t *data,
+                                   enum matio_types data_type, int len);
+static int ReadCompressedCharData(mat_t *mat, z_streamp z, void *data, enum matio_types data_type,
+                                  size_t len);
+static int ReadCompressedDataSlab1(mat_t *mat, z_streamp z, void *data,
+                                   enum matio_classes class_type, enum matio_types data_type,
+                                   int start, int stride, int edge);
+static int ReadCompressedDataSlab2(mat_t *mat, z_streamp z, void *data,
+                                   enum matio_classes class_type, enum matio_types data_type,
+                                   size_t *dims, int *start, int *stride, int *edge);
+static int ReadCompressedDataSlabN(mat_t *mat, z_streamp z, void *data,
+                                   enum matio_classes class_type, enum matio_types data_type,
+                                   int rank, size_t *dims, int *start, int *stride, int *edge);
 
 /* inflate.c */
-static int InflateSkip(mat_t *mat, z_streamp z, int nBytes, size_t* bytesread);
+static int InflateSkip(mat_t *mat, z_streamp z, int nBytes, size_t *bytesread);
 static int InflateSkipData(mat_t *mat, z_streamp z, enum matio_types data_type, int len);
-static int InflateRankDims(mat_t *mat, z_streamp z, void *buf, size_t nBytes, mat_uint32_t** dims, size_t* bytesread);
-static int Inflate(mat_t *mat, z_streamp z, void *buf, unsigned int nBytes, size_t* bytesread);
+static int InflateRankDims(mat_t *mat, z_streamp z, void *buf, size_t nBytes, mat_uint32_t **dims,
+                           size_t *bytesread);
+static int Inflate(mat_t *mat, z_streamp z, void *buf, unsigned int nBytes, size_t *bytesread);
 static int InflateData(mat_t *mat, z_streamp z, void *buf, unsigned int nBytes);
 #endif
 
 /* mat.c */
 static mat_complex_split_t *ComplexMalloc(size_t nbytes);
-static void ComplexFree(mat_complex_split_t* complex_data);
+static void ComplexFree(mat_complex_split_t *complex_data);
 static enum matio_types ClassType2DataType(enum matio_classes class_type);
-static int Add(size_t* res, size_t a, size_t b);
-static int Mul(size_t* res, size_t a, size_t b);
-static int Mat_MulDims(const matvar_t *matvar, size_t* nelems);
-static int Read(void* buf, size_t size, size_t count, FILE* fp, size_t* bytesread);
+static int Add(size_t *res, size_t a, size_t b);
+static int Mul(size_t *res, size_t a, size_t b);
+static int Mat_MulDims(const matvar_t *matvar, size_t *nelems);
+static int Read(void *buf, size_t size, size_t count, FILE *fp, size_t *bytesread);
+static int IsEndOfFile(FILE *fp, long *fpos);
 
 /* io.c */
 #if defined(_WIN32) && defined(_MSC_VER)
-static wchar_t* utf82u(const char* src);
+static wchar_t *utf82u(const char *src);
 #endif
 
 #endif
@@ -448,7 +444,10 @@ static wchar_t* utf82u(const char* src);
 /** @brief swap the bytes @c a and @c b
  * @ingroup mat_internal
  */
-#define swap(a,b)   a^=b;b^=a;a^=b
+#define swap(a, b) \
+    a ^= b;        \
+    b ^= a;        \
+    a ^= b
 
 #ifdef HAVE_MATIO_INT64_T
 /** @brief swap the bytes of a 64-bit signed integer
@@ -457,20 +456,19 @@ static wchar_t* utf82u(const char* src);
  * @return the swapped integer
  */
 static mat_int64_t
-Mat_int64Swap( mat_int64_t *a )
+Mat_int64Swap(mat_int64_t *a)
 {
-
     union {
-        mat_int8_t    i1[8];
-        mat_int64_t   i8;
+        mat_int8_t i1[8];
+        mat_int64_t i8;
     } tmp;
 
     tmp.i8 = *a;
 
-    swap( tmp.i1[0], tmp.i1[7] );
-    swap( tmp.i1[1], tmp.i1[6] );
-    swap( tmp.i1[2], tmp.i1[5] );
-    swap( tmp.i1[3], tmp.i1[4] );
+    swap(tmp.i1[0], tmp.i1[7]);
+    swap(tmp.i1[1], tmp.i1[6]);
+    swap(tmp.i1[2], tmp.i1[5]);
+    swap(tmp.i1[3], tmp.i1[4]);
 
     *a = tmp.i8;
 
@@ -485,20 +483,19 @@ Mat_int64Swap( mat_int64_t *a )
  * @return the swapped integer
  */
 static mat_uint64_t
-Mat_uint64Swap( mat_uint64_t *a )
+Mat_uint64Swap(mat_uint64_t *a)
 {
-
     union {
-        mat_uint8_t    i1[8];
-        mat_uint64_t   i8;
+        mat_uint8_t i1[8];
+        mat_uint64_t i8;
     } tmp;
 
     tmp.i8 = *a;
 
-    swap( tmp.i1[0], tmp.i1[7] );
-    swap( tmp.i1[1], tmp.i1[6] );
-    swap( tmp.i1[2], tmp.i1[5] );
-    swap( tmp.i1[3], tmp.i1[4] );
+    swap(tmp.i1[0], tmp.i1[7]);
+    swap(tmp.i1[1], tmp.i1[6]);
+    swap(tmp.i1[2], tmp.i1[5]);
+    swap(tmp.i1[3], tmp.i1[4]);
 
     *a = tmp.i8;
 
@@ -512,18 +509,17 @@ Mat_uint64Swap( mat_uint64_t *a )
  * @return the swapped integer
  */
 static mat_int32_t
-Mat_int32Swap( mat_int32_t *a )
+Mat_int32Swap(mat_int32_t *a)
 {
-
     union {
-        mat_int8_t    i1[4];
-        mat_int32_t   i4;
+        mat_int8_t i1[4];
+        mat_int32_t i4;
     } tmp;
 
     tmp.i4 = *a;
 
-    swap( tmp.i1[0], tmp.i1[3] );
-    swap( tmp.i1[1], tmp.i1[2] );
+    swap(tmp.i1[0], tmp.i1[3]);
+    swap(tmp.i1[1], tmp.i1[2]);
 
     *a = tmp.i4;
 
@@ -536,18 +532,17 @@ Mat_int32Swap( mat_int32_t *a )
  * @return the swapped integer
  */
 static mat_uint32_t
-Mat_uint32Swap( mat_uint32_t *a )
+Mat_uint32Swap(mat_uint32_t *a)
 {
-
     union {
-        mat_uint8_t    i1[4];
-        mat_uint32_t   i4;
+        mat_uint8_t i1[4];
+        mat_uint32_t i4;
     } tmp;
 
     tmp.i4 = *a;
 
-    swap( tmp.i1[0], tmp.i1[3] );
-    swap( tmp.i1[1], tmp.i1[2] );
+    swap(tmp.i1[0], tmp.i1[3]);
+    swap(tmp.i1[1], tmp.i1[2]);
 
     *a = tmp.i4;
 
@@ -560,17 +555,16 @@ Mat_uint32Swap( mat_uint32_t *a )
  * @return the swapped integer
  */
 static mat_int16_t
-Mat_int16Swap( mat_int16_t *a )
+Mat_int16Swap(mat_int16_t *a)
 {
-
     union {
-        mat_int8_t   i1[2];
-        mat_int16_t  i2;
+        mat_int8_t i1[2];
+        mat_int16_t i2;
     } tmp;
 
     tmp.i2 = *a;
 
-    swap( tmp.i1[0], tmp.i1[1] );
+    swap(tmp.i1[0], tmp.i1[1]);
 
     *a = tmp.i2;
     return *a;
@@ -582,17 +576,16 @@ Mat_int16Swap( mat_int16_t *a )
  * @return the swapped integer
  */
 static mat_uint16_t
-Mat_uint16Swap( mat_uint16_t *a )
+Mat_uint16Swap(mat_uint16_t *a)
 {
-
     union {
-        mat_uint8_t   i1[2];
-        mat_uint16_t  i2;
+        mat_uint8_t i1[2];
+        mat_uint16_t i2;
     } tmp;
 
     tmp.i2 = *a;
 
-    swap( tmp.i1[0], tmp.i1[1] );
+    swap(tmp.i1[0], tmp.i1[1]);
 
     *a = tmp.i2;
     return *a;
@@ -604,18 +597,17 @@ Mat_uint16Swap( mat_uint16_t *a )
  * @return the swapped integer
  */
 static float
-Mat_floatSwap( float *a )
+Mat_floatSwap(float *a)
 {
-
     union {
-        char  i1[4];
+        char i1[4];
         float r4;
     } tmp;
 
     tmp.r4 = *a;
 
-    swap( tmp.i1[0], tmp.i1[3] );
-    swap( tmp.i1[1], tmp.i1[2] );
+    swap(tmp.i1[0], tmp.i1[3]);
+    swap(tmp.i1[1], tmp.i1[2]);
 
     *a = tmp.r4;
     return *a;
@@ -627,36 +619,36 @@ Mat_floatSwap( float *a )
  * @return the swapped integer
  */
 static double
-Mat_doubleSwap( double *a )
+Mat_doubleSwap(double *a)
 {
 #ifndef SIZEOF_DOUBLE
 #define SIZEOF_DOUBLE 8
 #endif
 
     union {
-        char   a[SIZEOF_DOUBLE];
+        char a[SIZEOF_DOUBLE];
         double b;
     } tmp;
 
     tmp.b = *a;
 
 #if SIZEOF_DOUBLE == 4
-    swap( tmp.a[0], tmp.a[3] );
-    swap( tmp.a[1], tmp.a[2] );
+    swap(tmp.a[0], tmp.a[3]);
+    swap(tmp.a[1], tmp.a[2]);
 #elif SIZEOF_DOUBLE == 8
-    swap( tmp.a[0], tmp.a[7] );
-    swap( tmp.a[1], tmp.a[6] );
-    swap( tmp.a[2], tmp.a[5] );
-    swap( tmp.a[3], tmp.a[4] );
+    swap(tmp.a[0], tmp.a[7]);
+    swap(tmp.a[1], tmp.a[6]);
+    swap(tmp.a[2], tmp.a[5]);
+    swap(tmp.a[3], tmp.a[4]);
 #elif SIZEOF_DOUBLE == 16
-    swap( tmp.a[0], tmp.a[15] );
-    swap( tmp.a[1], tmp.a[14] );
-    swap( tmp.a[2], tmp.a[13] );
-    swap( tmp.a[3], tmp.a[12] );
-    swap( tmp.a[4], tmp.a[11] );
-    swap( tmp.a[5], tmp.a[10] );
-    swap( tmp.a[6], tmp.a[9] );
-    swap( tmp.a[7], tmp.a[8] );
+    swap(tmp.a[0], tmp.a[15]);
+    swap(tmp.a[1], tmp.a[14]);
+    swap(tmp.a[2], tmp.a[13]);
+    swap(tmp.a[3], tmp.a[12]);
+    swap(tmp.a[4], tmp.a[11]);
+    swap(tmp.a[5], tmp.a[10]);
+    swap(tmp.a[6], tmp.a[9]);
+    swap(tmp.a[7], tmp.a[8]);
 #endif
     *a = tmp.b;
     return *a;
@@ -687,7 +679,7 @@ Mat_doubleSwap( double *a )
 
  */
 static int
-InflateSkip(mat_t *mat, z_streamp z, int nBytes, size_t* bytesread)
+InflateSkip(mat_t *mat, z_streamp z, int nBytes, size_t *bytesread)
 {
     mat_uint8_t comp_buf[READ_BLOCK_SIZE], uncomp_buf[READ_BLOCK_SIZE];
     int n, err = MATIO_E_NO_ERROR, cnt = 0;
@@ -697,7 +689,7 @@ InflateSkip(mat_t *mat, z_streamp z, int nBytes, size_t* bytesread)
 
     n = nBytes < READ_BLOCK_SIZE ? nBytes : READ_BLOCK_SIZE;
     if ( !z->avail_in ) {
-        size_t nbytes = fread(comp_buf, 1, n, (FILE*)mat->fp);
+        size_t nbytes = fread(comp_buf, 1, n, (FILE *)mat->fp);
         if ( 0 == nbytes ) {
             return err;
         }
@@ -708,12 +700,13 @@ InflateSkip(mat_t *mat, z_streamp z, int nBytes, size_t* bytesread)
         z->next_in = comp_buf;
     }
     z->avail_out = n;
-    z->next_out  = uncomp_buf;
-    err = inflate(z,Z_FULL_FLUSH);
+    z->next_out = uncomp_buf;
+    err = inflate(z, Z_FULL_FLUSH);
     if ( err == Z_STREAM_END ) {
         return MATIO_E_NO_ERROR;
     } else if ( err != Z_OK ) {
-        Mat_Critical("InflateSkip: inflate returned %s",zError(err == Z_NEED_DICT ? Z_DATA_ERROR : err));
+        Mat_Critical("InflateSkip: inflate returned %s",
+                     zError(err == Z_NEED_DICT ? Z_DATA_ERROR : err));
         return MATIO_E_FILE_FORMAT_VIOLATION;
     } else {
         err = MATIO_E_NO_ERROR;
@@ -725,11 +718,11 @@ InflateSkip(mat_t *mat, z_streamp z, int nBytes, size_t* bytesread)
             n = READ_BLOCK_SIZE;
         }
         z->avail_out = n;
-        z->next_out  = uncomp_buf;
+        z->next_out = uncomp_buf;
     }
     while ( cnt < nBytes ) {
         if ( !z->avail_in ) {
-            size_t nbytes = fread(comp_buf, 1, n, (FILE*)mat->fp);
+            size_t nbytes = fread(comp_buf, 1, n, (FILE *)mat->fp);
             if ( 0 == nbytes ) {
                 break;
             }
@@ -739,12 +732,12 @@ InflateSkip(mat_t *mat, z_streamp z, int nBytes, size_t* bytesread)
             z->avail_in = (uInt)nbytes;
             z->next_in = comp_buf;
         }
-        err = inflate(z,Z_FULL_FLUSH);
+        err = inflate(z, Z_FULL_FLUSH);
         if ( err == Z_STREAM_END ) {
             err = MATIO_E_NO_ERROR;
             break;
         } else if ( err != Z_OK ) {
-            const char* errMsg = zError(err == Z_NEED_DICT ? Z_DATA_ERROR : err);
+            const char *errMsg = zError(err == Z_NEED_DICT ? Z_DATA_ERROR : err);
             err = MATIO_E_FILE_FORMAT_VIOLATION;
             Mat_Critical("InflateSkip: inflate returned %s", errMsg);
             break;
@@ -758,13 +751,13 @@ InflateSkip(mat_t *mat, z_streamp z, int nBytes, size_t* bytesread)
                 n = READ_BLOCK_SIZE;
             }
             z->avail_out = n;
-            z->next_out  = uncomp_buf;
+            z->next_out = uncomp_buf;
         }
     }
 
     if ( z->avail_in ) {
         const long offset = -(long)z->avail_in;
-        (void)fseek((FILE*)mat->fp, offset, SEEK_CUR);
+        (void)fseek((FILE *)mat->fp, offset, SEEK_CUR);
         if ( NULL != bytesread ) {
             *bytesread -= z->avail_in;
         }
@@ -801,7 +794,7 @@ InflateSkipData(mat_t *mat, z_streamp z, enum matio_types data_type, int len)
             break;
     }
 
-    return InflateSkip(mat, z, (unsigned int)Mat_SizeOf(data_type)*len, NULL);
+    return InflateSkip(mat, z, (unsigned int)Mat_SizeOf(data_type) * len, NULL);
 }
 
 /** @brief Inflates the dimensions tag and the dimensions data
@@ -820,7 +813,8 @@ InflateSkipData(mat_t *mat, z_streamp z, enum matio_types data_type, int len)
 
  */
 static int
-InflateRankDims(mat_t *mat, z_streamp z, void *buf, size_t nBytes, mat_uint32_t** dims, size_t* bytesread)
+InflateRankDims(mat_t *mat, z_streamp z, void *buf, size_t nBytes, mat_uint32_t **dims,
+                size_t *bytesread)
 {
     mat_int32_t tag[2];
     int rank, i, err;
@@ -833,10 +827,10 @@ InflateRankDims(mat_t *mat, z_streamp z, void *buf, size_t nBytes, mat_uint32_t*
         return err;
     }
     tag[0] = *(int *)buf;
-    tag[1] = *((int *)buf+1);
+    tag[1] = *((int *)buf + 1);
     if ( mat->byteswap ) {
         Mat_int32Swap(tag);
-        Mat_int32Swap(tag+1);
+        Mat_int32Swap(tag + 1);
     }
     if ( (tag[0] & 0x0000ffff) != MAT_T_INT32 ) {
         Mat_Critical("InflateRankDims: Reading dimensions expected type MAT_T_INT32");
@@ -844,20 +838,20 @@ InflateRankDims(mat_t *mat, z_streamp z, void *buf, size_t nBytes, mat_uint32_t*
     }
     rank = tag[1];
     if ( rank % 8 != 0 )
-        i = 8-(rank %8);
+        i = 8 - (rank % 8);
     else
         i = 0;
     rank += i;
 
-    if ( sizeof(mat_uint32_t)*(rank + 2) <= nBytes ) {
-        err = Inflate(mat, z, (mat_int32_t *)buf+2, (unsigned int)rank, bytesread);
+    if ( sizeof(mat_uint32_t) * (rank + 2) <= nBytes ) {
+        err = Inflate(mat, z, (mat_int32_t *)buf + 2, (unsigned int)rank, bytesread);
     } else {
         /* Cannot use too small buf, but can allocate output buffer dims */
-        *dims = (mat_uint32_t*)calloc(rank, sizeof(mat_uint32_t));
+        *dims = (mat_uint32_t *)calloc(rank, sizeof(mat_uint32_t));
         if ( NULL != *dims ) {
             err = Inflate(mat, z, *dims, (unsigned int)rank, bytesread);
         } else {
-            *((mat_int32_t *)buf+1) = 0;
+            *((mat_int32_t *)buf + 1) = 0;
             Mat_Critical("Error allocating memory for dims");
             return MATIO_E_OUT_OF_MEMORY;
         }
@@ -879,7 +873,7 @@ InflateRankDims(mat_t *mat, z_streamp z, void *buf, size_t nBytes, mat_uint32_t*
 
  */
 static int
-Inflate(mat_t *mat, z_streamp z, void *buf, unsigned int nBytes, size_t* bytesread)
+Inflate(mat_t *mat, z_streamp z, void *buf, unsigned int nBytes, size_t *bytesread)
 {
     mat_uint8_t comp_buf[4];
     int err = MATIO_E_NO_ERROR;
@@ -888,7 +882,7 @@ Inflate(mat_t *mat, z_streamp z, void *buf, unsigned int nBytes, size_t* bytesre
         return MATIO_E_BAD_ARGUMENT;
 
     if ( !z->avail_in ) {
-        size_t nbytes = fread(comp_buf, 1, 1, (FILE*)mat->fp);
+        size_t nbytes = fread(comp_buf, 1, 1, (FILE *)mat->fp);
         if ( 0 == nbytes ) {
             return err;
         }
@@ -900,15 +894,16 @@ Inflate(mat_t *mat, z_streamp z, void *buf, unsigned int nBytes, size_t* bytesre
     }
     z->avail_out = nBytes;
     z->next_out = ZLIB_BYTE_PTR(buf);
-    err = inflate(z,Z_NO_FLUSH);
+    err = inflate(z, Z_NO_FLUSH);
     if ( err != Z_OK ) {
-        Mat_Critical("Inflate: inflate returned %s",zError(err == Z_NEED_DICT ? Z_DATA_ERROR : err));
+        Mat_Critical("Inflate: inflate returned %s",
+                     zError(err == Z_NEED_DICT ? Z_DATA_ERROR : err));
         return MATIO_E_FILE_FORMAT_VIOLATION;
     } else {
         err = MATIO_E_NO_ERROR;
     }
     while ( z->avail_out && !z->avail_in ) {
-        size_t nbytes = fread(comp_buf, 1, 1, (FILE*)mat->fp);
+        size_t nbytes = fread(comp_buf, 1, 1, (FILE *)mat->fp);
         if ( 0 == nbytes ) {
             break;
         }
@@ -917,9 +912,10 @@ Inflate(mat_t *mat, z_streamp z, void *buf, unsigned int nBytes, size_t* bytesre
         }
         z->avail_in = (uInt)nbytes;
         z->next_in = comp_buf;
-        err = inflate(z,Z_NO_FLUSH);
+        err = inflate(z, Z_NO_FLUSH);
         if ( err != Z_OK ) {
-            Mat_Critical("Inflate: inflate returned %s",zError(err == Z_NEED_DICT ? Z_DATA_ERROR : err));
+            Mat_Critical("Inflate: inflate returned %s",
+                         zError(err == Z_NEED_DICT ? Z_DATA_ERROR : err));
             return MATIO_E_FILE_FORMAT_VIOLATION;
         } else {
             err = MATIO_E_NO_ERROR;
@@ -928,15 +924,16 @@ Inflate(mat_t *mat, z_streamp z, void *buf, unsigned int nBytes, size_t* bytesre
 
     if ( z->avail_in ) {
         const long offset = -(long)z->avail_in;
-        (void)fseek((FILE*)mat->fp, offset, SEEK_CUR);
+        (void)fseek((FILE *)mat->fp, offset, SEEK_CUR);
         if ( NULL != bytesread ) {
             *bytesread -= z->avail_in;
         }
         z->avail_in = 0;
     }
 
-    if ( z->avail_out && feof((FILE*)mat->fp) ) {
-        Mat_Warning("Unexpected end-of-file: "
+    if ( z->avail_out && feof((FILE *)mat->fp) ) {
+        Mat_Warning(
+            "Unexpected end-of-file: "
             "Processed %u bytes, expected %u bytes",
             nBytes - z->avail_out, nBytes);
         memset(buf, 0, nBytes);
@@ -973,7 +970,7 @@ InflateData(mat_t *mat, z_streamp z, void *buf, unsigned int nBytes)
 
     n = nBytes < READ_BLOCK_SIZE ? nBytes : READ_BLOCK_SIZE;
     if ( !z->avail_in ) {
-        size_t nbytes = fread(comp_buf, 1, n, (FILE*)mat->fp);
+        size_t nbytes = fread(comp_buf, 1, n, (FILE *)mat->fp);
         if ( 0 == nbytes ) {
             return err;
         }
@@ -983,11 +980,12 @@ InflateData(mat_t *mat, z_streamp z, void *buf, unsigned int nBytes)
     }
     z->avail_out = nBytes;
     z->next_out = ZLIB_BYTE_PTR(buf);
-    err = inflate(z,Z_FULL_FLUSH);
+    err = inflate(z, Z_FULL_FLUSH);
     if ( err == Z_STREAM_END ) {
         return MATIO_E_NO_ERROR;
     } else if ( err != Z_OK ) {
-        Mat_Critical("InflateData: inflate returned %s",zError( err == Z_NEED_DICT ? Z_DATA_ERROR : err ));
+        Mat_Critical("InflateData: inflate returned %s",
+                     zError(err == Z_NEED_DICT ? Z_DATA_ERROR : err));
         return MATIO_E_FAIL_TO_IDENTIFY;
     } else {
         err = MATIO_E_NO_ERROR;
@@ -995,11 +993,11 @@ InflateData(mat_t *mat, z_streamp z, void *buf, unsigned int nBytes)
     while ( z->avail_out && !z->avail_in ) {
         size_t nbytes;
         if ( nBytes > READ_BLOCK_SIZE + bytesread ) {
-            nbytes = fread(comp_buf, 1, READ_BLOCK_SIZE, (FILE*)mat->fp);
+            nbytes = fread(comp_buf, 1, READ_BLOCK_SIZE, (FILE *)mat->fp);
         } else if ( nBytes < 1 + bytesread ) { /* Read a byte at a time */
-            nbytes = fread(comp_buf, 1, 1, (FILE*)mat->fp);
+            nbytes = fread(comp_buf, 1, 1, (FILE *)mat->fp);
         } else {
-            nbytes = fread(comp_buf, 1, nBytes - bytesread, (FILE*)mat->fp);
+            nbytes = fread(comp_buf, 1, nBytes - bytesread, (FILE *)mat->fp);
         }
         if ( 0 == nbytes ) {
             break;
@@ -1007,12 +1005,12 @@ InflateData(mat_t *mat, z_streamp z, void *buf, unsigned int nBytes)
         bytesread += nbytes;
         z->avail_in = (uInt)nbytes;
         z->next_in = comp_buf;
-        err = inflate(z,Z_FULL_FLUSH);
+        err = inflate(z, Z_FULL_FLUSH);
         if ( err == Z_STREAM_END ) {
             err = MATIO_E_NO_ERROR;
             break;
         } else if ( err != Z_OK ) {
-            const char* errMsg = zError(err == Z_NEED_DICT ? Z_DATA_ERROR : err);
+            const char *errMsg = zError(err == Z_NEED_DICT ? Z_DATA_ERROR : err);
             err = MATIO_E_FAIL_TO_IDENTIFY;
             Mat_Critical("InflateData: inflate returned %s", errMsg);
             break;
@@ -1023,14 +1021,14 @@ InflateData(mat_t *mat, z_streamp z, void *buf, unsigned int nBytes)
 
     if ( z->avail_in ) {
         const long offset = -(long)z->avail_in;
-        (void)fseek((FILE*)mat->fp, offset, SEEK_CUR);
+        (void)fseek((FILE *)mat->fp, offset, SEEK_CUR);
         bytesread -= z->avail_in;
         z->avail_in = 0;
     }
 
-    if ( z->avail_out && feof((FILE*)mat->fp) ) {
+    if ( z->avail_out && feof((FILE *)mat->fp) ) {
         Mat_Warning("InflateData: Read beyond EOF error: Processed %u bytes, expected %u bytes",
-            nBytes - z->avail_out, nBytes);
+                    nBytes - z->avail_out, nBytes);
         memset(buf, 0, nBytes);
     }
 
@@ -1049,15 +1047,15 @@ InflateData(mat_t *mat, z_streamp z, void *buf, unsigned int nBytes)
  * MAT File I/O Utility Functions
  */
 #if defined(_WIN32) && defined(_MSC_VER)
-#   define WIN32_LEAN_AND_MEAN
-#   define NOGDI
-#   include <Windows.h>
+#define WIN32_LEAN_AND_MEAN
+#define NOGDI
+#include <Windows.h>
 #endif
 
 #if !defined(HAVE_VA_COPY) && !defined(va_copy) && defined(HAVE___VA_COPY)
-#    define va_copy(d,s) __va_copy(d,s)
+#define va_copy(d, s) __va_copy(d, s)
 #elif !defined(HAVE_VA_COPY) && !defined(va_copy)
-#    define va_copy(d,s) memcpy(&(d),&(s),sizeof(va_list))
+#define va_copy(d, s) memcpy(&(d), &(s), sizeof(va_list))
 #endif
 
 #if defined(_WIN32) && defined(_MSC_VER)
@@ -1067,15 +1065,15 @@ InflateData(mat_t *mat, z_streamp z, void *buf, unsigned int nBytes)
  * @param src narrow string
  * @return Pointer to resulting wide string, or NULL if there was an error
  */
-wchar_t*
-utf82u(const char* src)
+wchar_t *
+utf82u(const char *src)
 {
     if ( NULL != src ) {
         int srcLen = (int)strlen(src);
         if ( 0 != srcLen ) {
             int rc = MultiByteToWideChar(CP_UTF8, 0, src, srcLen, 0, 0);
             if ( 0 != rc ) {
-                wchar_t* w = (wchar_t*)malloc(sizeof(wchar_t)*(rc + 1));
+                wchar_t *w = (wchar_t *)malloc(sizeof(wchar_t) * (rc + 1));
                 if ( NULL != w ) {
                     w[rc] = L'\0';
                     rc = MultiByteToWideChar(CP_UTF8, 0, src, srcLen, w, rc);
@@ -1087,7 +1085,7 @@ utf82u(const char* src)
                 }
             }
         } else {
-            wchar_t* w = (wchar_t*)malloc(sizeof(wchar_t));
+            wchar_t *w = (wchar_t *)malloc(sizeof(wchar_t));
             if ( NULL != w ) {
                 w[0] = L'\0';
                 return w;
@@ -1105,7 +1103,8 @@ utf82u(const char* src)
  * @param format format string identical to printf format
  * @param ... arguments to the format string
  */
-void Mat_Critical(const char *format, ... )
+void
+Mat_Critical(const char *format, ...)
 {
     va_list ap;
     va_start(ap, format);
@@ -1121,7 +1120,7 @@ void Mat_Critical(const char *format, ... )
  * @param ... arguments to the format string
  */
 void
-Mat_Warning(const char *format, ... )
+Mat_Warning(const char *format, ...)
 {
     va_list ap;
     va_start(ap, format);
@@ -1138,7 +1137,7 @@ Mat_Warning(const char *format, ... )
 size_t
 Mat_SizeOf(enum matio_types data_type)
 {
-    switch (data_type) {
+    switch ( data_type ) {
         case MAT_T_DOUBLE:
             return sizeof(double);
         case MAT_T_SINGLE:
@@ -1185,140 +1184,140 @@ Mat_SizeOf(enum matio_types data_type)
 
 /* FIXME: Implement Unicode support */
 
-#define READ_DATA_NOSWAP(T) \
-    do { \
-        const size_t block_size = READ_BLOCK_SIZE/data_size; \
-        if ( len <= block_size ) { \
-            readcount = fread(v, data_size, len, (FILE*)mat->fp); \
-            if ( readcount == len ) { \
-                for ( i = 0; i < len; i++ ) { \
-                    data[i] = (T)v[i]; \
-                } \
-            } \
-        } else { \
-            size_t j; \
-            int err = 0 ; \
-            readcount = 0; \
-            for ( i = 0; i < len - block_size; i += block_size ) { \
-                j = fread(v, data_size, block_size, (FILE*)mat->fp); \
-                readcount += j; \
-                if ( j == block_size ) { \
-                    for ( j = 0; j < block_size; j++ ) { \
-                        data[i + j] = (T)v[j]; \
-                    } \
-                } else { \
-                    err = 1; \
-                    break;\
-                } \
-            } \
-            if ( 0 == err && len > i ) { \
-                j = fread(v, data_size, len - i, (FILE*)mat->fp); \
-                readcount += j; \
-                if ( j == len - i ) { \
-                    for ( j = 0; j < len - i; j++ ) { \
-                        data[i + j] = (T)v[j]; \
-                    } \
-                } \
-            } \
-        } \
-    } while (0)
+#define READ_DATA_NOSWAP(T)                                           \
+    do {                                                              \
+        const size_t block_size = READ_BLOCK_SIZE / data_size;        \
+        if ( len <= block_size ) {                                    \
+            readcount = fread(v, data_size, len, (FILE *)mat->fp);    \
+            if ( readcount == len ) {                                 \
+                for ( i = 0; i < len; i++ ) {                         \
+                    data[i] = (T)v[i];                                \
+                }                                                     \
+            }                                                         \
+        } else {                                                      \
+            size_t j;                                                 \
+            int err = 0;                                              \
+            readcount = 0;                                            \
+            for ( i = 0; i < len - block_size; i += block_size ) {    \
+                j = fread(v, data_size, block_size, (FILE *)mat->fp); \
+                readcount += j;                                       \
+                if ( j == block_size ) {                              \
+                    for ( j = 0; j < block_size; j++ ) {              \
+                        data[i + j] = (T)v[j];                        \
+                    }                                                 \
+                } else {                                              \
+                    err = 1;                                          \
+                    break;                                            \
+                }                                                     \
+            }                                                         \
+            if ( 0 == err && len > i ) {                              \
+                j = fread(v, data_size, len - i, (FILE *)mat->fp);    \
+                readcount += j;                                       \
+                if ( j == len - i ) {                                 \
+                    for ( j = 0; j < len - i; j++ ) {                 \
+                        data[i + j] = (T)v[j];                        \
+                    }                                                 \
+                }                                                     \
+            }                                                         \
+        }                                                             \
+    } while ( 0 )
 
-#define READ_DATA(T, SwapFunc) \
-    do { \
-        if ( mat->byteswap ) { \
-            const size_t block_size = READ_BLOCK_SIZE/data_size; \
-            if ( len <= block_size ) { \
-                readcount = fread(v, data_size, len, (FILE*)mat->fp); \
-                if ( readcount == len ) { \
-                    for ( i = 0; i < len; i++ ) { \
-                        data[i] = (T)SwapFunc(&v[i]); \
-                    } \
-                } \
-            } else { \
-                size_t j; \
-                int err = 0 ; \
-                readcount = 0; \
-                for ( i = 0; i < len - block_size; i += block_size ) { \
-                    j = fread(v, data_size, block_size, (FILE*)mat->fp); \
-                    readcount += j; \
-                    if ( j == block_size ) { \
-                        for ( j = 0; j < block_size; j++ ) { \
-                            data[i + j] = (T)SwapFunc(&v[j]); \
-                        } \
-                    } else { \
-                        err = 1; \
-                        break; \
-                    } \
-                } \
-                if ( 0 == err && len > i ) { \
-                    j = fread(v, data_size, len - i, (FILE*)mat->fp); \
-                    readcount += j; \
-                    if ( j == len - i ) { \
-                        for ( j = 0; j < len-i; j++ ) { \
-                            data[i + j] = (T)SwapFunc(&v[j]); \
-                        } \
-                    } \
-                } \
-            } \
-        } else { \
-            READ_DATA_NOSWAP(T); \
-        } \
-    } while (0)
+#define READ_DATA(T, SwapFunc)                                            \
+    do {                                                                  \
+        if ( mat->byteswap ) {                                            \
+            const size_t block_size = READ_BLOCK_SIZE / data_size;        \
+            if ( len <= block_size ) {                                    \
+                readcount = fread(v, data_size, len, (FILE *)mat->fp);    \
+                if ( readcount == len ) {                                 \
+                    for ( i = 0; i < len; i++ ) {                         \
+                        data[i] = (T)SwapFunc(&v[i]);                     \
+                    }                                                     \
+                }                                                         \
+            } else {                                                      \
+                size_t j;                                                 \
+                int err = 0;                                              \
+                readcount = 0;                                            \
+                for ( i = 0; i < len - block_size; i += block_size ) {    \
+                    j = fread(v, data_size, block_size, (FILE *)mat->fp); \
+                    readcount += j;                                       \
+                    if ( j == block_size ) {                              \
+                        for ( j = 0; j < block_size; j++ ) {              \
+                            data[i + j] = (T)SwapFunc(&v[j]);             \
+                        }                                                 \
+                    } else {                                              \
+                        err = 1;                                          \
+                        break;                                            \
+                    }                                                     \
+                }                                                         \
+                if ( 0 == err && len > i ) {                              \
+                    j = fread(v, data_size, len - i, (FILE *)mat->fp);    \
+                    readcount += j;                                       \
+                    if ( j == len - i ) {                                 \
+                        for ( j = 0; j < len - i; j++ ) {                 \
+                            data[i + j] = (T)SwapFunc(&v[j]);             \
+                        }                                                 \
+                    }                                                     \
+                }                                                         \
+            }                                                             \
+        } else {                                                          \
+            READ_DATA_NOSWAP(T);                                          \
+        }                                                                 \
+    } while ( 0 )
 
 #if HAVE_ZLIB
-#define READ_COMPRESSED_DATA_NOSWAP(T) \
-    do { \
-        const size_t block_size = READ_BLOCK_SIZE/data_size; \
-        if ( len <= block_size ) { \
-            InflateData(mat, z, v, len*data_size); \
-            for ( i = 0; i < len; i++ ) { \
-                data[i] = (T)v[i]; \
-            } \
-        } else { \
-            mat_uint32_t j; \
-            len -= block_size; \
-            for ( i = 0; i < len; i += block_size ) { \
-                InflateData(mat, z, v, block_size*data_size); \
-                for ( j = 0; j < block_size; j++ ) { \
-                    data[i + j] = (T)v[j]; \
-                } \
-            } \
-            len -= (i - block_size); \
-            InflateData(mat, z, v, len*data_size); \
-            for ( j = 0; j < len; j++ ) { \
-                data[i + j] = (T)v[j]; \
-            } \
-        } \
-    } while (0)
+#define READ_COMPRESSED_DATA_NOSWAP(T)                         \
+    do {                                                       \
+        const size_t block_size = READ_BLOCK_SIZE / data_size; \
+        if ( len <= block_size ) {                             \
+            InflateData(mat, z, v, len *data_size);            \
+            for ( i = 0; i < len; i++ ) {                      \
+                data[i] = (T)v[i];                             \
+            }                                                  \
+        } else {                                               \
+            mat_uint32_t j;                                    \
+            len -= block_size;                                 \
+            for ( i = 0; i < len; i += block_size ) {          \
+                InflateData(mat, z, v, block_size *data_size); \
+                for ( j = 0; j < block_size; j++ ) {           \
+                    data[i + j] = (T)v[j];                     \
+                }                                              \
+            }                                                  \
+            len -= (i - block_size);                           \
+            InflateData(mat, z, v, len *data_size);            \
+            for ( j = 0; j < len; j++ ) {                      \
+                data[i + j] = (T)v[j];                         \
+            }                                                  \
+        }                                                      \
+    } while ( 0 )
 
-#define READ_COMPRESSED_DATA(T, SwapFunc) \
-    do { \
-        if ( mat->byteswap ) { \
-            const size_t block_size = READ_BLOCK_SIZE/data_size; \
-            if ( len <= block_size ) { \
-                InflateData(mat, z, v, len*data_size); \
-                for ( i = 0; i < len; i++ ) { \
-                    data[i] = (T)SwapFunc(&v[i]); \
-                } \
-            } else { \
-                mat_uint32_t j; \
-                len -= block_size; \
-                for ( i = 0; i < len; i += block_size ) { \
-                    InflateData(mat, z, v, block_size*data_size); \
-                    for ( j = 0; j < block_size; j++ ) { \
-                        data[i + j] = (T)SwapFunc(&v[j]); \
-                    } \
-                } \
-                len -= (i - block_size); \
-                InflateData(mat, z, v, len*data_size); \
-                for ( j = 0; j < len; j++ ) { \
-                    data[i + j] = (T)SwapFunc(&v[j]); \
-                } \
-            } \
-        } else { \
-            READ_COMPRESSED_DATA_NOSWAP(T); \
-        } \
-    } while (0)
+#define READ_COMPRESSED_DATA(T, SwapFunc)                          \
+    do {                                                           \
+        if ( mat->byteswap ) {                                     \
+            const size_t block_size = READ_BLOCK_SIZE / data_size; \
+            if ( len <= block_size ) {                             \
+                InflateData(mat, z, v, len *data_size);            \
+                for ( i = 0; i < len; i++ ) {                      \
+                    data[i] = (T)SwapFunc(&v[i]);                  \
+                }                                                  \
+            } else {                                               \
+                mat_uint32_t j;                                    \
+                len -= block_size;                                 \
+                for ( i = 0; i < len; i += block_size ) {          \
+                    InflateData(mat, z, v, block_size *data_size); \
+                    for ( j = 0; j < block_size; j++ ) {           \
+                        data[i + j] = (T)SwapFunc(&v[j]);          \
+                    }                                              \
+                }                                                  \
+                len -= (i - block_size);                           \
+                InflateData(mat, z, v, len *data_size);            \
+                for ( j = 0; j < len; j++ ) {                      \
+                    data[i + j] = (T)SwapFunc(&v[j]);              \
+                }                                                  \
+            }                                                      \
+        } else {                                                   \
+            READ_COMPRESSED_DATA_NOSWAP(T);                        \
+        }                                                          \
+    } while ( 0 )
 
 #endif
 
@@ -1332,13 +1331,13 @@ Mat_SizeOf(enum matio_types data_type)
 
 #define READ_TYPE_DOUBLE 1
 #define READ_TYPE_SINGLE 2
-#define READ_TYPE_INT64  3
+#define READ_TYPE_INT64 3
 #define READ_TYPE_UINT64 4
-#define READ_TYPE_INT32  5
+#define READ_TYPE_INT32 5
 #define READ_TYPE_UINT32 6
-#define READ_TYPE_INT16  7
+#define READ_TYPE_INT16 7
 #define READ_TYPE_UINT16 8
-#define READ_TYPE_INT8   9
+#define READ_TYPE_INT8 9
 #define READ_TYPE_UINT8 10
 
 #define READ_TYPE double
@@ -1460,73 +1459,88 @@ Mat_SizeOf(enum matio_types data_type)
  * @retval Number of bytes read from the file
  */
 static int
-ReadCompressedCharData(mat_t *mat,z_streamp z,char *data,
-    enum matio_types data_type,int len)
+ReadCompressedCharData(mat_t *mat, z_streamp z, void *data, enum matio_types data_type, size_t len)
 {
-    int nBytes = 0;
-    unsigned int data_size;
+    size_t nBytes = 0;
+    int err;
 
     if ( mat == NULL || data == NULL || mat->fp == NULL )
         return 0;
 
-    data_size = (unsigned int)Mat_SizeOf(data_type);
+    err = Mul(&nBytes, len, Mat_SizeOf(data_type));
+    if ( err ) {
+        return 0;
+    }
 
     switch ( data_type ) {
         case MAT_T_UINT8:
         case MAT_T_UTF8:
-            InflateData(mat,z,data,len*data_size);
+            err = InflateData(mat, z, data, (mat_uint32_t)nBytes);
             break;
         case MAT_T_UINT16:
         case MAT_T_UTF16:
-            InflateData(mat,z,data,len*data_size);
+            err = InflateData(mat, z, data, (mat_uint32_t)nBytes);
             if ( mat->byteswap ) {
-                int i;
+                mat_uint16_t *ptr = (mat_uint16_t *)data;
+                size_t i;
                 for ( i = 0; i < len; i++ ) {
-                    Mat_uint16Swap((mat_uint16_t*)&data[2*i]);
+                    Mat_uint16Swap((mat_uint16_t *)&ptr[i]);
                 }
             }
             break;
         default:
-            Mat_Warning("ReadCompressedCharData: %d is not a supported data "
-                "type for character data", data_type);
+            Mat_Warning(
+                "ReadCompressedCharData: %d is not a supported data "
+                "type for character data",
+                data_type);
             break;
     }
-    nBytes = len*data_size;
-    return nBytes;
+
+    if ( err ) {
+        nBytes = 0;
+    }
+    return (int)nBytes;
 }
 #endif
 
 static size_t
-ReadCharData(mat_t *mat,char *data,enum matio_types data_type,size_t len)
+ReadCharData(mat_t *mat, void *_data, enum matio_types data_type, size_t len)
 {
+    size_t nBytes = 0;
+    int err = 0;
     size_t data_size;
 
-    if ( mat == NULL || data == NULL || mat->fp == NULL )
+    if ( mat == NULL || _data == NULL || mat->fp == NULL )
         return 0;
 
     data_size = Mat_SizeOf(data_type);
 
     switch ( data_type ) {
         case MAT_T_UINT8:
-        case MAT_T_UTF8:
-        {
-            size_t readcount = fread(data,Mat_SizeOf(data_type),len,(FILE*)mat->fp);
-            return readcount*data_size;
+        case MAT_T_UTF8: {
+            err = Read(_data, data_size, len, (FILE *)mat->fp, &nBytes);
+            break;
         }
         case MAT_T_UINT16:
-        case MAT_T_UTF16:
-        {
+        case MAT_T_UTF16: {
             size_t i, readcount;
-            mat_uint16_t v[READ_BLOCK_SIZE/sizeof(mat_uint16_t)];
+            mat_uint16_t *data = (mat_uint16_t *)_data;
+            mat_uint16_t v[READ_BLOCK_SIZE / sizeof(mat_uint16_t)];
             READ_DATA(mat_uint16_t, Mat_uint16Swap);
-            return readcount*data_size;
+            err = Mul(&nBytes, readcount, data_size);
+            break;
         }
         default:
-            Mat_Warning("ReadCharData: %d is not a supported data type for "
-                "character data", data_type);
+            Mat_Warning(
+                "ReadCharData: %d is not a supported data type for "
+                "character data",
+                data_type);
             break;
     }
-    return 0;
+    if ( err ) {
+        nBytes = 0;
+    }
+    return nBytes;
 }
 
 #undef READ_DATA
@@ -1538,74 +1552,76 @@ ReadCharData(mat_t *mat,char *data,enum matio_types data_type,size_t len)
  *-------------------------------------------------------------------
  */
 
-#define READ_DATA_SLABN_RANK_LOOP \
-    do { \
-        for ( j = 1; j < rank; j++ ) { \
-            cnt[j]++; \
-            if ( (cnt[j] % edge[j]) == 0 ) { \
-                cnt[j] = 0; \
-                if ( (I % dimp[j]) != 0 ) { \
-                    (void)fseek((FILE*)mat->fp,data_size*(dimp[j]-(I % dimp[j]) + dimp[j-1]*start[j]),SEEK_CUR); \
-                    I += dimp[j]-(I % dimp[j]) + (ptrdiff_t)dimp[j-1]*start[j]; \
-                } else if ( start[j] ) { \
-                    (void)fseek((FILE*)mat->fp,data_size*(dimp[j-1]*start[j]),SEEK_CUR); \
-                    I += (ptrdiff_t)dimp[j-1]*start[j]; \
-                } \
-            } else { \
-                I += inc[j]; \
-                (void)fseek((FILE*)mat->fp,data_size*inc[j],SEEK_CUR); \
-                break; \
-            } \
-        } \
-    } while (0)
+#define READ_DATA_SLABN_RANK_LOOP                                                                \
+    do {                                                                                         \
+        for ( j = 1; j < rank; j++ ) {                                                           \
+            cnt[j]++;                                                                            \
+            if ( (cnt[j] % edge[j]) == 0 ) {                                                     \
+                cnt[j] = 0;                                                                      \
+                if ( (I % dimp[j]) != 0 ) {                                                      \
+                    (void)fseek((FILE *)mat->fp,                                                 \
+                                data_size *(dimp[j] - (I % dimp[j]) + dimp[j - 1] * start[j]),   \
+                                SEEK_CUR);                                                       \
+                    I += dimp[j] - (I % dimp[j]) + (ptrdiff_t)dimp[j - 1] * start[j];            \
+                } else if ( start[j] ) {                                                         \
+                    (void)fseek((FILE *)mat->fp, data_size *(dimp[j - 1] * start[j]), SEEK_CUR); \
+                    I += (ptrdiff_t)dimp[j - 1] * start[j];                                      \
+                }                                                                                \
+            } else {                                                                             \
+                I += inc[j];                                                                     \
+                (void)fseek((FILE *)mat->fp, data_size *inc[j], SEEK_CUR);                       \
+                break;                                                                           \
+            }                                                                                    \
+        }                                                                                        \
+    } while ( 0 )
 
-#define READ_DATA_SLABN(ReadDataFunc) \
-    do { \
-        inc[0]  = stride[0]-1; \
-        dimp[0] = dims[0]; \
-        N       = edge[0]; \
-        I       = 0; /* start[0]; */ \
-        for ( i = 1; i < rank; i++ ) { \
-            inc[i]  = stride[i]-1; \
-            dimp[i] = dims[i-1]; \
-            for ( j = i; j--; ) { \
-                inc[i]  *= dims[j]; \
-                dimp[i] *= dims[j+1]; \
-            } \
-            N *= edge[i]; \
-            I += (ptrdiff_t)dimp[i-1]*start[i]; \
-        } \
-        (void)fseek((FILE*)mat->fp,I*data_size,SEEK_CUR); \
-        if ( stride[0] == 1 ) { \
-            for ( i = 0; i < N; i+=edge[0] ) { \
-                if ( start[0] ) { \
-                    (void)fseek((FILE*)mat->fp,start[0]*data_size,SEEK_CUR); \
-                    I += start[0]; \
-                } \
-                ReadDataFunc(mat,ptr+i,data_type,edge[0]); \
-                I += dims[0]-start[0]; \
-                (void)fseek((FILE*)mat->fp,data_size*(dims[0]-edge[0]-start[0]), \
-                    SEEK_CUR); \
-                READ_DATA_SLABN_RANK_LOOP; \
-            } \
-        } else { \
-            for ( i = 0; i < N; i+=edge[0] ) { \
-                if ( start[0] ) { \
-                    (void)fseek((FILE*)mat->fp,start[0]*data_size,SEEK_CUR); \
-                    I += start[0]; \
-                } \
-                for ( j = 0; j < edge[0]; j++ ) { \
-                    ReadDataFunc(mat,ptr+i+j,data_type,1); \
-                    (void)fseek((FILE*)mat->fp,data_size*(stride[0]-1),SEEK_CUR); \
-                    I += stride[0]; \
-                } \
-                I += dims[0]-(ptrdiff_t)edge[0]*stride[0]-start[0]; \
-                (void)fseek((FILE*)mat->fp,data_size* \
-                    (dims[0]-(ptrdiff_t)edge[0]*stride[0]-start[0]),SEEK_CUR); \
-                READ_DATA_SLABN_RANK_LOOP; \
-            } \
-        } \
-    } while (0)
+#define READ_DATA_SLABN(ReadDataFunc)                                                              \
+    do {                                                                                           \
+        inc[0] = stride[0] - 1;                                                                    \
+        dimp[0] = dims[0];                                                                         \
+        N = edge[0];                                                                               \
+        I = 0; /* start[0]; */                                                                     \
+        for ( i = 1; i < rank; i++ ) {                                                             \
+            inc[i] = stride[i] - 1;                                                                \
+            dimp[i] = dims[i - 1];                                                                 \
+            for ( j = i; j--; ) {                                                                  \
+                inc[i] *= dims[j];                                                                 \
+                dimp[i] *= dims[j + 1];                                                            \
+            }                                                                                      \
+            N *= edge[i];                                                                          \
+            I += (ptrdiff_t)dimp[i - 1] * start[i];                                                \
+        }                                                                                          \
+        (void)fseek((FILE *)mat->fp, I *data_size, SEEK_CUR);                                      \
+        if ( stride[0] == 1 ) {                                                                    \
+            for ( i = 0; i < N; i += edge[0] ) {                                                   \
+                if ( start[0] ) {                                                                  \
+                    (void)fseek((FILE *)mat->fp, start[0] * data_size, SEEK_CUR);                  \
+                    I += start[0];                                                                 \
+                }                                                                                  \
+                ReadDataFunc(mat, ptr + i, data_type, edge[0]);                                    \
+                I += dims[0] - start[0];                                                           \
+                (void)fseek((FILE *)mat->fp, data_size *(dims[0] - edge[0] - start[0]), SEEK_CUR); \
+                READ_DATA_SLABN_RANK_LOOP;                                                         \
+            }                                                                                      \
+        } else {                                                                                   \
+            for ( i = 0; i < N; i += edge[0] ) {                                                   \
+                if ( start[0] ) {                                                                  \
+                    (void)fseek((FILE *)mat->fp, start[0] * data_size, SEEK_CUR);                  \
+                    I += start[0];                                                                 \
+                }                                                                                  \
+                for ( j = 0; j < edge[0]; j++ ) {                                                  \
+                    ReadDataFunc(mat, ptr + i + j, data_type, 1);                                  \
+                    (void)fseek((FILE *)mat->fp, data_size *(stride[0] - 1), SEEK_CUR);            \
+                    I += stride[0];                                                                \
+                }                                                                                  \
+                I += dims[0] - (ptrdiff_t)edge[0] * stride[0] - start[0];                          \
+                (void)fseek((FILE *)mat->fp,                                                       \
+                            data_size *(dims[0] - (ptrdiff_t)edge[0] * stride[0] - start[0]),      \
+                            SEEK_CUR);                                                             \
+                READ_DATA_SLABN_RANK_LOOP;                                                         \
+            }                                                                                      \
+        }                                                                                          \
+    } while ( 0 )
 
 /** @brief Reads data of type @c data_type by user-defined dimensions
  *
@@ -1622,16 +1638,25 @@ ReadCharData(mat_t *mat,char *data,enum matio_types data_type,size_t len)
  * @retval Number of bytes read from the file, or -1 on error
  */
 static int
-ReadDataSlabN(mat_t *mat,void *data,enum matio_classes class_type,
-    enum matio_types data_type,int rank,size_t *dims,int *start,int *stride,
-    int *edge)
+ReadDataSlabN(mat_t *mat, void *data, enum matio_classes class_type, enum matio_types data_type,
+              int rank, size_t *dims, int *start, int *stride, int *edge)
 {
     int nBytes = 0, i, j, N, I = 0;
-    int inc[10] = {0,}, cnt[10] = {0,}, dimp[10] = {0,};
+    int inc[10] =
+        {
+            0,
+        },
+        cnt[10] =
+            {
+                0,
+            },
+        dimp[10] = {
+            0,
+        };
     size_t data_size;
 
-    if ( (mat   == NULL) || (data   == NULL) || (mat->fp == NULL) ||
-         (start == NULL) || (stride == NULL) || (edge    == NULL) ) {
+    if ( (mat == NULL) || (data == NULL) || (mat->fp == NULL) || (start == NULL) ||
+         (stride == NULL) || (edge == NULL) ) {
         return -1;
     } else if ( rank > 10 ) {
         return -1;
@@ -1640,67 +1665,57 @@ ReadDataSlabN(mat_t *mat,void *data,enum matio_classes class_type,
     data_size = Mat_SizeOf(data_type);
 
     switch ( class_type ) {
-        case MAT_C_DOUBLE:
-        {
-            double *ptr = (double*)data;
+        case MAT_C_DOUBLE: {
+            double *ptr = (double *)data;
             READ_DATA_SLABN(ReadDoubleData);
             break;
         }
-        case MAT_C_SINGLE:
-        {
-            float *ptr = (float*)data;
+        case MAT_C_SINGLE: {
+            float *ptr = (float *)data;
             READ_DATA_SLABN(ReadSingleData);
             break;
         }
 #ifdef HAVE_MATIO_INT64_T
-        case MAT_C_INT64:
-        {
-            mat_int64_t *ptr = (mat_int64_t*)data;
+        case MAT_C_INT64: {
+            mat_int64_t *ptr = (mat_int64_t *)data;
             READ_DATA_SLABN(ReadInt64Data);
             break;
         }
 #endif /* HAVE_MATIO_INT64_T */
 #ifdef HAVE_MATIO_UINT64_T
-        case MAT_C_UINT64:
-        {
-            mat_uint64_t *ptr = (mat_uint64_t*)data;
+        case MAT_C_UINT64: {
+            mat_uint64_t *ptr = (mat_uint64_t *)data;
             READ_DATA_SLABN(ReadUInt64Data);
             break;
         }
 #endif /* HAVE_MATIO_UINT64_T */
-        case MAT_C_INT32:
-        {
-            mat_int32_t *ptr = (mat_int32_t*)data;
+        case MAT_C_INT32: {
+            mat_int32_t *ptr = (mat_int32_t *)data;
             READ_DATA_SLABN(ReadInt32Data);
             break;
         }
-        case MAT_C_UINT32:
-        {
-            mat_uint32_t *ptr = (mat_uint32_t*)data;
+        case MAT_C_UINT32: {
+            mat_uint32_t *ptr = (mat_uint32_t *)data;
             READ_DATA_SLABN(ReadUInt32Data);
             break;
         }
-        case MAT_C_INT16:
-        {
-            mat_int16_t *ptr = (mat_int16_t*)data;
+        case MAT_C_INT16: {
+            mat_int16_t *ptr = (mat_int16_t *)data;
             READ_DATA_SLABN(ReadInt16Data);
             break;
         }
-        case MAT_C_UINT16:
-        {
-            mat_uint16_t *ptr = (mat_uint16_t*)data;
+        case MAT_C_UINT16: {
+            mat_uint16_t *ptr = (mat_uint16_t *)data;
             READ_DATA_SLABN(ReadUInt16Data);
             break;
         }
-        case MAT_C_INT8:
-        {
-            mat_int8_t *ptr = (mat_int8_t*)data;
+        case MAT_C_INT8: {
+            mat_int8_t *ptr = (mat_int8_t *)data;
             READ_DATA_SLABN(ReadInt8Data);
             break;
         }
-        case MAT_C_UINT8:
-        {
-            mat_uint8_t *ptr = (mat_uint8_t*)data;
+        case MAT_C_UINT8: {
+            mat_uint8_t *ptr = (mat_uint8_t *)data;
             READ_DATA_SLABN(ReadUInt8Data);
             break;
         }
@@ -1714,76 +1729,78 @@ ReadDataSlabN(mat_t *mat,void *data,enum matio_classes class_type,
 #undef READ_DATA_SLABN_RANK_LOOP
 
 #if HAVE_ZLIB
-#define READ_COMPRESSED_DATA_SLABN_RANK_LOOP \
-    do { \
-        for ( j = 1; j < rank; j++ ) { \
-            cnt[j]++; \
-            if ( (cnt[j] % edge[j]) == 0 ) { \
-                cnt[j] = 0; \
-                if ( (I % dimp[j]) != 0 ) { \
-                    InflateSkipData(mat,&z_copy,data_type, dimp[j]-(I % dimp[j]) + dimp[j-1]*start[j]); \
-                    I += dimp[j]-(I % dimp[j]) + (ptrdiff_t)dimp[j-1]*start[j]; \
-                } else if ( start[j] ) { \
-                    InflateSkipData(mat,&z_copy,data_type, dimp[j-1]*start[j]); \
-                    I += (ptrdiff_t)dimp[j-1]*start[j]; \
-                } \
-            } else { \
-                if ( inc[j] ) { \
-                    I += inc[j]; \
-                    InflateSkipData(mat,&z_copy,data_type,inc[j]); \
-                } \
-                break; \
-            } \
-        } \
-    } while (0)
+#define READ_COMPRESSED_DATA_SLABN_RANK_LOOP                                           \
+    do {                                                                               \
+        for ( j = 1; j < rank; j++ ) {                                                 \
+            cnt[j]++;                                                                  \
+            if ( (cnt[j] % edge[j]) == 0 ) {                                           \
+                cnt[j] = 0;                                                            \
+                if ( (I % dimp[j]) != 0 ) {                                            \
+                    InflateSkipData(mat, &z_copy, data_type,                           \
+                                    dimp[j] - (I % dimp[j]) + dimp[j - 1] * start[j]); \
+                    I += dimp[j] - (I % dimp[j]) + (ptrdiff_t)dimp[j - 1] * start[j];  \
+                } else if ( start[j] ) {                                               \
+                    InflateSkipData(mat, &z_copy, data_type, dimp[j - 1] * start[j]);  \
+                    I += (ptrdiff_t)dimp[j - 1] * start[j];                            \
+                }                                                                      \
+            } else {                                                                   \
+                if ( inc[j] ) {                                                        \
+                    I += inc[j];                                                       \
+                    InflateSkipData(mat, &z_copy, data_type, inc[j]);                  \
+                }                                                                      \
+                break;                                                                 \
+            }                                                                          \
+        }                                                                              \
+    } while ( 0 )
 
-#define READ_COMPRESSED_DATA_SLABN(ReadDataFunc) \
-    do { \
-        inc[0]  = stride[0]-1; \
-        dimp[0] = dims[0]; \
-        N       = edge[0]; \
-        I       = 0; \
-        for ( i = 1; i < rank; i++ ) { \
-            inc[i]  = stride[i]-1; \
-            dimp[i] = dims[i-1]; \
-            for ( j = i; j--; ) { \
-                inc[i]  *= dims[j]; \
-                dimp[i] *= dims[j+1]; \
-            } \
-            N *= edge[i]; \
-            I += (ptrdiff_t)dimp[i-1]*start[i]; \
-        } \
-        /* Skip all data to the starting indices */ \
-        InflateSkipData(mat,&z_copy,data_type,I); \
-        if ( stride[0] == 1 ) { \
-            for ( i = 0; i < N; i+=edge[0] ) { \
-                if ( start[0] ) { \
-                    InflateSkipData(mat,&z_copy,data_type,start[0]); \
-                    I += start[0]; \
-                } \
-                ReadDataFunc(mat,&z_copy,ptr+i,data_type,edge[0]); \
-                InflateSkipData(mat,&z_copy,data_type,dims[0]-start[0]-edge[0]); \
-                I += dims[0]-start[0]; \
-                READ_COMPRESSED_DATA_SLABN_RANK_LOOP; \
-            } \
-        } else { \
-            for ( i = 0; i < N; i+=edge[0] ) { \
-                if ( start[0] ) { \
-                    InflateSkipData(mat,&z_copy,data_type,start[0]); \
-                    I += start[0]; \
-                } \
-                for ( j = 0; j < edge[0]-1; j++ ) { \
-                    ReadDataFunc(mat,&z_copy,ptr+i+j,data_type,1); \
-                    InflateSkipData(mat,&z_copy,data_type,(stride[0]-1)); \
-                    I += stride[0]; \
-                } \
-                ReadDataFunc(mat,&z_copy,ptr+i+j,data_type,1); \
-                I += dims[0]-(ptrdiff_t)(edge[0]-1)*stride[0]-start[0]; \
-                InflateSkipData(mat,&z_copy,data_type,dims[0]-(ptrdiff_t)(edge[0]-1)*stride[0]-start[0]-1); \
-                READ_COMPRESSED_DATA_SLABN_RANK_LOOP; \
-            } \
-        } \
-    } while (0)
+#define READ_COMPRESSED_DATA_SLABN(ReadDataFunc)                                                \
+    do {                                                                                        \
+        inc[0] = stride[0] - 1;                                                                 \
+        dimp[0] = dims[0];                                                                      \
+        N = edge[0];                                                                            \
+        I = 0;                                                                                  \
+        for ( i = 1; i < rank; i++ ) {                                                          \
+            inc[i] = stride[i] - 1;                                                             \
+            dimp[i] = dims[i - 1];                                                              \
+            for ( j = i; j--; ) {                                                               \
+                inc[i] *= dims[j];                                                              \
+                dimp[i] *= dims[j + 1];                                                         \
+            }                                                                                   \
+            N *= edge[i];                                                                       \
+            I += (ptrdiff_t)dimp[i - 1] * start[i];                                             \
+        }                                                                                       \
+        /* Skip all data to the starting indices */                                             \
+        InflateSkipData(mat, &z_copy, data_type, I);                                            \
+        if ( stride[0] == 1 ) {                                                                 \
+            for ( i = 0; i < N; i += edge[0] ) {                                                \
+                if ( start[0] ) {                                                               \
+                    InflateSkipData(mat, &z_copy, data_type, start[0]);                         \
+                    I += start[0];                                                              \
+                }                                                                               \
+                ReadDataFunc(mat, &z_copy, ptr + i, data_type, edge[0]);                        \
+                InflateSkipData(mat, &z_copy, data_type, dims[0] - start[0] - edge[0]);         \
+                I += dims[0] - start[0];                                                        \
+                READ_COMPRESSED_DATA_SLABN_RANK_LOOP;                                           \
+            }                                                                                   \
+        } else {                                                                                \
+            for ( i = 0; i < N; i += edge[0] ) {                                                \
+                if ( start[0] ) {                                                               \
+                    InflateSkipData(mat, &z_copy, data_type, start[0]);                         \
+                    I += start[0];                                                              \
+                }                                                                               \
+                for ( j = 0; j < edge[0] - 1; j++ ) {                                           \
+                    ReadDataFunc(mat, &z_copy, ptr + i + j, data_type, 1);                      \
+                    InflateSkipData(mat, &z_copy, data_type, (stride[0] - 1));                  \
+                    I += stride[0];                                                             \
+                }                                                                               \
+                ReadDataFunc(mat, &z_copy, ptr + i + j, data_type, 1);                          \
+                I += dims[0] - (ptrdiff_t)(edge[0] - 1) * stride[0] - start[0];                 \
+                InflateSkipData(mat, &z_copy, data_type,                                        \
+                                dims[0] - (ptrdiff_t)(edge[0] - 1) * stride[0] - start[0] - 1); \
+                READ_COMPRESSED_DATA_SLABN_RANK_LOOP;                                           \
+            }                                                                                   \
+        }                                                                                       \
+    } while ( 0 )
 
 /** @brief Reads data of type @c data_type by user-defined dimensions
  *
@@ -1801,88 +1818,90 @@ ReadDataSlabN(mat_t *mat,void *data,enum matio_classes class_type,
  * @retval Number of bytes read from the file, or -1 on error
  */
 static int
-ReadCompressedDataSlabN(mat_t *mat,z_streamp z,void *data,
-    enum matio_classes class_type,enum matio_types data_type,int rank,
-    size_t *dims,int *start,int *stride,int *edge)
+ReadCompressedDataSlabN(mat_t *mat, z_streamp z, void *data, enum matio_classes class_type,
+                        enum matio_types data_type, int rank, size_t *dims, int *start, int *stride,
+                        int *edge)
 {
     int nBytes = 0, i, j, N, I = 0, err;
-    int inc[10] = {0,}, cnt[10] = {0,}, dimp[10] = {0,};
-    z_stream z_copy = {0,};
+    int inc[10] =
+        {
+            0,
+        },
+        cnt[10] =
+            {
+                0,
+            },
+        dimp[10] = {
+            0,
+        };
+    z_stream z_copy = {
+        0,
+    };
 
-    if ( (mat   == NULL) || (data   == NULL) || (mat->fp == NULL) ||
-         (start == NULL) || (stride == NULL) || (edge    == NULL) ) {
+    if ( (mat == NULL) || (data == NULL) || (mat->fp == NULL) || (start == NULL) ||
+         (stride == NULL) || (edge == NULL) ) {
         return 0;
     } else if ( rank > 10 ) {
         return 0;
     }
 
-    err = inflateCopy(&z_copy,z);
+    err = inflateCopy(&z_copy, z);
     if ( err != Z_OK ) {
-        Mat_Critical("inflateCopy returned error %s",zError(err));
+        Mat_Critical("inflateCopy returned error %s", zError(err));
         return -1;
     }
     switch ( class_type ) {
-        case MAT_C_DOUBLE:
-        {
-            double *ptr = (double*)data;
+        case MAT_C_DOUBLE: {
+            double *ptr = (double *)data;
             READ_COMPRESSED_DATA_SLABN(ReadCompressedDoubleData);
             break;
         }
-        case MAT_C_SINGLE:
-        {
-            float *ptr = (float*)data;
+        case MAT_C_SINGLE: {
+            float *ptr = (float *)data;
             READ_COMPRESSED_DATA_SLABN(ReadCompressedSingleData);
             break;
         }
 #ifdef HAVE_MATIO_INT64_T
-        case MAT_C_INT64:
-        {
-            mat_int64_t *ptr = (mat_int64_t*)data;
+        case MAT_C_INT64: {
+            mat_int64_t *ptr = (mat_int64_t *)data;
             READ_COMPRESSED_DATA_SLABN(ReadCompressedInt64Data);
             break;
         }
 #endif /* HAVE_MATIO_INT64_T */
 #ifdef HAVE_MATIO_UINT64_T
-        case MAT_C_UINT64:
-        {
-            mat_uint64_t *ptr = (mat_uint64_t*)data;
+        case MAT_C_UINT64: {
+            mat_uint64_t *ptr = (mat_uint64_t *)data;
             READ_COMPRESSED_DATA_SLABN(ReadCompressedUInt64Data);
             break;
         }
 #endif /* HAVE_MATIO_UINT64_T */
-        case MAT_C_INT32:
-        {
-            mat_int32_t *ptr = (mat_int32_t*)data;
+        case MAT_C_INT32: {
+            mat_int32_t *ptr = (mat_int32_t *)data;
             READ_COMPRESSED_DATA_SLABN(ReadCompressedInt32Data);
             break;
         }
-        case MAT_C_UINT32:
-        {
-            mat_uint32_t *ptr = (mat_uint32_t*)data;
+        case MAT_C_UINT32: {
+            mat_uint32_t *ptr = (mat_uint32_t *)data;
             READ_COMPRESSED_DATA_SLABN(ReadCompressedUInt32Data);
             break;
         }
-        case MAT_C_INT16:
-        {
-            mat_int16_t *ptr = (mat_int16_t*)data;
+        case MAT_C_INT16: {
+            mat_int16_t *ptr = (mat_int16_t *)data;
             READ_COMPRESSED_DATA_SLABN(ReadCompressedInt16Data);
             break;
         }
-        case MAT_C_UINT16:
-        {
-            mat_uint16_t *ptr = (mat_uint16_t*)data;
+        case MAT_C_UINT16: {
+            mat_uint16_t *ptr = (mat_uint16_t *)data;
             READ_COMPRESSED_DATA_SLABN(ReadCompressedUInt16Data);
             break;
         }
-        case MAT_C_INT8:
-        {
-            mat_int8_t *ptr = (mat_int8_t*)data;
+        case MAT_C_INT8: {
+            mat_int8_t *ptr = (mat_int8_t *)data;
             READ_COMPRESSED_DATA_SLABN(ReadCompressedInt8Data);
             break;
         }
-        case MAT_C_UINT8:
-        {
-            mat_uint8_t *ptr = (mat_uint8_t*)data;
+        case MAT_C_UINT8: {
+            mat_uint8_t *ptr = (mat_uint8_t *)data;
             READ_COMPRESSED_DATA_SLABN(ReadCompressedUInt8Data);
             break;
         }
@@ -1897,17 +1916,17 @@ ReadCompressedDataSlabN(mat_t *mat,z_streamp z,void *data,
 #undef READ_COMPRESSED_DATA_SLABN_RANK_LOOP
 #endif
 
-#define READ_DATA_SLAB1(ReadDataFunc) \
-    do { \
-        if ( !stride ) { \
-            bytesread+=ReadDataFunc(mat,ptr,data_type,edge); \
-        } else { \
-            for ( i = 0; i < edge; i++ ) { \
-                bytesread+=ReadDataFunc(mat,ptr+i,data_type,1); \
-                (void)fseek((FILE*)mat->fp,stride,SEEK_CUR); \
-            } \
-        } \
-    } while (0)
+#define READ_DATA_SLAB1(ReadDataFunc)                                  \
+    do {                                                               \
+        if ( !stride ) {                                               \
+            bytesread += ReadDataFunc(mat, ptr, data_type, edge);      \
+        } else {                                                       \
+            for ( i = 0; i < edge; i++ ) {                             \
+                bytesread += ReadDataFunc(mat, ptr + i, data_type, 1); \
+                (void)fseek((FILE *)mat->fp, stride, SEEK_CUR);        \
+            }                                                          \
+        }                                                              \
+    } while ( 0 )
 
 /** @brief Reads data of type @c data_type by user-defined dimensions for 1-D
  *         data
@@ -1923,79 +1942,69 @@ ReadCompressedDataSlabN(mat_t *mat,z_streamp z,void *data,
  * @return Number of bytes read from the file, or -1 on error
  */
 static int
-ReadDataSlab1(mat_t *mat,void *data,enum matio_classes class_type,
-    enum matio_types data_type,int start,int stride,int edge)
+ReadDataSlab1(mat_t *mat, void *data, enum matio_classes class_type, enum matio_types data_type,
+              int start, int stride, int edge)
 {
     int i;
     size_t data_size;
-    int    bytesread = 0;
+    int bytesread = 0;
 
     data_size = Mat_SizeOf(data_type);
-    (void)fseek((FILE*)mat->fp,start*data_size,SEEK_CUR);
-    stride = data_size*(stride-1);
+    (void)fseek((FILE *)mat->fp, start * data_size, SEEK_CUR);
+    stride = data_size * (stride - 1);
 
     switch ( class_type ) {
-        case MAT_C_DOUBLE:
-        {
-            double *ptr = (double*)data;
+        case MAT_C_DOUBLE: {
+            double *ptr = (double *)data;
             READ_DATA_SLAB1(ReadDoubleData);
             break;
         }
-        case MAT_C_SINGLE:
-        {
-            float *ptr = (float*)data;
+        case MAT_C_SINGLE: {
+            float *ptr = (float *)data;
             READ_DATA_SLAB1(ReadSingleData);
             break;
         }
 #ifdef HAVE_MATIO_INT64_T
-        case MAT_C_INT64:
-        {
-            mat_int64_t *ptr = (mat_int64_t*)data;
+        case MAT_C_INT64: {
+            mat_int64_t *ptr = (mat_int64_t *)data;
             READ_DATA_SLAB1(ReadInt64Data);
             break;
         }
 #endif /* HAVE_MATIO_INT64_T */
 #ifdef HAVE_MATIO_UINT64_T
-        case MAT_C_UINT64:
-        {
-            mat_uint64_t *ptr = (mat_uint64_t*)data;
+        case MAT_C_UINT64: {
+            mat_uint64_t *ptr = (mat_uint64_t *)data;
             READ_DATA_SLAB1(ReadUInt64Data);
             break;
         }
 #endif /* HAVE_MATIO_UINT64_T */
-        case MAT_C_INT32:
-        {
-            mat_int32_t *ptr = (mat_int32_t*)data;
+        case MAT_C_INT32: {
+            mat_int32_t *ptr = (mat_int32_t *)data;
             READ_DATA_SLAB1(ReadInt32Data);
             break;
         }
-        case MAT_C_UINT32:
-        {
-            mat_uint32_t *ptr = (mat_uint32_t*)data;
+        case MAT_C_UINT32: {
+            mat_uint32_t *ptr = (mat_uint32_t *)data;
             READ_DATA_SLAB1(ReadUInt32Data);
             break;
         }
-        case MAT_C_INT16:
-        {
-            mat_int16_t *ptr = (mat_int16_t*)data;
+        case MAT_C_INT16: {
+            mat_int16_t *ptr = (mat_int16_t *)data;
             READ_DATA_SLAB1(ReadInt16Data);
             break;
         }
-        case MAT_C_UINT16:
-        {
-            mat_uint16_t *ptr = (mat_uint16_t*)data;
+        case MAT_C_UINT16: {
+            mat_uint16_t *ptr = (mat_uint16_t *)data;
             READ_DATA_SLAB1(ReadUInt16Data);
             break;
         }
-        case MAT_C_INT8:
-        {
-            mat_int8_t *ptr = (mat_int8_t*)data;
+        case MAT_C_INT8: {
+            mat_int8_t *ptr = (mat_int8_t *)data;
             READ_DATA_SLAB1(ReadInt8Data);
             break;
         }
-        case MAT_C_UINT8:
-        {
-            mat_uint8_t *ptr = (mat_uint8_t*)data;
+        case MAT_C_UINT8: {
+            mat_uint8_t *ptr = (mat_uint8_t *)data;
             READ_DATA_SLAB1(ReadUInt8Data);
             break;
         }
@@ -2008,43 +2017,42 @@ ReadDataSlab1(mat_t *mat,void *data,enum matio_classes class_type,
 
 #undef READ_DATA_SLAB1
 
-#define READ_DATA_SLAB2(ReadDataFunc) \
-    do { \
-        /* If stride[0] is 1 and stride[1] is 1, we are reading all of the */ \
-        /* data so get rid of the loops. */ \
-        if ( (stride[0] == 1 && (size_t)edge[0] == dims[0]) && \
-             (stride[1] == 1) ) { \
-            ReadDataFunc(mat,ptr,data_type,(ptrdiff_t)edge[0]*edge[1]); \
-        } else { \
-            row_stride = (long)(stride[0]-1)*data_size; \
-            col_stride = (long)stride[1]*dims[0]*data_size; \
-            pos = ftell((FILE*)mat->fp); \
-            if ( pos == -1L ) { \
-                Mat_Critical("Couldn't determine file position"); \
-                return -1; \
-            } \
-            (void)fseek((FILE*)mat->fp,(long)start[1]*dims[0]*data_size,SEEK_CUR); \
-            for ( i = 0; i < edge[1]; i++ ) { \
-                pos = ftell((FILE*)mat->fp); \
-                if ( pos == -1L ) { \
-                    Mat_Critical("Couldn't determine file position"); \
-                    return -1; \
-                } \
-                (void)fseek((FILE*)mat->fp,(long)start[0]*data_size,SEEK_CUR); \
-                for ( j = 0; j < edge[0]; j++ ) { \
-                    ReadDataFunc(mat,ptr++,data_type,1); \
-                    (void)fseek((FILE*)mat->fp,row_stride,SEEK_CUR); \
-                } \
-                pos2 = ftell((FILE*)mat->fp); \
-                if ( pos2 == -1L ) { \
-                    Mat_Critical("Couldn't determine file position"); \
-                    return -1; \
-                } \
-                pos +=col_stride-pos2; \
-                (void)fseek((FILE*)mat->fp,pos,SEEK_CUR); \
-            } \
-        } \
-    } while (0)
+#define READ_DATA_SLAB2(ReadDataFunc)                                                     \
+    do {                                                                                  \
+        /* If stride[0] is 1 and stride[1] is 1, we are reading all of the */             \
+        /* data so get rid of the loops. */                                               \
+        if ( (stride[0] == 1 && (size_t)edge[0] == dims[0]) && (stride[1] == 1) ) {       \
+            ReadDataFunc(mat, ptr, data_type, (ptrdiff_t)edge[0] * edge[1]);              \
+        } else {                                                                          \
+            row_stride = (long)(stride[0] - 1) * data_size;                               \
+            col_stride = (long)stride[1] * dims[0] * data_size;                           \
+            pos = ftell((FILE *)mat->fp);                                                 \
+            if ( pos == -1L ) {                                                           \
+                Mat_Critical("Couldn't determine file position");                         \
+                return -1;                                                                \
+            }                                                                             \
+            (void)fseek((FILE *)mat->fp, (long)start[1] * dims[0] * data_size, SEEK_CUR); \
+            for ( i = 0; i < edge[1]; i++ ) {                                             \
+                pos = ftell((FILE *)mat->fp);                                             \
+                if ( pos == -1L ) {                                                       \
+                    Mat_Critical("Couldn't determine file position");                     \
+                    return -1;                                                            \
+                }                                                                         \
+                (void)fseek((FILE *)mat->fp, (long)start[0] * data_size, SEEK_CUR);       \
+                for ( j = 0; j < edge[0]; j++ ) {                                         \
+                    ReadDataFunc(mat, ptr++, data_type, 1);                               \
+                    (void)fseek((FILE *)mat->fp, row_stride, SEEK_CUR);                   \
+                }                                                                         \
+                pos2 = ftell((FILE *)mat->fp);                                            \
+                if ( pos2 == -1L ) {                                                      \
+                    Mat_Critical("Couldn't determine file position");                     \
+                    return -1;                                                            \
+                }                                                                         \
+                pos += col_stride - pos2;                                                 \
+                (void)fseek((FILE *)mat->fp, pos, SEEK_CUR);                              \
+            }                                                                             \
+        }                                                                                 \
+    } while ( 0 )
 
 /** @brief Reads data of type @c data_type by user-defined dimensions for 2-D
  *         data
@@ -2061,81 +2069,71 @@ ReadDataSlab1(mat_t *mat,void *data,enum matio_classes class_type,
  * @retval Number of bytes read from the file, or -1 on error
  */
 static int
-ReadDataSlab2(mat_t *mat,void *data,enum matio_classes class_type,
-    enum matio_types data_type,size_t *dims,int *start,int *stride,int *edge)
+ReadDataSlab2(mat_t *mat, void *data, enum matio_classes class_type, enum matio_types data_type,
+              size_t *dims, int *start, int *stride, int *edge)
 {
     int nBytes = 0, data_size, i, j;
     long pos, row_stride, col_stride, pos2;
 
-    if ( (mat   == NULL) || (data   == NULL) || (mat->fp == NULL) ||
-         (start == NULL) || (stride == NULL) || (edge    == NULL) ) {
+    if ( (mat == NULL) || (data == NULL) || (mat->fp == NULL) || (start == NULL) ||
+         (stride == NULL) || (edge == NULL) ) {
         return 0;
     }
 
     data_size = Mat_SizeOf(data_type);
 
     switch ( class_type ) {
-        case MAT_C_DOUBLE:
-        {
-            double *ptr = (double*)data;
+        case MAT_C_DOUBLE: {
+            double *ptr = (double *)data;
             READ_DATA_SLAB2(ReadDoubleData);
             break;
         }
-        case MAT_C_SINGLE:
-        {
-            float *ptr = (float*)data;
+        case MAT_C_SINGLE: {
+            float *ptr = (float *)data;
             READ_DATA_SLAB2(ReadSingleData);
             break;
         }
 #ifdef HAVE_MATIO_INT64_T
-        case MAT_C_INT64:
-        {
-            mat_int64_t *ptr = (mat_int64_t*)data;
+        case MAT_C_INT64: {
+            mat_int64_t *ptr = (mat_int64_t *)data;
             READ_DATA_SLAB2(ReadInt64Data);
             break;
         }
 #endif /* HAVE_MATIO_INT64_T */
 #ifdef HAVE_MATIO_UINT64_T
-        case MAT_C_UINT64:
-        {
-            mat_uint64_t *ptr = (mat_uint64_t*)data;
+        case MAT_C_UINT64: {
+            mat_uint64_t *ptr = (mat_uint64_t *)data;
             READ_DATA_SLAB2(ReadUInt64Data);
             break;
         }
 #endif /* HAVE_MATIO_UINT64_T */
-        case MAT_C_INT32:
-        {
-            mat_int32_t *ptr = (mat_int32_t*)data;
+        case MAT_C_INT32: {
+            mat_int32_t *ptr = (mat_int32_t *)data;
             READ_DATA_SLAB2(ReadInt32Data);
             break;
         }
-        case MAT_C_UINT32:
-        {
-            mat_uint32_t *ptr = (mat_uint32_t*)data;
+        case MAT_C_UINT32: {
+            mat_uint32_t *ptr = (mat_uint32_t *)data;
             READ_DATA_SLAB2(ReadUInt32Data);
             break;
         }
-        case MAT_C_INT16:
-        {
-            mat_int16_t *ptr = (mat_int16_t*)data;
+        case MAT_C_INT16: {
+            mat_int16_t *ptr = (mat_int16_t *)data;
             READ_DATA_SLAB2(ReadInt16Data);
             break;
         }
-        case MAT_C_UINT16:
-        {
-            mat_uint16_t *ptr = (mat_uint16_t*)data;
+        case MAT_C_UINT16: {
+            mat_uint16_t *ptr = (mat_uint16_t *)data;
             READ_DATA_SLAB2(ReadUInt16Data);
             break;
         }
-        case MAT_C_INT8:
-        {
-            mat_int8_t *ptr = (mat_int8_t*)data;
+        case MAT_C_INT8: {
+            mat_int8_t *ptr = (mat_int8_t *)data;
             READ_DATA_SLAB2(ReadInt8Data);
             break;
         }
-        case MAT_C_UINT8:
-        {
-            mat_uint8_t *ptr = (mat_uint8_t*)data;
+        case MAT_C_UINT8: {
+            mat_uint8_t *ptr = (mat_uint8_t *)data;
             READ_DATA_SLAB2(ReadUInt8Data);
             break;
         }
@@ -2148,17 +2146,17 @@ ReadDataSlab2(mat_t *mat,void *data,enum matio_classes class_type,
 #undef READ_DATA_SLAB2
 
 #if HAVE_ZLIB
-#define READ_COMPRESSED_DATA_SLAB1(ReadDataFunc) \
-    do { \
-        if ( !stride ) { \
-            nBytes+=ReadDataFunc(mat,&z_copy,ptr,data_type,edge); \
-        } else { \
-            for ( i = 0; i < edge; i++ ) { \
-                nBytes+=ReadDataFunc(mat,&z_copy,ptr+i,data_type,1); \
-                InflateSkipData(mat,&z_copy,data_type,stride); \
-            } \
-        } \
-    } while (0)
+#define READ_COMPRESSED_DATA_SLAB1(ReadDataFunc)                             \
+    do {                                                                     \
+        if ( !stride ) {                                                     \
+            nBytes += ReadDataFunc(mat, &z_copy, ptr, data_type, edge);      \
+        } else {                                                             \
+            for ( i = 0; i < edge; i++ ) {                                   \
+                nBytes += ReadDataFunc(mat, &z_copy, ptr + i, data_type, 1); \
+                InflateSkipData(mat, &z_copy, data_type, stride);            \
+            }                                                                \
+        }                                                                    \
+    } while ( 0 )
 
 /** @brief Reads data of type @c data_type by user-defined dimensions for 1-D
  *         data
@@ -2176,85 +2174,76 @@ ReadDataSlab2(mat_t *mat,void *data,enum matio_classes class_type,
  * @retval Number of bytes read from the file, or -1 on error
  */
 static int
-ReadCompressedDataSlab1(mat_t *mat,z_streamp z,void *data,
-    enum matio_classes class_type,enum matio_types data_type,int start,
-    int stride,int edge)
+ReadCompressedDataSlab1(mat_t *mat, z_streamp z, void *data, enum matio_classes class_type,
+                        enum matio_types data_type, int start, int stride, int edge)
 {
     int nBytes = 0, i, err;
-    z_stream z_copy = {0,};
+    z_stream z_copy = {
+        0,
+    };
 
     if ( (mat == NULL) || (data == NULL) || (mat->fp == NULL) )
         return 0;
 
     stride--;
-    err = inflateCopy(&z_copy,z);
+    err = inflateCopy(&z_copy, z);
     if ( err != Z_OK ) {
-        Mat_Critical("inflateCopy returned error %s",zError(err));
+        Mat_Critical("inflateCopy returned error %s", zError(err));
         return -1;
     }
     InflateSkipData(mat, &z_copy, data_type, start);
     switch ( class_type ) {
-        case MAT_C_DOUBLE:
-        {
-            double *ptr = (double*)data;
+        case MAT_C_DOUBLE: {
+            double *ptr = (double *)data;
             READ_COMPRESSED_DATA_SLAB1(ReadCompressedDoubleData);
             break;
         }
-        case MAT_C_SINGLE:
-        {
-            float *ptr = (float*)data;
+        case MAT_C_SINGLE: {
+            float *ptr = (float *)data;
             READ_COMPRESSED_DATA_SLAB1(ReadCompressedSingleData);
             break;
         }
 #ifdef HAVE_MATIO_INT64_T
-        case MAT_C_INT64:
-        {
-            mat_int64_t *ptr = (mat_int64_t*)data;
+        case MAT_C_INT64: {
+            mat_int64_t *ptr = (mat_int64_t *)data;
             READ_COMPRESSED_DATA_SLAB1(ReadCompressedInt64Data);
             break;
         }
 #endif /* HAVE_MATIO_INT64_T */
 #ifdef HAVE_MATIO_UINT64_T
-        case MAT_C_UINT64:
-        {
-            mat_uint64_t *ptr = (mat_uint64_t*)data;
+        case MAT_C_UINT64: {
+            mat_uint64_t *ptr = (mat_uint64_t *)data;
             READ_COMPRESSED_DATA_SLAB1(ReadCompressedUInt64Data);
             break;
         }
 #endif /* HAVE_MATIO_UINT64_T */
-        case MAT_C_INT32:
-        {
-            mat_int32_t *ptr = (mat_int32_t*)data;
+        case MAT_C_INT32: {
+            mat_int32_t *ptr = (mat_int32_t *)data;
             READ_COMPRESSED_DATA_SLAB1(ReadCompressedInt32Data);
             break;
         }
-        case MAT_C_UINT32:
-        {
-            mat_uint32_t *ptr = (mat_uint32_t*)data;
+        case MAT_C_UINT32: {
+            mat_uint32_t *ptr = (mat_uint32_t *)data;
             READ_COMPRESSED_DATA_SLAB1(ReadCompressedUInt32Data);
             break;
         }
-        case MAT_C_INT16:
-        {
-            mat_int16_t *ptr = (mat_int16_t*)data;
+        case MAT_C_INT16: {
+            mat_int16_t *ptr = (mat_int16_t *)data;
             READ_COMPRESSED_DATA_SLAB1(ReadCompressedInt16Data);
             break;
         }
-        case MAT_C_UINT16:
-        {
-            mat_uint16_t *ptr = (mat_uint16_t*)data;
+        case MAT_C_UINT16: {
+            mat_uint16_t *ptr = (mat_uint16_t *)data;
             READ_COMPRESSED_DATA_SLAB1(ReadCompressedUInt16Data);
             break;
         }
-        case MAT_C_INT8:
-        {
-            mat_int8_t *ptr = (mat_int8_t*)data;
+        case MAT_C_INT8: {
+            mat_int8_t *ptr = (mat_int8_t *)data;
             READ_COMPRESSED_DATA_SLAB1(ReadCompressedInt8Data);
             break;
         }
-        case MAT_C_UINT8:
-        {
-            mat_uint8_t *ptr = (mat_uint8_t*)data;
+        case MAT_C_UINT8: {
+            mat_uint8_t *ptr = (mat_uint8_t *)data;
             READ_COMPRESSED_DATA_SLAB1(ReadCompressedUInt8Data);
             break;
         }
@@ -2267,39 +2256,38 @@ ReadCompressedDataSlab1(mat_t *mat,z_streamp z,void *data,
 
 #undef READ_COMPRESSED_DATA_SLAB1
 
-#define READ_COMPRESSED_DATA_SLAB2(ReadDataFunc) \
-    do {\
-        row_stride = (stride[0]-1); \
-        col_stride = (stride[1]-1)*dims[0]; \
-        InflateSkipData(mat,&z_copy,data_type,start[1]*dims[0]); \
-        /* If stride[0] is 1 and stride[1] is 1, we are reading all of the */ \
-        /* data so get rid of the loops.  If stride[0] is 1 and stride[1] */ \
-        /* is not 0, we are reading whole columns, so get rid of inner loop */ \
-        /* to speed up the code */ \
-        if ( (stride[0] == 1 && (size_t)edge[0] == dims[0]) && \
-             (stride[1] == 1) ) { \
-            ReadDataFunc(mat,&z_copy,ptr,data_type,(ptrdiff_t)edge[0]*edge[1]); \
-        } else if ( stride[0] == 1 ) { \
-            for ( i = 0; i < edge[1]; i++ ) { \
-                InflateSkipData(mat,&z_copy,data_type,start[0]); \
-                ReadDataFunc(mat,&z_copy,ptr,data_type,edge[0]); \
-                ptr += edge[0]; \
-                pos = dims[0]-(ptrdiff_t)(edge[0]-1)*stride[0]-1-start[0] + col_stride; \
-                InflateSkipData(mat,&z_copy,data_type,pos); \
-            } \
-        } else { \
-            for ( i = 0; i < edge[1]; i++ ) { \
-                InflateSkipData(mat,&z_copy,data_type,start[0]); \
-                for ( j = 0; j < edge[0]-1; j++ ) { \
-                    ReadDataFunc(mat,&z_copy,ptr++,data_type,1); \
-                    InflateSkipData(mat,&z_copy,data_type,row_stride); \
-                } \
-                ReadDataFunc(mat,&z_copy,ptr++,data_type,1); \
-                pos = dims[0]-(ptrdiff_t)(edge[0]-1)*stride[0]-1-start[0] + col_stride; \
-                InflateSkipData(mat,&z_copy,data_type,pos); \
-            } \
-        } \
-    } while (0)
+#define READ_COMPRESSED_DATA_SLAB2(ReadDataFunc)                                                  \
+    do {                                                                                          \
+        row_stride = (stride[0] - 1);                                                             \
+        col_stride = (stride[1] - 1) * dims[0];                                                   \
+        InflateSkipData(mat, &z_copy, data_type, start[1] * dims[0]);                             \
+        /* If stride[0] is 1 and stride[1] is 1, we are reading all of the */                     \
+        /* data so get rid of the loops.  If stride[0] is 1 and stride[1] */                      \
+        /* is not 0, we are reading whole columns, so get rid of inner loop */                    \
+        /* to speed up the code */                                                                \
+        if ( (stride[0] == 1 && (size_t)edge[0] == dims[0]) && (stride[1] == 1) ) {               \
+            ReadDataFunc(mat, &z_copy, ptr, data_type, (ptrdiff_t)edge[0] * edge[1]);             \
+        } else if ( stride[0] == 1 ) {                                                            \
+            for ( i = 0; i < edge[1]; i++ ) {                                                     \
+                InflateSkipData(mat, &z_copy, data_type, start[0]);                               \
+                ReadDataFunc(mat, &z_copy, ptr, data_type, edge[0]);                              \
+                ptr += edge[0];                                                                   \
+                pos = dims[0] - (ptrdiff_t)(edge[0] - 1) * stride[0] - 1 - start[0] + col_stride; \
+                InflateSkipData(mat, &z_copy, data_type, pos);                                    \
+            }                                                                                     \
+        } else {                                                                                  \
+            for ( i = 0; i < edge[1]; i++ ) {                                                     \
+                InflateSkipData(mat, &z_copy, data_type, start[0]);                               \
+                for ( j = 0; j < edge[0] - 1; j++ ) {                                             \
+                    ReadDataFunc(mat, &z_copy, ptr++, data_type, 1);                              \
+                    InflateSkipData(mat, &z_copy, data_type, row_stride);                         \
+                }                                                                                 \
+                ReadDataFunc(mat, &z_copy, ptr++, data_type, 1);                                  \
+                pos = dims[0] - (ptrdiff_t)(edge[0] - 1) * stride[0] - 1 - start[0] + col_stride; \
+                InflateSkipData(mat, &z_copy, data_type, pos);                                    \
+            }                                                                                     \
+        }                                                                                         \
+    } while ( 0 )
 
 /** @brief Reads data of type @c data_type by user-defined dimensions for 2-D
  *         data
@@ -2317,86 +2305,78 @@ ReadCompressedDataSlab1(mat_t *mat,z_streamp z,void *data,
  * @retval Number of bytes read from the file, or -1 on error
  */
 static int
-ReadCompressedDataSlab2(mat_t *mat,z_streamp z,void *data,
-    enum matio_classes class_type,enum matio_types data_type,size_t *dims,
-    int *start,int *stride,int *edge)
+ReadCompressedDataSlab2(mat_t *mat, z_streamp z, void *data, enum matio_classes class_type,
+                        enum matio_types data_type, size_t *dims, int *start, int *stride,
+                        int *edge)
 {
     int nBytes = 0, i, j, err;
     int pos, row_stride, col_stride;
-    z_stream z_copy = {0,};
+    z_stream z_copy = {
+        0,
+    };
 
-    if ( (mat   == NULL) || (data   == NULL) || (mat->fp == NULL) ||
-         (start == NULL) || (stride == NULL) || (edge    == NULL) ) {
+    if ( (mat == NULL) || (data == NULL) || (mat->fp == NULL) || (start == NULL) ||
+         (stride == NULL) || (edge == NULL) ) {
         return 0;
     }
 
-    err = inflateCopy(&z_copy,z);
+    err = inflateCopy(&z_copy, z);
     if ( err != Z_OK ) {
-        Mat_Critical("inflateCopy returned error %s",zError(err));
+        Mat_Critical("inflateCopy returned error %s", zError(err));
         return -1;
     }
     switch ( class_type ) {
-        case MAT_C_DOUBLE:
-        {
-            double *ptr = (double*)data;
+        case MAT_C_DOUBLE: {
+            double *ptr = (double *)data;
             READ_COMPRESSED_DATA_SLAB2(ReadCompressedDoubleData);
             break;
         }
-        case MAT_C_SINGLE:
-        {
-            float *ptr = (float*)data;
+        case MAT_C_SINGLE: {
+            float *ptr = (float *)data;
             READ_COMPRESSED_DATA_SLAB2(ReadCompressedSingleData);
             break;
         }
 #ifdef HAVE_MATIO_INT64_T
-        case MAT_C_INT64:
-        {
-            mat_int64_t *ptr = (mat_int64_t*)data;
+        case MAT_C_INT64: {
+            mat_int64_t *ptr = (mat_int64_t *)data;
             READ_COMPRESSED_DATA_SLAB2(ReadCompressedInt64Data);
             break;
         }
 #endif /* HAVE_MATIO_INT64_T */
 #ifdef HAVE_MATIO_UINT64_T
-        case MAT_C_UINT64:
-        {
-            mat_uint64_t *ptr = (mat_uint64_t*)data;
+        case MAT_C_UINT64: {
+            mat_uint64_t *ptr = (mat_uint64_t *)data;
             READ_COMPRESSED_DATA_SLAB2(ReadCompressedUInt64Data);
             break;
         }
 #endif /* HAVE_MATIO_UINT64_T */
-        case MAT_C_INT32:
-        {
-            mat_int32_t *ptr = (mat_int32_t*)data;
+        case MAT_C_INT32: {
+            mat_int32_t *ptr = (mat_int32_t *)data;
             READ_COMPRESSED_DATA_SLAB2(ReadCompressedInt32Data);
             break;
         }
-        case MAT_C_UINT32:
-        {
-            mat_uint32_t *ptr = (mat_uint32_t*)data;
+        case MAT_C_UINT32: {
+            mat_uint32_t *ptr = (mat_uint32_t *)data;
             READ_COMPRESSED_DATA_SLAB2(ReadCompressedUInt32Data);
             break;
         }
-        case MAT_C_INT16:
-        {
-            mat_int16_t *ptr = (mat_int16_t*)data;
+        case MAT_C_INT16: {
+            mat_int16_t *ptr = (mat_int16_t *)data;
             READ_COMPRESSED_DATA_SLAB2(ReadCompressedInt16Data);
             break;
         }
-        case MAT_C_UINT16:
-        {
-            mat_uint16_t *ptr = (mat_uint16_t*)data;
+        case MAT_C_UINT16: {
+            mat_uint16_t *ptr = (mat_uint16_t *)data;
             READ_COMPRESSED_DATA_SLAB2(ReadCompressedUInt16Data);
             break;
         }
-        case MAT_C_INT8:
-        {
-            mat_int8_t *ptr = (mat_int8_t*)data;
+        case MAT_C_INT8: {
+            mat_int8_t *ptr = (mat_int8_t *)data;
             READ_COMPRESSED_DATA_SLAB2(ReadCompressedInt8Data);
             break;
         }
-        case MAT_C_UINT8:
-        {
-            mat_uint8_t *ptr = (mat_uint8_t*)data;
+        case MAT_C_UINT8: {
+            mat_uint8_t *ptr = (mat_uint8_t *)data;
             READ_COMPRESSED_DATA_SLAB2(ReadCompressedUInt8Data);
             break;
         }
@@ -2426,29 +2406,29 @@ ReadCompressedDataSlab2(mat_t *mat,z_streamp z,void *data,
 #ifndef MAT5_H
 #define MAT5_H
 
-static mat_t    *Mat_Create5(const char *matname,const char *hdr_str);
+static mat_t *Mat_Create5(const char *matname, const char *hdr_str);
 
-static matvar_t *Mat_VarReadNextInfo5( mat_t *mat );
-static int       Mat_VarRead5(mat_t *mat, matvar_t *matvar);
-static int       Mat_VarReadData5(mat_t *mat,matvar_t *matvar,void *data,
-                     int *start,int *stride,int *edge);
-static int       Mat_VarReadDataLinear5(mat_t *mat,matvar_t *matvar,void *data,
-                     int start,int stride,int edge);
-static int       Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress);
+static matvar_t *Mat_VarReadNextInfo5(mat_t *mat);
+static int Mat_VarRead5(mat_t *mat, matvar_t *matvar);
+static int Mat_VarReadData5(mat_t *mat, matvar_t *matvar, void *data, int *start, int *stride,
+                            int *edge);
+static int Mat_VarReadDataLinear5(mat_t *mat, matvar_t *matvar, void *data, int start, int stride,
+                                  int edge);
+static int Mat_VarWrite5(mat_t *mat, matvar_t *matvar, int compress);
 
 #endif
 
 #ifndef MAT4_H
 #define MAT4_H
 
-static mat_t    *Mat_Create4(const char* matname);
+static mat_t *Mat_Create4(const char *matname);
 
-static int       Mat_VarWrite4(mat_t *mat,matvar_t *matvar);
-static int       Mat_VarRead4(mat_t *mat, matvar_t *matvar);
-static int       Mat_VarReadData4(mat_t *mat,matvar_t *matvar,void *data,
-                     int *start,int *stride,int *edge);
-static int       Mat_VarReadDataLinear4(mat_t *mat,matvar_t *matvar,void *data,int start,
-                     int stride,int edge);
+static int Mat_VarWrite4(mat_t *mat, matvar_t *matvar);
+static int Mat_VarRead4(mat_t *mat, matvar_t *matvar);
+static int Mat_VarReadData4(mat_t *mat, matvar_t *matvar, void *data, int *start, int *stride,
+                            int *edge);
+static int Mat_VarReadDataLinear4(mat_t *mat, matvar_t *matvar, void *data, int start, int stride,
+                                  int edge);
 static matvar_t *Mat_VarReadNextInfo4(mat_t *mat);
 
 #endif
@@ -2457,17 +2437,16 @@ static matvar_t *Mat_VarReadNextInfo4(mat_t *mat);
 #define MAT73_H
 
 #if HAVE_HDF5
-static mat_t    *Mat_Create73(const char *matname,const char *hdr_str);
-static int       Mat_Close73(mat_t *mat);
-static int       Mat_VarRead73(mat_t *mat,matvar_t *matvar);
-static int       Mat_VarReadData73(mat_t *mat,matvar_t *matvar,void *data,
-                     int *start,int *stride,int *edge);
-static int       Mat_VarReadDataLinear73(mat_t *mat,matvar_t *matvar,void *data,
-                     int start,int stride,int edge);
+static mat_t *Mat_Create73(const char *matname, const char *hdr_str);
+static int Mat_Close73(mat_t *mat);
+static int Mat_VarRead73(mat_t *mat, matvar_t *matvar);
+static int Mat_VarReadData73(mat_t *mat, matvar_t *matvar, void *data, int *start, int *stride,
+                             int *edge);
+static int Mat_VarReadDataLinear73(mat_t *mat, matvar_t *matvar, void *data, int start, int stride,
+                                   int edge);
 static matvar_t *Mat_VarReadNextInfo73(mat_t *mat);
-static int       Mat_VarWrite73(mat_t *mat,matvar_t *matvar,int compress);
-static int       Mat_VarWriteAppend73(mat_t *mat,matvar_t *matvar,int compress,
-                     int dim);
+static int Mat_VarWrite73(mat_t *mat, matvar_t *matvar, int compress);
+static int Mat_VarWriteAppend73(mat_t *mat, matvar_t *matvar, int compress, int dim);
 #endif
 #endif
 
@@ -2477,11 +2456,12 @@ static int       Mat_VarWriteAppend73(mat_t *mat,matvar_t *matvar,int compress,
  *===================================================================
  */
 
-static char* Mat_strdup(const char *s)
+static char *
+Mat_strdup(const char *s)
 {
     size_t len = strlen(s) + 1;
-    char *d = (char*)malloc(len);
-    return d ? (char*)memcpy(d, s, len) : NULL;
+    char *d = (char *)malloc(len);
+    return d ? (char *)memcpy(d, s, len) : NULL;
 }
 
 #define MAT_MKTEMP_DIR "/tmp/"
@@ -2489,7 +2469,7 @@ static char* Mat_strdup(const char *s)
 #define MAT_MKTEMP_FILE "/temp.mat"
 
 #define MAT_MKTEMP_BUF_SIZE \
-  (sizeof(MAT_MKTEMP_DIR)+sizeof(MAT_MKTEMP_TPL)+sizeof(MAT_MKTEMP_FILE)-2)
+    (sizeof(MAT_MKTEMP_DIR) + sizeof(MAT_MKTEMP_TPL) + sizeof(MAT_MKTEMP_FILE) - 2)
 
 static char *
 Mat_mktemp(char *path_buf, char *dir_buf)
@@ -2497,9 +2477,9 @@ Mat_mktemp(char *path_buf, char *dir_buf)
     char *ret = NULL;
 
     *path_buf = '\0';
-    *dir_buf  = '\0';
+    *dir_buf = '\0';
 
-#if (defined(_WIN64) || defined(_WIN32)) && !defined(__CYGWIN__)
+#if ( defined(_WIN64) || defined(_WIN32) ) && !defined(__CYGWIN__)
     strcpy(path_buf, MAT_MKTEMP_TPL);
     if ( NULL != _mktemp(path_buf) )
         ret = path_buf;
@@ -2525,13 +2505,13 @@ ReadData(mat_t *mat, matvar_t *matvar)
     if ( mat == NULL || matvar == NULL || mat->fp == NULL )
         return MATIO_E_BAD_ARGUMENT;
     else if ( mat->version == MAT_FT_MAT5 )
-        return Mat_VarRead5(mat,matvar);
+        return Mat_VarRead5(mat, matvar);
 #if HAVE_HDF5
     else if ( mat->version == MAT_FT_MAT73 )
-        return Mat_VarRead73(mat,matvar);
+        return Mat_VarRead73(mat, matvar);
 #endif
     else if ( mat->version == MAT_FT_MAT4 )
-        return Mat_VarRead4(mat,matvar);
+        return Mat_VarRead4(mat, matvar);
     return MATIO_E_FAIL_TO_IDENTIFY;
 }
 
@@ -2540,61 +2520,61 @@ Mat_PrintNumber(enum matio_types type, void *data)
 {
     switch ( type ) {
         case MAT_T_DOUBLE:
-            printf("%g",*(double*)data);
+            printf("%g", *(double *)data);
             break;
         case MAT_T_SINGLE:
-            printf("%g",*(float*)data);
+            printf("%g", *(float *)data);
             break;
 #ifdef HAVE_MATIO_INT64_T
         case MAT_T_INT64:
 #if HAVE_INTTYPES_H
-            printf("%" PRIi64,*(mat_int64_t*)data);
+            printf("%" PRIi64, *(mat_int64_t *)data);
 #elif defined(_MSC_VER) && _MSC_VER >= 1200
-            printf("%I64i",*(mat_int64_t*)data);
+            printf("%I64i", *(mat_int64_t *)data);
 #elif defined(HAVE_LONG_LONG_INT)
-            printf("%lld",(long long)(*(mat_int64_t*)data));
+            printf("%lld", (long long)(*(mat_int64_t *)data));
 #else
-            printf("%ld",(long)(*(mat_int64_t*)data));
+            printf("%ld", (long)(*(mat_int64_t *)data));
 #endif
             break;
 #endif
 #ifdef HAVE_MATIO_UINT64_T
         case MAT_T_UINT64:
 #if HAVE_INTTYPES_H
-            printf("%" PRIu64,*(mat_uint64_t*)data);
+            printf("%" PRIu64, *(mat_uint64_t *)data);
 #elif defined(_MSC_VER) && _MSC_VER >= 1200
-            printf("%I64u",*(mat_uint64_t*)data);
+            printf("%I64u", *(mat_uint64_t *)data);
 #elif defined(HAVE_UNSIGNED_LONG_LONG_INT)
-            printf("%llu",(unsigned long long)(*(mat_uint64_t*)data));
+            printf("%llu", (unsigned long long)(*(mat_uint64_t *)data));
 #else
-            printf("%lu",(unsigned long)(*(mat_uint64_t*)data));
+            printf("%lu", (unsigned long)(*(mat_uint64_t *)data));
 #endif
             break;
 #endif
         case MAT_T_INT32:
-            printf("%d",*(mat_int32_t*)data);
+            printf("%d", *(mat_int32_t *)data);
             break;
         case MAT_T_UINT32:
-            printf("%u",*(mat_uint32_t*)data);
+            printf("%u", *(mat_uint32_t *)data);
             break;
         case MAT_T_INT16:
-            printf("%hd",*(mat_int16_t*)data);
+            printf("%hd", *(mat_int16_t *)data);
             break;
         case MAT_T_UINT16:
-            printf("%hu",*(mat_uint16_t*)data);
+            printf("%hu", *(mat_uint16_t *)data);
             break;
         case MAT_T_INT8:
 #if defined(__GNUC__) && __STDC_VERSION__ >= 199901L
-            printf("%hhd",*(mat_int8_t*)data);
+            printf("%hhd", *(mat_int8_t *)data);
 #else
-            printf("%hd",(mat_int16_t)(*(mat_int8_t*)data));
+            printf("%hd", (mat_int16_t)(*(mat_int8_t *)data));
 #endif
             break;
         case MAT_T_UINT8:
 #if defined(__GNUC__) && __STDC_VERSION__ >= 199901L
-            printf("%hhu",*(mat_uint8_t*)data);
+            printf("%hhu", *(mat_uint8_t *)data);
 #else
-            printf("%hu",(mat_uint16_t)(*(mat_uint8_t*)data));
+            printf("%hu", (mat_uint16_t)(*(mat_uint8_t *)data));
 #endif
             break;
         default:
@@ -2605,7 +2585,7 @@ Mat_PrintNumber(enum matio_types type, void *data)
 static mat_complex_split_t *
 ComplexMalloc(size_t nbytes)
 {
-    mat_complex_split_t *complex_data = (mat_complex_split_t*)malloc(sizeof(*complex_data));
+    mat_complex_split_t *complex_data = (mat_complex_split_t *)malloc(sizeof(*complex_data));
     if ( NULL != complex_data ) {
         complex_data->Re = malloc(nbytes);
         if ( NULL != complex_data->Re ) {
@@ -2615,8 +2595,7 @@ ComplexMalloc(size_t nbytes)
                 free(complex_data);
                 complex_data = NULL;
             }
-        }
-        else {
+        } else {
             free(complex_data);
             complex_data = NULL;
         }
@@ -2626,7 +2605,7 @@ ComplexMalloc(size_t nbytes)
 }
 
 static void
-ComplexFree(mat_complex_split_t* complex_data)
+ComplexFree(mat_complex_split_t *complex_data)
 {
     free(complex_data->Re);
     free(complex_data->Im);
@@ -2681,7 +2660,8 @@ ClassType2DataType(enum matio_classes class_type)
  * @param nelems Number of elements
  * @retval 0 on success
  */
-static int Mat_MulDims(const matvar_t *matvar, size_t* nelems)
+static int
+Mat_MulDims(const matvar_t *matvar, size_t *nelems)
 {
     int i;
 
@@ -2711,7 +2691,8 @@ static int Mat_MulDims(const matvar_t *matvar, size_t* nelems)
  * @param b Second operand
  * @retval 0 on success
  */
-static int Mul(size_t* res, size_t a, size_t b)
+static int
+Mul(size_t *res, size_t a, size_t b)
 {
 #if HAVE_SAFE_MATH
     if ( !psnip_safe_size_mul(res, a, b) ) {
@@ -2719,7 +2700,7 @@ static int Mul(size_t* res, size_t a, size_t b)
         return MATIO_E_INDEX_TOO_BIG;
     }
 #else
-    *res = a*b;
+    *res = a * b;
 #endif
     return MATIO_E_NO_ERROR;
 }
@@ -2731,7 +2712,8 @@ static int Mul(size_t* res, size_t a, size_t b)
  * @param b Second operand
  * @retval 0 on success
  */
-static int Add(size_t* res, size_t a, size_t b)
+static int
+Add(size_t *res, size_t a, size_t b)
 {
 #if HAVE_SAFE_MATH
     if ( !psnip_safe_size_add(res, a, b) ) {
@@ -2739,7 +2721,7 @@ static int Add(size_t* res, size_t a, size_t b)
         return MATIO_E_INDEX_TOO_BIG;
     }
 #else
-    *res = a+b;
+    *res = a + b;
 #endif
     return MATIO_E_NO_ERROR;
 }
@@ -2754,22 +2736,50 @@ static int Add(size_t* res, size_t a, size_t b)
  * @retval 0 on success
  */
 static int
-Read(void* buf, size_t size, size_t count, FILE* fp, size_t* bytesread) {
+Read(void *buf, size_t size, size_t count, FILE *fp, size_t *bytesread)
+{
     const size_t readcount = fread(buf, size, count, fp);
     int err = readcount != count;
     if ( NULL != bytesread ) {
-        *bytesread += readcount*size;
-    }
-    if ( err && feof(fp) && 0 == readcount) {
-        err = MATIO_E_NO_ERROR;
+        *bytesread += readcount * size;
     }
     if ( err ) {
-        Mat_Warning("Unexpected end-of-file: Read %"
-            SIZE_T_FMTSTR " bytes, expected %"
-            SIZE_T_FMTSTR " bytes", readcount*size, count*size);
-        memset(buf, 0, count*size);
+        Mat_Warning(
+            "Unexpected end-of-file: Read %zu"
+            " bytes, expected %zu"
+            " bytes",
+            readcount * size, count * size);
+        memset(buf, 0, count * size);
     }
     return err;
+}
+
+/** @brief Check for End of file
+ *
+ * @param fp File pointer
+ * @param[out] fpos Current file position
+ * @retval 0 on success
+ */
+static int
+IsEndOfFile(FILE *fp, long *fpos)
+{
+    int isEOF = feof(fp);
+    long fPos = ftell(fp);
+    if ( !isEOF ) {
+        if ( fPos == -1L ) {
+            Mat_Critical("Couldn't determine file position");
+        } else {
+            (void)fseek(fp, 0, SEEK_END);
+            isEOF = fPos == ftell(fp);
+            if ( !isEOF ) {
+                (void)fseek(fp, fPos, SEEK_SET);
+            }
+        }
+    }
+    if ( NULL != fpos ) {
+        *fpos = fPos;
+    }
+    return isEOF;
 }
 
 /*
@@ -2786,7 +2796,7 @@ Read(void* buf, size_t size, size_t count, FILE* fp, size_t* bytesread) {
  * @param release Pointer to store the library release version number
  */
 void
-Mat_GetLibraryVersion(int *major,int *minor,int *release)
+Mat_GetLibraryVersion(int *major, int *minor, int *release)
 {
     if ( NULL != major )
         *major = MATIO_MAJOR_VERSION;
@@ -2812,7 +2822,7 @@ Mat_GetLibraryVersion(int *major,int *minor,int *release)
  * simple FILE * and should not be used as one.
  */
 mat_t *
-Mat_CreateVer(const char *matname,const char *hdr_str,enum mat_ft mat_file_ver)
+Mat_CreateVer(const char *matname, const char *hdr_str, enum mat_ft mat_file_ver)
 {
     mat_t *mat;
 
@@ -2821,11 +2831,11 @@ Mat_CreateVer(const char *matname,const char *hdr_str,enum mat_ft mat_file_ver)
             mat = Mat_Create4(matname);
             break;
         case MAT_FT_MAT5:
-            mat = Mat_Create5(matname,hdr_str);
+            mat = Mat_Create5(matname, hdr_str);
             break;
         case MAT_FT_MAT73:
 #if HAVE_HDF5
-            mat = Mat_Create73(matname,hdr_str);
+            mat = Mat_Create73(matname, hdr_str);
 #else
             mat = NULL;
 #endif
@@ -2848,7 +2858,7 @@ Mat_CreateVer(const char *matname,const char *hdr_str,enum mat_ft mat_file_ver)
  * simple FILE * and should not be used as one.
  */
 mat_t *
-Mat_Open(const char *matname,int mode)
+Mat_Open(const char *matname, int mode)
 {
     FILE *fp = NULL;
     mat_int16_t tmp, tmp2;
@@ -2857,7 +2867,7 @@ Mat_Open(const char *matname,int mode)
 
     if ( (mode & 0x01) == MAT_ACC_RDONLY ) {
 #if defined(_WIN32) && defined(_MSC_VER)
-        wchar_t* wname = utf82u(matname);
+        wchar_t *wname = utf82u(matname);
         if ( NULL != wname ) {
             fp = _wfopen(wname, L"rb");
             free(wname);
@@ -2869,7 +2879,7 @@ Mat_Open(const char *matname,int mode)
             return NULL;
     } else if ( (mode & 0x01) == MAT_ACC_RDWR ) {
 #if defined(_WIN32) && defined(_MSC_VER)
-        wchar_t* wname = utf82u(matname);
+        wchar_t *wname = utf82u(matname);
         if ( NULL != wname ) {
             fp = _wfopen(wname, L"r+b");
             free(wname);
@@ -2878,7 +2888,7 @@ Mat_Open(const char *matname,int mode)
         fp = fopen(matname, "r+b");
 #endif
         if ( !fp ) {
-            mat = Mat_CreateVer(matname,NULL,(enum mat_ft)(mode&0xfffffffe));
+            mat = Mat_CreateVer(matname, NULL, (enum mat_ft)(mode & 0xfffffffe));
             return mat;
         }
     } else {
@@ -2886,7 +2896,7 @@ Mat_Open(const char *matname,int mode)
         return NULL;
     }
 
-    mat = (mat_t*)malloc(sizeof(*mat));
+    mat = (mat_t *)malloc(sizeof(*mat));
     if ( NULL == mat ) {
         fclose(fp);
         Mat_Critical("Couldn't allocate memory for the MAT file");
@@ -2894,14 +2904,14 @@ Mat_Open(const char *matname,int mode)
     }
 
     mat->fp = fp;
-    mat->header = (char*)calloc(128,sizeof(char));
+    mat->header = (char *)calloc(128, sizeof(char));
     if ( NULL == mat->header ) {
         free(mat);
         fclose(fp);
         Mat_Critical("Couldn't allocate memory for the MAT file header");
         return NULL;
     }
-    mat->subsys_offset = (char*)calloc(8,sizeof(char));
+    mat->subsys_offset = (char *)calloc(8, sizeof(char));
     if ( NULL == mat->subsys_offset ) {
         free(mat->header);
         free(mat);
@@ -2909,20 +2919,20 @@ Mat_Open(const char *matname,int mode)
         Mat_Critical("Couldn't allocate memory for the MAT file subsys offset");
         return NULL;
     }
-    mat->filename      = NULL;
-    mat->version       = 0;
-    mat->byteswap      = 0;
-    mat->num_datasets  = 0;
+    mat->filename = NULL;
+    mat->version = 0;
+    mat->byteswap = 0;
+    mat->num_datasets = 0;
 #if HAVE_HDF5
-    mat->refs_id       = -1;
+    mat->refs_id = -1;
 #endif
-    mat->dir           = NULL;
+    mat->dir = NULL;
 
-    bytesread += fread(mat->header,1,116,fp);
+    bytesread += fread(mat->header, 1, 116, fp);
     mat->header[116] = '\0';
-    bytesread += fread(mat->subsys_offset,1,8,fp);
-    bytesread += 2*fread(&tmp2,2,1,fp);
-    bytesread += fread(&tmp,1,2,fp);
+    bytesread += fread(mat->subsys_offset, 1, 8, fp);
+    bytesread += 2 * fread(&tmp2, 2, 1, fp);
+    bytesread += fread(&tmp, 1, 2, fp);
 
     if ( 128 == bytesread ) {
         /* v5 and v7.3 files have at least 128 byte header */
@@ -2935,9 +2945,8 @@ Mat_Open(const char *matname,int mode)
         }
 
         mat->version = (int)tmp2;
-        if ( (mat->version == 0x0100 || mat->version == 0x0200) &&
-             -1 != mat->byteswap ) {
-            mat->bof = ftell((FILE*)mat->fp);
+        if ( (mat->version == 0x0100 || mat->version == 0x0200) && -1 != mat->byteswap ) {
+            mat->bof = ftell((FILE *)mat->fp);
             if ( mat->bof == -1L ) {
                 free(mat->header);
                 free(mat->subsys_offset);
@@ -2959,26 +2968,25 @@ Mat_Open(const char *matname,int mode)
         free(mat->header);
         free(mat->subsys_offset);
 
-        mat->header        = NULL;
+        mat->header = NULL;
         mat->subsys_offset = NULL;
-        mat->fp            = fp;
-        mat->version       = MAT_FT_MAT4;
-        mat->byteswap      = 0;
-        mat->mode          = mode;
-        mat->bof           = 0;
-        mat->next_index    = 0;
+        mat->fp = fp;
+        mat->version = MAT_FT_MAT4;
+        mat->byteswap = 0;
+        mat->mode = mode;
+        mat->bof = 0;
+        mat->next_index = 0;
 #if HAVE_HDF5
-        mat->refs_id       = -1;
+        mat->refs_id = -1;
 #endif
 
         Mat_Rewind(mat);
         var = Mat_VarReadNextInfo4(mat);
-        if ( NULL == var &&
-             bytesread != 0 ) { /* Accept 0 bytes files as a valid V4 file */
+        if ( NULL == var && bytesread != 0 ) { /* Accept 0 bytes files as a valid V4 file */
             /* Does not seem to be a valid V4 file */
             Mat_Close(mat);
             mat = NULL;
-            Mat_Critical("\"%s\" does not seem to be a valid MAT file",matname);
+            Mat_Critical("\"%s\" does not seem to be a valid MAT file", matname);
         } else {
             Mat_VarFree(var);
             Mat_Rewind(mat);
@@ -2992,19 +3000,19 @@ Mat_Open(const char *matname,int mode)
     mat->mode = mode;
 
     if ( mat->version == 0x0200 ) {
-        fclose((FILE*)mat->fp);
+        fclose((FILE *)mat->fp);
 #if HAVE_HDF5
         mat->fp = malloc(sizeof(hid_t));
 
         if ( (mode & 0x01) == MAT_ACC_RDONLY )
-            *(hid_t*)mat->fp=H5Fopen(matname,H5F_ACC_RDONLY,H5P_DEFAULT);
+            *(hid_t *)mat->fp = H5Fopen(matname, H5F_ACC_RDONLY, H5P_DEFAULT);
         else if ( (mode & 0x01) == MAT_ACC_RDWR ) {
             hid_t plist_ap;
             plist_ap = H5Pcreate(H5P_FILE_ACCESS);
-#if H5_VERSION_GE(1,10,2)
-            H5Pset_libver_bounds(plist_ap,H5F_LIBVER_EARLIEST,H5F_LIBVER_V18);
+#if H5_VERSION_GE(1, 10, 2)
+            H5Pset_libver_bounds(plist_ap, H5F_LIBVER_EARLIEST, H5F_LIBVER_V18);
 #endif
-            *(hid_t*)mat->fp=H5Fopen(matname,H5F_ACC_RDWR,plist_ap);
+            *(hid_t *)mat->fp = H5Fopen(matname, H5F_ACC_RDWR, plist_ap);
             H5Pclose(plist_ap);
         } else {
             mat->fp = NULL;
@@ -3012,19 +3020,27 @@ Mat_Open(const char *matname,int mode)
             mat = NULL;
         }
 
-        if ( -1 < *(hid_t*)mat->fp ) {
+        if ( -1 < *(hid_t *)mat->fp ) {
             H5G_info_t group_info;
+            herr_t herr;
             memset(&group_info, 0, sizeof(group_info));
-            H5Gget_info(*(hid_t*)mat->fp, &group_info);
-            mat->num_datasets = (size_t)group_info.nlinks;
-            mat->refs_id      = -1;
+            herr = H5Gget_info(*(hid_t *)mat->fp, &group_info);
+            if ( herr < 0 ) {
+                Mat_Close(mat);
+                mat = NULL;
+            } else {
+                mat->num_datasets = (size_t)group_info.nlinks;
+                mat->refs_id = -1;
+            }
         }
 #else
         mat->fp = NULL;
         Mat_Close(mat);
         mat = NULL;
-        Mat_Critical("No HDF5 support which is required to read the v7.3 "
-                     "MAT file \"%s\"",matname);
+        Mat_Critical(
+            "No HDF5 support which is required to read the v7.3 "
+            "MAT file \"%s\"",
+            matname);
 #endif
     }
 
@@ -3039,7 +3055,7 @@ Mat_Open(const char *matname,int mode)
  * @retval 0 on success
  */
 int
-Mat_Close( mat_t *mat )
+Mat_Close(mat_t *mat)
 {
     int err = MATIO_E_NO_ERROR;
 
@@ -3050,7 +3066,7 @@ Mat_Close( mat_t *mat )
         }
 #endif
         if ( NULL != mat->fp ) {
-            err = fclose((FILE*)mat->fp);
+            err = fclose((FILE *)mat->fp);
             if ( 0 == err ) {
                 err = MATIO_E_NO_ERROR;
             } else {
@@ -3138,7 +3154,7 @@ Mat_GetVersion(mat_t *mat)
 char **
 Mat_GetDir(mat_t *mat, size_t *n)
 {
-    char ** dir = NULL;
+    char **dir = NULL;
 
     if ( NULL == n )
         return dir;
@@ -3158,7 +3174,7 @@ Mat_GetDir(mat_t *mat, size_t *n)
                 *n = 0;
                 return dir;
             }
-            mat->dir = (char**)calloc(mat->num_datasets, sizeof(char*));
+            mat->dir = (char **)calloc(mat->num_datasets, sizeof(char *));
             if ( NULL == mat->dir ) {
                 *n = 0;
                 Mat_Critical("Couldn't allocate memory for the directory");
@@ -3180,23 +3196,23 @@ Mat_GetDir(mat_t *mat, size_t *n)
             mat->next_index = fpos;
             *n = i;
         } else {
-            long fpos = ftell((FILE*)mat->fp);
+            long fpos = ftell((FILE *)mat->fp);
             if ( fpos == -1L ) {
                 *n = 0;
                 Mat_Critical("Couldn't determine file position");
                 return dir;
             }
-            (void)fseek((FILE*)mat->fp,mat->bof,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, mat->bof, SEEK_SET);
             mat->num_datasets = 0;
             do {
                 matvar = Mat_VarReadNextInfo(mat);
                 if ( NULL != matvar ) {
                     if ( NULL != matvar->name ) {
                         if ( NULL == mat->dir ) {
-                            dir = (char**)malloc(sizeof(char*));
+                            dir = (char **)malloc(sizeof(char *));
                         } else {
-                            dir = (char**)realloc(mat->dir,
-                                (mat->num_datasets + 1)*(sizeof(char*)));
+                            dir = (char **)realloc(mat->dir,
+                                                   (mat->num_datasets + 1) * (sizeof(char *)));
                         }
                         if ( NULL != dir ) {
                             mat->dir = dir;
@@ -3207,12 +3223,12 @@ Mat_GetDir(mat_t *mat, size_t *n)
                         }
                     }
                     Mat_VarFree(matvar);
-                } else if ( !feof((FILE *)mat->fp) ) {
+                } else if ( !IsEndOfFile((FILE *)mat->fp, NULL) ) {
                     Mat_Critical("An error occurred in reading the MAT file");
                     break;
                 }
-            } while ( !feof((FILE *)mat->fp) );
-            (void)fseek((FILE*)mat->fp,fpos,SEEK_SET);
+            } while ( !IsEndOfFile((FILE *)mat->fp, NULL) );
+            (void)fseek((FILE *)mat->fp, fpos, SEEK_SET);
             *n = mat->num_datasets;
         }
     } else {
@@ -3237,19 +3253,19 @@ Mat_GetDir(mat_t *mat, size_t *n)
  * @retval 0 on success
  */
 int
-Mat_Rewind( mat_t *mat )
+Mat_Rewind(mat_t *mat)
 {
     int err = MATIO_E_NO_ERROR;
 
     switch ( mat->version ) {
         case MAT_FT_MAT5:
-            (void)fseek((FILE*)mat->fp,128L,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, 128L, SEEK_SET);
             break;
         case MAT_FT_MAT73:
             mat->next_index = 0;
             break;
         case MAT_FT_MAT4:
-            (void)fseek((FILE*)mat->fp,0L,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, 0L, SEEK_SET);
             break;
         default:
             err = MATIO_E_FAIL_TO_IDENTIFY;
@@ -3317,38 +3333,38 @@ Mat_VarCalloc(void)
 {
     matvar_t *matvar;
 
-    matvar = (matvar_t*)malloc(sizeof(*matvar));
+    matvar = (matvar_t *)malloc(sizeof(*matvar));
 
     if ( NULL != matvar ) {
-        matvar->nbytes       = 0;
-        matvar->rank         = 0;
-        matvar->data_type    = MAT_T_UNKNOWN;
-        matvar->data_size    = 0;
-        matvar->class_type   = MAT_C_EMPTY;
-        matvar->isComplex    = 0;
-        matvar->isGlobal     = 0;
-        matvar->isLogical    = 0;
-        matvar->dims         = NULL;
-        matvar->name         = NULL;
-        matvar->data         = NULL;
+        matvar->nbytes = 0;
+        matvar->rank = 0;
+        matvar->data_type = MAT_T_UNKNOWN;
+        matvar->data_size = 0;
+        matvar->class_type = MAT_C_EMPTY;
+        matvar->isComplex = 0;
+        matvar->isGlobal = 0;
+        matvar->isLogical = 0;
+        matvar->dims = NULL;
+        matvar->name = NULL;
+        matvar->data = NULL;
         matvar->mem_conserve = 0;
-        matvar->compression  = MAT_COMPRESSION_NONE;
-        matvar->internal     = (struct matvar_internal*)malloc(sizeof(*matvar->internal));
+        matvar->compression = MAT_COMPRESSION_NONE;
+        matvar->internal = (struct matvar_internal *)malloc(sizeof(*matvar->internal));
         if ( NULL == matvar->internal ) {
             free(matvar);
             matvar = NULL;
         } else {
 #if HAVE_HDF5
-            matvar->internal->hdf5_name  = NULL;
-            matvar->internal->hdf5_ref   =  0;
-            matvar->internal->id         = -1;
+            matvar->internal->hdf5_name = NULL;
+            matvar->internal->hdf5_ref = 0;
+            matvar->internal->id = -1;
 #endif
-            matvar->internal->datapos    = 0;
+            matvar->internal->datapos = 0;
             matvar->internal->num_fields = 0;
             matvar->internal->fieldnames = NULL;
 #if HAVE_ZLIB
-            matvar->internal->z          = NULL;
-            matvar->internal->data       = NULL;
+            matvar->internal->z = NULL;
+            matvar->internal->data = NULL;
 #endif
         }
     }
@@ -3413,8 +3429,8 @@ Mat_VarCalloc(void)
  * @return A MAT variable that can be written to a file or otherwise used
  */
 matvar_t *
-Mat_VarCreate(const char *name,enum matio_classes class_type,
-    enum matio_types data_type,int rank,size_t *dims,void *data,int opt)
+Mat_VarCreate(const char *name, enum matio_classes class_type, enum matio_types data_type, int rank,
+              size_t *dims, void *data, int opt)
 {
     size_t nelems = 1, data_size;
     matvar_t *matvar = NULL;
@@ -3428,19 +3444,19 @@ Mat_VarCreate(const char *name,enum matio_classes class_type,
         return NULL;
 
     matvar->compression = MAT_COMPRESSION_NONE;
-    matvar->isComplex   = opt & MAT_F_COMPLEX;
-    matvar->isGlobal    = opt & MAT_F_GLOBAL;
-    matvar->isLogical   = opt & MAT_F_LOGICAL;
+    matvar->isComplex = opt & MAT_F_COMPLEX;
+    matvar->isGlobal = opt & MAT_F_GLOBAL;
+    matvar->isLogical = opt & MAT_F_LOGICAL;
     if ( name )
         matvar->name = Mat_strdup(name);
     matvar->rank = rank;
-    matvar->dims = (size_t*)malloc(matvar->rank*sizeof(*matvar->dims));
+    matvar->dims = (size_t *)malloc(matvar->rank * sizeof(*matvar->dims));
     for ( j = 0; j < matvar->rank; j++ ) {
         matvar->dims[j] = dims[j];
         nelems *= dims[j];
     }
     matvar->class_type = class_type;
-    matvar->data_type  = data_type;
+    matvar->data_type = data_type;
     switch ( data_type ) {
         case MAT_T_INT8:
             data_size = 1;
@@ -3484,11 +3500,10 @@ Mat_VarCreate(const char *name,enum matio_classes class_type,
         case MAT_T_CELL:
             data_size = sizeof(matvar_t **);
             break;
-        case MAT_T_STRUCT:
-        {
+        case MAT_T_STRUCT: {
             data_size = sizeof(matvar_t **);
             if ( data != NULL ) {
-                matvar_t **fields = (matvar_t**)data;
+                matvar_t **fields = (matvar_t **)data;
                 size_t nfields = 0;
                 while ( fields[nfields] != NULL )
                     nfields++;
@@ -3498,7 +3513,7 @@ Mat_VarCreate(const char *name,enum matio_classes class_type,
                 if ( nfields ) {
                     size_t i;
                     matvar->internal->fieldnames =
-                        (char**)calloc(nfields,sizeof(*matvar->internal->fieldnames));
+                        (char **)calloc(nfields, sizeof(*matvar->internal->fieldnames));
                     for ( i = 0; i < nfields; i++ )
                         matvar->internal->fieldnames[i] = Mat_strdup(fields[i]->name);
                     err = Mul(&nelems, nelems, nfields);
@@ -3518,9 +3533,29 @@ Mat_VarCreate(const char *name,enum matio_classes class_type,
     }
     if ( matvar->class_type == MAT_C_SPARSE ) {
         matvar->data_size = sizeof(mat_sparse_t);
-        matvar->nbytes    = matvar->data_size;
+        matvar->nbytes = matvar->data_size;
+    } else if ( matvar->class_type == MAT_C_CHAR && matvar->data_type == MAT_T_UTF8 ) {
+        size_t k = 0;
+        if ( data != NULL ) {
+            size_t i;
+            mat_uint8_t *ptr = (mat_uint8_t *)data;
+            for ( i = 0; i < nelems; i++ ) {
+                const mat_uint8_t c = ptr[k];
+                if ( c <= 0x7F ) {
+                    k++;
+                } else if ( (c & 0xE0) == 0xC0 ) {
+                    k += 2;
+                } else if ( (c & 0xF0) == 0xE0 ) {
+                    k += 3;
+                } else if ( (c & 0xF8) == 0xF0 ) {
+                    k += 4;
+                }
+            }
+        }
+        matvar->nbytes = k;
+        matvar->data_size = (int)data_size;
     } else {
-        matvar->data_size = data_size;
+        matvar->data_size = (int)data_size;
         err = Mul(&matvar->nbytes, nelems, matvar->data_size);
         if ( err ) {
             Mat_VarFree(matvar);
@@ -3530,71 +3565,68 @@ Mat_VarCreate(const char *name,enum matio_classes class_type,
     }
     if ( data == NULL ) {
         if ( MAT_C_CELL == matvar->class_type && nelems > 0 )
-            matvar->data = calloc(nelems,sizeof(matvar_t*));
-        else
-            matvar->data = NULL;
+            matvar->data = calloc(nelems, sizeof(matvar_t *));
     } else if ( opt & MAT_F_DONT_COPY_DATA ) {
-        matvar->data         = data;
+        matvar->data = data;
         matvar->mem_conserve = 1;
     } else if ( MAT_C_SPARSE == matvar->class_type ) {
         mat_sparse_t *sparse_data, *sparse_data_in;
 
-        sparse_data_in = (mat_sparse_t*)data;
-        sparse_data    = (mat_sparse_t*)malloc(sizeof(mat_sparse_t));
+        sparse_data_in = (mat_sparse_t *)data;
+        sparse_data = (mat_sparse_t *)malloc(sizeof(mat_sparse_t));
         if ( NULL != sparse_data ) {
             sparse_data->nzmax = sparse_data_in->nzmax;
-            sparse_data->nir   = sparse_data_in->nir;
-            sparse_data->njc   = sparse_data_in->njc;
+            sparse_data->nir = sparse_data_in->nir;
+            sparse_data->njc = sparse_data_in->njc;
             sparse_data->ndata = sparse_data_in->ndata;
-            sparse_data->ir = (mat_uint32_t*)malloc(sparse_data->nir*sizeof(*sparse_data->ir));
+            sparse_data->ir = (mat_uint32_t *)malloc(sparse_data->nir * sizeof(*sparse_data->ir));
             if ( NULL != sparse_data->ir )
-                memcpy(sparse_data->ir,sparse_data_in->ir,
-                       sparse_data->nir*sizeof(*sparse_data->ir));
-            sparse_data->jc = (mat_uint32_t*)malloc(sparse_data->njc*sizeof(*sparse_data->jc));
+                memcpy(sparse_data->ir, sparse_data_in->ir,
+                       sparse_data->nir * sizeof(*sparse_data->ir));
+            sparse_data->jc = (mat_uint32_t *)malloc(sparse_data->njc * sizeof(*sparse_data->jc));
             if ( NULL != sparse_data->jc )
-                memcpy(sparse_data->jc,sparse_data_in->jc,
-                       sparse_data->njc*sizeof(*sparse_data->jc));
+                memcpy(sparse_data->jc, sparse_data_in->jc,
+                       sparse_data->njc * sizeof(*sparse_data->jc));
             if ( matvar->isComplex ) {
                 sparse_data->data = malloc(sizeof(mat_complex_split_t));
                 if ( NULL != sparse_data->data ) {
-                    mat_complex_split_t *complex_data,*complex_data_in;
-                    complex_data     = (mat_complex_split_t*)sparse_data->data;
-                    complex_data_in  = (mat_complex_split_t*)sparse_data_in->data;
-                    complex_data->Re = malloc(sparse_data->ndata*data_size);
-                    complex_data->Im = malloc(sparse_data->ndata*data_size);
+                    mat_complex_split_t *complex_data, *complex_data_in;
+                    complex_data = (mat_complex_split_t *)sparse_data->data;
+                    complex_data_in = (mat_complex_split_t *)sparse_data_in->data;
+                    complex_data->Re = malloc(sparse_data->ndata * data_size);
+                    complex_data->Im = malloc(sparse_data->ndata * data_size);
                     if ( NULL != complex_data->Re )
-                        memcpy(complex_data->Re,complex_data_in->Re,
-                               sparse_data->ndata*data_size);
+                        memcpy(complex_data->Re, complex_data_in->Re,
+                               sparse_data->ndata * data_size);
                     if ( NULL != complex_data->Im )
-                        memcpy(complex_data->Im,complex_data_in->Im,
-                               sparse_data->ndata*data_size);
+                        memcpy(complex_data->Im, complex_data_in->Im,
+                               sparse_data->ndata * data_size);
                 }
             } else {
-                sparse_data->data = malloc(sparse_data->ndata*data_size);
+                sparse_data->data = malloc(sparse_data->ndata * data_size);
                 if ( NULL != sparse_data->data )
-                    memcpy(sparse_data->data,sparse_data_in->data,
-                           sparse_data->ndata*data_size);
+                    memcpy(sparse_data->data, sparse_data_in->data, sparse_data->ndata * data_size);
             }
         }
         matvar->data = sparse_data;
     } else {
         if ( matvar->isComplex ) {
-            matvar->data   = malloc(sizeof(mat_complex_split_t));
+            matvar->data = malloc(sizeof(mat_complex_split_t));
             if ( NULL != matvar->data && matvar->nbytes > 0 ) {
-                mat_complex_split_t *complex_data    = (mat_complex_split_t*)matvar->data;
-                mat_complex_split_t *complex_data_in = (mat_complex_split_t*)data;
+                mat_complex_split_t *complex_data = (mat_complex_split_t *)matvar->data;
+                mat_complex_split_t *complex_data_in = (mat_complex_split_t *)data;
 
                 complex_data->Re = malloc(matvar->nbytes);
                 complex_data->Im = malloc(matvar->nbytes);
                 if ( NULL != complex_data->Re )
-                    memcpy(complex_data->Re,complex_data_in->Re,matvar->nbytes);
+                    memcpy(complex_data->Re, complex_data_in->Re, matvar->nbytes);
                 if ( NULL != complex_data->Im )
-                    memcpy(complex_data->Im,complex_data_in->Im,matvar->nbytes);
+                    memcpy(complex_data->Im, complex_data_in->Im, matvar->nbytes);
             }
         } else if ( matvar->nbytes > 0 ) {
-            matvar->data   = malloc(matvar->nbytes);
+            matvar->data = malloc(matvar->nbytes);
             if ( NULL != matvar->data )
-                memcpy(matvar->data,data,matvar->nbytes);
+                memcpy(matvar->data, data, matvar->nbytes);
         }
         matvar->mem_conserve = 0;
     }
@@ -3609,16 +3641,16 @@ Mat_VarCreate(const char *name,enum matio_classes class_type,
  * @retval 0 on success
  */
 static int
-Mat_CopyFile(const char* src, const char* dst)
+Mat_CopyFile(const char *src, const char *dst)
 {
     size_t len;
     char buf[BUFSIZ] = {'\0'};
-    FILE* in = NULL;
-    FILE* out = NULL;
+    FILE *in = NULL;
+    FILE *out = NULL;
 
 #if defined(_WIN32) && defined(_MSC_VER)
     {
-        wchar_t* wname = utf82u(src);
+        wchar_t *wname = utf82u(src);
         if ( NULL != wname ) {
             in = _wfopen(wname, L"rb");
             free(wname);
@@ -3634,7 +3666,7 @@ Mat_CopyFile(const char* src, const char* dst)
 
 #if defined(_WIN32) && defined(_MSC_VER)
     {
-        wchar_t* wname = utf82u(dst);
+        wchar_t *wname = utf82u(dst);
         if ( NULL != wname ) {
             out = _wfopen(wname, L"wb");
             free(wname);
@@ -3698,7 +3730,7 @@ Mat_VarDelete(mat_t *mat, const char *name)
                 break;
         }
 
-        tmp = Mat_CreateVer(path_buf,mat->header,mat_file_ver);
+        tmp = Mat_CreateVer(path_buf, mat->header, mat_file_ver);
         if ( tmp != NULL ) {
             matvar_t *matvar;
             char **dir;
@@ -3706,8 +3738,8 @@ Mat_VarDelete(mat_t *mat, const char *name)
 
             Mat_Rewind(mat);
             while ( NULL != (matvar = Mat_VarReadNext(mat)) ) {
-                if ( 0 != strcmp(matvar->name,name) )
-                    err = Mat_VarWrite(tmp,matvar,matvar->compression);
+                if ( 0 != strcmp(matvar->name, name) )
+                    err = Mat_VarWrite(tmp, matvar, matvar->compression);
                 else
                     err = MATIO_E_NO_ERROR;
                 Mat_VarFree(matvar);
@@ -3725,11 +3757,11 @@ Mat_VarDelete(mat_t *mat, const char *name)
                 }
 #endif
                 if ( mat->fp != NULL ) {
-                    fclose((FILE*)mat->fp);
+                    fclose((FILE *)mat->fp);
                     mat->fp = NULL;
                 }
 
-                if ( (err = Mat_CopyFile(path_buf,new_name)) != MATIO_E_NO_ERROR ) {
+                if ( (err = Mat_CopyFile(path_buf, new_name)) != MATIO_E_NO_ERROR ) {
                     if ( NULL != dir ) {
                         size_t i;
                         for ( i = 0; i < n; i++ ) {
@@ -3738,8 +3770,7 @@ Mat_VarDelete(mat_t *mat, const char *name)
                         }
                         free(dir);
                     }
-                    Mat_Critical("Cannot copy file from \"%s\" to \"%s\".",
-                        path_buf, new_name);
+                    Mat_Critical("Cannot copy file from \"%s\" to \"%s\".", path_buf, new_name);
                 } else if ( (err = remove(path_buf)) != 0 ) {
                     err = MATIO_E_UNKNOWN_ERROR;
                     if ( NULL != dir ) {
@@ -3750,7 +3781,7 @@ Mat_VarDelete(mat_t *mat, const char *name)
                         }
                         free(dir);
                     }
-                    Mat_Critical("Cannot remove file \"%s\".",path_buf);
+                    Mat_Critical("Cannot remove file \"%s\".", path_buf);
                 } else if ( *dir_buf != '\0' && (err = remove(dir_buf)) != 0 ) {
                     err = MATIO_E_UNKNOWN_ERROR;
                     if ( NULL != dir ) {
@@ -3761,9 +3792,9 @@ Mat_VarDelete(mat_t *mat, const char *name)
                         }
                         free(dir);
                     }
-                    Mat_Critical("Cannot remove directory \"%s\".",dir_buf);
+                    Mat_Critical("Cannot remove directory \"%s\".", dir_buf);
                 } else {
-                    tmp = Mat_Open(new_name,mat->mode);
+                    tmp = Mat_Open(new_name, mat->mode);
                     if ( NULL != tmp ) {
                         if ( mat->header )
                             free(mat->header);
@@ -3779,22 +3810,22 @@ Mat_VarDelete(mat_t *mat, const char *name)
                             }
                             free(mat->dir);
                         }
-                        memcpy(mat,tmp,sizeof(mat_t));
+                        memcpy(mat, tmp, sizeof(mat_t));
                         free(tmp);
                         mat->num_datasets = n;
                         mat->dir = dir;
                     } else {
-                        Mat_Critical("Cannot open file \"%s\".",new_name);
+                        Mat_Critical("Cannot open file \"%s\".", new_name);
                         err = MATIO_E_FILESYSTEM_COULD_NOT_OPEN;
                     }
                 }
                 free(new_name);
             } else if ( (err = remove(path_buf)) != 0 ) {
                 err = MATIO_E_UNKNOWN_ERROR;
-                Mat_Critical("Cannot remove file \"%s\".",path_buf);
+                Mat_Critical("Cannot remove file \"%s\".", path_buf);
             } else if ( *dir_buf != '\0' && (err = remove(dir_buf)) != 0 ) {
                 err = MATIO_E_UNKNOWN_ERROR;
-                Mat_Critical("Cannot remove directory \"%s\".",dir_buf);
+                Mat_Critical("Cannot remove directory \"%s\".", dir_buf);
             }
         } else {
             err = MATIO_E_UNKNOWN_ERROR;
@@ -3829,27 +3860,27 @@ Mat_VarDuplicate(const matvar_t *in, int opt)
     if ( out == NULL )
         return NULL;
 
-    out->nbytes       = in->nbytes;
-    out->rank         = in->rank;
-    out->data_type    = in->data_type;
-    out->data_size    = in->data_size;
-    out->class_type   = in->class_type;
-    out->isComplex    = in->isComplex;
-    out->isGlobal     = in->isGlobal;
-    out->isLogical    = in->isLogical;
+    out->nbytes = in->nbytes;
+    out->rank = in->rank;
+    out->data_type = in->data_type;
+    out->data_size = in->data_size;
+    out->class_type = in->class_type;
+    out->isComplex = in->isComplex;
+    out->isGlobal = in->isGlobal;
+    out->isLogical = in->isLogical;
     out->mem_conserve = in->mem_conserve;
-    out->compression  = in->compression;
+    out->compression = in->compression;
 
     if ( NULL != in->name ) {
         size_t len = strlen(in->name) + 1;
-        out->name = (char*)malloc(len);
+        out->name = (char *)malloc(len);
         if ( NULL != out->name )
-            memcpy(out->name,in->name,len);
+            memcpy(out->name, in->name, len);
     }
 
-    out->dims = (size_t*)malloc(in->rank*sizeof(*out->dims));
+    out->dims = (size_t *)malloc(in->rank * sizeof(*out->dims));
     if ( out->dims != NULL )
-        memcpy(out->dims,in->dims,in->rank*sizeof(*out->dims));
+        memcpy(out->dims, in->dims, in->rank * sizeof(*out->dims));
 
     if ( NULL != in->internal ) {
 #if HAVE_HDF5
@@ -3857,22 +3888,21 @@ Mat_VarDuplicate(const matvar_t *in, int opt)
             out->internal->hdf5_name = Mat_strdup(in->internal->hdf5_name);
 
         out->internal->hdf5_ref = in->internal->hdf5_ref;
-        out->internal->id       = in->internal->id;
+        out->internal->id = in->internal->id;
 #endif
-        out->internal->datapos  = in->internal->datapos;
+        out->internal->datapos = in->internal->datapos;
 #if HAVE_ZLIB
-        out->internal->z        = NULL;
-        out->internal->data     = NULL;
+        out->internal->z = NULL;
+        out->internal->data = NULL;
 #endif
         out->internal->num_fields = in->internal->num_fields;
         if ( NULL != in->internal->fieldnames && in->internal->num_fields > 0 ) {
-            out->internal->fieldnames = (char**)calloc(in->internal->num_fields,
-                                               sizeof(*in->internal->fieldnames));
+            out->internal->fieldnames =
+                (char **)calloc(in->internal->num_fields, sizeof(*in->internal->fieldnames));
             if ( NULL != out->internal->fieldnames ) {
                 for ( i = 0; i < in->internal->num_fields; i++ ) {
                     if ( NULL != in->internal->fieldnames[i] )
-                        out->internal->fieldnames[i] =
-                            Mat_strdup(in->internal->fieldnames[i]);
+                        out->internal->fieldnames[i] = Mat_strdup(in->internal->fieldnames[i]);
                 }
             }
         }
@@ -3892,52 +3922,54 @@ Mat_VarDuplicate(const matvar_t *in, int opt)
             if ( in->class_type == MAT_C_SPARSE ) {
                 out->internal->data = malloc(sizeof(mat_sparse_t));
                 if ( out->internal->data != NULL ) {
-                    mat_sparse_t *out_sparse = (mat_sparse_t*)out->internal->data;
-                    mat_sparse_t *in_sparse  = (mat_sparse_t*)in->internal->data;
+                    mat_sparse_t *out_sparse = (mat_sparse_t *)out->internal->data;
+                    mat_sparse_t *in_sparse = (mat_sparse_t *)in->internal->data;
                     out_sparse->nzmax = in_sparse->nzmax;
                     out_sparse->nir = in_sparse->nir;
-                    out_sparse->ir = (mat_uint32_t*)malloc(in_sparse->nir*sizeof(*out_sparse->ir));
+                    out_sparse->ir =
+                        (mat_uint32_t *)malloc(in_sparse->nir * sizeof(*out_sparse->ir));
                     if ( out_sparse->ir != NULL )
-                        memcpy(out_sparse->ir, in_sparse->ir, in_sparse->nir*sizeof(*out_sparse->ir));
+                        memcpy(out_sparse->ir, in_sparse->ir,
+                               in_sparse->nir * sizeof(*out_sparse->ir));
                     out_sparse->njc = in_sparse->njc;
-                    out_sparse->jc = (mat_uint32_t*)malloc(in_sparse->njc*sizeof(*out_sparse->jc));
+                    out_sparse->jc =
+                        (mat_uint32_t *)malloc(in_sparse->njc * sizeof(*out_sparse->jc));
                     if ( out_sparse->jc != NULL )
-                        memcpy(out_sparse->jc, in_sparse->jc, in_sparse->njc*sizeof(*out_sparse->jc));
+                        memcpy(out_sparse->jc, in_sparse->jc,
+                               in_sparse->njc * sizeof(*out_sparse->jc));
                     out_sparse->ndata = in_sparse->ndata;
                     if ( out->isComplex && NULL != in_sparse->data ) {
                         out_sparse->data = malloc(sizeof(mat_complex_split_t));
                         if ( out_sparse->data != NULL ) {
-                            mat_complex_split_t *out_data = (mat_complex_split_t*)out_sparse->data;
-                            mat_complex_split_t *in_data  = (mat_complex_split_t*)in_sparse->data;
-                            out_data->Re = malloc(
-                                in_sparse->ndata*Mat_SizeOf(in->data_type));
+                            mat_complex_split_t *out_data = (mat_complex_split_t *)out_sparse->data;
+                            mat_complex_split_t *in_data = (mat_complex_split_t *)in_sparse->data;
+                            out_data->Re = malloc(in_sparse->ndata * Mat_SizeOf(in->data_type));
                             if ( NULL != out_data->Re )
-                                memcpy(out_data->Re,in_data->Re,
-                                    in_sparse->ndata*Mat_SizeOf(in->data_type));
-                            out_data->Im = malloc(
-                                in_sparse->ndata*Mat_SizeOf(in->data_type));
+                                memcpy(out_data->Re, in_data->Re,
+                                       in_sparse->ndata * Mat_SizeOf(in->data_type));
+                            out_data->Im = malloc(in_sparse->ndata * Mat_SizeOf(in->data_type));
                             if ( NULL != out_data->Im )
-                                memcpy(out_data->Im,in_data->Im,
-                                    in_sparse->ndata*Mat_SizeOf(in->data_type));
+                                memcpy(out_data->Im, in_data->Im,
+                                       in_sparse->ndata * Mat_SizeOf(in->data_type));
                         }
                     } else if ( in_sparse->data != NULL ) {
-                        out_sparse->data = malloc(in_sparse->ndata*Mat_SizeOf(in->data_type));
+                        out_sparse->data = malloc(in_sparse->ndata * Mat_SizeOf(in->data_type));
                         if ( NULL != out_sparse->data )
                             memcpy(out_sparse->data, in_sparse->data,
-                                in_sparse->ndata*Mat_SizeOf(in->data_type));
+                                   in_sparse->ndata * Mat_SizeOf(in->data_type));
                     }
                 }
             } else if ( out->isComplex ) {
                 out->internal->data = malloc(sizeof(mat_complex_split_t));
                 if ( out->internal->data != NULL ) {
-                    mat_complex_split_t *out_data = (mat_complex_split_t*)out->internal->data;
-                    mat_complex_split_t *in_data  = (mat_complex_split_t*)in->internal->data;
+                    mat_complex_split_t *out_data = (mat_complex_split_t *)out->internal->data;
+                    mat_complex_split_t *in_data = (mat_complex_split_t *)in->internal->data;
                     out_data->Re = malloc(out->nbytes);
                     if ( NULL != out_data->Re )
-                        memcpy(out_data->Re,in_data->Re,out->nbytes);
+                        memcpy(out_data->Re, in_data->Re, out->nbytes);
                     out_data->Im = malloc(out->nbytes);
                     if ( NULL != out_data->Im )
-                        memcpy(out_data->Im,in_data->Im,out->nbytes);
+                        memcpy(out_data->Im, in_data->Im, out->nbytes);
                 }
             } else if ( NULL != (out->internal->data = malloc(in->nbytes)) ) {
                 memcpy(out->internal->data, in->internal->data, in->nbytes);
@@ -3955,53 +3987,56 @@ Mat_VarDuplicate(const matvar_t *in, int opt)
         out->data = malloc(in->nbytes);
         if ( out->data != NULL && in->data_size > 0 ) {
             size_t nfields = in->nbytes / in->data_size;
-            matvar_t **infields  = (matvar_t **)in->data;
+            matvar_t **infields = (matvar_t **)in->data;
             matvar_t **outfields = (matvar_t **)out->data;
             for ( i = 0; i < nfields; i++ ) {
-                outfields[i] = Mat_VarDuplicate(infields[i],opt);
+                outfields[i] = Mat_VarDuplicate(infields[i], opt);
             }
         }
     } else if ( (in->data != NULL) && (in->class_type == MAT_C_CELL) ) {
         out->data = malloc(in->nbytes);
         if ( out->data != NULL && in->data_size > 0 ) {
             size_t nelems = in->nbytes / in->data_size;
-            matvar_t **incells  = (matvar_t **)in->data;
+            matvar_t **incells = (matvar_t **)in->data;
             matvar_t **outcells = (matvar_t **)out->data;
             for ( i = 0; i < nelems; i++ ) {
-                outcells[i] = Mat_VarDuplicate(incells[i],opt);
+                outcells[i] = Mat_VarDuplicate(incells[i], opt);
             }
         }
     } else if ( (in->data != NULL) && (in->class_type == MAT_C_SPARSE) ) {
         out->data = malloc(sizeof(mat_sparse_t));
         if ( out->data != NULL ) {
-            mat_sparse_t *out_sparse = (mat_sparse_t*)out->data;
-            mat_sparse_t *in_sparse  = (mat_sparse_t*)in->data;
+            mat_sparse_t *out_sparse = (mat_sparse_t *)out->data;
+            mat_sparse_t *in_sparse = (mat_sparse_t *)in->data;
             out_sparse->nzmax = in_sparse->nzmax;
             out_sparse->nir = in_sparse->nir;
-            out_sparse->ir = (mat_uint32_t*)malloc(in_sparse->nir*sizeof(*out_sparse->ir));
+            out_sparse->ir = (mat_uint32_t *)malloc(in_sparse->nir * sizeof(*out_sparse->ir));
             if ( out_sparse->ir != NULL )
-                memcpy(out_sparse->ir, in_sparse->ir, in_sparse->nir*sizeof(*out_sparse->ir));
+                memcpy(out_sparse->ir, in_sparse->ir, in_sparse->nir * sizeof(*out_sparse->ir));
             out_sparse->njc = in_sparse->njc;
-            out_sparse->jc = (mat_uint32_t*)malloc(in_sparse->njc*sizeof(*out_sparse->jc));
+            out_sparse->jc = (mat_uint32_t *)malloc(in_sparse->njc * sizeof(*out_sparse->jc));
             if ( out_sparse->jc != NULL )
-                memcpy(out_sparse->jc, in_sparse->jc, in_sparse->njc*sizeof(*out_sparse->jc));
+                memcpy(out_sparse->jc, in_sparse->jc, in_sparse->njc * sizeof(*out_sparse->jc));
             out_sparse->ndata = in_sparse->ndata;
             if ( out->isComplex && NULL != in_sparse->data ) {
                 out_sparse->data = malloc(sizeof(mat_complex_split_t));
                 if ( out_sparse->data != NULL ) {
-                    mat_complex_split_t *out_data = (mat_complex_split_t*)out_sparse->data;
-                    mat_complex_split_t *in_data  = (mat_complex_split_t*)in_sparse->data;
-                    out_data->Re = malloc(in_sparse->ndata*Mat_SizeOf(in->data_type));
+                    mat_complex_split_t *out_data = (mat_complex_split_t *)out_sparse->data;
+                    mat_complex_split_t *in_data = (mat_complex_split_t *)in_sparse->data;
+                    out_data->Re = malloc(in_sparse->ndata * Mat_SizeOf(in->data_type));
                     if ( NULL != out_data->Re )
-                        memcpy(out_data->Re,in_data->Re,in_sparse->ndata*Mat_SizeOf(in->data_type));
-                    out_data->Im = malloc(in_sparse->ndata*Mat_SizeOf(in->data_type));
+                        memcpy(out_data->Re, in_data->Re,
+                               in_sparse->ndata * Mat_SizeOf(in->data_type));
+                    out_data->Im = malloc(in_sparse->ndata * Mat_SizeOf(in->data_type));
                     if ( NULL != out_data->Im )
-                        memcpy(out_data->Im,in_data->Im,in_sparse->ndata*Mat_SizeOf(in->data_type));
+                        memcpy(out_data->Im, in_data->Im,
+                               in_sparse->ndata * Mat_SizeOf(in->data_type));
                 }
             } else if ( in_sparse->data != NULL ) {
-                out_sparse->data = malloc(in_sparse->ndata*Mat_SizeOf(in->data_type));
+                out_sparse->data = malloc(in_sparse->ndata * Mat_SizeOf(in->data_type));
                 if ( NULL != out_sparse->data )
-                    memcpy(out_sparse->data, in_sparse->data, in_sparse->ndata*Mat_SizeOf(in->data_type));
+                    memcpy(out_sparse->data, in_sparse->data,
+                           in_sparse->ndata * Mat_SizeOf(in->data_type));
             } else {
                 out_sparse->data = NULL;
             }
@@ -4010,19 +4045,19 @@ Mat_VarDuplicate(const matvar_t *in, int opt)
         if ( out->isComplex ) {
             out->data = malloc(sizeof(mat_complex_split_t));
             if ( out->data != NULL ) {
-                mat_complex_split_t *out_data = (mat_complex_split_t*)out->data;
-                mat_complex_split_t *in_data  = (mat_complex_split_t*)in->data;
+                mat_complex_split_t *out_data = (mat_complex_split_t *)out->data;
+                mat_complex_split_t *in_data = (mat_complex_split_t *)in->data;
                 out_data->Re = malloc(out->nbytes);
                 if ( NULL != out_data->Re )
-                    memcpy(out_data->Re,in_data->Re,out->nbytes);
+                    memcpy(out_data->Re, in_data->Re, out->nbytes);
                 out_data->Im = malloc(out->nbytes);
                 if ( NULL != out_data->Im )
-                    memcpy(out_data->Im,in_data->Im,out->nbytes);
+                    memcpy(out_data->Im, in_data->Im, out->nbytes);
             }
         } else {
             out->data = malloc(in->nbytes);
             if ( out->data != NULL )
-                memcpy(out->data,in->data,in->nbytes);
+                memcpy(out->data, in->data, in->nbytes);
         }
     }
 
@@ -4052,11 +4087,11 @@ Mat_VarFree(matvar_t *matvar)
         err = MATIO_E_BAD_ARGUMENT;
     }
     if ( NULL != matvar->data ) {
-        switch (matvar->class_type ) {
+        switch ( matvar->class_type ) {
             case MAT_C_STRUCT:
                 if ( !matvar->mem_conserve ) {
                     if ( MATIO_E_NO_ERROR == err ) {
-                        matvar_t **fields = (matvar_t**)matvar->data;
+                        matvar_t **fields = (matvar_t **)matvar->data;
                         size_t nelems_x_nfields;
                         err = Mul(&nelems_x_nfields, nelems, matvar->internal->num_fields);
                         if ( MATIO_E_NO_ERROR == err && nelems_x_nfields > 0 ) {
@@ -4071,7 +4106,7 @@ Mat_VarFree(matvar_t *matvar)
             case MAT_C_CELL:
                 if ( !matvar->mem_conserve ) {
                     if ( MATIO_E_NO_ERROR == err ) {
-                        matvar_t **cells = (matvar_t**)matvar->data;
+                        matvar_t **cells = (matvar_t **)matvar->data;
                         size_t i;
                         for ( i = 0; i < nelems; i++ )
                             Mat_VarFree(cells[i]);
@@ -4082,13 +4117,13 @@ Mat_VarFree(matvar_t *matvar)
             case MAT_C_SPARSE:
                 if ( !matvar->mem_conserve ) {
                     mat_sparse_t *sparse;
-                    sparse = (mat_sparse_t*)matvar->data;
+                    sparse = (mat_sparse_t *)matvar->data;
                     if ( sparse->ir != NULL )
                         free(sparse->ir);
                     if ( sparse->jc != NULL )
                         free(sparse->jc);
                     if ( matvar->isComplex && NULL != sparse->data ) {
-                        ComplexFree((mat_complex_split_t*)sparse->data);
+                        ComplexFree((mat_complex_split_t *)sparse->data);
                     } else if ( sparse->data != NULL ) {
                         free(sparse->data);
                     }
@@ -4108,7 +4143,7 @@ Mat_VarFree(matvar_t *matvar)
             case MAT_C_CHAR:
                 if ( !matvar->mem_conserve ) {
                     if ( matvar->isComplex ) {
-                        ComplexFree((mat_complex_split_t*)matvar->data);
+                        ComplexFree((mat_complex_split_t *)matvar->data);
                     } else {
                         free(matvar->data);
                     }
@@ -4133,20 +4168,19 @@ Mat_VarFree(matvar_t *matvar)
             free(matvar->internal->z);
             if ( matvar->class_type == MAT_C_SPARSE && NULL != matvar->internal->data ) {
                 mat_sparse_t *sparse;
-                sparse = (mat_sparse_t*)matvar->internal->data;
+                sparse = (mat_sparse_t *)matvar->internal->data;
                 if ( sparse->ir != NULL )
                     free(sparse->ir);
                 if ( sparse->jc != NULL )
                     free(sparse->jc);
                 if ( matvar->isComplex && NULL != sparse->data ) {
-                    ComplexFree((mat_complex_split_t*)sparse->data);
+                    ComplexFree((mat_complex_split_t *)sparse->data);
                 } else if ( sparse->data != NULL ) {
                     free(sparse->data);
                 }
                 free(sparse);
-            }
-            else if ( matvar->isComplex && NULL != matvar->internal->data ) {
-                ComplexFree((mat_complex_split_t*)matvar->internal->data);
+            } else if ( matvar->isComplex && NULL != matvar->internal->data ) {
+                ComplexFree((mat_complex_split_t *)matvar->internal->data);
             } else if ( NULL != matvar->internal->data ) {
                 free(matvar->internal->data);
             }
@@ -4186,8 +4220,7 @@ Mat_VarFree(matvar_t *matvar)
             matvar->internal->hdf5_name = NULL;
         }
 #endif
-        if ( NULL != matvar->internal->fieldnames &&
-            matvar->internal->num_fields > 0 ) {
+        if ( NULL != matvar->internal->fieldnames && matvar->internal->num_fields > 0 ) {
             size_t i;
             for ( i = 0; i < matvar->internal->num_fields; i++ ) {
                 if ( NULL != matvar->internal->fieldnames[i] )
@@ -4220,7 +4253,7 @@ Mat_VarFree(matvar_t *matvar)
  * @return Single (linear) subscript
  */
 int
-Mat_CalcSingleSubscript(int rank,int *dims,int *subs)
+Mat_CalcSingleSubscript(int rank, int *dims, int *subs)
 {
     int index = 0, i, j, err = MATIO_E_NO_ERROR;
 
@@ -4263,7 +4296,7 @@ Mat_CalcSingleSubscript(int rank,int *dims,int *subs)
  * @retval 0 on success
  */
 int
-Mat_CalcSingleSubscript2(int rank,size_t *dims,size_t *subs,size_t *index)
+Mat_CalcSingleSubscript2(int rank, size_t *dims, size_t *subs, size_t *index)
 {
     int i, err = MATIO_E_NO_ERROR;
 
@@ -4306,13 +4339,13 @@ Mat_CalcSingleSubscript2(int rank,size_t *dims,size_t *subs,size_t *index)
  * @return Array of dimension subscripts
  */
 int *
-Mat_CalcSubscripts(int rank,int *dims,int index)
+Mat_CalcSubscripts(int rank, int *dims, int index)
 {
     int i, j, *subs;
     double l;
 
-    subs = (int*)malloc(rank*sizeof(int));
-    if ( NULL == subs) {
+    subs = (int *)malloc(rank * sizeof(int));
+    if ( NULL == subs ) {
         return subs;
     }
 
@@ -4322,7 +4355,7 @@ Mat_CalcSubscripts(int rank,int *dims,int index)
         for ( j = i; j--; )
             k *= dims[j];
         subs[i] = (int)floor(l / (double)k);
-        l -= subs[i]*k;
+        l -= subs[i] * k;
         subs[i]++;
     }
 
@@ -4348,14 +4381,14 @@ Mat_CalcSubscripts(int rank,int *dims,int index)
  * @return Array of dimension subscripts
  */
 size_t *
-Mat_CalcSubscripts2(int rank,size_t *dims,size_t index)
+Mat_CalcSubscripts2(int rank, size_t *dims, size_t index)
 {
     int i;
     size_t *subs;
     double l;
 
-    subs = (size_t*)malloc(rank*sizeof(size_t));
-    if ( NULL == subs) {
+    subs = (size_t *)malloc(rank * sizeof(size_t));
+    if ( NULL == subs ) {
         return subs;
     }
 
@@ -4366,7 +4399,7 @@ Mat_CalcSubscripts2(int rank,size_t *dims,size_t index)
         for ( j = i; j--; )
             k *= dims[j];
         subs[i] = (size_t)floor(l / (double)k);
-        l -= subs[i]*k;
+        l -= subs[i] * k;
         subs[i]++;
     }
 
@@ -4386,18 +4419,20 @@ Mat_VarGetSize(matvar_t *matvar)
     size_t i;
     size_t bytes = 0, overhead = 0, ptr = 0;
 
-#if defined(_WIN64) || (defined(__SIZEOF_POINTER__) && (__SIZEOF_POINTER__ == 8)) || (defined(SIZEOF_VOID_P) && (SIZEOF_VOID_P == 8))
+#if defined(_WIN64) || (defined(__SIZEOF_POINTER__) && (__SIZEOF_POINTER__ == 8)) || \
+    (defined(SIZEOF_VOID_P) && (SIZEOF_VOID_P == 8))
     /* 112 bytes cell/struct overhead for 64-bit system */
     overhead = 112;
     ptr = 8;
-#elif defined(_WIN32) || (defined(__SIZEOF_POINTER__) && (__SIZEOF_POINTER__ == 4)) || (defined(SIZEOF_VOID_P) && (SIZEOF_VOID_P == 4))
+#elif defined(_WIN32) || (defined(__SIZEOF_POINTER__) && (__SIZEOF_POINTER__ == 4)) || \
+    (defined(SIZEOF_VOID_P) && (SIZEOF_VOID_P == 4))
     /* 60 bytes cell/struct overhead for 32-bit system */
     overhead = 60;
     ptr = 4;
 #endif
 
     if ( matvar->class_type == MAT_C_STRUCT ) {
-        matvar_t **fields = (matvar_t**)matvar->data;
+        matvar_t **fields = (matvar_t **)matvar->data;
         size_t field_name_length;
         if ( NULL != fields ) {
             size_t nelems_x_nfields = matvar->internal->num_fields;
@@ -4424,7 +4459,7 @@ Mat_VarGetSize(matvar_t *matvar)
         if ( err )
             return 0;
     } else if ( matvar->class_type == MAT_C_CELL ) {
-        matvar_t **cells = (matvar_t**)matvar->data;
+        matvar_t **cells = (matvar_t **)matvar->data;
         if ( NULL != cells ) {
             size_t nelems = matvar->nbytes / matvar->data_size;
             err = Mul(&bytes, nelems, overhead);
@@ -4445,7 +4480,7 @@ Mat_VarGetSize(matvar_t *matvar)
             }
         }
     } else if ( matvar->class_type == MAT_C_SPARSE ) {
-        mat_sparse_t *sparse = (mat_sparse_t*)matvar->data;
+        mat_sparse_t *sparse = (mat_sparse_t *)matvar->data;
         if ( NULL != sparse ) {
             size_t sparse_size = 0;
             err = Mul(&bytes, sparse->ndata, Mat_SizeOf(matvar->data_type));
@@ -4458,10 +4493,12 @@ Mat_VarGetSize(matvar_t *matvar)
                     return 0;
             }
 
-#if defined(_WIN64) || (defined(__SIZEOF_POINTER__) && (__SIZEOF_POINTER__ == 8)) || (defined(SIZEOF_VOID_P) && (SIZEOF_VOID_P == 8))
+#if defined(_WIN64) || (defined(__SIZEOF_POINTER__) && (__SIZEOF_POINTER__ == 8)) || \
+    (defined(SIZEOF_VOID_P) && (SIZEOF_VOID_P == 8))
             /* 8 byte integers for 64-bit system (as displayed in MATLAB (x64) whos) */
             err = Mul(&sparse_size, sparse->nir + sparse->njc, 8);
-#elif defined(_WIN32) || (defined(__SIZEOF_POINTER__) && (__SIZEOF_POINTER__ == 4)) || (defined(SIZEOF_VOID_P) && (SIZEOF_VOID_P == 4))
+#elif defined(_WIN32) || (defined(__SIZEOF_POINTER__) && (__SIZEOF_POINTER__ == 4)) || \
+    (defined(SIZEOF_VOID_P) && (SIZEOF_VOID_P == 4))
             /* 4 byte integers for 32-bit system (as defined by mat_sparse_t) */
             err = Mul(&sparse_size, sparse->nir + sparse->njc, 4);
 #endif
@@ -4484,7 +4521,7 @@ Mat_VarGetSize(matvar_t *matvar)
 
             if ( matvar->isComplex ) {
                 err = Mul(&bytes, bytes, 2);
-                if (err)
+                if ( err )
                     return 0;
             }
         }
@@ -4501,16 +4538,27 @@ Mat_VarGetSize(matvar_t *matvar)
  * @param printdata set to 1 if the Variables data should be printed, else 0
  */
 void
-Mat_VarPrint( matvar_t *matvar, int printdata )
+Mat_VarPrint(matvar_t *matvar, int printdata)
 {
     size_t nelems = 0, i, j;
-    const char *class_type_desc[18] = {"Undefined","Cell Array","Structure",
-       "Object","Character Array","Sparse Array","Double Precision Array",
-       "Single Precision Array", "8-bit, signed integer array",
-       "8-bit, unsigned integer array","16-bit, signed integer array",
-       "16-bit, unsigned integer array","32-bit, signed integer array",
-       "32-bit, unsigned integer array","64-bit, signed integer array",
-       "64-bit, unsigned integer array","Function","Opaque"};
+    const char *class_type_desc[18] = {"Undefined",
+                                       "Cell Array",
+                                       "Structure",
+                                       "Object",
+                                       "Character Array",
+                                       "Sparse Array",
+                                       "Double Precision Array",
+                                       "Single Precision Array",
+                                       "8-bit, signed integer array",
+                                       "8-bit, unsigned integer array",
+                                       "16-bit, signed integer array",
+                                       "16-bit, unsigned integer array",
+                                       "32-bit, signed integer array",
+                                       "32-bit, unsigned integer array",
+                                       "64-bit, signed integer array",
+                                       "64-bit, unsigned integer array",
+                                       "Function",
+                                       "Opaque"};
 
     if ( matvar == NULL )
         return;
@@ -4523,32 +4571,47 @@ Mat_VarPrint( matvar_t *matvar, int printdata )
         int err;
         nelems = 1;
         err = Mat_MulDims(matvar, &nelems);
-        printf("Dimensions: %" SIZE_T_FMTSTR,matvar->dims[0]);
+        printf("Dimensions: %" SIZE_T_FMTSTR, matvar->dims[0]);
         if ( MATIO_E_NO_ERROR == err ) {
             int k;
             for ( k = 1; k < matvar->rank; k++ ) {
-                printf(" x %" SIZE_T_FMTSTR,matvar->dims[k]);
+                printf(" x %" SIZE_T_FMTSTR, matvar->dims[k]);
             }
         }
         printf("\n");
     }
-    printf("Class Type: %s",class_type_desc[matvar->class_type]);
+    printf("Class Type: %s", class_type_desc[matvar->class_type]);
     if ( matvar->isComplex )
         printf(" (complex)");
     else if ( matvar->isLogical )
         printf(" (logical)");
     printf("\n");
     if ( matvar->data_type ) {
-        const char *data_type_desc[25] = {"Unknown","8-bit, signed integer",
-           "8-bit, unsigned integer","16-bit, signed integer",
-           "16-bit, unsigned integer","32-bit, signed integer",
-           "32-bit, unsigned integer","IEEE 754 single-precision","RESERVED",
-           "IEEE 754 double-precision","RESERVED","RESERVED",
-           "64-bit, signed integer","64-bit, unsigned integer", "Matlab Array",
-           "Compressed Data","Unicode UTF-8 Encoded Character Data",
-           "Unicode UTF-16 Encoded Character Data",
-           "Unicode UTF-32 Encoded Character Data","RESERVED","String","Cell Array",
-           "Structure","Array","Function"};
+        const char *data_type_desc[25] = {"Unknown",
+                                          "8-bit, signed integer",
+                                          "8-bit, unsigned integer",
+                                          "16-bit, signed integer",
+                                          "16-bit, unsigned integer",
+                                          "32-bit, signed integer",
+                                          "32-bit, unsigned integer",
+                                          "IEEE 754 single-precision",
+                                          "RESERVED",
+                                          "IEEE 754 double-precision",
+                                          "RESERVED",
+                                          "RESERVED",
+                                          "64-bit, signed integer",
+                                          "64-bit, unsigned integer",
+                                          "Matlab Array",
+                                          "Compressed Data",
+                                          "Unicode UTF-8 Encoded Character Data",
+                                          "Unicode UTF-16 Encoded Character Data",
+                                          "Unicode UTF-32 Encoded Character Data",
+                                          "RESERVED",
+                                          "String",
+                                          "Cell Array",
+                                          "Structure",
+                                          "Array",
+                                          "Function"};
         printf(" Data Type: %s\n", data_type_desc[matvar->data_type]);
     }
 
@@ -4562,17 +4625,16 @@ Mat_VarPrint( matvar_t *matvar, int printdata )
             for ( i = 0; i < nelems_x_nfields; i++ ) {
                 if ( NULL == fields[i] ) {
                     printf("      Name: %s\n      Rank: %d\n",
-                           matvar->internal->fieldnames[i%nfields],0);
+                           matvar->internal->fieldnames[i % nfields], 0);
                 } else {
-                    Mat_VarPrint(fields[i],printdata);
+                    Mat_VarPrint(fields[i], printdata);
                 }
             }
             printf("}\n");
         } else {
             printf("Fields[%" SIZE_T_FMTSTR "] {\n", nfields);
             for ( i = 0; i < nfields; i++ )
-                printf("      Name: %s\n      Rank: %d\n",
-                       matvar->internal->fieldnames[i],0);
+                printf("      Name: %s\n      Rank: %d\n", matvar->internal->fieldnames[i], 0);
             printf("}\n");
         }
         return;
@@ -4585,7 +4647,7 @@ Mat_VarPrint( matvar_t *matvar, int printdata )
         nelems = matvar->nbytes / matvar->data_size;
         printf("{\n");
         for ( i = 0; i < nelems; i++ )
-            Mat_VarPrint(cells[i],printdata);
+            Mat_VarPrint(cells[i], printdata);
         printf("}\n");
         return;
     } else if ( !printdata ) {
@@ -4599,7 +4661,7 @@ Mat_VarPrint( matvar_t *matvar, int printdata )
     } else if ( matvar->rank == 1 && NULL != matvar->dims && matvar->dims[0] > 15 ) {
         printf("I won't print more than 15 elements in a vector\n");
     } else if ( matvar->rank == 2 && NULL != matvar->dims ) {
-        switch( matvar->class_type ) {
+        switch ( matvar->class_type ) {
             case MAT_C_DOUBLE:
             case MAT_C_SINGLE:
 #ifdef HAVE_MATIO_INT64_T
@@ -4613,19 +4675,18 @@ Mat_VarPrint( matvar_t *matvar, int printdata )
             case MAT_C_INT16:
             case MAT_C_UINT16:
             case MAT_C_INT8:
-            case MAT_C_UINT8:
-            {
+            case MAT_C_UINT8: {
                 size_t stride = Mat_SizeOf(matvar->data_type);
                 if ( matvar->isComplex ) {
-                    mat_complex_split_t *complex_data = (mat_complex_split_t*)matvar->data;
-                    char *rp = (char*)complex_data->Re;
-                    char *ip = (char*)complex_data->Im;
+                    mat_complex_split_t *complex_data = (mat_complex_split_t *)matvar->data;
+                    char *rp = (char *)complex_data->Re;
+                    char *ip = (char *)complex_data->Im;
                     for ( i = 0; i < matvar->dims[0] && i < 15; i++ ) {
                         for ( j = 0; j < matvar->dims[1] && j < 15; j++ ) {
-                            size_t idx = matvar->dims[0]*j+i;
-                            Mat_PrintNumber(matvar->data_type,rp+idx*stride);
+                            size_t idx = matvar->dims[0] * j + i;
+                            Mat_PrintNumber(matvar->data_type, rp + idx * stride);
                             printf(" + ");
-                            Mat_PrintNumber(matvar->data_type,ip+idx*stride);
+                            Mat_PrintNumber(matvar->data_type, ip + idx * stride);
                             printf("i ");
                         }
                         if ( j < matvar->dims[1] )
@@ -4634,13 +4695,12 @@ Mat_VarPrint( matvar_t *matvar, int printdata )
                     }
                     if ( i < matvar->dims[0] )
                         printf(".\n.\n.\n");
-               } else {
-                   char *data = (char*)matvar->data;
-                   for ( i = 0; i < matvar->dims[0] && i < 15; i++ ) {
+                } else {
+                    char *data = (char *)matvar->data;
+                    for ( i = 0; i < matvar->dims[0] && i < 15; i++ ) {
                         for ( j = 0; j < matvar->dims[1] && j < 15; j++ ) {
-                            size_t idx = matvar->dims[0]*j+i;
-                            Mat_PrintNumber(matvar->data_type,
-                                            data+idx*stride);
+                            size_t idx = matvar->dims[0] * j + i;
+                            Mat_PrintNumber(matvar->data_type, data + idx * stride);
                             printf(" ");
                         }
                         if ( j < matvar->dims[1] )
@@ -4652,31 +4712,28 @@ Mat_VarPrint( matvar_t *matvar, int printdata )
                 }
                 break;
             }
-            case MAT_C_CHAR:
-            {
+            case MAT_C_CHAR: {
                 switch ( matvar->data_type ) {
                     case MAT_T_UINT16:
-                    case MAT_T_UTF16:
-                    {
-                        const mat_uint16_t *data = (const mat_uint16_t*)matvar->data;
+                    case MAT_T_UTF16: {
+                        const mat_uint16_t *data = (const mat_uint16_t *)matvar->data;
                         for ( i = 0; i < matvar->dims[0]; i++ ) {
                             for ( j = 0; j < matvar->dims[1]; j++ ) {
-                                const mat_uint16_t c = data[j*matvar->dims[0]+i];
+                                const mat_uint16_t c = data[j * matvar->dims[0] + i];
 #if defined VARPRINT_UTF16
-                                printf("%c%c", c & 0xFF, (c>>8) & 0xFF);
+                                printf("%c%c", c & 0xFF, (c >> 8) & 0xFF);
 #elif defined VARPRINT_UTF16_DECIMAL
                                 Mat_PrintNumber(MAT_T_UINT16, &c);
                                 printf(" ");
 #else
                                 /* Convert to UTF-8 */
-                                if (c <= 0x7F) {
+                                if ( c <= 0x7F ) {
                                     printf("%c", c);
-                                }
-                                else if (c <= 0x7FF) {
-                                    printf("%c%c", 0xC0 | (c>>6), 0x80 | (c & 0x3F));
-                                }
-                                else /* if (c <= 0xFFFF) */ {
-                                    printf("%c%c%c", 0xE0 | (c>>12), 0x80 | ((c>>6) & 0x3F), 0x80 | (c & 0x3F));
+                                } else if ( c <= 0x7FF ) {
+                                    printf("%c%c", 0xC0 | (c >> 6), 0x80 | (c & 0x3F));
+                                } else /* if (c <= 0xFFFF) */ {
+                                    printf("%c%c%c", 0xE0 | (c >> 12), 0x80 | ((c >> 6) & 0x3F),
+                                           0x80 | (c & 0x3F));
                                 }
 #endif
                             }
@@ -4684,12 +4741,61 @@ Mat_VarPrint( matvar_t *matvar, int printdata )
                         }
                         break;
                     }
-                    default:
-                    {
-                        const char *data = (const char*)matvar->data;
+                    case MAT_T_UTF8: {
+                        const mat_uint8_t *data = (const mat_uint8_t *)matvar->data;
+                        size_t k = 0;
+                        size_t *idxOffset;
+                        if ( matvar->nbytes == 0 ) {
+                            break;
+                        }
+                        idxOffset = (size_t *)calloc(nelems, sizeof(size_t));
+                        if ( idxOffset == NULL ) {
+                            break;
+                        }
+                        for ( i = 0; i < matvar->dims[0]; i++ ) {
+                            for ( j = 0; j < matvar->dims[1]; j++ ) {
+                                mat_uint8_t c;
+                                if ( k >= matvar->nbytes ) {
+                                    break;
+                                }
+                                idxOffset[i * matvar->dims[1] + j] = k;
+                                c = data[k];
+                                if ( c <= 0x7F ) {
+                                } else if ( (c & 0xE0) == 0xC0 && k + 1 < matvar->nbytes ) {
+                                    k = k + 1;
+                                } else if ( (c & 0xF0) == 0xE0 && k + 2 < matvar->nbytes ) {
+                                    k = k + 2;
+                                } else if ( (c & 0xF8) == 0xF0 && k + 3 < matvar->nbytes ) {
+                                    k = k + 3;
+                                }
+                                ++k;
+                            }
+                        }
+                        for ( i = 0; i < matvar->dims[0]; i++ ) {
+                            for ( j = 0; j < matvar->dims[1]; j++ ) {
+                                mat_uint8_t c;
+                                k = idxOffset[j * matvar->dims[0] + i];
+                                c = data[k];
+                                if ( c <= 0x7F ) {
+                                    printf("%c", c);
+                                } else if ( (c & 0xE0) == 0xC0 ) {
+                                    printf("%c%c", c, data[k + 1]);
+                                } else if ( (c & 0xF0) == 0xE0 ) {
+                                    printf("%c%c%c", c, data[k + 1], data[k + 2]);
+                                } else if ( (c & 0xF8) == 0xF0 ) {
+                                    printf("%c%c%c%c", c, data[k + 1], data[k + 2], data[k + 3]);
+                                }
+                            }
+                            printf("\n");
+                        }
+                        free(idxOffset);
+                        break;
+                    }
+                    default: {
+                        const char *data = (const char *)matvar->data;
                         for ( i = 0; i < matvar->dims[0]; i++ ) {
                             for ( j = 0; j < matvar->dims[1]; j++ )
-                                printf("%c",data[j*matvar->dims[0]+i]);
+                                printf("%c", data[j * matvar->dims[0] + i]);
                             printf("\n");
                         }
                         break;
@@ -4697,36 +4803,35 @@ Mat_VarPrint( matvar_t *matvar, int printdata )
                 }
                 break;
             }
-            case MAT_C_SPARSE:
-            {
+            case MAT_C_SPARSE: {
                 mat_sparse_t *sparse;
                 size_t stride = Mat_SizeOf(matvar->data_type);
 #if !defined(EXTENDED_SPARSE)
                 if ( MAT_T_DOUBLE != matvar->data_type )
                     break;
 #endif
-                sparse = (mat_sparse_t*)matvar->data;
+                sparse = (mat_sparse_t *)matvar->data;
                 if ( matvar->isComplex ) {
-                    mat_complex_split_t *complex_data = (mat_complex_split_t*)sparse->data;
-                    char *re = (char*)complex_data->Re;
-                    char *im = (char*)complex_data->Im;
-                    for ( i = 0; i < (size_t)sparse->njc-1; i++ ) {
+                    mat_complex_split_t *complex_data = (mat_complex_split_t *)sparse->data;
+                    char *re = (char *)complex_data->Re;
+                    char *im = (char *)complex_data->Im;
+                    for ( i = 0; i < (size_t)sparse->njc - 1; i++ ) {
                         for ( j = sparse->jc[i];
-                              j < (size_t)sparse->jc[i+1] && j < (size_t)sparse->ndata; j++ ) {
-                            printf("    (%u,%" SIZE_T_FMTSTR ")  ",sparse->ir[j]+1,i+1);
-                            Mat_PrintNumber(matvar->data_type,re+j*stride);
+                              j < (size_t)sparse->jc[i + 1] && j < (size_t)sparse->ndata; j++ ) {
+                            printf("    (%u,%" SIZE_T_FMTSTR ")  ", sparse->ir[j] + 1, i + 1);
+                            Mat_PrintNumber(matvar->data_type, re + j * stride);
                             printf(" + ");
-                            Mat_PrintNumber(matvar->data_type,im+j*stride);
+                            Mat_PrintNumber(matvar->data_type, im + j * stride);
                             printf("i\n");
                         }
                     }
                 } else {
-                    char *data = (char*)sparse->data;
-                    for ( i = 0; i < (size_t)sparse->njc-1; i++ ) {
+                    char *data = (char *)sparse->data;
+                    for ( i = 0; i < (size_t)sparse->njc - 1; i++ ) {
                         for ( j = sparse->jc[i];
-                              j < (size_t)sparse->jc[i+1] && j < (size_t)sparse->ndata; j++ ) {
-                            printf("    (%u,%" SIZE_T_FMTSTR ")  ",sparse->ir[j]+1,i+1);
-                            Mat_PrintNumber(matvar->data_type,data+j*stride);
+                              j < (size_t)sparse->jc[i + 1] && j < (size_t)sparse->ndata; j++ ) {
+                            printf("    (%u,%" SIZE_T_FMTSTR ")  ", sparse->ir[j] + 1, i + 1);
+                            Mat_PrintNumber(matvar->data_type, data + j * stride);
                             printf("\n");
                         }
                     }
@@ -4757,8 +4862,7 @@ Mat_VarPrint( matvar_t *matvar, int printdata )
  * @retval 0 on success
  */
 int
-Mat_VarReadData(mat_t *mat,matvar_t *matvar,void *data,
-      int *start,int *stride,int *edge)
+Mat_VarReadData(mat_t *mat, matvar_t *matvar, void *data, int *start, int *stride, int *edge)
 {
     int err = MATIO_E_NO_ERROR;
 
@@ -4780,17 +4884,17 @@ Mat_VarReadData(mat_t *mat,matvar_t *matvar,void *data,
 
     switch ( mat->version ) {
         case MAT_FT_MAT5:
-            err = Mat_VarReadData5(mat,matvar,data,start,stride,edge);
+            err = Mat_VarReadData5(mat, matvar, data, start, stride, edge);
             break;
         case MAT_FT_MAT73:
 #if HAVE_HDF5
-            err = Mat_VarReadData73(mat,matvar,data,start,stride,edge);
+            err = Mat_VarReadData73(mat, matvar, data, start, stride, edge);
 #else
             err = MATIO_E_OPERATION_NOT_SUPPORTED;
 #endif
             break;
         case MAT_FT_MAT4:
-            err = Mat_VarReadData4(mat,matvar,data,start,stride,edge);
+            err = Mat_VarReadData4(mat, matvar, data, start, stride, edge);
             break;
         default:
             err = MATIO_E_FAIL_TO_IDENTIFY;
@@ -4809,14 +4913,14 @@ Mat_VarReadData(mat_t *mat,matvar_t *matvar,void *data,
  * @returns non-zero on error
  */
 int
-Mat_VarReadDataAll(mat_t *mat,matvar_t *matvar)
+Mat_VarReadDataAll(mat_t *mat, matvar_t *matvar)
 {
     int err = MATIO_E_NO_ERROR;
 
     if ( mat == NULL || matvar == NULL )
         err = MATIO_E_BAD_ARGUMENT;
     else
-        err = ReadData(mat,matvar);
+        err = ReadData(mat, matvar);
 
     return err;
 }
@@ -4835,8 +4939,7 @@ Mat_VarReadDataAll(mat_t *mat,matvar_t *matvar)
  * @retval 0 on success
  */
 int
-Mat_VarReadDataLinear(mat_t *mat,matvar_t *matvar,void *data,int start,
-    int stride,int edge)
+Mat_VarReadDataLinear(mat_t *mat, matvar_t *matvar, void *data, int start, int stride, int edge)
 {
     int err = MATIO_E_NO_ERROR;
 
@@ -4858,17 +4961,17 @@ Mat_VarReadDataLinear(mat_t *mat,matvar_t *matvar,void *data,int start,
 
     switch ( mat->version ) {
         case MAT_FT_MAT5:
-            err = Mat_VarReadDataLinear5(mat,matvar,data,start,stride,edge);
+            err = Mat_VarReadDataLinear5(mat, matvar, data, start, stride, edge);
             break;
         case MAT_FT_MAT73:
 #if HAVE_HDF5
-            err = Mat_VarReadDataLinear73(mat,matvar,data,start,stride,edge);
+            err = Mat_VarReadDataLinear73(mat, matvar, data, start, stride, edge);
 #else
             err = MATIO_E_OPERATION_NOT_SUPPORTED;
 #endif
             break;
         case MAT_FT_MAT4:
-            err = Mat_VarReadDataLinear4(mat,matvar,data,start,stride,edge);
+            err = Mat_VarReadDataLinear4(mat, matvar, data, start, stride, edge);
             break;
         default:
             err = MATIO_E_FAIL_TO_IDENTIFY;
@@ -4889,7 +4992,7 @@ Mat_VarReadDataLinear(mat_t *mat,matvar_t *matvar,void *data,int start,
  * variable information
  */
 matvar_t *
-Mat_VarReadNextInfo( mat_t *mat )
+Mat_VarReadNextInfo(mat_t *mat)
 {
     matvar_t *matvar;
     if ( mat == NULL )
@@ -4929,7 +5032,7 @@ Mat_VarReadNextInfo( mat_t *mat )
  * variable information
  */
 matvar_t *
-Mat_VarReadInfo( mat_t *mat, const char *name )
+Mat_VarReadInfo(mat_t *mat, const char *name)
 {
     matvar_t *matvar = NULL;
 
@@ -4942,7 +5045,7 @@ Mat_VarReadInfo( mat_t *mat, const char *name )
         while ( NULL == matvar && mat->next_index < mat->num_datasets ) {
             matvar = Mat_VarReadNextInfo(mat);
             if ( matvar != NULL ) {
-                if ( matvar->name == NULL || 0 != strcmp(matvar->name,name) ) {
+                if ( matvar->name == NULL || 0 != strcmp(matvar->name, name) ) {
                     Mat_VarFree(matvar);
                     matvar = NULL;
                 }
@@ -4953,22 +5056,22 @@ Mat_VarReadInfo( mat_t *mat, const char *name )
         }
         mat->next_index = fpos;
     } else {
-        long fpos = ftell((FILE*)mat->fp);
+        long fpos = ftell((FILE *)mat->fp);
         if ( fpos != -1L ) {
-            (void)fseek((FILE*)mat->fp,mat->bof,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, mat->bof, SEEK_SET);
             do {
                 matvar = Mat_VarReadNextInfo(mat);
                 if ( matvar != NULL ) {
-                    if ( matvar->name == NULL || 0 != strcmp(matvar->name,name) ) {
+                    if ( matvar->name == NULL || 0 != strcmp(matvar->name, name) ) {
                         Mat_VarFree(matvar);
                         matvar = NULL;
                     }
-                } else if ( !feof((FILE *)mat->fp) ) {
+                } else if ( !IsEndOfFile((FILE *)mat->fp, NULL) ) {
                     Mat_Critical("An error occurred in reading the MAT file");
                     break;
                 }
-            } while ( NULL == matvar && !feof((FILE *)mat->fp) );
-            (void)fseek((FILE*)mat->fp,fpos,SEEK_SET);
+            } while ( NULL == matvar && !IsEndOfFile((FILE *)mat->fp, NULL) );
+            (void)fseek((FILE *)mat->fp, fpos, SEEK_SET);
         } else {
             Mat_Critical("Couldn't determine file position");
         }
@@ -4987,7 +5090,7 @@ Mat_VarReadInfo( mat_t *mat, const char *name )
  * variable information
  */
 matvar_t *
-Mat_VarRead( mat_t *mat, const char *name )
+Mat_VarRead(mat_t *mat, const char *name)
 {
     matvar_t *matvar = NULL;
 
@@ -4995,26 +5098,26 @@ Mat_VarRead( mat_t *mat, const char *name )
         return NULL;
 
     if ( MAT_FT_MAT73 != mat->version ) {
-        long fpos = ftell((FILE*)mat->fp);
+        long fpos = ftell((FILE *)mat->fp);
         if ( fpos == -1L ) {
             Mat_Critical("Couldn't determine file position");
             return NULL;
         }
-        matvar = Mat_VarReadInfo(mat,name);
+        matvar = Mat_VarReadInfo(mat, name);
         if ( matvar ) {
-            const int err = ReadData(mat,matvar);
+            const int err = ReadData(mat, matvar);
             if ( err ) {
                 Mat_VarFree(matvar);
                 matvar = NULL;
             }
         }
-        (void)fseek((FILE*)mat->fp,fpos,SEEK_SET);
+        (void)fseek((FILE *)mat->fp, fpos, SEEK_SET);
     } else {
         size_t fpos = mat->next_index;
         mat->next_index = 0;
-        matvar = Mat_VarReadInfo(mat,name);
+        matvar = Mat_VarReadInfo(mat, name);
         if ( matvar ) {
-            const int err = ReadData(mat,matvar);
+            const int err = ReadData(mat, matvar);
             if ( err ) {
                 Mat_VarFree(matvar);
                 matvar = NULL;
@@ -5035,30 +5138,28 @@ Mat_VarRead( mat_t *mat, const char *name )
  * variable information
  */
 matvar_t *
-Mat_VarReadNext( mat_t *mat )
+Mat_VarReadNext(mat_t *mat)
 {
-    long fpos = 0;
-    matvar_t *matvar = NULL;
+    long fpos;
+    matvar_t *matvar;
 
     if ( mat->version != MAT_FT_MAT73 ) {
-        if ( feof((FILE *)mat->fp) )
+        if ( IsEndOfFile((FILE *)mat->fp, &fpos) )
             return NULL;
-        /* Read position so we can reset the file position if an error occurs */
-        fpos = ftell((FILE*)mat->fp);
         if ( fpos == -1L ) {
-            Mat_Critical("Couldn't determine file position");
             return NULL;
         }
     }
     matvar = Mat_VarReadNextInfo(mat);
     if ( matvar ) {
-        const int err = ReadData(mat,matvar);
+        const int err = ReadData(mat, matvar);
         if ( err ) {
             Mat_VarFree(matvar);
             matvar = NULL;
         }
     } else if ( mat->version != MAT_FT_MAT73 ) {
-        (void)fseek((FILE*)mat->fp,fpos,SEEK_SET);
+        /* Reset the file position */
+        (void)fseek((FILE *)mat->fp, fpos, SEEK_SET);
     }
 
     return matvar;
@@ -5076,11 +5177,12 @@ Mat_VarReadNext( mat_t *mat )
  * @see Mat_VarWrite/Mat_VarWriteAppend
  */
 int
-Mat_VarWriteInfo(mat_t *mat, matvar_t *matvar )
+Mat_VarWriteInfo(mat_t *mat, matvar_t *matvar)
 {
-    Mat_Critical("Mat_VarWriteInfo/Mat_VarWriteData is not supported. "
-        "Use %s instead!", mat->version == MAT_FT_MAT73 ?
-        "Mat_VarWrite/Mat_VarWriteAppend" : "Mat_VarWrite");
+    Mat_Critical(
+        "Mat_VarWriteInfo/Mat_VarWriteData is not supported. "
+        "Use %s instead!",
+        mat->version == MAT_FT_MAT73 ? "Mat_VarWrite/Mat_VarWriteAppend" : "Mat_VarWrite");
     return MATIO_E_OPERATION_NOT_SUPPORTED;
 }
 
@@ -5100,12 +5202,12 @@ Mat_VarWriteInfo(mat_t *mat, matvar_t *matvar )
  * @see Mat_VarWrite/Mat_VarWriteAppend
  */
 int
-Mat_VarWriteData(mat_t *mat,matvar_t *matvar,void *data,
-      int *start,int *stride,int *edge)
+Mat_VarWriteData(mat_t *mat, matvar_t *matvar, void *data, int *start, int *stride, int *edge)
 {
-    Mat_Critical("Mat_VarWriteInfo/Mat_VarWriteData is not supported. "
-        "Use %s instead!", mat->version == MAT_FT_MAT73 ?
-        "Mat_VarWrite/Mat_VarWriteAppend" : "Mat_VarWrite");
+    Mat_Critical(
+        "Mat_VarWriteInfo/Mat_VarWriteData is not supported. "
+        "Use %s instead!",
+        mat->version == MAT_FT_MAT73 ? "Mat_VarWrite/Mat_VarWriteAppend" : "Mat_VarWrite");
     return MATIO_E_OPERATION_NOT_SUPPORTED;
 }
 
@@ -5122,7 +5224,7 @@ Mat_VarWriteData(mat_t *mat,matvar_t *matvar,void *data,
  * @retval 0 on success
  */
 int
-Mat_VarWrite(mat_t *mat,matvar_t *matvar,enum matio_compression compress)
+Mat_VarWrite(mat_t *mat, matvar_t *matvar, enum matio_compression compress)
 {
     int err;
 
@@ -5138,8 +5240,7 @@ Mat_VarWrite(mat_t *mat,matvar_t *matvar,enum matio_compression compress)
         /* Error if MAT variable already exists in MAT file */
         size_t i;
         for ( i = 0; i < mat->num_datasets; i++ ) {
-            if ( NULL != mat->dir[i] &&
-                0 == strcmp(mat->dir[i], matvar->name) ) {
+            if ( NULL != mat->dir[i] && 0 == strcmp(mat->dir[i], matvar->name) ) {
                 Mat_Critical("Variable %s already exists.", matvar->name);
                 return MATIO_E_OUTPUT_BAD_DATA;
             }
@@ -5147,15 +5248,15 @@ Mat_VarWrite(mat_t *mat,matvar_t *matvar,enum matio_compression compress)
     }
 
     if ( mat->version == MAT_FT_MAT5 )
-        err = Mat_VarWrite5(mat,matvar,compress);
+        err = Mat_VarWrite5(mat, matvar, compress);
     else if ( mat->version == MAT_FT_MAT73 )
 #if HAVE_HDF5
-        err = Mat_VarWrite73(mat,matvar,compress);
+        err = Mat_VarWrite73(mat, matvar, compress);
 #else
         err = MATIO_E_OPERATION_NOT_SUPPORTED;
 #endif
     else if ( mat->version == MAT_FT_MAT4 )
-        err = Mat_VarWrite4(mat,matvar);
+        err = Mat_VarWrite4(mat, matvar);
     else
         err = MATIO_E_FAIL_TO_IDENTIFY;
 
@@ -5163,10 +5264,9 @@ Mat_VarWrite(mat_t *mat,matvar_t *matvar,enum matio_compression compress)
         /* Update directory */
         char **dir;
         if ( NULL == mat->dir ) {
-            dir = (char**)malloc(sizeof(char*));
+            dir = (char **)malloc(sizeof(char *));
         } else {
-            dir = (char**)realloc(mat->dir,
-            (mat->num_datasets + 1)*(sizeof(char*)));
+            dir = (char **)realloc(mat->dir, (mat->num_datasets + 1) * (sizeof(char *)));
         }
         if ( NULL != dir ) {
             mat->dir = dir;
@@ -5199,7 +5299,7 @@ Mat_VarWrite(mat_t *mat,matvar_t *matvar,enum matio_compression compress)
  * @retval 0 on success
  */
 int
-Mat_VarWriteAppend(mat_t *mat,matvar_t *matvar,enum matio_compression compress,int dim)
+Mat_VarWriteAppend(mat_t *mat, matvar_t *matvar, enum matio_compression compress, int dim)
 {
     int err;
 
@@ -5218,22 +5318,20 @@ Mat_VarWriteAppend(mat_t *mat,matvar_t *matvar,enum matio_compression compress,i
             /* Check if MAT variable already exists in MAT file */
             size_t i;
             for ( i = 0; i < mat->num_datasets; i++ ) {
-                if ( NULL != mat->dir[i] &&
-                    0 == strcmp(mat->dir[i], matvar->name) ) {
+                if ( NULL != mat->dir[i] && 0 == strcmp(mat->dir[i], matvar->name) ) {
                     append = 1;
                     break;
                 }
             }
         }
-        err = Mat_VarWriteAppend73(mat,matvar,compress,dim);
+        err = Mat_VarWriteAppend73(mat, matvar, compress, dim);
         if ( err == MATIO_E_NO_ERROR && 0 == append ) {
             /* Update directory */
             char **dir;
             if ( NULL == mat->dir ) {
-                dir = (char**)malloc(sizeof(char*));
+                dir = (char **)malloc(sizeof(char *));
             } else {
-                dir = (char**)realloc(mat->dir,
-                (mat->num_datasets + 1)*(sizeof(char*)));
+                dir = (char **)realloc(mat->dir, (mat->num_datasets + 1) * (sizeof(char *)));
             }
             if ( NULL != dir ) {
                 mat->dir = dir;
@@ -5250,8 +5348,7 @@ Mat_VarWriteAppend(mat_t *mat,matvar_t *matvar,enum matio_compression compress,i
 #else
         err = MATIO_E_OPERATION_NOT_SUPPORTED;
 #endif
-    }
-    else if ( mat->version == MAT_FT_MAT4 || mat->version == MAT_FT_MAT5 ) {
+    } else if ( mat->version == MAT_FT_MAT4 || mat->version == MAT_FT_MAT5 ) {
         err = MATIO_E_OPERATION_NOT_SUPPORTED;
     } else {
         err = MATIO_E_FAIL_TO_IDENTIFY;
@@ -5280,13 +5377,13 @@ Mat_VarWriteAppend(mat_t *mat,matvar_t *matvar,enum matio_compression compress,i
  * @endif
  */
 static mat_t *
-Mat_Create4(const char* matname)
+Mat_Create4(const char *matname)
 {
     FILE *fp = NULL;
     mat_t *mat = NULL;
 
 #if defined(_WIN32) && defined(_MSC_VER)
-    wchar_t* wname = utf82u(matname);
+    wchar_t *wname = utf82u(matname);
     if ( NULL != wname ) {
         fp = _wfopen(wname, L"w+b");
         free(wname);
@@ -5297,27 +5394,27 @@ Mat_Create4(const char* matname)
     if ( !fp )
         return NULL;
 
-    mat = (mat_t*)malloc(sizeof(*mat));
+    mat = (mat_t *)malloc(sizeof(*mat));
     if ( NULL == mat ) {
         fclose(fp);
         Mat_Critical("Couldn't allocate memory for the MAT file");
         return NULL;
     }
 
-    mat->fp            = fp;
-    mat->header        = NULL;
+    mat->fp = fp;
+    mat->header = NULL;
     mat->subsys_offset = NULL;
-    mat->filename      = Mat_strdup(matname);
-    mat->version       = MAT_FT_MAT4;
-    mat->byteswap      = 0;
-    mat->mode          = 0;
-    mat->bof           = 0;
-    mat->next_index    = 0;
-    mat->num_datasets  = 0;
+    mat->filename = Mat_strdup(matname);
+    mat->version = MAT_FT_MAT4;
+    mat->byteswap = 0;
+    mat->mode = 0;
+    mat->bof = 0;
+    mat->next_index = 0;
+    mat->num_datasets = 0;
 #if HAVE_HDF5
-    mat->refs_id       = -1;
+    mat->refs_id = -1;
 #endif
-    mat->dir           = NULL;
+    mat->dir = NULL;
 
     Mat_Rewind(mat);
 
@@ -5334,9 +5431,10 @@ Mat_Create4(const char* matname)
  * @endif
  */
 static int
-Mat_VarWrite4(mat_t *mat,matvar_t *matvar)
+Mat_VarWrite4(mat_t *mat, matvar_t *matvar)
 {
-    typedef struct {
+    typedef struct
+    {
         mat_int32_t type;
         mat_int32_t mrows;
         mat_int32_t ncols;
@@ -5376,7 +5474,7 @@ Mat_VarWrite4(mat_t *mat,matvar_t *matvar)
     }
 
 #if defined(__GLIBC__)
-#if (__BYTE_ORDER == __LITTLE_ENDIAN)
+#if ( __BYTE_ORDER == __LITTLE_ENDIAN )
 #elif (__BYTE_ORDER == __BIG_ENDIAN)
     x.type += 1000;
 #else
@@ -5386,12 +5484,13 @@ Mat_VarWrite4(mat_t *mat,matvar_t *matvar)
     x.type += 1000;
 #elif defined(_LITTLE_ENDIAN) && !defined(_BIG_ENDIAN)
 #elif defined(__sparc) || defined(__sparc__) || defined(_POWER) || defined(__powerpc__) || \
-      defined(__ppc__) || defined(__hpux) || defined(_MIPSEB) || defined(_POWER) || defined(__s390__)
+    defined(__ppc__) || defined(__hpux) || defined(_MIPSEB) || defined(_POWER) ||          \
+    defined(__s390__)
     x.type += 1000;
-#elif defined(__i386__) || defined(__alpha__) || defined(__ia64) || defined(__ia64__) || \
-      defined(_M_IX86) || defined(_M_IA64) || defined(_M_ALPHA) || defined(__amd64) || \
-      defined(__amd64__) || defined(_M_AMD64) || defined(__x86_64) || defined(__x86_64__) || \
-      defined(_M_X64) || defined(__bfin__)
+#elif defined(__i386__) || defined(__alpha__) || defined(__ia64) || defined(__ia64__) ||   \
+    defined(_M_IX86) || defined(_M_IA64) || defined(_M_ALPHA) || defined(__amd64) ||       \
+    defined(__amd64__) || defined(_M_AMD64) || defined(__x86_64) || defined(__x86_64__) || \
+    defined(_M_X64) || defined(__bfin__)
 #else
     return MATIO_E_OPERATION_NOT_SUPPORTED;
 #endif
@@ -5399,7 +5498,7 @@ Mat_VarWrite4(mat_t *mat,matvar_t *matvar)
     x.namelen = (mat_int32_t)strlen(matvar->name) + 1;
 
     /* FIXME: SEEK_END is not Guaranteed by the C standard */
-    (void)fseek((FILE*)mat->fp,0,SEEK_END);         /* Always write at end of file */
+    (void)fseek((FILE *)mat->fp, 0, SEEK_END); /* Always write at end of file */
 
     switch ( matvar->class_type ) {
         case MAT_C_CHAR:
@@ -5410,8 +5509,7 @@ Mat_VarWrite4(mat_t *mat,matvar_t *matvar)
         case MAT_C_INT32:
         case MAT_C_INT16:
         case MAT_C_UINT16:
-        case MAT_C_UINT8:
-        {
+        case MAT_C_UINT8: {
             size_t nelems = 1;
             int err = Mat_MulDims(matvar, &nelems);
             if ( err ) {
@@ -5422,23 +5520,21 @@ Mat_VarWrite4(mat_t *mat,matvar_t *matvar)
             x.mrows = (mat_int32_t)matvar->dims[0];
             x.ncols = (mat_int32_t)matvar->dims[1];
             x.imagf = matvar->isComplex ? 1 : 0;
-            fwrite(&x, sizeof(Fmatrix), 1, (FILE*)mat->fp);
-            fwrite(matvar->name, sizeof(char), x.namelen, (FILE*)mat->fp);
+            fwrite(&x, sizeof(Fmatrix), 1, (FILE *)mat->fp);
+            fwrite(matvar->name, sizeof(char), x.namelen, (FILE *)mat->fp);
             if ( matvar->isComplex ) {
                 mat_complex_split_t *complex_data;
 
-                complex_data = (mat_complex_split_t*)matvar->data;
-                fwrite(complex_data->Re, matvar->data_size, nelems, (FILE*)mat->fp);
-                fwrite(complex_data->Im, matvar->data_size, nelems, (FILE*)mat->fp);
-            }
-            else {
-                fwrite(matvar->data, matvar->data_size, nelems, (FILE*)mat->fp);
+                complex_data = (mat_complex_split_t *)matvar->data;
+                fwrite(complex_data->Re, matvar->data_size, nelems, (FILE *)mat->fp);
+                fwrite(complex_data->Im, matvar->data_size, nelems, (FILE *)mat->fp);
+            } else {
+                fwrite(matvar->data, matvar->data_size, nelems, (FILE *)mat->fp);
             }
             break;
         }
-        case MAT_C_SPARSE:
-        {
-            mat_sparse_t* sparse;
+        case MAT_C_SPARSE: {
+            mat_sparse_t *sparse;
             double tmp;
             mat_uint32_t j;
             size_t stride = Mat_SizeOf(matvar->data_type);
@@ -5447,64 +5543,59 @@ Mat_VarWrite4(mat_t *mat,matvar_t *matvar)
                 break;
 #endif
 
-            sparse = (mat_sparse_t*)matvar->data;
+            sparse = (mat_sparse_t *)matvar->data;
             x.type += 2;
             x.mrows = sparse->njc > 0 ? sparse->jc[sparse->njc - 1] + 1 : 1;
             x.ncols = matvar->isComplex ? 4 : 3;
             x.imagf = 0;
 
-            fwrite(&x, sizeof(Fmatrix), 1, (FILE*)mat->fp);
-            fwrite(matvar->name, sizeof(char), x.namelen, (FILE*)mat->fp);
+            fwrite(&x, sizeof(Fmatrix), 1, (FILE *)mat->fp);
+            fwrite(matvar->name, sizeof(char), x.namelen, (FILE *)mat->fp);
 
             for ( i = 0; i < sparse->njc - 1; i++ ) {
-                for ( j = sparse->jc[i];
-                      j < sparse->jc[i + 1] && j < sparse->ndata; j++ ) {
+                for ( j = sparse->jc[i]; j < sparse->jc[i + 1] && j < sparse->ndata; j++ ) {
                     tmp = sparse->ir[j] + 1;
-                    fwrite(&tmp, sizeof(double), 1, (FILE*)mat->fp);
+                    fwrite(&tmp, sizeof(double), 1, (FILE *)mat->fp);
                 }
             }
             tmp = (double)matvar->dims[0];
-            fwrite(&tmp, sizeof(double), 1, (FILE*)mat->fp);
+            fwrite(&tmp, sizeof(double), 1, (FILE *)mat->fp);
             for ( i = 0; i < sparse->njc - 1; i++ ) {
-                for ( j = sparse->jc[i];
-                      j < sparse->jc[i + 1] && j < sparse->ndata; j++ ) {
+                for ( j = sparse->jc[i]; j < sparse->jc[i + 1] && j < sparse->ndata; j++ ) {
                     tmp = i + 1;
-                    fwrite(&tmp, sizeof(double), 1, (FILE*)mat->fp);
+                    fwrite(&tmp, sizeof(double), 1, (FILE *)mat->fp);
                 }
             }
             tmp = (double)matvar->dims[1];
-            fwrite(&tmp, sizeof(double), 1, (FILE*)mat->fp);
+            fwrite(&tmp, sizeof(double), 1, (FILE *)mat->fp);
             tmp = 0.;
             if ( matvar->isComplex ) {
                 mat_complex_split_t *complex_data;
-                char* re, *im;
+                char *re, *im;
 
-                complex_data = (mat_complex_split_t*)sparse->data;
-                re = (char*)complex_data->Re;
-                im = (char*)complex_data->Im;
+                complex_data = (mat_complex_split_t *)sparse->data;
+                re = (char *)complex_data->Re;
+                im = (char *)complex_data->Im;
                 for ( i = 0; i < sparse->njc - 1; i++ ) {
-                    for ( j = sparse->jc[i];
-                          j < sparse->jc[i + 1] && j < sparse->ndata; j++ ) {
-                        fwrite(re + j*stride, stride, 1, (FILE*)mat->fp);
+                    for ( j = sparse->jc[i]; j < sparse->jc[i + 1] && j < sparse->ndata; j++ ) {
+                        fwrite(re + j * stride, stride, 1, (FILE *)mat->fp);
                     }
                 }
-                fwrite(&tmp, stride, 1, (FILE*)mat->fp);
+                fwrite(&tmp, stride, 1, (FILE *)mat->fp);
                 for ( i = 0; i < sparse->njc - 1; i++ ) {
-                    for ( j = sparse->jc[i];
-                          j < sparse->jc[i + 1] && j < sparse->ndata; j++ ) {
-                        fwrite(im + j*stride, stride, 1, (FILE*)mat->fp);
+                    for ( j = sparse->jc[i]; j < sparse->jc[i + 1] && j < sparse->ndata; j++ ) {
+                        fwrite(im + j * stride, stride, 1, (FILE *)mat->fp);
                     }
                 }
             } else {
-                char *data = (char*)sparse->data;
+                char *data = (char *)sparse->data;
                 for ( i = 0; i < sparse->njc - 1; i++ ) {
-                    for ( j = sparse->jc[i];
-                          j < sparse->jc[i + 1] && j < sparse->ndata; j++ ) {
-                        fwrite(data + j*stride, stride, 1, (FILE*)mat->fp);
+                    for ( j = sparse->jc[i]; j < sparse->jc[i + 1] && j < sparse->ndata; j++ ) {
+                        fwrite(data + j * stride, stride, 1, (FILE *)mat->fp);
                     }
                 }
             }
-            fwrite(&tmp, stride, 1, (FILE*)mat->fp);
+            fwrite(&tmp, stride, 1, (FILE *)mat->fp);
             break;
         }
         default:
@@ -5524,7 +5615,7 @@ Mat_VarWrite4(mat_t *mat,matvar_t *matvar)
  * @endif
  */
 static int
-Mat_VarRead4(mat_t *mat,matvar_t *matvar)
+Mat_VarRead4(mat_t *mat, matvar_t *matvar)
 {
     int err;
     size_t nelems = 1;
@@ -5535,7 +5626,7 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
         return err;
     }
 
-    (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+    (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
 
     switch ( matvar->class_type ) {
         case MAT_C_DOUBLE:
@@ -5550,32 +5641,33 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
                 mat_complex_split_t *complex_data = ComplexMalloc(matvar->nbytes);
                 if ( NULL != complex_data ) {
                     size_t readcount;
-                    readcount = ReadDoubleData(mat, (double*)complex_data->Re, matvar->data_type, nelems);
+                    readcount =
+                        ReadDoubleData(mat, (double *)complex_data->Re, matvar->data_type, nelems);
                     err = readcount != nelems;
-                    readcount = ReadDoubleData(mat, (double*)complex_data->Im, matvar->data_type, nelems);
+                    readcount =
+                        ReadDoubleData(mat, (double *)complex_data->Im, matvar->data_type, nelems);
                     err |= readcount != nelems;
                     if ( 0 == err ) {
-                       matvar->data = complex_data;
+                        matvar->data = complex_data;
                     } else {
                         ComplexFree(complex_data);
                         return MATIO_E_FILE_FORMAT_VIOLATION;
                     }
-                }
-                else {
+                } else {
                     Mat_Critical("Couldn't allocate memory for the complex data");
                     return MATIO_E_OUT_OF_MEMORY;
                 }
             } else {
                 matvar->data = malloc(matvar->nbytes);
                 if ( NULL != matvar->data ) {
-                    const size_t readcount = ReadDoubleData(mat, (double*)matvar->data, matvar->data_type, nelems);
+                    const size_t readcount =
+                        ReadDoubleData(mat, (double *)matvar->data, matvar->data_type, nelems);
                     if ( readcount != nelems ) {
                         free(matvar->data);
                         matvar->data = NULL;
                         return MATIO_E_FILE_FORMAT_VIOLATION;
                     }
-                }
-                else {
+                } else {
                     Mat_Critical("Couldn't allocate memory for the data");
                     return MATIO_E_OUT_OF_MEMORY;
                 }
@@ -5588,14 +5680,14 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
             matvar->nbytes = nelems;
             matvar->data = malloc(matvar->nbytes);
             if ( NULL != matvar->data ) {
-                const size_t readcount = ReadUInt8Data(mat, (mat_uint8_t*)matvar->data, matvar->data_type, nelems);
+                const size_t readcount =
+                    ReadUInt8Data(mat, (mat_uint8_t *)matvar->data, matvar->data_type, nelems);
                 if ( readcount != nelems ) {
                     free(matvar->data);
                     matvar->data = NULL;
                     return MATIO_E_FILE_FORMAT_VIOLATION;
                 }
-            }
-            else {
+            } else {
                 Mat_Critical("Couldn't allocate memory for the data");
                 return MATIO_E_OUT_OF_MEMORY;
             }
@@ -5603,11 +5695,11 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
             break;
         case MAT_C_SPARSE:
             matvar->data_size = sizeof(mat_sparse_t);
-            matvar->data      = calloc(1, matvar->data_size);
+            matvar->data = calloc(1, matvar->data_size);
             if ( NULL != matvar->data ) {
                 double tmp;
                 mat_uint32_t i;
-                mat_sparse_t* sparse;
+                mat_sparse_t *sparse;
                 long fpos;
                 enum matio_types data_type = MAT_T_DOUBLE;
                 size_t readcount;
@@ -5617,7 +5709,7 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
                 if ( matvar->dims[0] < 2 ) {
                     return MATIO_E_FILE_FORMAT_VIOLATION;
                 }
-                sparse = (mat_sparse_t*)matvar->data;
+                sparse = (mat_sparse_t *)matvar->data;
                 sparse->nir = matvar->dims[0] - 1;
                 sparse->nzmax = sparse->nir;
                 err = Mul(&readcount, sparse->nir, sizeof(mat_uint32_t));
@@ -5625,7 +5717,7 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
                     Mat_Critical("Integer multiplication overflow");
                     return err;
                 }
-                sparse->ir = (mat_uint32_t*)malloc(readcount);
+                sparse->ir = (mat_uint32_t *)malloc(readcount);
                 if ( sparse->ir != NULL ) {
                     readcount = ReadUInt32Data(mat, sparse->ir, data_type, sparse->nir);
                     if ( readcount != sparse->nir ) {
@@ -5663,7 +5755,7 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
                 }
                 matvar->dims[0] = (size_t)tmp;
 
-                fpos = ftell((FILE*)mat->fp);
+                fpos = ftell((FILE *)mat->fp);
                 if ( fpos == -1L ) {
                     free(sparse->ir);
                     free(matvar->data);
@@ -5671,7 +5763,7 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
                     Mat_Critical("Couldn't determine file position");
                     return MATIO_E_FILE_FORMAT_VIOLATION;
                 }
-                (void)fseek((FILE*)mat->fp,sparse->nir*Mat_SizeOf(data_type),SEEK_CUR);
+                (void)fseek((FILE *)mat->fp, sparse->nir * Mat_SizeOf(data_type), SEEK_CUR);
                 readcount = ReadDoubleData(mat, &tmp, data_type, 1);
                 if ( readcount != 1 || tmp > UINT_MAX - 1 || tmp < 0 ) {
                     free(sparse->ir);
@@ -5681,7 +5773,7 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
                     return MATIO_E_FILE_FORMAT_VIOLATION;
                 }
                 matvar->dims[1] = (size_t)tmp;
-                (void)fseek((FILE*)mat->fp,fpos,SEEK_SET);
+                (void)fseek((FILE *)mat->fp, fpos, SEEK_SET);
                 if ( matvar->dims[1] > UINT_MAX - 1 ) {
                     free(sparse->ir);
                     free(matvar->data);
@@ -5695,7 +5787,7 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
                     Mat_Critical("Integer multiplication overflow");
                     return err;
                 }
-                sparse->jc = (mat_uint32_t*)malloc(readcount);
+                sparse->jc = (mat_uint32_t *)malloc(readcount);
                 if ( sparse->jc != NULL ) {
                     mat_uint32_t *jc;
                     err = Mul(&readcount, sparse->nir, sizeof(mat_uint32_t));
@@ -5703,7 +5795,7 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
                         Mat_Critical("Integer multiplication overflow");
                         return err;
                     }
-                    jc = (mat_uint32_t*)malloc(readcount);
+                    jc = (mat_uint32_t *)malloc(readcount);
                     if ( jc != NULL ) {
                         mat_uint32_t j = 0;
                         sparse->jc[0] = 0;
@@ -5751,93 +5843,88 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
                 data_type = matvar->data_type;
                 if ( matvar->isComplex ) {
                     mat_complex_split_t *complex_data =
-                        ComplexMalloc(sparse->ndata*Mat_SizeOf(data_type));
+                        ComplexMalloc(sparse->ndata * Mat_SizeOf(data_type));
                     if ( NULL != complex_data ) {
                         sparse->data = complex_data;
 #if defined(EXTENDED_SPARSE)
                         switch ( data_type ) {
                             case MAT_T_DOUBLE:
-                                readcount = ReadDoubleData(mat, (double*)complex_data->Re,
-                                    data_type, sparse->ndata);
+                                readcount = ReadDoubleData(mat, (double *)complex_data->Re,
+                                                           data_type, sparse->ndata);
                                 err = readcount != sparse->ndata;
                                 readcount = ReadDoubleData(mat, &tmp, data_type, 1);
                                 err |= readcount != 1;
-                                readcount = ReadDoubleData(mat, (double*)complex_data->Im,
-                                    data_type, sparse->ndata);
+                                readcount = ReadDoubleData(mat, (double *)complex_data->Im,
+                                                           data_type, sparse->ndata);
                                 err |= readcount != sparse->ndata;
                                 readcount = ReadDoubleData(mat, &tmp, data_type, 1);
                                 err |= readcount != 1;
                                 break;
-                            case MAT_T_SINGLE:
-                            {
+                            case MAT_T_SINGLE: {
                                 float tmp2;
-                                readcount = ReadSingleData(mat, (float*)complex_data->Re,
-                                    data_type, sparse->ndata);
+                                readcount = ReadSingleData(mat, (float *)complex_data->Re,
+                                                           data_type, sparse->ndata);
                                 err = readcount != sparse->ndata;
                                 readcount = ReadSingleData(mat, &tmp2, data_type, 1);
                                 err |= readcount != 1;
-                                readcount = ReadSingleData(mat, (float*)complex_data->Im,
-                                    data_type, sparse->ndata);
+                                readcount = ReadSingleData(mat, (float *)complex_data->Im,
+                                                           data_type, sparse->ndata);
                                 err |= readcount != sparse->ndata;
                                 readcount = ReadSingleData(mat, &tmp2, data_type, 1);
                                 err |= readcount != 1;
                                 break;
                             }
-                            case MAT_T_INT32:
-                            {
+                            case MAT_T_INT32: {
                                 mat_int32_t tmp2;
-                                readcount = ReadInt32Data(mat, (mat_int32_t*)complex_data->Re,
-                                    data_type, sparse->ndata);
+                                readcount = ReadInt32Data(mat, (mat_int32_t *)complex_data->Re,
+                                                          data_type, sparse->ndata);
                                 err = readcount != sparse->ndata;
                                 readcount = ReadInt32Data(mat, &tmp2, data_type, 1);
                                 err |= readcount != 1;
-                                readcount = ReadInt32Data(mat, (mat_int32_t*)complex_data->Im,
-                                    data_type, sparse->ndata);
+                                readcount = ReadInt32Data(mat, (mat_int32_t *)complex_data->Im,
+                                                          data_type, sparse->ndata);
                                 err |= readcount != sparse->ndata;
                                 readcount = ReadInt32Data(mat, &tmp2, data_type, 1);
                                 err |= readcount != 1;
                                 break;
                             }
-                            case MAT_T_INT16:
-                            {
+                            case MAT_T_INT16: {
                                 mat_int16_t tmp2;
-                                readcount = ReadInt16Data(mat, (mat_int16_t*)complex_data->Re,
-                                    data_type, sparse->ndata);
+                                readcount = ReadInt16Data(mat, (mat_int16_t *)complex_data->Re,
+                                                          data_type, sparse->ndata);
                                 err = readcount != sparse->ndata;
                                 readcount = ReadInt16Data(mat, &tmp2, data_type, 1);
                                 err |= readcount != 1;
-                                readcount = ReadInt16Data(mat, (mat_int16_t*)complex_data->Im,
-                                    data_type, sparse->ndata);
+                                readcount = ReadInt16Data(mat, (mat_int16_t *)complex_data->Im,
+                                                          data_type, sparse->ndata);
                                 err |= readcount != sparse->ndata;
                                 readcount = ReadInt16Data(mat, &tmp2, data_type, 1);
                                 err |= readcount != 1;
                                 break;
                             }
-                            case MAT_T_UINT16:
-                            {
+                            case MAT_T_UINT16: {
                                 mat_uint16_t tmp2;
-                                readcount = ReadUInt16Data(mat, (mat_uint16_t*)complex_data->Re,
-                                    data_type, sparse->ndata);
+                                readcount = ReadUInt16Data(mat, (mat_uint16_t *)complex_data->Re,
+                                                           data_type, sparse->ndata);
                                 err = readcount != sparse->ndata;
                                 readcount = ReadUInt16Data(mat, &tmp2, data_type, 1);
                                 err |= readcount != 1;
-                                readcount = ReadUInt16Data(mat, (mat_uint16_t*)complex_data->Im,
-                                    data_type, sparse->ndata);
+                                readcount = ReadUInt16Data(mat, (mat_uint16_t *)complex_data->Im,
+                                                           data_type, sparse->ndata);
                                 err |= readcount != sparse->ndata;
                                 readcount = ReadUInt16Data(mat, &tmp2, data_type, 1);
                                 err |= readcount != 1;
                                 break;
                             }
-                            case MAT_T_UINT8:
-                            {
+                            case MAT_T_UINT8: {
                                 mat_uint8_t tmp2;
-                                readcount = ReadUInt8Data(mat, (mat_uint8_t*)complex_data->Re,
-                                    data_type, sparse->ndata);
+                                readcount = ReadUInt8Data(mat, (mat_uint8_t *)complex_data->Re,
+                                                          data_type, sparse->ndata);
                                 err = readcount != sparse->ndata;
                                 readcount = ReadUInt8Data(mat, &tmp2, data_type, 1);
                                 err |= readcount != 1;
-                                readcount = ReadUInt8Data(mat, (mat_uint8_t*)complex_data->Im,
-                                    data_type, sparse->ndata);
+                                readcount = ReadUInt8Data(mat, (mat_uint8_t *)complex_data->Im,
+                                                          data_type, sparse->ndata);
                                 err |= readcount != sparse->ndata;
                                 readcount = ReadUInt8Data(mat, &tmp2, data_type, 1);
                                 err |= readcount != 1;
@@ -5849,18 +5936,20 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
                                 free(sparse->ir);
                                 free(matvar->data);
                                 matvar->data = NULL;
-                                Mat_Critical("Mat_VarRead4: %d is not a supported data type for "
-                                    "extended sparse", data_type);
+                                Mat_Critical(
+                                    "Mat_VarRead4: %d is not a supported data type for "
+                                    "extended sparse",
+                                    data_type);
                                 return MATIO_E_FILE_FORMAT_VIOLATION;
                         }
 #else
-                        readcount = ReadDoubleData(mat, (double*)complex_data->Re,
-                            data_type, sparse->ndata);
+                        readcount = ReadDoubleData(mat, (double *)complex_data->Re, data_type,
+                                                   sparse->ndata);
                         err = readcount != sparse->ndata;
                         readcount = ReadDoubleData(mat, &tmp, data_type, 1);
                         err |= readcount != 1;
-                        readcount = ReadDoubleData(mat, (double*)complex_data->Im,
-                            data_type, sparse->ndata);
+                        readcount = ReadDoubleData(mat, (double *)complex_data->Im, data_type,
+                                                   sparse->ndata);
                         err |= readcount != sparse->ndata;
                         readcount = ReadDoubleData(mat, &tmp, data_type, 1);
                         err |= readcount != 1;
@@ -5873,8 +5962,7 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
                             matvar->data = NULL;
                             return MATIO_E_FILE_FORMAT_VIOLATION;
                         }
-                    }
-                    else {
+                    } else {
                         free(sparse->jc);
                         free(sparse->ir);
                         free(matvar->data);
@@ -5883,62 +5971,57 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
                         return MATIO_E_OUT_OF_MEMORY;
                     }
                 } else {
-                    sparse->data = malloc(sparse->ndata*Mat_SizeOf(data_type));
+                    sparse->data = malloc(sparse->ndata * Mat_SizeOf(data_type));
                     if ( sparse->data != NULL ) {
 #if defined(EXTENDED_SPARSE)
                         switch ( data_type ) {
                             case MAT_T_DOUBLE:
-                                readcount = ReadDoubleData(mat, (double*)sparse->data,
-                                    data_type, sparse->ndata);
+                                readcount = ReadDoubleData(mat, (double *)sparse->data, data_type,
+                                                           sparse->ndata);
                                 err = readcount != sparse->ndata;
                                 readcount = ReadDoubleData(mat, &tmp, data_type, 1);
                                 err |= readcount != 1;
                                 break;
-                            case MAT_T_SINGLE:
-                            {
+                            case MAT_T_SINGLE: {
                                 float tmp2;
-                                readcount = ReadSingleData(mat, (float*)sparse->data,
-                                    data_type, sparse->ndata);
+                                readcount = ReadSingleData(mat, (float *)sparse->data, data_type,
+                                                           sparse->ndata);
                                 err = readcount != sparse->ndata;
                                 readcount = ReadSingleData(mat, &tmp2, data_type, 1);
                                 err |= readcount != 1;
                                 break;
                             }
-                            case MAT_T_INT32:
-                            {
+                            case MAT_T_INT32: {
                                 mat_int32_t tmp2;
-                                readcount = ReadInt32Data(mat, (mat_int32_t*)sparse->data,
-                                    data_type, sparse->ndata);
+                                readcount = ReadInt32Data(mat, (mat_int32_t *)sparse->data,
+                                                          data_type, sparse->ndata);
                                 err = readcount != sparse->ndata;
                                 readcount = ReadInt32Data(mat, &tmp2, data_type, 1);
                                 err |= readcount != 1;
                                 break;
                             }
-                            case MAT_T_INT16:
-                            {
+                            case MAT_T_INT16: {
                                 mat_int16_t tmp2;
-                                readcount = ReadInt16Data(mat, (mat_int16_t*)sparse->data,
-                                    data_type, sparse->ndata);
+                                readcount = ReadInt16Data(mat, (mat_int16_t *)sparse->data,
+                                                          data_type, sparse->ndata);
                                 err = readcount != sparse->ndata;
                                 readcount = ReadInt16Data(mat, &tmp2, data_type, 1);
                                 err |= readcount != 1;
                                 break;
                             }
-                            case MAT_T_UINT16:
-                            {
+                            case MAT_T_UINT16: {
                                 mat_uint16_t tmp2;
-                                readcount = ReadUInt16Data(mat, (mat_uint16_t*)sparse->data,
-                                    data_type, sparse->ndata);
+                                readcount = ReadUInt16Data(mat, (mat_uint16_t *)sparse->data,
+                                                           data_type, sparse->ndata);
                                 err = readcount != sparse->ndata;
                                 readcount = ReadUInt16Data(mat, &tmp2, data_type, 1);
                                 err |= readcount != 1;
                                 break;
                             }
-                            case MAT_T_UINT8:
-                            {
+                            case MAT_T_UINT8: {
                                 mat_uint8_t tmp2;
-                                readcount = ReadUInt8Data(mat, (mat_uint8_t*)sparse->data,
-                                    data_type, sparse->ndata);
+                                readcount = ReadUInt8Data(mat, (mat_uint8_t *)sparse->data,
+                                                          data_type, sparse->ndata);
                                 err = readcount != sparse->ndata;
                                 readcount = ReadUInt8Data(mat, &tmp2, data_type, 1);
                                 err |= readcount != 1;
@@ -5950,12 +6033,15 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
                                 free(sparse->ir);
                                 free(matvar->data);
                                 matvar->data = NULL;
-                                Mat_Critical("Mat_VarRead4: %d is not a supported data type for "
-                                    "extended sparse", data_type);
+                                Mat_Critical(
+                                    "Mat_VarRead4: %d is not a supported data type for "
+                                    "extended sparse",
+                                    data_type);
                                 return MATIO_E_FILE_FORMAT_VIOLATION;
                         }
 #else
-                        readcount = ReadDoubleData(mat, (double*)sparse->data, data_type, sparse->ndata);
+                        readcount =
+                            ReadDoubleData(mat, (double *)sparse->data, data_type, sparse->ndata);
                         err = readcount != sparse->ndata;
                         readcount = ReadDoubleData(mat, &tmp, data_type, 1);
                         err |= readcount != 1;
@@ -5978,8 +6064,7 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
                     }
                 }
                 break;
-            }
-            else {
+            } else {
                 Mat_Critical("Couldn't allocate memory for the data");
                 return MATIO_E_OUT_OF_MEMORY;
             }
@@ -6006,14 +6091,13 @@ Mat_VarRead4(mat_t *mat,matvar_t *matvar)
  * @endif
  */
 static int
-Mat_VarReadData4(mat_t *mat,matvar_t *matvar,void *data,
-      int *start,int *stride,int *edge)
+Mat_VarReadData4(mat_t *mat, matvar_t *matvar, void *data, int *start, int *stride, int *edge)
 {
     int err = MATIO_E_NO_ERROR;
 
-    (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+    (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
 
-    switch( matvar->data_type ) {
+    switch ( matvar->data_type ) {
         case MAT_T_DOUBLE:
         case MAT_T_SINGLE:
         case MAT_T_INT32:
@@ -6026,12 +6110,12 @@ Mat_VarReadData4(mat_t *mat,matvar_t *matvar,void *data,
     }
 
     if ( matvar->rank == 2 ) {
-        if ( (size_t)stride[0]*(edge[0]-1)+start[0]+1 > matvar->dims[0] )
+        if ( (size_t)stride[0] * (edge[0] - 1) + start[0] + 1 > matvar->dims[0] )
             err = MATIO_E_BAD_ARGUMENT;
-        else if ( (size_t)stride[1]*(edge[1]-1)+start[1]+1 > matvar->dims[1] )
+        else if ( (size_t)stride[1] * (edge[1] - 1) + start[1] + 1 > matvar->dims[1] )
             err = MATIO_E_BAD_ARGUMENT;
         if ( matvar->isComplex ) {
-            mat_complex_split_t *cdata = (mat_complex_split_t*)data;
+            mat_complex_split_t *cdata = (mat_complex_split_t *)data;
             size_t nbytes = Mat_SizeOf(matvar->data_type);
             err = Mat_MulDims(matvar, &nbytes);
             if ( err ) {
@@ -6039,17 +6123,17 @@ Mat_VarReadData4(mat_t *mat,matvar_t *matvar,void *data,
                 return err;
             }
 
-            ReadDataSlab2(mat,cdata->Re,matvar->class_type,matvar->data_type,
-                matvar->dims,start,stride,edge);
-            (void)fseek((FILE*)mat->fp,matvar->internal->datapos+nbytes,SEEK_SET);
-            ReadDataSlab2(mat,cdata->Im,matvar->class_type,
-                matvar->data_type,matvar->dims,start,stride,edge);
+            ReadDataSlab2(mat, cdata->Re, matvar->class_type, matvar->data_type, matvar->dims,
+                          start, stride, edge);
+            (void)fseek((FILE *)mat->fp, matvar->internal->datapos + nbytes, SEEK_SET);
+            ReadDataSlab2(mat, cdata->Im, matvar->class_type, matvar->data_type, matvar->dims,
+                          start, stride, edge);
         } else {
-            ReadDataSlab2(mat,data,matvar->class_type,matvar->data_type,
-                matvar->dims,start,stride,edge);
+            ReadDataSlab2(mat, data, matvar->class_type, matvar->data_type, matvar->dims, start,
+                          stride, edge);
         }
     } else if ( matvar->isComplex ) {
-        mat_complex_split_t *cdata = (mat_complex_split_t*)data;
+        mat_complex_split_t *cdata = (mat_complex_split_t *)data;
         size_t nbytes = Mat_SizeOf(matvar->data_type);
         err = Mat_MulDims(matvar, &nbytes);
         if ( err ) {
@@ -6057,14 +6141,14 @@ Mat_VarReadData4(mat_t *mat,matvar_t *matvar,void *data,
             return err;
         }
 
-        ReadDataSlabN(mat,cdata->Re,matvar->class_type,matvar->data_type,
-            matvar->rank,matvar->dims,start,stride,edge);
-        (void)fseek((FILE*)mat->fp,matvar->internal->datapos+nbytes,SEEK_SET);
-        ReadDataSlabN(mat,cdata->Im,matvar->class_type,matvar->data_type,
-            matvar->rank,matvar->dims,start,stride,edge);
+        ReadDataSlabN(mat, cdata->Re, matvar->class_type, matvar->data_type, matvar->rank,
+                      matvar->dims, start, stride, edge);
+        (void)fseek((FILE *)mat->fp, matvar->internal->datapos + nbytes, SEEK_SET);
+        ReadDataSlabN(mat, cdata->Im, matvar->class_type, matvar->data_type, matvar->rank,
+                      matvar->dims, start, stride, edge);
     } else {
-        ReadDataSlabN(mat,data,matvar->class_type,matvar->data_type,
-            matvar->rank,matvar->dims,start,stride,edge);
+        ReadDataSlabN(mat, data, matvar->class_type, matvar->data_type, matvar->rank, matvar->dims,
+                      start, stride, edge);
     }
 
     return err;
@@ -6084,8 +6168,7 @@ Mat_VarReadData4(mat_t *mat,matvar_t *matvar,void *data,
  * @retval 0 on success
  */
 static int
-Mat_VarReadDataLinear4(mat_t *mat,matvar_t *matvar,void *data,int start,
-                       int stride,int edge)
+Mat_VarReadDataLinear4(mat_t *mat, matvar_t *matvar, void *data, int start, int stride, int edge)
 {
     int err;
     size_t nelems = 1;
@@ -6096,29 +6179,28 @@ Mat_VarReadDataLinear4(mat_t *mat,matvar_t *matvar,void *data,int start,
         return err;
     }
 
-    (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+    (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
 
     matvar->data_size = Mat_SizeOf(matvar->data_type);
 
-    if ( (size_t)stride*(edge-1)+start+1 > nelems ) {
+    if ( (size_t)stride * (edge - 1) + start + 1 > nelems ) {
         return MATIO_E_BAD_ARGUMENT;
     }
     if ( matvar->isComplex ) {
-        mat_complex_split_t *complex_data = (mat_complex_split_t*)data;
+        mat_complex_split_t *complex_data = (mat_complex_split_t *)data;
         err = Mul(&nelems, nelems, matvar->data_size);
         if ( err ) {
             Mat_Critical("Integer multiplication overflow");
             return err;
         }
 
-        ReadDataSlab1(mat,complex_data->Re,matvar->class_type,
-                      matvar->data_type,start,stride,edge);
-        (void)fseek((FILE*)mat->fp,matvar->internal->datapos+nelems,SEEK_SET);
-        ReadDataSlab1(mat,complex_data->Im,matvar->class_type,
-                      matvar->data_type,start,stride,edge);
+        ReadDataSlab1(mat, complex_data->Re, matvar->class_type, matvar->data_type, start, stride,
+                      edge);
+        (void)fseek((FILE *)mat->fp, matvar->internal->datapos + nelems, SEEK_SET);
+        ReadDataSlab1(mat, complex_data->Im, matvar->class_type, matvar->data_type, start, stride,
+                      edge);
     } else {
-        ReadDataSlab1(mat,data,matvar->class_type,matvar->data_type,start,
-                      stride,edge);
+        ReadDataSlab1(mat, data, matvar->class_type, matvar->data_type, start, stride, edge);
     }
 
     return err;
@@ -6135,21 +6217,27 @@ Mat_VarReadDataLinear4(mat_t *mat,matvar_t *matvar,void *data,int start,
 static matvar_t *
 Mat_VarReadNextInfo4(mat_t *mat)
 {
-    int       M,O,data_type,class_type;
+    int M, O, data_type, class_type;
     mat_int32_t tmp;
-    long      nBytes;
+    long nBytes, fpos;
     matvar_t *matvar = NULL;
     union {
         mat_uint32_t u;
-        mat_uint8_t  c[4];
+        mat_uint8_t c[4];
     } endian;
 
     if ( mat == NULL || mat->fp == NULL )
         return NULL;
 
+    if ( IsEndOfFile((FILE *)mat->fp, &fpos) )
+        return NULL;
+
+    if ( fpos == -1L )
+        return NULL;
+
     {
         size_t nbytes = 0;
-        int err = Read(&tmp, sizeof(mat_int32_t), 1, (FILE*)mat->fp, &nbytes);
+        int err = Read(&tmp, sizeof(mat_int32_t), 1, (FILE *)mat->fp, &nbytes);
         if ( err || 0 == nbytes )
             return NULL;
     }
@@ -6178,7 +6266,7 @@ Mat_VarReadNextInfo4(mat_t *mat)
             return NULL;
     }
 
-    tmp -= M*1000;
+    tmp -= M * 1000;
     O = (int)floor(tmp / 100.0);
     /* O must be zero */
     if ( 0 != O ) {
@@ -6188,7 +6276,7 @@ Mat_VarReadNextInfo4(mat_t *mat)
     if ( NULL == (matvar = Mat_VarCalloc()) )
         return NULL;
 
-    tmp -= O*100;
+    tmp -= O * 100;
     data_type = (int)floor(tmp / 10.0);
     /* Convert the V4 data type */
     switch ( data_type ) {
@@ -6215,7 +6303,7 @@ Mat_VarReadNextInfo4(mat_t *mat)
             return NULL;
     }
 
-    tmp -= data_type*10;
+    tmp -= data_type * 10;
     class_type = (int)floor(tmp / 1.0);
     switch ( class_type ) {
         case 0:
@@ -6233,12 +6321,12 @@ Mat_VarReadNextInfo4(mat_t *mat)
     }
 
     matvar->rank = 2;
-    matvar->dims = (size_t*)calloc(2, sizeof(*matvar->dims));
+    matvar->dims = (size_t *)calloc(2, sizeof(*matvar->dims));
     if ( NULL == matvar->dims ) {
         Mat_VarFree(matvar);
         return NULL;
     }
-    if ( 0 != Read(&tmp, sizeof(int), 1, (FILE*)mat->fp, NULL) ) {
+    if ( 0 != Read(&tmp, sizeof(int), 1, (FILE *)mat->fp, NULL) ) {
         Mat_VarFree(matvar);
         return NULL;
     }
@@ -6246,7 +6334,7 @@ Mat_VarReadNextInfo4(mat_t *mat)
         Mat_int32Swap(&tmp);
     matvar->dims[0] = tmp;
 
-    if ( 0 != Read(&tmp, sizeof(int), 1, (FILE*)mat->fp, NULL) ) {
+    if ( 0 != Read(&tmp, sizeof(int), 1, (FILE *)mat->fp, NULL) ) {
         Mat_VarFree(matvar);
         return NULL;
     }
@@ -6254,7 +6342,7 @@ Mat_VarReadNextInfo4(mat_t *mat)
         Mat_int32Swap(&tmp);
     matvar->dims[1] = tmp;
 
-    if ( 0 != Read(&(matvar->isComplex), sizeof(int), 1, (FILE*)mat->fp, NULL) ) {
+    if ( 0 != Read(&(matvar->isComplex), sizeof(int), 1, (FILE *)mat->fp, NULL) ) {
         Mat_VarFree(matvar);
         return NULL;
     }
@@ -6262,7 +6350,7 @@ Mat_VarReadNextInfo4(mat_t *mat)
         Mat_VarFree(matvar);
         return NULL;
     }
-    if ( 0 != Read(&tmp, sizeof(int), 1, (FILE*)mat->fp, NULL) ) {
+    if ( 0 != Read(&tmp, sizeof(int), 1, (FILE *)mat->fp, NULL) ) {
         Mat_VarFree(matvar);
         return NULL;
     }
@@ -6273,19 +6361,19 @@ Mat_VarReadNextInfo4(mat_t *mat)
         Mat_VarFree(matvar);
         return NULL;
     }
-    matvar->name = (char*)malloc(tmp);
+    matvar->name = (char *)malloc(tmp);
     if ( NULL == matvar->name ) {
         Mat_VarFree(matvar);
         return NULL;
     }
-    if ( 0 != Read(matvar->name, sizeof(char), tmp, (FILE*)mat->fp, NULL) ) {
+    if ( 0 != Read(matvar->name, sizeof(char), tmp, (FILE *)mat->fp, NULL) ) {
         Mat_VarFree(matvar);
         return NULL;
     } else {
         matvar->name[tmp - 1] = '\0';
     }
 
-    matvar->internal->datapos = ftell((FILE*)mat->fp);
+    matvar->internal->datapos = ftell((FILE *)mat->fp);
     if ( matvar->internal->datapos == -1L ) {
         Mat_VarFree(matvar);
         Mat_Critical("Couldn't determine file position");
@@ -6305,7 +6393,7 @@ Mat_VarReadNextInfo4(mat_t *mat)
 
         nBytes = (long)tmp2;
     }
-    (void)fseek((FILE*)mat->fp,nBytes,SEEK_CUR);
+    (void)fseek((FILE *)mat->fp, nBytes, SEEK_CUR);
 
     return matvar;
 }
@@ -6322,13 +6410,15 @@ Mat_VarReadNextInfo4(mat_t *mat)
 /* FIXME: Implement Unicode support */
 
 /** Get type from tag */
-#define TYPE_FROM_TAG(a)          ( ((a) & 0x000000ff) <= MAT_T_FUNCTION ) ? (enum matio_types)((a) & 0x000000ff) : MAT_T_UNKNOWN
+#define TYPE_FROM_TAG(a) \
+    (((a)&0x000000ff) <= MAT_T_FUNCTION) ? (enum matio_types)((a)&0x000000ff) : MAT_T_UNKNOWN
 /** Get class from array flag */
-#define CLASS_FROM_ARRAY_FLAGS(a) ( ((a) & 0x000000ff) <= MAT_C_OPAQUE ) ? ((enum matio_classes)((a) & 0x000000ff)) : MAT_C_EMPTY
+#define CLASS_FROM_ARRAY_FLAGS(a) \
+    (((a)&0x000000ff) <= MAT_C_OPAQUE) ? ((enum matio_classes)((a)&0x000000ff)) : MAT_C_EMPTY
 /** Class type mask */
-#define CLASS_TYPE_MASK           0x000000ff
+#define CLASS_TYPE_MASK 0x000000ff
 
-static mat_complex_split_t null_complex_data = {NULL,NULL};
+static mat_complex_split_t null_complex_data = {NULL, NULL};
 
 /*===========================================================================
  *  Private functions
@@ -6338,39 +6428,35 @@ static int GetTypeBufSize(matvar_t *matvar, size_t *size);
 static int GetStructFieldBufSize(matvar_t *matvar, size_t *size);
 static int GetCellArrayFieldBufSize(matvar_t *matvar, size_t *size);
 static void SetFieldNames(matvar_t *matvar, char *buf, size_t nfields,
-                  mat_uint32_t fieldname_length);
+                          mat_uint32_t fieldname_length);
 static size_t ReadSparse(mat_t *mat, matvar_t *matvar, mat_uint32_t *n, mat_uint32_t **v);
 #if HAVE_ZLIB
 static int GetMatrixMaxBufSize(matvar_t *matvar, size_t *size);
 #endif
 static int GetEmptyMatrixMaxBufSize(const char *name, int rank, size_t *size);
-static size_t WriteCharData(mat_t *mat, void *data, int N,enum matio_types data_type);
-static size_t ReadNextCell( mat_t *mat, matvar_t *matvar );
-static size_t ReadNextStructField( mat_t *mat, matvar_t *matvar );
+static size_t WriteCharData(mat_t *mat, void *data, size_t N, enum matio_types data_type);
+static size_t ReadNextCell(mat_t *mat, matvar_t *matvar);
+static size_t ReadNextStructField(mat_t *mat, matvar_t *matvar);
 static size_t ReadNextFunctionHandle(mat_t *mat, matvar_t *matvar);
-static int    ReadRankDims(mat_t *mat, matvar_t *matvar, enum matio_types data_type,
-                  mat_uint32_t nbytes, size_t *read_bytes);
-static int    WriteType(mat_t *mat,matvar_t *matvar);
-static int    WriteCellArrayField(mat_t *mat,matvar_t *matvar );
-static int    WriteStructField(mat_t *mat,matvar_t *matvar);
-static int    WriteData(mat_t *mat,void *data,size_t N,enum matio_types data_type);
-static size_t Mat_WriteEmptyVariable5(mat_t *mat,const char *name,int rank,
-                  size_t *dims);
-static int    Mat_VarReadNumeric5(mat_t *mat,matvar_t *matvar,void *data,size_t N);
+static int ReadRankDims(mat_t *mat, matvar_t *matvar, enum matio_types data_type,
+                        mat_uint32_t nbytes, size_t *read_bytes);
+static int WriteType(mat_t *mat, matvar_t *matvar);
+static int WriteCellArrayField(mat_t *mat, matvar_t *matvar);
+static int WriteStructField(mat_t *mat, matvar_t *matvar);
+static int WriteData(mat_t *mat, void *data, size_t N, enum matio_types data_type);
+static size_t Mat_WriteEmptyVariable5(mat_t *mat, const char *name, int rank, size_t *dims);
+static int Mat_VarReadNumeric5(mat_t *mat, matvar_t *matvar, void *data, size_t N);
 #if HAVE_ZLIB
-static size_t WriteCompressedCharData(mat_t *mat,z_streamp z,void *data,int N,
-                  enum matio_types data_type);
-static size_t WriteCompressedData(mat_t *mat,z_streamp z,void *data,int N,
-                  enum matio_types data_type);
-static size_t WriteCompressedTypeArrayFlags(mat_t *mat,matvar_t *matvar,
-                  z_streamp z);
-static size_t WriteCompressedType(mat_t *mat,matvar_t *matvar,z_streamp z);
-static size_t WriteCompressedCellArrayField(mat_t *mat,matvar_t *matvar,
-                  z_streamp z);
-static size_t WriteCompressedStructField(mat_t *mat,matvar_t *matvar,
-                  z_streamp z);
-static size_t Mat_WriteCompressedEmptyVariable5(mat_t *mat,const char *name,
-                  int rank,size_t *dims,z_streamp z);
+static size_t WriteCompressedCharData(mat_t *mat, z_streamp z, void *data, size_t N,
+                                      enum matio_types data_type);
+static size_t WriteCompressedData(mat_t *mat, z_streamp z, void *data, int N,
+                                  enum matio_types data_type);
+static size_t WriteCompressedTypeArrayFlags(mat_t *mat, matvar_t *matvar, z_streamp z);
+static size_t WriteCompressedType(mat_t *mat, matvar_t *matvar, z_streamp z);
+static size_t WriteCompressedCellArrayField(mat_t *mat, matvar_t *matvar, z_streamp z);
+static size_t WriteCompressedStructField(mat_t *mat, matvar_t *matvar, z_streamp z);
+static size_t Mat_WriteCompressedEmptyVariable5(mat_t *mat, const char *name, int rank,
+                                                size_t *dims, z_streamp z);
 #endif
 
 /** @brief determines the number of bytes for a given class type
@@ -6410,9 +6496,8 @@ GetTypeBufSize(matvar_t *matvar, size_t *size)
         return err;
 
     switch ( matvar->class_type ) {
-        case MAT_C_STRUCT:
-        {
-            matvar_t **fields = (matvar_t**)matvar->data;
+        case MAT_C_STRUCT: {
+            matvar_t **fields = (matvar_t **)matvar->data;
             size_t nfields = matvar->internal->num_fields;
             size_t maxlen = 0, i, field_buf_size;
 
@@ -6422,7 +6507,7 @@ GetTypeBufSize(matvar_t *matvar, size_t *size)
                     maxlen = strlen(fieldname);
             }
             maxlen++;
-            while ( nfields*maxlen % 8 != 0 )
+            while ( nfields * maxlen % 8 != 0 )
                 maxlen++;
 
             err = Mul(&field_buf_size, maxlen, nfields);
@@ -6456,9 +6541,8 @@ GetTypeBufSize(matvar_t *matvar, size_t *size)
             }
             break;
         }
-        case MAT_C_CELL:
-        {
-            matvar_t **cells = (matvar_t**)matvar->data;
+        case MAT_C_CELL: {
+            matvar_t **cells = (matvar_t **)matvar->data;
 
             if ( matvar->nbytes == 0 || matvar->data_size == 0 )
                 break;
@@ -6480,9 +6564,8 @@ GetTypeBufSize(matvar_t *matvar, size_t *size)
             }
             break;
         }
-        case MAT_C_SPARSE:
-        {
-            mat_sparse_t *sparse = (mat_sparse_t*)matvar->data;
+        case MAT_C_SPARSE: {
+            mat_sparse_t *sparse = (mat_sparse_t *)matvar->data;
 
             err = Mul(&data_bytes, sparse->nir, sizeof(mat_uint32_t));
             if ( err )
@@ -6541,8 +6624,7 @@ GetTypeBufSize(matvar_t *matvar, size_t *size)
             break;
         }
         case MAT_C_CHAR:
-            if ( MAT_T_UINT8 == matvar->data_type ||
-                 MAT_T_INT8 == matvar->data_type )
+            if ( MAT_T_UINT8 == matvar->data_type || MAT_T_INT8 == matvar->data_type )
                 err = Mul(&data_bytes, nelems, Mat_SizeOf(MAT_T_UINT16));
             else
                 err = Mul(&data_bytes, nelems, Mat_SizeOf(matvar->data_type));
@@ -6740,15 +6822,15 @@ static void
 SetFieldNames(matvar_t *matvar, char *buf, size_t nfields, mat_uint32_t fieldname_length)
 {
     matvar->internal->num_fields = nfields;
-    matvar->internal->fieldnames =
-        (char**)calloc(nfields,sizeof(*matvar->internal->fieldnames));
+    matvar->internal->fieldnames = (char **)calloc(nfields, sizeof(*matvar->internal->fieldnames));
     if ( NULL != matvar->internal->fieldnames ) {
         size_t i;
         for ( i = 0; i < nfields; i++ ) {
-            matvar->internal->fieldnames[i] = (char*)malloc(fieldname_length);
+            matvar->internal->fieldnames[i] = (char *)malloc(fieldname_length);
             if ( NULL != matvar->internal->fieldnames[i] ) {
-                memcpy(matvar->internal->fieldnames[i], buf+i*fieldname_length, fieldname_length);
-                matvar->internal->fieldnames[i][fieldname_length-1] = '\0';
+                memcpy(matvar->internal->fieldnames[i], buf + i * fieldname_length,
+                       fieldname_length);
+                matvar->internal->fieldnames[i][fieldname_length - 1] = '\0';
             }
         }
     }
@@ -6777,12 +6859,11 @@ ReadSparse(mat_t *mat, matvar_t *matvar, mat_uint32_t *n, mat_uint32_t **v)
             N = (tag[0] & 0xffff0000) >> 16;
         } else {
             data_in_tag = 0;
-            (void)ReadCompressedUInt32Data(mat,matvar->internal->z,
-                        &N,MAT_T_UINT32,1);
+            (void)ReadCompressedUInt32Data(mat, matvar->internal->z, &N, MAT_T_UINT32, 1);
         }
 #endif
     } else {
-        if ( 0 != Read(tag, 4, 1, (FILE*)mat->fp, &bytesread) ) {
+        if ( 0 != Read(tag, 4, 1, (FILE *)mat->fp, &bytesread) ) {
             return bytesread;
         }
         if ( mat->byteswap )
@@ -6793,7 +6874,7 @@ ReadSparse(mat_t *mat, matvar_t *matvar, mat_uint32_t *n, mat_uint32_t **v)
             N = (tag[0] & 0xffff0000) >> 16;
         } else {
             data_in_tag = 0;
-            if ( 0 != Read(&N, 4, 1, (FILE*)mat->fp, &bytesread) ) {
+            if ( 0 != Read(&N, 4, 1, (FILE *)mat->fp, &bytesread) ) {
                 return bytesread;
             }
             if ( mat->byteswap )
@@ -6803,32 +6884,31 @@ ReadSparse(mat_t *mat, matvar_t *matvar, mat_uint32_t *n, mat_uint32_t **v)
     if ( 0 == N )
         return bytesread;
     *n = N / 4;
-    *v = (mat_uint32_t*)calloc(N, 1);
+    *v = (mat_uint32_t *)calloc(N, 1);
     if ( NULL != *v ) {
         int nBytes;
         if ( matvar->compression == MAT_COMPRESSION_NONE ) {
-            nBytes = ReadUInt32Data(mat,*v,packed_type,*n);
+            nBytes = ReadUInt32Data(mat, *v, packed_type, *n);
             /*
                 * If the data was in the tag we started on a 4-byte
                 * boundary so add 4 to make it an 8-byte
                 */
             nBytes *= Mat_SizeOf(packed_type);
             if ( data_in_tag )
-                nBytes+=4;
+                nBytes += 4;
             if ( (nBytes % 8) != 0 )
-                (void)fseek((FILE*)mat->fp,8-(nBytes % 8),SEEK_CUR);
+                (void)fseek((FILE *)mat->fp, 8 - (nBytes % 8), SEEK_CUR);
 #if HAVE_ZLIB
         } else if ( matvar->compression == MAT_COMPRESSION_ZLIB ) {
-            nBytes = ReadCompressedUInt32Data(mat,matvar->internal->z,
-                            *v,packed_type,*n);
+            nBytes = ReadCompressedUInt32Data(mat, matvar->internal->z, *v, packed_type, *n);
             /*
                 * If the data was in the tag we started on a 4-byte
                 * boundary so add 4 to make it an 8-byte
                 */
             if ( data_in_tag )
-                nBytes+=4;
+                nBytes += 4;
             if ( (nBytes % 8) != 0 )
-                InflateSkip(mat, matvar->internal->z, 8-(nBytes % 8), NULL);
+                InflateSkip(mat, matvar->internal->z, 8 - (nBytes % 8), NULL);
 #endif
         }
     } else {
@@ -6909,7 +6989,7 @@ GetMatrixMaxBufSize(matvar_t *matvar, size_t *size)
  * @endif
  */
 static mat_t *
-Mat_Create5(const char *matname,const char *hdr_str)
+Mat_Create5(const char *matname, const char *hdr_str)
 {
     FILE *fp = NULL;
     mat_int16_t endian = 0, version;
@@ -6918,7 +6998,7 @@ Mat_Create5(const char *matname,const char *hdr_str)
     time_t t;
 
 #if defined(_WIN32) && defined(_MSC_VER)
-    wchar_t* wname = utf82u(matname);
+    wchar_t *wname = utf82u(matname);
     if ( NULL != wname ) {
         fp = _wfopen(wname, L"w+b");
         free(wname);
@@ -6929,55 +7009,56 @@ Mat_Create5(const char *matname,const char *hdr_str)
     if ( !fp )
         return NULL;
 
-    mat = (mat_t*)malloc(sizeof(*mat));
+    mat = (mat_t *)malloc(sizeof(*mat));
     if ( mat == NULL ) {
         fclose(fp);
         return NULL;
     }
 
-    mat->fp            = NULL;
-    mat->header        = NULL;
+    mat->fp = NULL;
+    mat->header = NULL;
     mat->subsys_offset = NULL;
-    mat->filename      = NULL;
-    mat->version       = 0;
-    mat->byteswap      = 0;
-    mat->mode          = 0;
-    mat->bof           = 128;
-    mat->next_index    = 0;
-    mat->num_datasets  = 0;
+    mat->filename = NULL;
+    mat->version = 0;
+    mat->byteswap = 0;
+    mat->mode = 0;
+    mat->bof = 128;
+    mat->next_index = 0;
+    mat->num_datasets = 0;
 #if HAVE_HDF5
-    mat->refs_id       = -1;
+    mat->refs_id = -1;
 #endif
-    mat->dir           = NULL;
+    mat->dir = NULL;
 
     t = time(NULL);
-    mat->fp       = fp;
+    mat->fp = fp;
     mat->filename = Mat_strdup(matname);
-    mat->mode     = MAT_ACC_RDWR;
+    mat->mode = MAT_ACC_RDWR;
     mat->byteswap = 0;
-    mat->header   = (char*)malloc(128*sizeof(char));
-    mat->subsys_offset = (char*)malloc(8*sizeof(char));
-    memset(mat->header,' ',128);
+    mat->header = (char *)malloc(128 * sizeof(char));
+    mat->subsys_offset = (char *)malloc(8 * sizeof(char));
+    memset(mat->header, ' ', 128);
     if ( hdr_str == NULL ) {
-        err = mat_snprintf(mat->header,116,"MATLAB 5.0 MAT-file, Platform: %s, "
-                "Created by: libmatio v%d.%d.%d on %s", MATIO_PLATFORM,
-                MATIO_MAJOR_VERSION, MATIO_MINOR_VERSION, MATIO_RELEASE_LEVEL,
-                ctime(&t));
+        err = mat_snprintf(mat->header, 116,
+                           "MATLAB 5.0 MAT-file, Platform: %s, "
+                           "Created by: libmatio v%d.%d.%d on %s",
+                           MATIO_PLATFORM, MATIO_MAJOR_VERSION, MATIO_MINOR_VERSION,
+                           MATIO_RELEASE_LEVEL, ctime(&t));
     } else {
-        err = mat_snprintf(mat->header,116,"%s",hdr_str);
+        err = mat_snprintf(mat->header, 116, "%s", hdr_str);
     }
     if ( err >= 116 )
         mat->header[115] = '\0'; /* Just to make sure it's NULL terminated */
-    memset(mat->subsys_offset,' ',8);
+    memset(mat->subsys_offset, ' ', 8);
     mat->version = (int)0x0100;
     endian = 0x4d49;
 
     version = 0x0100;
 
-    fwrite(mat->header,1,116,(FILE*)mat->fp);
-    fwrite(mat->subsys_offset,1,8,(FILE*)mat->fp);
-    fwrite(&version,2,1,(FILE*)mat->fp);
-    fwrite(&endian,2,1,(FILE*)mat->fp);
+    fwrite(mat->header, 1, 116, (FILE *)mat->fp);
+    fwrite(mat->subsys_offset, 1, 8, (FILE *)mat->fp);
+    fwrite(&version, 2, 1, (FILE *)mat->fp);
+    fwrite(&endian, 2, 1, (FILE *)mat->fp);
 
     return mat;
 }
@@ -6999,79 +7080,80 @@ Mat_Create5(const char *matname,const char *hdr_str)
  * @endif
  */
 static size_t
-WriteCharData(mat_t *mat, void *data, int N,enum matio_types data_type)
+WriteCharData(mat_t *mat, void *data, size_t N, enum matio_types data_type)
 {
-    int nBytes = 0, i;
+    mat_uint32_t nBytes = 0;
+    size_t nbytes, i;
     size_t byteswritten = 0;
     const mat_uint8_t pad1 = 0;
+    int err;
 
     switch ( data_type ) {
+        case MAT_T_UINT8:
         case MAT_T_UINT16:
-        {
-            nBytes = N*2;
-            fwrite(&data_type,4,1,(FILE*)mat->fp);
-            fwrite(&nBytes,4,1,(FILE*)mat->fp);
+        case MAT_T_UTF8:
+        case MAT_T_UTF16: {
+            data_type = MAT_T_UINT8 == data_type ? MAT_T_UTF8 : data_type;
+            err = Mul(&nbytes, N, Mat_SizeOf(data_type));
+            if ( err ) {
+                return 0;
+            }
+            nBytes = (mat_uint32_t)nbytes;
+            fwrite(&data_type, 4, 1, (FILE *)mat->fp);
+            fwrite(&nBytes, 4, 1, (FILE *)mat->fp);
             if ( NULL != data && N > 0 )
-                fwrite(data,2,N,(FILE*)mat->fp);
-            if ( nBytes % 8 )
-                for ( i = nBytes % 8; i < 8; i++ )
-                    fwrite(&pad1,1,1,(FILE*)mat->fp);
+                fwrite(data, 1, nbytes, (FILE *)mat->fp);
+            if ( nBytes % 8 ) {
+                for ( i = nbytes % 8; i < 8; i++ )
+                    fwrite(&pad1, 1, 1, (FILE *)mat->fp);
+            }
             break;
         }
-        case MAT_T_INT8:
-        case MAT_T_UINT8:
-        {
-            mat_uint8_t *ptr;
+        case MAT_T_INT8: {
+            mat_int8_t *ptr;
             mat_uint16_t c;
 
-            /* Matlab can't read MAT_C_CHAR as uint8, needs uint16 */
-            nBytes = N*2;
+            /* Matlab can't read MAT_C_CHAR as int8, needs uint16 */
             data_type = MAT_T_UINT16;
-            fwrite(&data_type,4,1,(FILE*)mat->fp);
-            fwrite(&nBytes,4,1,(FILE*)mat->fp);
-            ptr = (mat_uint8_t*)data;
-            if ( NULL == ptr )
+            err = Mul(&nbytes, N, Mat_SizeOf(data_type));
+            if ( err ) {
+                return 0;
+            }
+            nBytes = (mat_uint32_t)nbytes;
+            fwrite(&data_type, 4, 1, (FILE *)mat->fp);
+            fwrite(&nBytes, 4, 1, (FILE *)mat->fp);
+            ptr = (mat_int8_t *)data;
+            if ( NULL == data )
                 break;
             for ( i = 0; i < N; i++ ) {
-                c = (mat_uint16_t)*(char *)ptr;
-                fwrite(&c,2,1,(FILE*)mat->fp);
+                c = (mat_uint16_t) * (char *)ptr;
+                fwrite(&c, 2, 1, (FILE *)mat->fp);
                 ptr++;
             }
-            if ( nBytes % 8 )
-                for ( i = nBytes % 8; i < 8; i++ )
-                    fwrite(&pad1,1,1,(FILE*)mat->fp);
+            if ( nbytes % 8 )
+                for ( i = nbytes % 8; i < 8; i++ )
+                    fwrite(&pad1, 1, 1, (FILE *)mat->fp);
             break;
         }
-        case MAT_T_UTF8:
-        {
-            mat_uint8_t *ptr;
-
-            nBytes = N;
-            fwrite(&data_type,4,1,(FILE*)mat->fp);
-            fwrite(&nBytes,4,1,(FILE*)mat->fp);
-            ptr = (mat_uint8_t*)data;
-            if ( NULL != ptr && nBytes > 0 )
-                fwrite(ptr,1,nBytes,(FILE*)mat->fp);
-            if ( nBytes % 8 )
-                for ( i = nBytes % 8; i < 8; i++ )
-                    fwrite(&pad1,1,1,(FILE*)mat->fp);
-            break;
-        }
-        case MAT_T_UNKNOWN:
-        {
+        case MAT_T_UNKNOWN: {
             /* Sometimes empty char data will have MAT_T_UNKNOWN, so just write
              * a data tag
              */
-            nBytes = N*2;
             data_type = MAT_T_UINT16;
-            fwrite(&data_type,4,1,(FILE*)mat->fp);
-            fwrite(&nBytes,4,1,(FILE*)mat->fp);
+            err = Mul(&nbytes, N, Mat_SizeOf(data_type));
+            if ( err ) {
+                return 0;
+            }
+            nBytes = (mat_uint32_t)nbytes;
+            fwrite(&data_type, 4, 1, (FILE *)mat->fp);
+            fwrite(&nBytes, 4, 1, (FILE *)mat->fp);
             break;
         }
         default:
+            nbytes = 0;
             break;
     }
-    byteswritten += nBytes;
+    byteswritten += nbytes;
     return byteswritten;
 }
 
@@ -7092,69 +7174,79 @@ WriteCharData(mat_t *mat, void *data, int N,enum matio_types data_type)
  * @return number of bytes written
  */
 static size_t
-WriteCompressedCharData(mat_t *mat,z_streamp z,void *data,int N,
-    enum matio_types data_type)
+WriteCompressedCharData(mat_t *mat, z_streamp z, void *data, size_t N, enum matio_types data_type)
 {
-    int data_size, data_tag[2], byteswritten = 0;
+    size_t data_size, byteswritten = 0, nbytes;
+    mat_uint32_t data_tag[2];
     int buf_size = 1024;
-    mat_uint8_t   buf[1024], pad[8] = {0,};
+    int err;
+    mat_uint8_t buf[1024], pad[8] = {0, 0, 0, 0, 0, 0, 0, 0};
 
     if ( mat == NULL || mat->fp == NULL )
         return 0;
+
+    if ( data_type == MAT_T_UNKNOWN ) {
+        data_size = Mat_SizeOf(MAT_T_UINT16);
+    } else {
+        data_size = Mat_SizeOf(data_type);
+    }
+
+    err = Mul(&nbytes, N, data_size);
+    if ( err ) {
+        return byteswritten;
+    }
 
     switch ( data_type ) {
         case MAT_T_UINT8:
         case MAT_T_UINT16:
         case MAT_T_UTF8:
         case MAT_T_UTF16:
-            data_size = Mat_SizeOf(data_type);
             data_tag[0] = MAT_T_UINT8 == data_type ? MAT_T_UTF8 : data_type;
-            data_tag[1] = N*data_size;
-            z->next_in  = ZLIB_BYTE_PTR(data_tag);
+            data_tag[1] = (mat_uint32_t)nbytes;
+            z->next_in = ZLIB_BYTE_PTR(data_tag);
             z->avail_in = 8;
             do {
-                z->next_out  = buf;
+                z->next_out = buf;
                 z->avail_out = buf_size;
-                deflate(z,Z_NO_FLUSH);
-                byteswritten += fwrite(buf,1,buf_size-z->avail_out,(FILE*)mat->fp);
+                deflate(z, Z_NO_FLUSH);
+                byteswritten += fwrite(buf, 1, buf_size - z->avail_out, (FILE *)mat->fp);
             } while ( z->avail_out == 0 );
 
             /* exit early if this is an empty data */
             if ( NULL == data || N < 1 )
                 break;
 
-            z->next_in  = (Bytef*)data;
-            z->avail_in = data_size*N;
+            z->next_in = (Bytef *)data;
+            z->avail_in = (mat_uint32_t)nbytes;
             do {
-                z->next_out  = buf;
+                z->next_out = buf;
                 z->avail_out = buf_size;
-                deflate(z,Z_NO_FLUSH);
-                byteswritten += fwrite(buf,1,buf_size-z->avail_out,(FILE*)mat->fp);
+                deflate(z, Z_NO_FLUSH);
+                byteswritten += fwrite(buf, 1, buf_size - z->avail_out, (FILE *)mat->fp);
             } while ( z->avail_out == 0 );
             /* Add/Compress padding to pad to 8-byte boundary */
-            if ( N*data_size % 8 ) {
-                z->next_in  = pad;
-                z->avail_in = 8 - (N*data_size % 8);
+            if ( nbytes % 8 ) {
+                z->next_in = pad;
+                z->avail_in = 8 - (nbytes % 8);
                 do {
-                    z->next_out  = buf;
+                    z->next_out = buf;
                     z->avail_out = buf_size;
-                    deflate(z,Z_NO_FLUSH);
-                    byteswritten += fwrite(buf,1,buf_size-z->avail_out,(FILE*)mat->fp);
+                    deflate(z, Z_NO_FLUSH);
+                    byteswritten += fwrite(buf, 1, buf_size - z->avail_out, (FILE *)mat->fp);
                 } while ( z->avail_out == 0 );
             }
             break;
         case MAT_T_UNKNOWN:
             /* Sometimes empty char data will have MAT_T_UNKNOWN, so just write a data tag */
-            data_size = 2;
             data_tag[0] = MAT_T_UINT16;
-            data_tag[1] = N*data_size;
-            z->next_in  = ZLIB_BYTE_PTR(data_tag);
+            data_tag[1] = (mat_uint32_t)nbytes;
+            z->next_in = ZLIB_BYTE_PTR(data_tag);
             z->avail_in = 8;
             do {
-                z->next_out  = buf;
+                z->next_out = buf;
                 z->avail_out = buf_size;
-                deflate(z,Z_NO_FLUSH);
-                byteswritten += fwrite(buf,1,buf_size-z->avail_out,(FILE*)mat->fp);
+                deflate(z, Z_NO_FLUSH);
+                byteswritten += fwrite(buf, 1, buf_size - z->avail_out, (FILE *)mat->fp);
             } while ( z->avail_out == 0 );
             break;
         default:
@@ -7174,7 +7266,7 @@ WriteCompressedCharData(mat_t *mat,z_streamp z,void *data,int N,
  * @return number of bytes written
  */
 static int
-WriteData(mat_t *mat,void *data,size_t N,enum matio_types data_type)
+WriteData(mat_t *mat, void *data, size_t N, enum matio_types data_type)
 {
     int nBytes = 0, data_size;
 
@@ -7182,12 +7274,12 @@ WriteData(mat_t *mat,void *data,size_t N,enum matio_types data_type)
         return 0;
 
     data_size = Mat_SizeOf(data_type);
-    nBytes    = N*data_size;
-    fwrite(&data_type,4,1,(FILE*)mat->fp);
-    fwrite(&nBytes,4,1,(FILE*)mat->fp);
+    nBytes = N * data_size;
+    fwrite(&data_type, 4, 1, (FILE *)mat->fp);
+    fwrite(&nBytes, 4, 1, (FILE *)mat->fp);
 
     if ( data != NULL && N > 0 )
-        fwrite(data,data_size,N,(FILE*)mat->fp);
+        fwrite(data, data_size, N, (FILE *)mat->fp);
 
     return nBytes;
 }
@@ -7195,49 +7287,48 @@ WriteData(mat_t *mat,void *data,size_t N,enum matio_types data_type)
 #if HAVE_ZLIB
 /* Compresses the data buffer and writes it to the file */
 static size_t
-WriteCompressedData(mat_t *mat,z_streamp z,void *data,int N,
-    enum matio_types data_type)
+WriteCompressedData(mat_t *mat, z_streamp z, void *data, int N, enum matio_types data_type)
 {
     int nBytes = 0, data_size, data_tag[2], byteswritten = 0;
     int buf_size = 1024;
-    mat_uint8_t buf[1024], pad[8] = {0,};
+    mat_uint8_t buf[1024], pad[8] = {0, 0, 0, 0, 0, 0, 0, 0};
 
     if ( mat == NULL || mat->fp == NULL )
         return 0;
 
-    data_size   = Mat_SizeOf(data_type);
+    data_size = Mat_SizeOf(data_type);
     data_tag[0] = data_type;
-    data_tag[1] = data_size*N;
-    z->next_in  = ZLIB_BYTE_PTR(data_tag);
+    data_tag[1] = data_size * N;
+    z->next_in = ZLIB_BYTE_PTR(data_tag);
     z->avail_in = 8;
     do {
-        z->next_out  = buf;
+        z->next_out = buf;
         z->avail_out = buf_size;
-        deflate(z,Z_NO_FLUSH);
-        byteswritten += fwrite(buf,1,buf_size-z->avail_out,(FILE*)mat->fp);
+        deflate(z, Z_NO_FLUSH);
+        byteswritten += fwrite(buf, 1, buf_size - z->avail_out, (FILE *)mat->fp);
     } while ( z->avail_out == 0 );
 
     /* exit early if this is an empty data */
     if ( NULL == data || N < 1 )
         return byteswritten;
 
-    z->next_in  = (Bytef*)data;
-    z->avail_in = N*data_size;
+    z->next_in = (Bytef *)data;
+    z->avail_in = N * data_size;
     do {
-        z->next_out  = buf;
+        z->next_out = buf;
         z->avail_out = buf_size;
-        deflate(z,Z_NO_FLUSH);
-        byteswritten += fwrite(buf,1,buf_size-z->avail_out,(FILE*)mat->fp);
+        deflate(z, Z_NO_FLUSH);
+        byteswritten += fwrite(buf, 1, buf_size - z->avail_out, (FILE *)mat->fp);
     } while ( z->avail_out == 0 );
     /* Add/Compress padding to pad to 8-byte boundary */
-    if ( N*data_size % 8 ) {
-        z->next_in  = pad;
-        z->avail_in = 8 - (N*data_size % 8);
+    if ( N * data_size % 8 ) {
+        z->next_in = pad;
+        z->avail_in = 8 - (N * data_size % 8);
         do {
-            z->next_out  = buf;
+            z->next_out = buf;
             z->avail_out = buf_size;
-            deflate(z,Z_NO_FLUSH);
-            byteswritten += fwrite(buf,1,buf_size-z->avail_out,(FILE*)mat->fp);
+            deflate(z, Z_NO_FLUSH);
+            byteswritten += fwrite(buf, 1, buf_size - z->avail_out, (FILE *)mat->fp);
         } while ( z->avail_out == 0 );
     }
     nBytes = byteswritten;
@@ -7253,7 +7344,7 @@ WriteCompressedData(mat_t *mat,z_streamp z,void *data,int N,
  * @return Number of bytes read
  */
 static size_t
-ReadNextCell( mat_t *mat, matvar_t *matvar )
+ReadNextCell(mat_t *mat, matvar_t *matvar)
 {
     size_t bytesread = 0, i;
     int err;
@@ -7282,14 +7373,15 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
 
     if ( matvar->compression == MAT_COMPRESSION_ZLIB ) {
 #if HAVE_ZLIB
-        mat_uint32_t uncomp_buf[16] = {0,};
+        mat_uint32_t uncomp_buf[16];
         mat_uint32_t nBytes;
         mat_uint32_t array_flags;
 
+        memset(&uncomp_buf, 0, sizeof(uncomp_buf));
         for ( i = 0; i < nelems; i++ ) {
             cells[i] = Mat_VarCalloc();
             if ( NULL == cells[i] ) {
-                Mat_Critical("Couldn't allocate memory for cell %" SIZE_T_FMTSTR, i);
+                Mat_Critical("Couldn't allocate memory for cell %zu", i);
                 continue;
             }
 
@@ -7304,7 +7396,7 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
             }
             if ( mat->byteswap ) {
                 (void)Mat_uint32Swap(uncomp_buf);
-                (void)Mat_uint32Swap(uncomp_buf+1);
+                (void)Mat_uint32Swap(uncomp_buf + 1);
             }
             nBytes = uncomp_buf[1];
             if ( 0 == nBytes ) {
@@ -7315,7 +7407,7 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
             } else if ( uncomp_buf[0] != MAT_T_MATRIX ) {
                 Mat_VarFree(cells[i]);
                 cells[i] = NULL;
-                Mat_Critical("cells[%" SIZE_T_FMTSTR "], Uncompressed type not MAT_T_MATRIX", i);
+                Mat_Critical("cells[%zu], Uncompressed type not MAT_T_MATRIX", i);
                 break;
             }
             cells[i]->compression = MAT_COMPRESSION_ZLIB;
@@ -7328,17 +7420,17 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
             nBytes -= 16;
             if ( mat->byteswap ) {
                 (void)Mat_uint32Swap(uncomp_buf);
-                (void)Mat_uint32Swap(uncomp_buf+1);
-                (void)Mat_uint32Swap(uncomp_buf+2);
-                (void)Mat_uint32Swap(uncomp_buf+3);
+                (void)Mat_uint32Swap(uncomp_buf + 1);
+                (void)Mat_uint32Swap(uncomp_buf + 2);
+                (void)Mat_uint32Swap(uncomp_buf + 3);
             }
             /* Array Flags */
             if ( uncomp_buf[0] == MAT_T_UINT32 ) {
                 array_flags = uncomp_buf[2];
                 cells[i]->class_type = CLASS_FROM_ARRAY_FLAGS(array_flags);
-                cells[i]->isComplex  = (array_flags & MAT_F_COMPLEX);
-                cells[i]->isGlobal   = (array_flags & MAT_F_GLOBAL);
-                cells[i]->isLogical  = (array_flags & MAT_F_LOGICAL);
+                cells[i]->isComplex = (array_flags & MAT_F_COMPLEX);
+                cells[i]->isGlobal = (array_flags & MAT_F_GLOBAL);
+                cells[i]->isLogical = (array_flags & MAT_F_LOGICAL);
                 if ( cells[i]->class_type == MAT_C_SPARSE ) {
                     /* Need to find a more appropriate place to store nzmax */
                     cells[i]->nbytes = uncomp_buf[3];
@@ -7348,9 +7440,10 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
                 InflateSkip(mat, matvar->internal->z, nBytes, &bytesread);
             }
             if ( cells[i]->class_type != MAT_C_OPAQUE ) {
-                mat_uint32_t* dims = NULL;
+                mat_uint32_t *dims = NULL;
                 int do_clean = 0;
-                err = InflateRankDims(mat, matvar->internal->z, uncomp_buf, sizeof(uncomp_buf), &dims, &bytesread);
+                err = InflateRankDims(mat, matvar->internal->z, uncomp_buf, sizeof(uncomp_buf),
+                                      &dims, &bytesread);
                 if ( NULL == dims ) {
                     dims = uncomp_buf + 2;
                 } else {
@@ -7367,7 +7460,7 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
                 nBytes -= 8;
                 if ( mat->byteswap ) {
                     (void)Mat_uint32Swap(uncomp_buf);
-                    (void)Mat_uint32Swap(uncomp_buf+1);
+                    (void)Mat_uint32Swap(uncomp_buf + 1);
                 }
                 /* Rank and Dimension */
                 if ( uncomp_buf[0] == MAT_T_INT32 ) {
@@ -7392,7 +7485,7 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
                         Mat_Critical("Integer multiplication overflow");
                         continue;
                     }
-                    cells[i]->dims = (size_t*)malloc(size);
+                    cells[i]->dims = (size_t *)malloc(size);
                     if ( mat->byteswap ) {
                         for ( j = 0; j < cells[i]->rank; j++ )
                             cells[i]->dims[j] = Mat_uint32Swap(dims + j);
@@ -7403,7 +7496,7 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
                     if ( cells[i]->rank % 2 != 0 )
                         nBytes -= 4;
                 }
-                if ( do_clean ){
+                if ( do_clean ) {
                     free(dims);
                 }
                 /* Variable name tag */
@@ -7416,28 +7509,29 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
                 nBytes -= 8;
                 if ( mat->byteswap ) {
                     (void)Mat_uint32Swap(uncomp_buf);
-                    (void)Mat_uint32Swap(uncomp_buf+1);
+                    (void)Mat_uint32Swap(uncomp_buf + 1);
                 }
                 /* Handle cell elements written with a variable name */
                 if ( uncomp_buf[1] > 0 ) {
                     /* Name of variable */
-                    if ( uncomp_buf[0] == MAT_T_INT8 ) {    /* Name not in tag */
+                    if ( uncomp_buf[0] == MAT_T_INT8 ) { /* Name not in tag */
                         mat_uint32_t len = uncomp_buf[1];
 
                         if ( len % 8 > 0 ) {
                             if ( len < UINT32_MAX - 8 + (len % 8) )
-                              len = len + 8 - (len % 8);
+                                len = len + 8 - (len % 8);
                             else {
                                 Mat_VarFree(cells[i]);
                                 cells[i] = NULL;
                                 break;
                             }
                         }
-                        cells[i]->name = (char*)malloc(len + 1);
+                        cells[i]->name = (char *)malloc(len + 1);
                         nBytes -= len;
                         if ( NULL != cells[i]->name ) {
                             /* Variable name */
-                            err = Inflate(mat, matvar->internal->z, cells[i]->name, len, &bytesread);
+                            err =
+                                Inflate(mat, matvar->internal->z, cells[i]->name, len, &bytesread);
                             if ( err ) {
                                 Mat_VarFree(cells[i]);
                                 cells[i] = NULL;
@@ -7449,19 +7543,19 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
                         mat_uint32_t len = (uncomp_buf[0] & 0xffff0000) >> 16;
                         if ( ((uncomp_buf[0] & 0x0000ffff) == MAT_T_INT8) && len > 0 && len <= 4 ) {
                             /* Name packed in tag */
-                            cells[i]->name = (char*)malloc(len+1);
+                            cells[i]->name = (char *)malloc(len + 1);
                             if ( NULL != cells[i]->name ) {
-                                memcpy(cells[i]->name,uncomp_buf+1,len);
+                                memcpy(cells[i]->name, uncomp_buf + 1, len);
                                 cells[i]->name[len] = '\0';
                             }
                         }
                     }
                 }
-                cells[i]->internal->z = (z_streamp)calloc(1,sizeof(z_stream));
+                cells[i]->internal->z = (z_streamp)calloc(1, sizeof(z_stream));
                 if ( cells[i]->internal->z != NULL ) {
-                    err = inflateCopy(cells[i]->internal->z,matvar->internal->z);
+                    err = inflateCopy(cells[i]->internal->z, matvar->internal->z);
                     if ( err == Z_OK ) {
-                        cells[i]->internal->datapos = ftell((FILE*)mat->fp);
+                        cells[i]->internal->datapos = ftell((FILE *)mat->fp);
                         if ( cells[i]->internal->datapos != -1L ) {
                             cells[i]->internal->datapos -= matvar->internal->z->avail_in;
                             if ( cells[i]->class_type == MAT_C_STRUCT )
@@ -7475,7 +7569,7 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
                                 cells[i]->internal->data = cells[i]->data;
                                 cells[i]->data = NULL;
                             }
-                            (void)fseek((FILE*)mat->fp,cells[i]->internal->datapos,SEEK_SET);
+                            (void)fseek((FILE *)mat->fp, cells[i]->internal->datapos, SEEK_SET);
                         } else {
                             Mat_Critical("Couldn't determine file position");
                         }
@@ -7488,7 +7582,7 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
                             cells[i]->internal->z = NULL;
                         }
                     } else {
-                        Mat_Critical("inflateCopy returned error %s",zError(err));
+                        Mat_Critical("inflateCopy returned error %s", zError(err));
                     }
                 } else {
                     Mat_Critical("Couldn't allocate memory");
@@ -7501,7 +7595,7 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
 #endif
 
     } else {
-        mat_uint32_t buf[6] = {0,};
+        mat_uint32_t buf[6] = {0, 0, 0, 0, 0, 0};
         mat_uint32_t nBytes;
         mat_uint32_t array_flags;
 
@@ -7510,12 +7604,12 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
             mat_uint32_t name_len;
             cells[i] = Mat_VarCalloc();
             if ( NULL == cells[i] ) {
-                Mat_Critical("Couldn't allocate memory for cell %" SIZE_T_FMTSTR, i);
+                Mat_Critical("Couldn't allocate memory for cell %zu", i);
                 continue;
             }
 
             /* Read variable tag for cell */
-            err = Read(buf, 4, 2, (FILE*)mat->fp, &nbytes);
+            err = Read(buf, 4, 2, (FILE *)mat->fp, &nbytes);
 
             /* Empty cells at the end of a file may cause an EOF */
             if ( 0 == err && 0 == nbytes )
@@ -7528,7 +7622,7 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
             }
             if ( mat->byteswap ) {
                 (void)Mat_uint32Swap(buf);
-                (void)Mat_uint32Swap(buf+1);
+                (void)Mat_uint32Swap(buf + 1);
             }
             nBytes = buf[1];
             if ( 0 == nBytes ) {
@@ -7539,13 +7633,12 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
             } else if ( buf[0] != MAT_T_MATRIX ) {
                 Mat_VarFree(cells[i]);
                 cells[i] = NULL;
-                Mat_Critical("cells[%" SIZE_T_FMTSTR "] not MAT_T_MATRIX, fpos = %ld", i,
-                    ftell((FILE*)mat->fp));
+                Mat_Critical("cells[%zu] not MAT_T_MATRIX, fpos = %ld", i, ftell((FILE *)mat->fp));
                 break;
             }
 
             /* Read array flags and the dimensions tag */
-            err = Read(buf, 4, 6, (FILE*)mat->fp, &bytesread);
+            err = Read(buf, 4, 6, (FILE *)mat->fp, &bytesread);
             if ( err ) {
                 Mat_VarFree(cells[i]);
                 cells[i] = NULL;
@@ -7553,24 +7646,24 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
             }
             if ( mat->byteswap ) {
                 (void)Mat_uint32Swap(buf);
-                (void)Mat_uint32Swap(buf+1);
-                (void)Mat_uint32Swap(buf+2);
-                (void)Mat_uint32Swap(buf+3);
-                (void)Mat_uint32Swap(buf+4);
-                (void)Mat_uint32Swap(buf+5);
+                (void)Mat_uint32Swap(buf + 1);
+                (void)Mat_uint32Swap(buf + 2);
+                (void)Mat_uint32Swap(buf + 3);
+                (void)Mat_uint32Swap(buf + 4);
+                (void)Mat_uint32Swap(buf + 5);
             }
-            nBytes-=24;
+            nBytes -= 24;
             /* Array flags */
             if ( buf[0] == MAT_T_UINT32 ) {
-               array_flags = buf[2];
-               cells[i]->class_type = CLASS_FROM_ARRAY_FLAGS(array_flags);
-               cells[i]->isComplex  = (array_flags & MAT_F_COMPLEX);
-               cells[i]->isGlobal   = (array_flags & MAT_F_GLOBAL);
-               cells[i]->isLogical  = (array_flags & MAT_F_LOGICAL);
-               if ( cells[i]->class_type == MAT_C_SPARSE ) {
-                   /* Need to find a more appropriate place to store nzmax */
-                   cells[i]->nbytes = buf[3];
-               }
+                array_flags = buf[2];
+                cells[i]->class_type = CLASS_FROM_ARRAY_FLAGS(array_flags);
+                cells[i]->isComplex = (array_flags & MAT_F_COMPLEX);
+                cells[i]->isGlobal = (array_flags & MAT_F_GLOBAL);
+                cells[i]->isLogical = (array_flags & MAT_F_LOGICAL);
+                if ( cells[i]->class_type == MAT_C_SPARSE ) {
+                    /* Need to find a more appropriate place to store nzmax */
+                    cells[i]->nbytes = buf[3];
+                }
             }
             /* Rank and dimension */
             nbytes = 0;
@@ -7583,7 +7676,7 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
                 break;
             }
             /* Variable name tag */
-            if ( 0 != Read(buf, 1, 8, (FILE*)mat->fp, &bytesread) ) {
+            if ( 0 != Read(buf, 1, 8, (FILE *)mat->fp, &bytesread) ) {
                 Mat_VarFree(cells[i]);
                 cells[i] = NULL;
                 break;
@@ -7591,12 +7684,12 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
             nBytes -= 8;
             if ( mat->byteswap ) {
                 (void)Mat_uint32Swap(buf);
-                (void)Mat_uint32Swap(buf+1);
+                (void)Mat_uint32Swap(buf + 1);
             }
             name_len = 0;
             if ( buf[1] > 0 ) {
                 /* Name of variable */
-                if ( buf[0] == MAT_T_INT8 ) {    /* Name not in tag */
+                if ( buf[0] == MAT_T_INT8 ) { /* Name not in tag */
                     name_len = buf[1];
                     if ( name_len % 8 > 0 ) {
                         if ( name_len < UINT32_MAX - 8 + (name_len % 8) ) {
@@ -7608,16 +7701,16 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
                         }
                     }
                     nBytes -= name_len;
-                    (void)fseek((FILE*)mat->fp,name_len,SEEK_CUR);
+                    (void)fseek((FILE *)mat->fp, name_len, SEEK_CUR);
                 }
             }
-            cells[i]->internal->datapos = ftell((FILE*)mat->fp);
+            cells[i]->internal->datapos = ftell((FILE *)mat->fp);
             if ( cells[i]->internal->datapos != -1L ) {
                 if ( cells[i]->class_type == MAT_C_STRUCT )
-                    bytesread+=ReadNextStructField(mat,cells[i]);
+                    bytesread += ReadNextStructField(mat, cells[i]);
                 if ( cells[i]->class_type == MAT_C_CELL )
-                    bytesread+=ReadNextCell(mat,cells[i]);
-                (void)fseek((FILE*)mat->fp,cells[i]->internal->datapos+nBytes,SEEK_SET);
+                    bytesread += ReadNextCell(mat, cells[i]);
+                (void)fseek((FILE *)mat->fp, cells[i]->internal->datapos + nBytes, SEEK_SET);
             } else {
                 Mat_Critical("Couldn't determine file position");
             }
@@ -7637,7 +7730,7 @@ ReadNextCell( mat_t *mat, matvar_t *matvar )
  * @return Number of bytes read
  */
 static size_t
-ReadNextStructField( mat_t *mat, matvar_t *matvar )
+ReadNextStructField(mat_t *mat, matvar_t *matvar)
 {
     mat_uint32_t fieldname_size;
     int err;
@@ -7652,9 +7745,10 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
     }
     if ( matvar->compression == MAT_COMPRESSION_ZLIB ) {
 #if HAVE_ZLIB
-        mat_uint32_t uncomp_buf[16] = {0,};
+        mat_uint32_t uncomp_buf[16];
         mat_uint32_t array_flags, len;
 
+        memset(&uncomp_buf, 0, sizeof(uncomp_buf));
         /* Field name length */
         err = Inflate(mat, matvar->internal->z, uncomp_buf, 8, &bytesread);
         if ( err ) {
@@ -7662,7 +7756,7 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
         }
         if ( mat->byteswap ) {
             (void)Mat_uint32Swap(uncomp_buf);
-            (void)Mat_uint32Swap(uncomp_buf+1);
+            (void)Mat_uint32Swap(uncomp_buf + 1);
         }
         if ( (uncomp_buf[0] & 0x0000ffff) == MAT_T_INT32 && uncomp_buf[1] > 0 ) {
             fieldname_size = uncomp_buf[1];
@@ -7679,23 +7773,25 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
         if ( mat->byteswap )
             (void)Mat_uint32Swap(uncomp_buf);
         /* Name of field */
-        if ( uncomp_buf[0] == MAT_T_INT8 ) {    /* Name not in tag */
+        if ( uncomp_buf[0] == MAT_T_INT8 ) { /* Name not in tag */
             if ( mat->byteswap )
-                len = Mat_uint32Swap(uncomp_buf+1);
+                len = Mat_uint32Swap(uncomp_buf + 1);
             else
                 len = uncomp_buf[1];
             nfields = len / fieldname_size;
-            if ( nfields*fieldname_size % 8 != 0 )
-                i = 8-(nfields*fieldname_size % 8);
+            if ( nfields * fieldname_size % 8 != 0 )
+                i = 8 - (nfields * fieldname_size % 8);
             else
                 i = 0;
             if ( nfields ) {
-                char *ptr = (char*)malloc(nfields*fieldname_size+i);
+                char *ptr = (char *)malloc(nfields * fieldname_size + i);
                 if ( NULL != ptr ) {
-                    err = Inflate(mat, matvar->internal->z, ptr, (unsigned int)(nfields*fieldname_size+i), &bytesread);
+                    err = Inflate(mat, matvar->internal->z, ptr,
+                                  (unsigned int)(nfields * fieldname_size + i), &bytesread);
                     if ( 0 == err ) {
                         SetFieldNames(matvar, ptr, nfields, fieldname_size);
                     } else {
+                        matvar->internal->num_fields = nfields;
                         matvar->internal->fieldnames = NULL;
                     }
                     free(ptr);
@@ -7710,7 +7806,7 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
                 /* Name packed in tag */
                 nfields = len / fieldname_size;
                 if ( nfields ) {
-                    SetFieldNames(matvar, (char*)(uncomp_buf + 1), nfields, fieldname_size);
+                    SetFieldNames(matvar, (char *)(uncomp_buf + 1), nfields, fieldname_size);
                 } else {
                     matvar->internal->num_fields = 0;
                     matvar->internal->fieldnames = NULL;
@@ -7740,11 +7836,11 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
             return bytesread;
         }
 
-        fields = (matvar_t**)matvar->data;
+        fields = (matvar_t **)matvar->data;
         for ( i = 0; i < nelems; i++ ) {
             size_t k;
             for ( k = 0; k < nfields; k++ ) {
-                fields[i*nfields+k] = Mat_VarCalloc();
+                fields[i * nfields + k] = Mat_VarCalloc();
             }
         }
         if ( NULL != matvar->internal->fieldnames ) {
@@ -7752,7 +7848,7 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
                 size_t k;
                 for ( k = 0; k < nfields; k++ ) {
                     if ( NULL != matvar->internal->fieldnames[k] ) {
-                        fields[i*nfields+k]->name = Mat_strdup(matvar->internal->fieldnames[k]);
+                        fields[i * nfields + k]->name = Mat_strdup(matvar->internal->fieldnames[k]);
                     }
                 }
             }
@@ -7761,7 +7857,7 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
         for ( i = 0; i < nelems_x_nfields; i++ ) {
             mat_uint32_t nBytes;
             /* Read variable tag for struct field */
-            err = Inflate(mat, matvar->internal->z,uncomp_buf, 8, &bytesread);
+            err = Inflate(mat, matvar->internal->z, uncomp_buf, 8, &bytesread);
             if ( err ) {
                 Mat_VarFree(fields[i]);
                 fields[i] = NULL;
@@ -7769,13 +7865,13 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
             }
             if ( mat->byteswap ) {
                 (void)Mat_uint32Swap(uncomp_buf);
-                (void)Mat_uint32Swap(uncomp_buf+1);
+                (void)Mat_uint32Swap(uncomp_buf + 1);
             }
             nBytes = uncomp_buf[1];
             if ( uncomp_buf[0] != MAT_T_MATRIX ) {
                 Mat_VarFree(fields[i]);
                 fields[i] = NULL;
-                Mat_Critical("fields[%" SIZE_T_FMTSTR "], Uncompressed type not MAT_T_MATRIX", i);
+                Mat_Critical("fields[%zu], Uncompressed type not MAT_T_MATRIX", i);
                 break;
             } else if ( 0 == nBytes ) {
                 /* Empty field: Memory optimization */
@@ -7792,30 +7888,31 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
             }
             if ( mat->byteswap ) {
                 (void)Mat_uint32Swap(uncomp_buf);
-                (void)Mat_uint32Swap(uncomp_buf+1);
-                (void)Mat_uint32Swap(uncomp_buf+2);
-                (void)Mat_uint32Swap(uncomp_buf+3);
+                (void)Mat_uint32Swap(uncomp_buf + 1);
+                (void)Mat_uint32Swap(uncomp_buf + 2);
+                (void)Mat_uint32Swap(uncomp_buf + 3);
             }
             nBytes -= 16;
             /* Array flags */
             if ( uncomp_buf[0] == MAT_T_UINT32 ) {
-               array_flags = uncomp_buf[2];
-               fields[i]->class_type = CLASS_FROM_ARRAY_FLAGS(array_flags);
-               fields[i]->isComplex  = (array_flags & MAT_F_COMPLEX);
-               fields[i]->isGlobal   = (array_flags & MAT_F_GLOBAL);
-               fields[i]->isLogical  = (array_flags & MAT_F_LOGICAL);
-               if ( fields[i]->class_type == MAT_C_SPARSE ) {
-                   /* Need to find a more appropriate place to store nzmax */
-                   fields[i]->nbytes = uncomp_buf[3];
-               }
+                array_flags = uncomp_buf[2];
+                fields[i]->class_type = CLASS_FROM_ARRAY_FLAGS(array_flags);
+                fields[i]->isComplex = (array_flags & MAT_F_COMPLEX);
+                fields[i]->isGlobal = (array_flags & MAT_F_GLOBAL);
+                fields[i]->isLogical = (array_flags & MAT_F_LOGICAL);
+                if ( fields[i]->class_type == MAT_C_SPARSE ) {
+                    /* Need to find a more appropriate place to store nzmax */
+                    fields[i]->nbytes = uncomp_buf[3];
+                }
             } else {
                 Mat_Critical("Expected MAT_T_UINT32 for array tags, got %d", uncomp_buf[0]);
                 InflateSkip(mat, matvar->internal->z, nBytes, &bytesread);
             }
             if ( fields[i]->class_type != MAT_C_OPAQUE ) {
-                mat_uint32_t* dims = NULL;
+                mat_uint32_t *dims = NULL;
                 int do_clean = 0;
-                err = InflateRankDims(mat, matvar->internal->z, uncomp_buf, sizeof(uncomp_buf), &dims, &bytesread);
+                err = InflateRankDims(mat, matvar->internal->z, uncomp_buf, sizeof(uncomp_buf),
+                                      &dims, &bytesread);
                 if ( NULL == dims ) {
                     dims = uncomp_buf + 2;
                 } else {
@@ -7832,7 +7929,7 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
                 nBytes -= 8;
                 if ( mat->byteswap ) {
                     (void)Mat_uint32Swap(uncomp_buf);
-                    (void)Mat_uint32Swap(uncomp_buf+1);
+                    (void)Mat_uint32Swap(uncomp_buf + 1);
                 }
                 /* Rank and dimension */
                 if ( uncomp_buf[0] == MAT_T_INT32 ) {
@@ -7857,10 +7954,10 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
                         Mat_Critical("Integer multiplication overflow");
                         continue;
                     }
-                    fields[i]->dims = (size_t*)malloc(size);
+                    fields[i]->dims = (size_t *)malloc(size);
                     if ( mat->byteswap ) {
                         for ( j = 0; j < fields[i]->rank; j++ )
-                            fields[i]->dims[j] = Mat_uint32Swap(dims+j);
+                            fields[i]->dims[j] = Mat_uint32Swap(dims + j);
                     } else {
                         for ( j = 0; j < fields[i]->rank; j++ )
                             fields[i]->dims[j] = dims[j];
@@ -7881,9 +7978,9 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
                 nBytes -= 8;
                 fields[i]->internal->z = (z_streamp)calloc(1, sizeof(z_stream));
                 if ( fields[i]->internal->z != NULL ) {
-                    err = inflateCopy(fields[i]->internal->z,matvar->internal->z);
+                    err = inflateCopy(fields[i]->internal->z, matvar->internal->z);
                     if ( err == Z_OK ) {
-                        fields[i]->internal->datapos = ftell((FILE*)mat->fp);
+                        fields[i]->internal->datapos = ftell((FILE *)mat->fp);
                         if ( fields[i]->internal->datapos != -1L ) {
                             fields[i]->internal->datapos -= matvar->internal->z->avail_in;
                             if ( fields[i]->class_type == MAT_C_STRUCT )
@@ -7893,11 +7990,11 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
                             else if ( nBytes <= (1 << MAX_WBITS) ) {
                                 /* Memory optimization: Read data if less in size
                                    than the zlib inflate state (approximately) */
-                                err = Mat_VarRead5(mat,fields[i]);
+                                err = Mat_VarRead5(mat, fields[i]);
                                 fields[i]->internal->data = fields[i]->data;
                                 fields[i]->data = NULL;
                             }
-                            (void)fseek((FILE*)mat->fp,fields[i]->internal->datapos,SEEK_SET);
+                            (void)fseek((FILE *)mat->fp, fields[i]->internal->datapos, SEEK_SET);
                         } else {
                             Mat_Critical("Couldn't determine file position");
                         }
@@ -7910,7 +8007,7 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
                             fields[i]->internal->z = NULL;
                         }
                     } else {
-                        Mat_Critical("inflateCopy returned error %s",zError(err));
+                        Mat_Critical("inflateCopy returned error %s", zError(err));
                     }
                 } else {
                     Mat_Critical("Couldn't allocate memory");
@@ -7922,16 +8019,16 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
         Mat_Critical("Not compiled with zlib support");
 #endif
     } else {
-        mat_uint32_t buf[6] = {0,};
+        mat_uint32_t buf[6] = {0, 0, 0, 0, 0, 0};
         mat_uint32_t array_flags, len;
 
-        err = Read(buf, 4, 2, (FILE*)mat->fp, &bytesread);
+        err = Read(buf, 4, 2, (FILE *)mat->fp, &bytesread);
         if ( err ) {
             return bytesread;
         }
         if ( mat->byteswap ) {
             (void)Mat_uint32Swap(buf);
-            (void)Mat_uint32Swap(buf+1);
+            (void)Mat_uint32Swap(buf + 1);
         }
         if ( (buf[0] & 0x0000ffff) == MAT_T_INT32 && buf[1] > 0 ) {
             fieldname_size = buf[1];
@@ -7941,45 +8038,46 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
         }
 
         /* Field name tag */
-        err = Read(buf, 4, 2, (FILE*)mat->fp, &bytesread);
+        err = Read(buf, 4, 2, (FILE *)mat->fp, &bytesread);
         if ( err ) {
             return bytesread;
         }
         if ( mat->byteswap )
             (void)Mat_uint32Swap(buf);
         /* Name of field */
-        if ( buf[0] == MAT_T_INT8 ) {    /* Name not in tag */
+        if ( buf[0] == MAT_T_INT8 ) { /* Name not in tag */
             if ( mat->byteswap )
-                len = Mat_uint32Swap(buf+1);
+                len = Mat_uint32Swap(buf + 1);
             else
                 len = buf[1];
             nfields = len / fieldname_size;
             if ( nfields ) {
-                char *ptr = (char*)malloc(nfields*fieldname_size);
+                char *ptr = (char *)malloc(nfields * fieldname_size);
                 if ( NULL != ptr ) {
-                    err = Read(ptr, 1, nfields*fieldname_size, (FILE*)mat->fp, &bytesread);
+                    err = Read(ptr, 1, nfields * fieldname_size, (FILE *)mat->fp, &bytesread);
                     if ( 0 == err ) {
                         SetFieldNames(matvar, ptr, nfields, fieldname_size);
                     } else {
+                        matvar->internal->num_fields = nfields;
                         matvar->internal->fieldnames = NULL;
                     }
                     free(ptr);
                 }
-                if ( (nfields*fieldname_size) % 8 ) {
-                    (void)fseek((FILE*)mat->fp,8-((nfields*fieldname_size) % 8),SEEK_CUR);
-                    bytesread+=8-((nfields*fieldname_size) % 8);
+                if ( (nfields * fieldname_size) % 8 ) {
+                    (void)fseek((FILE *)mat->fp, 8 - ((nfields * fieldname_size) % 8), SEEK_CUR);
+                    bytesread += 8 - ((nfields * fieldname_size) % 8);
                 }
             } else {
                 matvar->internal->num_fields = 0;
                 matvar->internal->fieldnames = NULL;
             }
-       } else {
+        } else {
             len = (buf[0] & 0xffff0000) >> 16;
             if ( ((buf[0] & 0x0000ffff) == MAT_T_INT8) && len > 0 && len <= 4 ) {
                 /* Name packed in tag */
                 nfields = len / fieldname_size;
                 if ( nfields ) {
-                    SetFieldNames(matvar, (char*)(buf + 1), nfields, fieldname_size);
+                    SetFieldNames(matvar, (char *)(buf + 1), nfields, fieldname_size);
                 } else {
                     matvar->internal->num_fields = 0;
                     matvar->internal->fieldnames = NULL;
@@ -8004,21 +8102,23 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
             return bytesread;
 
         matvar->data = calloc(nelems_x_nfields, matvar->data_size);
-        if ( NULL == matvar->data )
+        if ( NULL == matvar->data ) {
+            Mat_Critical("Couldn't allocate memory for the data");
             return bytesread;
+        }
 
-        fields = (matvar_t**)matvar->data;
+        fields = (matvar_t **)matvar->data;
         for ( i = 0; i < nelems_x_nfields; i++ ) {
             mat_uint32_t nBytes;
 
             fields[i] = Mat_VarCalloc();
             if ( NULL == fields[i] ) {
-                Mat_Critical("Couldn't allocate memory for field %" SIZE_T_FMTSTR, i);
+                Mat_Critical("Couldn't allocate memory for field %zu", i);
                 continue;
             }
 
             /* Read variable tag for struct field */
-            err = Read(buf, 4, 2, (FILE*)mat->fp, &bytesread);
+            err = Read(buf, 4, 2, (FILE *)mat->fp, &bytesread);
             if ( err ) {
                 Mat_VarFree(fields[i]);
                 fields[i] = NULL;
@@ -8026,14 +8126,13 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
             }
             if ( mat->byteswap ) {
                 (void)Mat_uint32Swap(buf);
-                (void)Mat_uint32Swap(buf+1);
+                (void)Mat_uint32Swap(buf + 1);
             }
             nBytes = buf[1];
             if ( buf[0] != MAT_T_MATRIX ) {
                 Mat_VarFree(fields[i]);
                 fields[i] = NULL;
-                Mat_Critical("fields[%" SIZE_T_FMTSTR "] not MAT_T_MATRIX, fpos = %ld", i,
-                    ftell((FILE*)mat->fp));
+                Mat_Critical("fields[%zu] not MAT_T_MATRIX, fpos = %ld", i, ftell((FILE *)mat->fp));
                 break;
             } else if ( 0 == nBytes ) {
                 /* Empty field: Memory optimization */
@@ -8043,7 +8142,7 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
             }
 
             /* Read array flags and the dimensions tag */
-            err = Read(buf, 4, 6, (FILE*)mat->fp, &bytesread);
+            err = Read(buf, 4, 6, (FILE *)mat->fp, &bytesread);
             if ( err ) {
                 Mat_VarFree(fields[i]);
                 fields[i] = NULL;
@@ -8051,20 +8150,20 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
             }
             if ( mat->byteswap ) {
                 (void)Mat_uint32Swap(buf);
-                (void)Mat_uint32Swap(buf+1);
-                (void)Mat_uint32Swap(buf+2);
-                (void)Mat_uint32Swap(buf+3);
-                (void)Mat_uint32Swap(buf+4);
-                (void)Mat_uint32Swap(buf+5);
+                (void)Mat_uint32Swap(buf + 1);
+                (void)Mat_uint32Swap(buf + 2);
+                (void)Mat_uint32Swap(buf + 3);
+                (void)Mat_uint32Swap(buf + 4);
+                (void)Mat_uint32Swap(buf + 5);
             }
-            nBytes-=24;
+            nBytes -= 24;
             /* Array flags */
             if ( buf[0] == MAT_T_UINT32 ) {
                 array_flags = buf[2];
                 fields[i]->class_type = CLASS_FROM_ARRAY_FLAGS(array_flags);
-                fields[i]->isComplex  = (array_flags & MAT_F_COMPLEX);
-                fields[i]->isGlobal   = (array_flags & MAT_F_GLOBAL);
-                fields[i]->isLogical  = (array_flags & MAT_F_LOGICAL);
+                fields[i]->isComplex = (array_flags & MAT_F_COMPLEX);
+                fields[i]->isGlobal = (array_flags & MAT_F_GLOBAL);
+                fields[i]->isLogical = (array_flags & MAT_F_LOGICAL);
                 if ( fields[i]->class_type == MAT_C_SPARSE ) {
                     /* Need to find a more appropriate place to store nzmax */
                     fields[i]->nbytes = buf[3];
@@ -8083,20 +8182,20 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
                 }
             }
             /* Variable name tag */
-            err = Read(buf, 1, 8, (FILE*)mat->fp, &bytesread);
+            err = Read(buf, 1, 8, (FILE *)mat->fp, &bytesread);
             if ( err ) {
                 Mat_VarFree(fields[i]);
                 fields[i] = NULL;
                 break;
             }
-            nBytes-=8;
-            fields[i]->internal->datapos = ftell((FILE*)mat->fp);
+            nBytes -= 8;
+            fields[i]->internal->datapos = ftell((FILE *)mat->fp);
             if ( fields[i]->internal->datapos != -1L ) {
                 if ( fields[i]->class_type == MAT_C_STRUCT )
-                    bytesread+=ReadNextStructField(mat,fields[i]);
+                    bytesread += ReadNextStructField(mat, fields[i]);
                 else if ( fields[i]->class_type == MAT_C_CELL )
-                    bytesread+=ReadNextCell(mat,fields[i]);
-                (void)fseek((FILE*)mat->fp,fields[i]->internal->datapos+nBytes,SEEK_SET);
+                    bytesread += ReadNextCell(mat, fields[i]);
+                (void)fseek((FILE *)mat->fp, fields[i]->internal->datapos + nBytes, SEEK_SET);
             } else {
                 Mat_Critical("Couldn't determine file position");
             }
@@ -8106,8 +8205,9 @@ ReadNextStructField( mat_t *mat, matvar_t *matvar )
             for ( i = 0; i < nelems; i++ ) {
                 size_t k;
                 for ( k = 0; k < nfields; k++ ) {
-                    if ( NULL != matvar->internal->fieldnames[k] && NULL != fields[i*nfields+k] ) {
-                        fields[i*nfields+k]->name = Mat_strdup(matvar->internal->fieldnames[k]);
+                    if ( NULL != matvar->internal->fieldnames[k] &&
+                         NULL != fields[i * nfields + k] ) {
+                        fields[i * nfields + k]->name = Mat_strdup(matvar->internal->fieldnames[k]);
                     }
                 }
             }
@@ -8139,7 +8239,7 @@ ReadNextFunctionHandle(mat_t *mat, matvar_t *matvar)
     matvar->data = malloc(matvar->nbytes);
     if ( matvar->data != NULL ) {
         size_t i;
-        matvar_t **functions = (matvar_t**)matvar->data;
+        matvar_t **functions = (matvar_t **)matvar->data;
         for ( i = 0; i < nelems; i++ ) {
             functions[i] = Mat_VarReadNextInfo(mat);
             err = NULL == functions[i];
@@ -8150,11 +8250,11 @@ ReadNextFunctionHandle(mat_t *mat, matvar_t *matvar)
             free(matvar->data);
             matvar->data = NULL;
             matvar->data_size = 0;
-            matvar->nbytes    = 0;
+            matvar->nbytes = 0;
         }
     } else {
         matvar->data_size = 0;
-        matvar->nbytes    = 0;
+        matvar->nbytes = 0;
     }
 
     return 0;
@@ -8171,19 +8271,20 @@ ReadNextFunctionHandle(mat_t *mat, matvar_t *matvar)
  * @retval 0 on success
  */
 static int
-ReadRankDims(mat_t *mat, matvar_t *matvar, enum matio_types data_type, mat_uint32_t nbytes, size_t* read_bytes)
+ReadRankDims(mat_t *mat, matvar_t *matvar, enum matio_types data_type, mat_uint32_t nbytes,
+             size_t *read_bytes)
 {
     int err = MATIO_E_NO_ERROR;
     /* Rank and dimension */
     if ( data_type == MAT_T_INT32 ) {
         matvar->rank = nbytes / sizeof(mat_uint32_t);
-        matvar->dims = (size_t*)malloc(matvar->rank*sizeof(*matvar->dims));
+        matvar->dims = (size_t *)malloc(matvar->rank * sizeof(*matvar->dims));
         if ( NULL != matvar->dims ) {
             int i;
             mat_uint32_t buf;
 
-            for ( i = 0; i < matvar->rank; i++) {
-                err = Read(&buf, sizeof(mat_uint32_t), 1, (FILE*)mat->fp, read_bytes);
+            for ( i = 0; i < matvar->rank; i++ ) {
+                err = Read(&buf, sizeof(mat_uint32_t), 1, (FILE *)mat->fp, read_bytes);
                 if ( MATIO_E_NO_ERROR == err ) {
                     if ( mat->byteswap ) {
                         matvar->dims[i] = Mat_uint32Swap(&buf);
@@ -8199,7 +8300,7 @@ ReadRankDims(mat_t *mat, matvar_t *matvar, enum matio_types data_type, mat_uint3
             }
 
             if ( matvar->rank % 2 != 0 ) {
-                err = Read(&buf, sizeof(mat_uint32_t), 1, (FILE*)mat->fp, read_bytes);
+                err = Read(&buf, sizeof(mat_uint32_t), 1, (FILE *)mat->fp, read_bytes);
                 if ( err ) {
                     free(matvar->dims);
                     matvar->dims = NULL;
@@ -8224,7 +8325,7 @@ ReadRankDims(mat_t *mat, matvar_t *matvar, enum matio_types data_type, mat_uint3
  * @retval 0 on success
  */
 static int
-WriteType(mat_t *mat,matvar_t *matvar)
+WriteType(mat_t *mat, matvar_t *matvar)
 {
     int err;
     const mat_uint8_t pad1 = 0;
@@ -8245,49 +8346,48 @@ WriteType(mat_t *mat,matvar_t *matvar)
         case MAT_C_INT16:
         case MAT_C_UINT16:
         case MAT_C_INT8:
-        case MAT_C_UINT8:
-        {
+        case MAT_C_UINT8: {
             if ( matvar->isComplex ) {
-                mat_complex_split_t *complex_data = (mat_complex_split_t*)matvar->data;
+                mat_complex_split_t *complex_data = (mat_complex_split_t *)matvar->data;
 
                 if ( NULL == matvar->data )
                     complex_data = &null_complex_data;
 
-                nBytes=WriteData(mat,complex_data->Re,nelems,matvar->data_type);
+                nBytes = WriteData(mat, complex_data->Re, nelems, matvar->data_type);
                 if ( nBytes % 8 )
                     for ( j = nBytes % 8; j < 8; j++ )
-                        fwrite(&pad1,1,1,(FILE*)mat->fp);
-                nBytes=WriteData(mat,complex_data->Im,nelems,matvar->data_type);
+                        fwrite(&pad1, 1, 1, (FILE *)mat->fp);
+                nBytes = WriteData(mat, complex_data->Im, nelems, matvar->data_type);
                 if ( nBytes % 8 )
                     for ( j = nBytes % 8; j < 8; j++ )
-                        fwrite(&pad1,1,1,(FILE*)mat->fp);
+                        fwrite(&pad1, 1, 1, (FILE *)mat->fp);
             } else {
-                nBytes=WriteData(mat,matvar->data,nelems,matvar->data_type);
+                nBytes = WriteData(mat, matvar->data, nelems, matvar->data_type);
                 if ( nBytes % 8 )
                     for ( j = nBytes % 8; j < 8; j++ )
-                        fwrite(&pad1,1,1,(FILE*)mat->fp);
+                        fwrite(&pad1, 1, 1, (FILE *)mat->fp);
             }
             break;
         }
         case MAT_C_CHAR:
-            nBytes=WriteCharData(mat,matvar->data,nelems,matvar->data_type);
+            if ( matvar->data_type == MAT_T_UTF8 ) {
+                nelems = matvar->nbytes;
+            }
+            nBytes = WriteCharData(mat, matvar->data, nelems, matvar->data_type);
             break;
-        case MAT_C_CELL:
-        {
+        case MAT_C_CELL: {
             size_t i;
             matvar_t **cells = (matvar_t **)matvar->data;
 
             /* Check for an empty cell array */
-            if ( matvar->nbytes == 0 || matvar->data_size == 0 ||
-                 matvar->data   == NULL )
+            if ( matvar->nbytes == 0 || matvar->data_size == 0 || matvar->data == NULL )
                 break;
             nelems = matvar->nbytes / matvar->data_size;
             for ( i = 0; i < nelems; i++ )
-                WriteCellArrayField(mat,cells[i]);
+                WriteCellArrayField(mat, cells[i]);
             break;
         }
-        case MAT_C_STRUCT:
-        {
+        case MAT_C_STRUCT: {
             const mat_uint32_t array_name_type = MAT_T_INT8;
             const mat_uint32_t fieldname_type = MAT_T_INT32;
             const mat_uint32_t fieldname_data_size = 4;
@@ -8306,12 +8406,12 @@ WriteType(mat_t *mat,matvar_t *matvar)
             /* Check for a structure with no fields */
             if ( nfields < 1 ) {
                 fieldname = (fieldname_data_size << 16) | fieldname_type;
-                fwrite(&fieldname,4,1,(FILE*)mat->fp);
+                fwrite(&fieldname, 4, 1, (FILE *)mat->fp);
                 fieldname_size = 1;
-                fwrite(&fieldname_size,4,1,(FILE*)mat->fp);
-                fwrite(&array_name_type,4,1,(FILE*)mat->fp);
+                fwrite(&fieldname_size, 4, 1, (FILE *)mat->fp);
+                fwrite(&array_name_type, 4, 1, (FILE *)mat->fp);
                 nBytes = 0;
-                fwrite(&nBytes,4,1,(FILE*)mat->fp);
+                fwrite(&nBytes, 4, 1, (FILE *)mat->fp);
                 break;
             }
 
@@ -8322,58 +8422,54 @@ WriteType(mat_t *mat,matvar_t *matvar)
             }
             maxlen++;
             fieldname_size = maxlen;
-            while ( nfields*fieldname_size % 8 != 0 )
+            while ( nfields * fieldname_size % 8 != 0 )
                 fieldname_size++;
             fieldname = (fieldname_data_size << 16) | fieldname_type;
-            fwrite(&fieldname,4,1,(FILE*)mat->fp);
-            fwrite(&fieldname_size,4,1,(FILE*)mat->fp);
-            fwrite(&array_name_type,4,1,(FILE*)mat->fp);
-            nBytes = nfields*fieldname_size;
-            fwrite(&nBytes,4,1,(FILE*)mat->fp);
-            padzero = (char*)calloc(fieldname_size,1);
+            fwrite(&fieldname, 4, 1, (FILE *)mat->fp);
+            fwrite(&fieldname_size, 4, 1, (FILE *)mat->fp);
+            fwrite(&array_name_type, 4, 1, (FILE *)mat->fp);
+            nBytes = nfields * fieldname_size;
+            fwrite(&nBytes, 4, 1, (FILE *)mat->fp);
+            padzero = (char *)calloc(fieldname_size, 1);
             for ( i = 0; i < nfields; i++ ) {
                 size_t len = strlen(matvar->internal->fieldnames[i]);
-                fwrite(matvar->internal->fieldnames[i],1,len,(FILE*)mat->fp);
-                fwrite(padzero,1,fieldname_size-len,(FILE*)mat->fp);
+                fwrite(matvar->internal->fieldnames[i], 1, len, (FILE *)mat->fp);
+                fwrite(padzero, 1, fieldname_size - len, (FILE *)mat->fp);
             }
             free(padzero);
             err = Mul(&nelems_x_nfields, nelems, nfields);
             if ( err )
                 break;
             for ( i = 0; i < nelems_x_nfields; i++ )
-                WriteStructField(mat,fields[i]);
+                WriteStructField(mat, fields[i]);
             break;
         }
-        case MAT_C_SPARSE:
-        {
-            mat_sparse_t *sparse = (mat_sparse_t*)matvar->data;
+        case MAT_C_SPARSE: {
+            mat_sparse_t *sparse = (mat_sparse_t *)matvar->data;
 
-            nBytes = WriteData(mat,sparse->ir,sparse->nir,MAT_T_UINT32);
+            nBytes = WriteData(mat, sparse->ir, sparse->nir, MAT_T_UINT32);
             if ( nBytes % 8 )
                 for ( j = nBytes % 8; j < 8; j++ )
-                    fwrite(&pad1,1,1,(FILE*)mat->fp);
-            nBytes = WriteData(mat,sparse->jc,sparse->njc,MAT_T_UINT32);
+                    fwrite(&pad1, 1, 1, (FILE *)mat->fp);
+            nBytes = WriteData(mat, sparse->jc, sparse->njc, MAT_T_UINT32);
             if ( nBytes % 8 )
                 for ( j = nBytes % 8; j < 8; j++ )
-                    fwrite(&pad1,1,1,(FILE*)mat->fp);
+                    fwrite(&pad1, 1, 1, (FILE *)mat->fp);
             if ( matvar->isComplex ) {
-                mat_complex_split_t *complex_data = (mat_complex_split_t*)sparse->data;
-                nBytes = WriteData(mat,complex_data->Re,sparse->ndata,
-                                   matvar->data_type);
+                mat_complex_split_t *complex_data = (mat_complex_split_t *)sparse->data;
+                nBytes = WriteData(mat, complex_data->Re, sparse->ndata, matvar->data_type);
                 if ( nBytes % 8 )
                     for ( j = nBytes % 8; j < 8; j++ )
-                        fwrite(&pad1,1,1,(FILE*)mat->fp);
-                nBytes = WriteData(mat,complex_data->Im,sparse->ndata,
-                                   matvar->data_type);
+                        fwrite(&pad1, 1, 1, (FILE *)mat->fp);
+                nBytes = WriteData(mat, complex_data->Im, sparse->ndata, matvar->data_type);
                 if ( nBytes % 8 )
                     for ( j = nBytes % 8; j < 8; j++ )
-                        fwrite(&pad1,1,1,(FILE*)mat->fp);
+                        fwrite(&pad1, 1, 1, (FILE *)mat->fp);
             } else {
-                nBytes = WriteData(mat,sparse->data,sparse->ndata,
-                                   matvar->data_type);
+                nBytes = WriteData(mat, sparse->data, sparse->ndata, matvar->data_type);
                 if ( nBytes % 8 )
                     for ( j = nBytes % 8; j < 8; j++ )
-                        fwrite(&pad1,1,1,(FILE*)mat->fp);
+                        fwrite(&pad1, 1, 1, (FILE *)mat->fp);
             }
         }
         case MAT_C_FUNCTION:
@@ -8397,7 +8493,7 @@ WriteType(mat_t *mat,matvar_t *matvar)
  * @retval 0 on success
  */
 static int
-WriteCellArrayField(mat_t *mat,matvar_t *matvar)
+WriteCellArrayField(mat_t *mat, matvar_t *matvar)
 {
     mat_uint32_t array_flags, nzmax = 0;
     int array_flags_type = MAT_T_UINT32, dims_array_type = MAT_T_INT32;
@@ -8410,13 +8506,13 @@ WriteCellArrayField(mat_t *mat,matvar_t *matvar)
     if ( matvar == NULL || mat == NULL )
         return MATIO_E_BAD_ARGUMENT;
 
-    fwrite(&matrix_type,4,1,(FILE*)mat->fp);
-    fwrite(&pad4,4,1,(FILE*)mat->fp);
+    fwrite(&matrix_type, 4, 1, (FILE *)mat->fp);
+    fwrite(&pad4, 4, 1, (FILE *)mat->fp);
     if ( MAT_C_EMPTY == matvar->class_type ) {
         /* exit early if this is an empty data */
         return MATIO_E_NO_ERROR;
     }
-    start = ftell((FILE*)mat->fp);
+    start = ftell((FILE *)mat->fp);
 
     /* Array Flags */
     array_flags = matvar->class_type & CLASS_TYPE_MASK;
@@ -8430,53 +8526,53 @@ WriteCellArrayField(mat_t *mat,matvar_t *matvar)
         nzmax = ((mat_sparse_t *)matvar->data)->nzmax;
 
     if ( mat->byteswap )
-        array_flags = Mat_int32Swap((mat_int32_t*)&array_flags);
-    fwrite(&array_flags_type,4,1,(FILE*)mat->fp);
-    fwrite(&array_flags_size,4,1,(FILE*)mat->fp);
-    fwrite(&array_flags,4,1,(FILE*)mat->fp);
-    fwrite(&nzmax,4,1,(FILE*)mat->fp);
+        array_flags = Mat_int32Swap((mat_int32_t *)&array_flags);
+    fwrite(&array_flags_type, 4, 1, (FILE *)mat->fp);
+    fwrite(&array_flags_size, 4, 1, (FILE *)mat->fp);
+    fwrite(&array_flags, 4, 1, (FILE *)mat->fp);
+    fwrite(&nzmax, 4, 1, (FILE *)mat->fp);
     /* Rank and Dimension */
     nBytes = matvar->rank * 4;
-    fwrite(&dims_array_type,4,1,(FILE*)mat->fp);
-    fwrite(&nBytes,4,1,(FILE*)mat->fp);
+    fwrite(&dims_array_type, 4, 1, (FILE *)mat->fp);
+    fwrite(&nBytes, 4, 1, (FILE *)mat->fp);
     for ( i = 0; i < matvar->rank; i++ ) {
         mat_int32_t dim;
         dim = matvar->dims[i];
-        fwrite(&dim,4,1,(FILE*)mat->fp);
+        fwrite(&dim, 4, 1, (FILE *)mat->fp);
     }
     if ( matvar->rank % 2 != 0 )
-        fwrite(&pad4,4,1,(FILE*)mat->fp);
+        fwrite(&pad4, 4, 1, (FILE *)mat->fp);
     /* Name of variable */
     if ( !matvar->name ) {
         const mat_uint32_t array_name_type = MAT_T_INT8;
-        fwrite(&array_name_type,4,1,(FILE*)mat->fp);
-        fwrite(&pad4,4,1,(FILE*)mat->fp);
+        fwrite(&array_name_type, 4, 1, (FILE *)mat->fp);
+        fwrite(&pad4, 4, 1, (FILE *)mat->fp);
     } else if ( strlen(matvar->name) <= 4 ) {
         mat_uint32_t array_name_type = MAT_T_INT8;
         const mat_uint32_t array_name_len = (mat_uint32_t)strlen(matvar->name);
         array_name_type |= array_name_len << 16;
-        fwrite(&array_name_type,4,1,(FILE*)mat->fp);
-        fwrite(matvar->name,1,array_name_len,(FILE*)mat->fp);
+        fwrite(&array_name_type, 4, 1, (FILE *)mat->fp);
+        fwrite(matvar->name, 1, array_name_len, (FILE *)mat->fp);
         for ( i = array_name_len; i < 4; i++ )
-            fwrite(&pad1,1,1,(FILE*)mat->fp);
+            fwrite(&pad1, 1, 1, (FILE *)mat->fp);
     } else {
         const mat_uint32_t array_name_type = MAT_T_INT8;
         const mat_uint32_t array_name_len = (mat_uint32_t)strlen(matvar->name);
-        fwrite(&array_name_type,4,1,(FILE*)mat->fp);
-        fwrite(&array_name_len,4,1,(FILE*)mat->fp);
-        fwrite(matvar->name,1,array_name_len,(FILE*)mat->fp);
+        fwrite(&array_name_type, 4, 1, (FILE *)mat->fp);
+        fwrite(&array_name_len, 4, 1, (FILE *)mat->fp);
+        fwrite(matvar->name, 1, array_name_len, (FILE *)mat->fp);
         if ( array_name_len % 8 )
             for ( i = array_name_len % 8; i < 8; i++ )
-                fwrite(&pad1,1,1,(FILE*)mat->fp);
+                fwrite(&pad1, 1, 1, (FILE *)mat->fp);
     }
 
-    WriteType(mat,matvar);
-    end = ftell((FILE*)mat->fp);
+    WriteType(mat, matvar);
+    end = ftell((FILE *)mat->fp);
     if ( start != -1L && end != -1L ) {
-        nBytes = (int)(end-start);
-        (void)fseek((FILE*)mat->fp,(long)-(nBytes+4),SEEK_CUR);
-        fwrite(&nBytes,4,1,(FILE*)mat->fp);
-        (void)fseek((FILE*)mat->fp,end,SEEK_SET);
+        nBytes = (int)(end - start);
+        (void)fseek((FILE *)mat->fp, (long)-(nBytes + 4), SEEK_CUR);
+        fwrite(&nBytes, 4, 1, (FILE *)mat->fp);
+        (void)fseek((FILE *)mat->fp, end, SEEK_SET);
     } else {
         Mat_Critical("Couldn't determine file position");
     }
@@ -8493,7 +8589,7 @@ WriteCellArrayField(mat_t *mat,matvar_t *matvar)
  * @return number of bytes written to the MAT file
  */
 static size_t
-WriteCompressedTypeArrayFlags(mat_t *mat,matvar_t *matvar,z_streamp z)
+WriteCompressedTypeArrayFlags(mat_t *mat, matvar_t *matvar, z_streamp z)
 {
     mat_uint32_t array_flags;
     const mat_uint32_t array_name_type = MAT_T_INT8;
@@ -8502,7 +8598,7 @@ WriteCompressedTypeArrayFlags(mat_t *mat,matvar_t *matvar,z_streamp z)
     int nBytes, i, nzmax = 0;
 
     mat_uint32_t comp_buf[512];
-    mat_uint32_t uncomp_buf[512] = {0,};
+    mat_uint32_t uncomp_buf[512];
     int buf_size = 512;
     size_t byteswritten = 0;
 
@@ -8511,6 +8607,7 @@ WriteCompressedTypeArrayFlags(mat_t *mat,matvar_t *matvar,z_streamp z)
         return byteswritten;
     }
 
+    memset(&uncomp_buf, 0, sizeof(uncomp_buf));
     /* Array Flags */
     array_flags = matvar->class_type & CLASS_TYPE_MASK;
     if ( matvar->isComplex )
@@ -8532,42 +8629,42 @@ WriteCompressedTypeArrayFlags(mat_t *mat,matvar_t *matvar,z_streamp z)
     for ( i = 0; i < matvar->rank; i++ ) {
         mat_int32_t dim;
         dim = matvar->dims[i];
-        uncomp_buf[6+i] = dim;
+        uncomp_buf[6 + i] = dim;
     }
     if ( matvar->rank % 2 != 0 ) {
         const mat_uint32_t pad4 = 0;
-        uncomp_buf[6+i] = pad4;
+        uncomp_buf[6 + i] = pad4;
         i++;
     }
 
-    z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
-    z->avail_in = (6+i)*sizeof(*uncomp_buf);
+    z->next_in = ZLIB_BYTE_PTR(uncomp_buf);
+    z->avail_in = (6 + i) * sizeof(*uncomp_buf);
     do {
-        z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-        z->avail_out = buf_size*sizeof(*comp_buf);
-        deflate(z,Z_NO_FLUSH);
-        byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-z->avail_out,
-            (FILE*)mat->fp);
+        z->next_out = ZLIB_BYTE_PTR(comp_buf);
+        z->avail_out = buf_size * sizeof(*comp_buf);
+        deflate(z, Z_NO_FLUSH);
+        byteswritten +=
+            fwrite(comp_buf, 1, buf_size * sizeof(*comp_buf) - z->avail_out, (FILE *)mat->fp);
     } while ( z->avail_out == 0 );
     /* Name of variable */
     uncomp_buf[0] = array_name_type;
     uncomp_buf[1] = 0;
-    z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+    z->next_in = ZLIB_BYTE_PTR(uncomp_buf);
     z->avail_in = 8;
     do {
-        z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-        z->avail_out = buf_size*sizeof(*comp_buf);
-        deflate(z,Z_NO_FLUSH);
-        byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-z->avail_out,
-            (FILE*)mat->fp);
+        z->next_out = ZLIB_BYTE_PTR(comp_buf);
+        z->avail_out = buf_size * sizeof(*comp_buf);
+        deflate(z, Z_NO_FLUSH);
+        byteswritten +=
+            fwrite(comp_buf, 1, buf_size * sizeof(*comp_buf) - z->avail_out, (FILE *)mat->fp);
     } while ( z->avail_out == 0 );
 
-    matvar->internal->datapos = ftell((FILE*)mat->fp);
+    matvar->internal->datapos = ftell((FILE *)mat->fp);
     if ( matvar->internal->datapos == -1L ) {
         Mat_Critical("Couldn't determine file position");
     }
 
-    byteswritten += WriteCompressedType(mat,matvar,z);
+    byteswritten += WriteCompressedType(mat, matvar, z);
     return byteswritten;
 }
 
@@ -8579,11 +8676,11 @@ WriteCompressedTypeArrayFlags(mat_t *mat,matvar_t *matvar,z_streamp z)
  * @return number of bytes written to the MAT file
  */
 static size_t
-WriteCompressedType(mat_t *mat,matvar_t *matvar,z_streamp z)
+WriteCompressedType(mat_t *mat, matvar_t *matvar, z_streamp z)
 {
     int err;
     mat_uint32_t comp_buf[512];
-    mat_uint32_t uncomp_buf[512] = {0,};
+    mat_uint32_t uncomp_buf[512];
     size_t byteswritten = 0, nelems = 1;
 
     if ( MAT_C_EMPTY == matvar->class_type ) {
@@ -8591,6 +8688,7 @@ WriteCompressedType(mat_t *mat,matvar_t *matvar,z_streamp z)
         return byteswritten;
     }
 
+    memset(&uncomp_buf, 0, sizeof(uncomp_buf));
     err = Mat_MulDims(matvar, &nelems);
     if ( err ) {
         Mat_Critical("Integer multiplication overflow");
@@ -8607,48 +8705,46 @@ WriteCompressedType(mat_t *mat,matvar_t *matvar,z_streamp z)
         case MAT_C_INT16:
         case MAT_C_UINT16:
         case MAT_C_INT8:
-        case MAT_C_UINT8:
-        {
+        case MAT_C_UINT8: {
             /* WriteCompressedData makes sure uncompressed data is aligned
              * on an 8-byte boundary */
             if ( matvar->isComplex ) {
-                mat_complex_split_t *complex_data = (mat_complex_split_t*)matvar->data;
+                mat_complex_split_t *complex_data = (mat_complex_split_t *)matvar->data;
 
                 if ( NULL == matvar->data )
                     complex_data = &null_complex_data;
 
-                byteswritten += WriteCompressedData(mat,z,
-                    complex_data->Re,nelems,matvar->data_type);
-                byteswritten += WriteCompressedData(mat,z,
-                    complex_data->Im,nelems,matvar->data_type);
+                byteswritten +=
+                    WriteCompressedData(mat, z, complex_data->Re, nelems, matvar->data_type);
+                byteswritten +=
+                    WriteCompressedData(mat, z, complex_data->Im, nelems, matvar->data_type);
             } else {
-                byteswritten += WriteCompressedData(mat,z,
-                    matvar->data,nelems,matvar->data_type);
+                byteswritten +=
+                    WriteCompressedData(mat, z, matvar->data, nelems, matvar->data_type);
             }
             break;
         }
-        case MAT_C_CHAR:
-        {
-            byteswritten += WriteCompressedCharData(mat,z,matvar->data,
-                nelems,matvar->data_type);
+        case MAT_C_CHAR: {
+            if ( matvar->data_type == MAT_T_UTF8 ) {
+                nelems = matvar->nbytes;
+            }
+            byteswritten +=
+                WriteCompressedCharData(mat, z, matvar->data, nelems, matvar->data_type);
             break;
         }
-        case MAT_C_CELL:
-        {
+        case MAT_C_CELL: {
             size_t i;
             matvar_t **cells = (matvar_t **)matvar->data;
 
             /* Check for an empty cell array */
-            if ( matvar->nbytes == 0 || matvar->data_size == 0 ||
-                 matvar->data   == NULL )
+            if ( matvar->nbytes == 0 || matvar->data_size == 0 || matvar->data == NULL )
                 break;
             nelems = matvar->nbytes / matvar->data_size;
             for ( i = 0; i < nelems; i++ )
-                WriteCompressedCellArrayField(mat,cells[i],z);
+                WriteCompressedCellArrayField(mat, cells[i], z);
             break;
         }
-        case MAT_C_STRUCT:
-        {
+        case MAT_C_STRUCT: {
             int buf_size = 512;
             const mat_uint32_t fieldname_type = MAT_T_INT32;
             const mat_uint32_t fieldname_data_size = 4;
@@ -8666,14 +8762,14 @@ WriteCompressedType(mat_t *mat,matvar_t *matvar,z_streamp z)
                 uncomp_buf[1] = fieldname_size;
                 uncomp_buf[2] = array_name_type;
                 uncomp_buf[3] = 0;
-                z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+                z->next_in = ZLIB_BYTE_PTR(uncomp_buf);
                 z->avail_in = 16;
                 do {
-                    z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-                    z->avail_out = buf_size*sizeof(*comp_buf);
-                    deflate(z,Z_NO_FLUSH);
-                    byteswritten += fwrite(comp_buf,1,buf_size*
-                        sizeof(*comp_buf)-z->avail_out,(FILE*)mat->fp);
+                    z->next_out = ZLIB_BYTE_PTR(comp_buf);
+                    z->avail_out = buf_size * sizeof(*comp_buf);
+                    deflate(z, Z_NO_FLUSH);
+                    byteswritten += fwrite(comp_buf, 1, buf_size * sizeof(*comp_buf) - z->avail_out,
+                                           (FILE *)mat->fp);
                 } while ( z->avail_out == 0 );
                 break;
             }
@@ -8685,35 +8781,35 @@ WriteCompressedType(mat_t *mat,matvar_t *matvar,z_streamp z)
             }
             maxlen++;
             fieldname_size = maxlen;
-            while ( nfields*fieldname_size % 8 != 0 )
+            while ( nfields * fieldname_size % 8 != 0 )
                 fieldname_size++;
             uncomp_buf[0] = (fieldname_data_size << 16) | fieldname_type;
             uncomp_buf[1] = fieldname_size;
             uncomp_buf[2] = array_name_type;
-            uncomp_buf[3] = nfields*fieldname_size;
+            uncomp_buf[3] = nfields * fieldname_size;
 
-            padzero = (unsigned char*)calloc(fieldname_size,1);
-            z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+            padzero = (unsigned char *)calloc(fieldname_size, 1);
+            z->next_in = ZLIB_BYTE_PTR(uncomp_buf);
             z->avail_in = 16;
             do {
-                z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-                z->avail_out = buf_size*sizeof(*comp_buf);
-                deflate(z,Z_NO_FLUSH);
-                byteswritten += fwrite(comp_buf,1,
-                    buf_size*sizeof(*comp_buf)-z->avail_out,(FILE*)mat->fp);
+                z->next_out = ZLIB_BYTE_PTR(comp_buf);
+                z->avail_out = buf_size * sizeof(*comp_buf);
+                deflate(z, Z_NO_FLUSH);
+                byteswritten += fwrite(comp_buf, 1, buf_size * sizeof(*comp_buf) - z->avail_out,
+                                       (FILE *)mat->fp);
             } while ( z->avail_out == 0 );
             for ( i = 0; i < nfields; i++ ) {
                 size_t len = strlen(matvar->internal->fieldnames[i]);
-                memset(padzero,'\0',fieldname_size);
-                memcpy(padzero,matvar->internal->fieldnames[i],len);
-                z->next_in  = ZLIB_BYTE_PTR(padzero);
+                memset(padzero, '\0', fieldname_size);
+                memcpy(padzero, matvar->internal->fieldnames[i], len);
+                z->next_in = ZLIB_BYTE_PTR(padzero);
                 z->avail_in = fieldname_size;
                 do {
-                    z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-                    z->avail_out = buf_size*sizeof(*comp_buf);
-                    deflate(z,Z_NO_FLUSH);
-                    byteswritten += fwrite(comp_buf,1,
-                        buf_size*sizeof(*comp_buf)-z->avail_out,(FILE*)mat->fp);
+                    z->next_out = ZLIB_BYTE_PTR(comp_buf);
+                    z->avail_out = buf_size * sizeof(*comp_buf);
+                    deflate(z, Z_NO_FLUSH);
+                    byteswritten += fwrite(comp_buf, 1, buf_size * sizeof(*comp_buf) - z->avail_out,
+                                           (FILE *)mat->fp);
                 } while ( z->avail_out == 0 );
             }
             free(padzero);
@@ -8723,26 +8819,23 @@ WriteCompressedType(mat_t *mat,matvar_t *matvar,z_streamp z)
                 return byteswritten;
             }
             for ( i = 0; i < nelems_x_nfields; i++ )
-                byteswritten += WriteCompressedStructField(mat,fields[i],z);
+                byteswritten += WriteCompressedStructField(mat, fields[i], z);
             break;
         }
-        case MAT_C_SPARSE:
-        {
-            mat_sparse_t *sparse = (mat_sparse_t*)matvar->data;
+        case MAT_C_SPARSE: {
+            mat_sparse_t *sparse = (mat_sparse_t *)matvar->data;
 
-            byteswritten += WriteCompressedData(mat,z,sparse->ir,
-                sparse->nir,MAT_T_UINT32);
-            byteswritten += WriteCompressedData(mat,z,sparse->jc,
-                sparse->njc,MAT_T_UINT32);
+            byteswritten += WriteCompressedData(mat, z, sparse->ir, sparse->nir, MAT_T_UINT32);
+            byteswritten += WriteCompressedData(mat, z, sparse->jc, sparse->njc, MAT_T_UINT32);
             if ( matvar->isComplex ) {
-                mat_complex_split_t *complex_data = (mat_complex_split_t*)sparse->data;
-                byteswritten += WriteCompressedData(mat,z,
-                    complex_data->Re,sparse->ndata,matvar->data_type);
-                byteswritten += WriteCompressedData(mat,z,
-                    complex_data->Im,sparse->ndata,matvar->data_type);
+                mat_complex_split_t *complex_data = (mat_complex_split_t *)sparse->data;
+                byteswritten +=
+                    WriteCompressedData(mat, z, complex_data->Re, sparse->ndata, matvar->data_type);
+                byteswritten +=
+                    WriteCompressedData(mat, z, complex_data->Im, sparse->ndata, matvar->data_type);
             } else {
-                byteswritten += WriteCompressedData(mat,z,
-                    sparse->data,sparse->ndata,matvar->data_type);
+                byteswritten +=
+                    WriteCompressedData(mat, z, sparse->data, sparse->ndata, matvar->data_type);
             }
             break;
         }
@@ -8764,37 +8857,38 @@ WriteCompressedType(mat_t *mat,matvar_t *matvar,z_streamp z)
  * @return number of bytes written to the MAT file
  */
 static size_t
-WriteCompressedCellArrayField(mat_t *mat,matvar_t *matvar,z_streamp z)
+WriteCompressedCellArrayField(mat_t *mat, matvar_t *matvar, z_streamp z)
 {
     mat_uint32_t comp_buf[512];
-    mat_uint32_t uncomp_buf[512] = {0,};
+    mat_uint32_t uncomp_buf[512];
     int buf_size = 512;
     size_t byteswritten = 0, field_buf_size;
 
-    if ( NULL == matvar || NULL == mat || NULL == z)
+    if ( NULL == matvar || NULL == mat || NULL == z )
         return 0;
 
+    memset(&uncomp_buf, 0, sizeof(uncomp_buf));
     uncomp_buf[0] = MAT_T_MATRIX;
     if ( MAT_C_EMPTY != matvar->class_type ) {
         int err = GetCellArrayFieldBufSize(matvar, &field_buf_size);
-        if (err || field_buf_size > UINT32_MAX)
+        if ( err || field_buf_size > UINT32_MAX )
             return 0;
 
         uncomp_buf[1] = field_buf_size;
     } else {
         uncomp_buf[1] = 0;
     }
-    z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+    z->next_in = ZLIB_BYTE_PTR(uncomp_buf);
     z->avail_in = 8;
     do {
-        z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-        z->avail_out = buf_size*sizeof(*comp_buf);
-        deflate(z,Z_NO_FLUSH);
-        byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-z->avail_out,
-            (FILE*)mat->fp);
+        z->next_out = ZLIB_BYTE_PTR(comp_buf);
+        z->avail_out = buf_size * sizeof(*comp_buf);
+        deflate(z, Z_NO_FLUSH);
+        byteswritten +=
+            fwrite(comp_buf, 1, buf_size * sizeof(*comp_buf) - z->avail_out, (FILE *)mat->fp);
     } while ( z->avail_out == 0 );
 
-    byteswritten += WriteCompressedTypeArrayFlags(mat,matvar,z);
+    byteswritten += WriteCompressedTypeArrayFlags(mat, matvar, z);
     return byteswritten;
 }
 #endif
@@ -8807,7 +8901,7 @@ WriteCompressedCellArrayField(mat_t *mat,matvar_t *matvar,z_streamp z)
  * @retval 0 on success
  */
 static int
-WriteStructField(mat_t *mat,matvar_t *matvar)
+WriteStructField(mat_t *mat, matvar_t *matvar)
 {
     mat_uint32_t array_flags;
     const mat_uint32_t array_name_type = MAT_T_INT8;
@@ -8821,18 +8915,18 @@ WriteStructField(mat_t *mat,matvar_t *matvar)
         return MATIO_E_BAD_ARGUMENT;
 
     if ( NULL == matvar ) {
-        size_t dims[2] = {0,0};
+        size_t dims[2] = {0, 0};
         Mat_WriteEmptyVariable5(mat, NULL, 2, dims);
         return MATIO_E_NO_ERROR;
     }
 
-    fwrite(&matrix_type,4,1,(FILE*)mat->fp);
-    fwrite(&pad4,4,1,(FILE*)mat->fp);
+    fwrite(&matrix_type, 4, 1, (FILE *)mat->fp);
+    fwrite(&pad4, 4, 1, (FILE *)mat->fp);
     if ( MAT_C_EMPTY == matvar->class_type ) {
         /* exit early if this is an empty data */
         return MATIO_E_NO_ERROR;
     }
-    start = ftell((FILE*)mat->fp);
+    start = ftell((FILE *)mat->fp);
 
     /* Array Flags */
     array_flags = matvar->class_type & CLASS_TYPE_MASK;
@@ -8846,34 +8940,34 @@ WriteStructField(mat_t *mat,matvar_t *matvar)
         nzmax = ((mat_sparse_t *)matvar->data)->nzmax;
 
     if ( mat->byteswap )
-        array_flags = Mat_int32Swap((mat_int32_t*)&array_flags);
-    fwrite(&array_flags_type,4,1,(FILE*)mat->fp);
-    fwrite(&array_flags_size,4,1,(FILE*)mat->fp);
-    fwrite(&array_flags,4,1,(FILE*)mat->fp);
-    fwrite(&nzmax,4,1,(FILE*)mat->fp);
+        array_flags = Mat_int32Swap((mat_int32_t *)&array_flags);
+    fwrite(&array_flags_type, 4, 1, (FILE *)mat->fp);
+    fwrite(&array_flags_size, 4, 1, (FILE *)mat->fp);
+    fwrite(&array_flags, 4, 1, (FILE *)mat->fp);
+    fwrite(&nzmax, 4, 1, (FILE *)mat->fp);
     /* Rank and Dimension */
     nBytes = matvar->rank * 4;
-    fwrite(&dims_array_type,4,1,(FILE*)mat->fp);
-    fwrite(&nBytes,4,1,(FILE*)mat->fp);
+    fwrite(&dims_array_type, 4, 1, (FILE *)mat->fp);
+    fwrite(&nBytes, 4, 1, (FILE *)mat->fp);
     for ( i = 0; i < matvar->rank; i++ ) {
         mat_int32_t dim;
         dim = matvar->dims[i];
-        fwrite(&dim,4,1,(FILE*)mat->fp);
+        fwrite(&dim, 4, 1, (FILE *)mat->fp);
     }
     if ( matvar->rank % 2 != 0 )
-        fwrite(&pad4,4,1,(FILE*)mat->fp);
+        fwrite(&pad4, 4, 1, (FILE *)mat->fp);
 
     /* Name of variable */
-    fwrite(&array_name_type,4,1,(FILE*)mat->fp);
-    fwrite(&pad4,4,1,(FILE*)mat->fp);
+    fwrite(&array_name_type, 4, 1, (FILE *)mat->fp);
+    fwrite(&pad4, 4, 1, (FILE *)mat->fp);
 
-    WriteType(mat,matvar);
-    end = ftell((FILE*)mat->fp);
+    WriteType(mat, matvar);
+    end = ftell((FILE *)mat->fp);
     if ( start != -1L && end != -1L ) {
-        nBytes = (int)(end-start);
-        (void)fseek((FILE*)mat->fp,(long)-(nBytes+4),SEEK_CUR);
-        fwrite(&nBytes,4,1,(FILE*)mat->fp);
-        (void)fseek((FILE*)mat->fp,end,SEEK_SET);
+        nBytes = (int)(end - start);
+        (void)fseek((FILE *)mat->fp, (long)-(nBytes + 4), SEEK_CUR);
+        fwrite(&nBytes, 4, 1, (FILE *)mat->fp);
+        (void)fseek((FILE *)mat->fp, end, SEEK_SET);
     } else {
         Mat_Critical("Couldn't determine file position");
     }
@@ -8891,48 +8985,49 @@ WriteStructField(mat_t *mat,matvar_t *matvar)
  * @return number of bytes written to the MAT file
  */
 static size_t
-WriteCompressedStructField(mat_t *mat,matvar_t *matvar,z_streamp z)
+WriteCompressedStructField(mat_t *mat, matvar_t *matvar, z_streamp z)
 {
     mat_uint32_t comp_buf[512];
-    mat_uint32_t uncomp_buf[512] = {0,};
+    mat_uint32_t uncomp_buf[512];
     int buf_size = 512;
     size_t byteswritten = 0, field_buf_size;
 
-    if ( NULL == mat || NULL == z)
+    if ( NULL == mat || NULL == z )
         return 0;
 
     if ( NULL == matvar ) {
-        size_t dims[2] = {0,0};
+        size_t dims[2] = {0, 0};
         byteswritten = Mat_WriteCompressedEmptyVariable5(mat, NULL, 2, dims, z);
         return byteswritten;
     }
 
+    memset(&uncomp_buf, 0, sizeof(uncomp_buf));
     uncomp_buf[0] = MAT_T_MATRIX;
     if ( MAT_C_EMPTY != matvar->class_type ) {
         int err = GetStructFieldBufSize(matvar, &field_buf_size);
-        if (err || field_buf_size > UINT32_MAX)
+        if ( err || field_buf_size > UINT32_MAX )
             return 0;
         uncomp_buf[1] = field_buf_size;
     } else {
         uncomp_buf[1] = 0;
     }
-    z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+    z->next_in = ZLIB_BYTE_PTR(uncomp_buf);
     z->avail_in = 8;
     do {
-        z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-        z->avail_out = buf_size*sizeof(*comp_buf);
-        deflate(z,Z_NO_FLUSH);
-        byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-z->avail_out,
-            (FILE*)mat->fp);
+        z->next_out = ZLIB_BYTE_PTR(comp_buf);
+        z->avail_out = buf_size * sizeof(*comp_buf);
+        deflate(z, Z_NO_FLUSH);
+        byteswritten +=
+            fwrite(comp_buf, 1, buf_size * sizeof(*comp_buf) - z->avail_out, (FILE *)mat->fp);
     } while ( z->avail_out == 0 );
 
-    byteswritten += WriteCompressedTypeArrayFlags(mat,matvar,z);
+    byteswritten += WriteCompressedTypeArrayFlags(mat, matvar, z);
     return byteswritten;
 }
 #endif
 
 static size_t
-Mat_WriteEmptyVariable5(mat_t *mat,const char *name,int rank,size_t *dims)
+Mat_WriteEmptyVariable5(mat_t *mat, const char *name, int rank, size_t *dims)
 {
     mat_uint32_t array_flags;
     mat_uint32_t array_name_type = MAT_T_INT8;
@@ -8944,66 +9039,66 @@ Mat_WriteEmptyVariable5(mat_t *mat,const char *name,int rank,size_t *dims)
     size_t byteswritten = 0;
     long start = 0, end = 0;
 
-    fwrite(&matrix_type,4,1,(FILE*)mat->fp);
-    fwrite(&pad4,4,1,(FILE*)mat->fp);
-    start = ftell((FILE*)mat->fp);
+    fwrite(&matrix_type, 4, 1, (FILE *)mat->fp);
+    fwrite(&pad4, 4, 1, (FILE *)mat->fp);
+    start = ftell((FILE *)mat->fp);
 
     /* Array Flags */
     array_flags = MAT_C_DOUBLE;
 
     if ( mat->byteswap )
-        array_flags = Mat_int32Swap((mat_int32_t*)&array_flags);
-    byteswritten += fwrite(&array_flags_type,4,1,(FILE*)mat->fp);
-    byteswritten += fwrite(&array_flags_size,4,1,(FILE*)mat->fp);
-    byteswritten += fwrite(&array_flags,4,1,(FILE*)mat->fp);
-    byteswritten += fwrite(&pad4,4,1,(FILE*)mat->fp);
+        array_flags = Mat_int32Swap((mat_int32_t *)&array_flags);
+    byteswritten += fwrite(&array_flags_type, 4, 1, (FILE *)mat->fp);
+    byteswritten += fwrite(&array_flags_size, 4, 1, (FILE *)mat->fp);
+    byteswritten += fwrite(&array_flags, 4, 1, (FILE *)mat->fp);
+    byteswritten += fwrite(&pad4, 4, 1, (FILE *)mat->fp);
     /* Rank and Dimension */
     nBytes = rank * 4;
-    byteswritten += fwrite(&dims_array_type,4,1,(FILE*)mat->fp);
-    byteswritten += fwrite(&nBytes,4,1,(FILE*)mat->fp);
+    byteswritten += fwrite(&dims_array_type, 4, 1, (FILE *)mat->fp);
+    byteswritten += fwrite(&nBytes, 4, 1, (FILE *)mat->fp);
     for ( i = 0; i < rank; i++ ) {
         mat_int32_t dim;
         dim = dims[i];
-        byteswritten += fwrite(&dim,4,1,(FILE*)mat->fp);
+        byteswritten += fwrite(&dim, 4, 1, (FILE *)mat->fp);
     }
     if ( rank % 2 != 0 )
-        byteswritten += fwrite(&pad4,4,1,(FILE*)mat->fp);
+        byteswritten += fwrite(&pad4, 4, 1, (FILE *)mat->fp);
 
     if ( NULL == name ) {
         /* Name of variable */
-        byteswritten += fwrite(&array_name_type,4,1,(FILE*)mat->fp);
-        byteswritten += fwrite(&pad4,4,1,(FILE*)mat->fp);
+        byteswritten += fwrite(&array_name_type, 4, 1, (FILE *)mat->fp);
+        byteswritten += fwrite(&pad4, 4, 1, (FILE *)mat->fp);
     } else {
         mat_int32_t array_name_len = (mat_int32_t)strlen(name);
         /* Name of variable */
         if ( array_name_len <= 4 ) {
             array_name_type |= array_name_len << 16;
-            byteswritten += fwrite(&array_name_type,4,1,(FILE*)mat->fp);
-            byteswritten += fwrite(name,1,array_name_len,(FILE*)mat->fp);
+            byteswritten += fwrite(&array_name_type, 4, 1, (FILE *)mat->fp);
+            byteswritten += fwrite(name, 1, array_name_len, (FILE *)mat->fp);
             for ( i = array_name_len; i < 4; i++ )
-                byteswritten += fwrite(&pad1,1,1,(FILE*)mat->fp);
+                byteswritten += fwrite(&pad1, 1, 1, (FILE *)mat->fp);
         } else {
-            byteswritten += fwrite(&array_name_type,4,1,(FILE*)mat->fp);
-            byteswritten += fwrite(&array_name_len,4,1,(FILE*)mat->fp);
-            byteswritten += fwrite(name,1,array_name_len,(FILE*)mat->fp);
+            byteswritten += fwrite(&array_name_type, 4, 1, (FILE *)mat->fp);
+            byteswritten += fwrite(&array_name_len, 4, 1, (FILE *)mat->fp);
+            byteswritten += fwrite(name, 1, array_name_len, (FILE *)mat->fp);
             if ( array_name_len % 8 )
                 for ( i = array_name_len % 8; i < 8; i++ )
-                    byteswritten += fwrite(&pad1,1,1,(FILE*)mat->fp);
+                    byteswritten += fwrite(&pad1, 1, 1, (FILE *)mat->fp);
         }
     }
 
-    nBytes = WriteData(mat,NULL,0,MAT_T_DOUBLE);
+    nBytes = WriteData(mat, NULL, 0, MAT_T_DOUBLE);
     byteswritten += nBytes;
     if ( nBytes % 8 )
         for ( i = nBytes % 8; i < 8; i++ )
-            byteswritten += fwrite(&pad1,1,1,(FILE*)mat->fp);
+            byteswritten += fwrite(&pad1, 1, 1, (FILE *)mat->fp);
 
-    end = ftell((FILE*)mat->fp);
+    end = ftell((FILE *)mat->fp);
     if ( start != -1L && end != -1L ) {
-        nBytes = (int)(end-start);
-        (void)fseek((FILE*)mat->fp,(long)-(nBytes+4),SEEK_CUR);
-        fwrite(&nBytes,4,1,(FILE*)mat->fp);
-        (void)fseek((FILE*)mat->fp,end,SEEK_SET);
+        nBytes = (int)(end - start);
+        (void)fseek((FILE *)mat->fp, (long)-(nBytes + 4), SEEK_CUR);
+        fwrite(&nBytes, 4, 1, (FILE *)mat->fp);
+        (void)fseek((FILE *)mat->fp, end, SEEK_SET);
     } else {
         Mat_Critical("Couldn't determine file position");
     }
@@ -9013,8 +9108,7 @@ Mat_WriteEmptyVariable5(mat_t *mat,const char *name,int rank,size_t *dims)
 
 #if HAVE_ZLIB
 static size_t
-Mat_WriteCompressedEmptyVariable5(mat_t *mat,const char *name,int rank,
-                                  size_t *dims,z_streamp z)
+Mat_WriteCompressedEmptyVariable5(mat_t *mat, const char *name, int rank, size_t *dims, z_streamp z)
 {
     mat_uint32_t array_flags;
     int array_flags_type = MAT_T_UINT32, dims_array_type = MAT_T_INT32;
@@ -9023,30 +9117,31 @@ Mat_WriteCompressedEmptyVariable5(mat_t *mat,const char *name,int rank,
     size_t nBytes, empty_matrix_max_buf_size;
 
     mat_uint32_t comp_buf[512];
-    mat_uint32_t uncomp_buf[512] = {0,};
+    mat_uint32_t uncomp_buf[512];
     int buf_size = 512;
     size_t byteswritten = 0, buf_size_bytes;
 
-    if ( NULL == mat || NULL == z)
+    if ( NULL == mat || NULL == z )
         return byteswritten;
 
-    buf_size_bytes = buf_size*sizeof(*comp_buf);
+    buf_size_bytes = buf_size * sizeof(*comp_buf);
 
     /* Array Flags */
     array_flags = MAT_C_DOUBLE;
 
+    memset(&uncomp_buf, 0, sizeof(uncomp_buf));
     uncomp_buf[0] = MAT_T_MATRIX;
     err = GetEmptyMatrixMaxBufSize(name, rank, &empty_matrix_max_buf_size);
-    if (err || empty_matrix_max_buf_size > UINT32_MAX)
+    if ( err || empty_matrix_max_buf_size > UINT32_MAX )
         return byteswritten;
     uncomp_buf[1] = empty_matrix_max_buf_size;
-    z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+    z->next_in = ZLIB_BYTE_PTR(uncomp_buf);
     z->avail_in = 8;
     do {
-        z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+        z->next_out = ZLIB_BYTE_PTR(comp_buf);
         z->avail_out = buf_size_bytes;
-        deflate(z,Z_NO_FLUSH);
-        byteswritten += fwrite(comp_buf,1,buf_size_bytes-z->avail_out,(FILE*)mat->fp);
+        deflate(z, Z_NO_FLUSH);
+        byteswritten += fwrite(comp_buf, 1, buf_size_bytes - z->avail_out, (FILE *)mat->fp);
     } while ( z->avail_out == 0 );
     uncomp_buf[0] = array_flags_type;
     uncomp_buf[1] = array_flags_size;
@@ -9059,76 +9154,74 @@ Mat_WriteCompressedEmptyVariable5(mat_t *mat,const char *name,int rank,
     for ( i = 0; i < rank; i++ ) {
         mat_int32_t dim;
         dim = dims[i];
-        uncomp_buf[6+i] = dim;
+        uncomp_buf[6 + i] = dim;
     }
     if ( rank % 2 != 0 ) {
         const mat_uint32_t pad4 = 0;
-        uncomp_buf[6+i] = pad4;
+        uncomp_buf[6 + i] = pad4;
         i++;
     }
 
-    z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
-    z->avail_in = (6+i)*sizeof(*uncomp_buf);
+    z->next_in = ZLIB_BYTE_PTR(uncomp_buf);
+    z->avail_in = (6 + i) * sizeof(*uncomp_buf);
     do {
-        z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+        z->next_out = ZLIB_BYTE_PTR(comp_buf);
         z->avail_out = buf_size_bytes;
-        deflate(z,Z_NO_FLUSH);
-        byteswritten += fwrite(comp_buf,1,buf_size_bytes-z->avail_out,(FILE*)mat->fp);
+        deflate(z, Z_NO_FLUSH);
+        byteswritten += fwrite(comp_buf, 1, buf_size_bytes - z->avail_out, (FILE *)mat->fp);
     } while ( z->avail_out == 0 );
     /* Name of variable */
     if ( NULL == name ) {
         const mat_uint32_t array_name_type = MAT_T_INT8;
         uncomp_buf[0] = array_name_type;
         uncomp_buf[1] = 0;
-        z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+        z->next_in = ZLIB_BYTE_PTR(uncomp_buf);
         z->avail_in = 8;
         do {
-            z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+            z->next_out = ZLIB_BYTE_PTR(comp_buf);
             z->avail_out = buf_size_bytes;
-            deflate(z,Z_NO_FLUSH);
-            byteswritten += fwrite(comp_buf,1,buf_size_bytes-z->avail_out,(FILE*)mat->fp);
+            deflate(z, Z_NO_FLUSH);
+            byteswritten += fwrite(comp_buf, 1, buf_size_bytes - z->avail_out, (FILE *)mat->fp);
         } while ( z->avail_out == 0 );
     } else if ( strlen(name) <= 4 ) {
         mat_uint32_t array_name_len = (mat_uint32_t)strlen(name);
         const mat_uint32_t array_name_type = MAT_T_INT8;
 
-        memset(uncomp_buf,0,8);
+        memset(uncomp_buf, 0, 8);
         uncomp_buf[0] = (array_name_len << 16) | array_name_type;
-        memcpy(uncomp_buf+1,name,array_name_len);
+        memcpy(uncomp_buf + 1, name, array_name_len);
         if ( array_name_len % 4 )
-            array_name_len += 4-(array_name_len % 4);
+            array_name_len += 4 - (array_name_len % 4);
 
-        z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+        z->next_in = ZLIB_BYTE_PTR(uncomp_buf);
         z->avail_in = 8;
         do {
-            z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+            z->next_out = ZLIB_BYTE_PTR(comp_buf);
             z->avail_out = buf_size_bytes;
-            deflate(z,Z_NO_FLUSH);
-            byteswritten += fwrite(comp_buf,1,buf_size_bytes-z->avail_out,
-                (FILE*)mat->fp);
+            deflate(z, Z_NO_FLUSH);
+            byteswritten += fwrite(comp_buf, 1, buf_size_bytes - z->avail_out, (FILE *)mat->fp);
         } while ( z->avail_out == 0 );
     } else {
         mat_uint32_t array_name_len = (mat_uint32_t)strlen(name);
         const mat_uint32_t array_name_type = MAT_T_INT8;
 
-        memset(uncomp_buf,0,buf_size*sizeof(*uncomp_buf));
+        memset(uncomp_buf, 0, buf_size * sizeof(*uncomp_buf));
         uncomp_buf[0] = array_name_type;
         uncomp_buf[1] = array_name_len;
-        memcpy(uncomp_buf+2,name,array_name_len);
+        memcpy(uncomp_buf + 2, name, array_name_len);
         if ( array_name_len % 8 )
-            array_name_len += 8-(array_name_len % 8);
-        z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
-        z->avail_in = 8+array_name_len;
+            array_name_len += 8 - (array_name_len % 8);
+        z->next_in = ZLIB_BYTE_PTR(uncomp_buf);
+        z->avail_in = 8 + array_name_len;
         do {
-            z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+            z->next_out = ZLIB_BYTE_PTR(comp_buf);
             z->avail_out = buf_size_bytes;
-            deflate(z,Z_NO_FLUSH);
-            byteswritten += fwrite(comp_buf,1,buf_size_bytes-z->avail_out,
-                (FILE*)mat->fp);
+            deflate(z, Z_NO_FLUSH);
+            byteswritten += fwrite(comp_buf, 1, buf_size_bytes - z->avail_out, (FILE *)mat->fp);
         } while ( z->avail_out == 0 );
     }
 
-    byteswritten += WriteCompressedData(mat,z,NULL,0,MAT_T_DOUBLE);
+    byteswritten += WriteCompressedData(mat, z, NULL, 0, MAT_T_DOUBLE);
     return byteswritten;
 }
 #endif
@@ -9145,7 +9238,7 @@ Mat_WriteCompressedEmptyVariable5(mat_t *mat,const char *name,int rank,
  * @endif
  */
 static int
-Mat_VarReadNumeric5(mat_t *mat,matvar_t *matvar,void *data,size_t N)
+Mat_VarReadNumeric5(mat_t *mat, matvar_t *matvar, void *data, size_t N)
 {
     int nBytes = 0, data_in_tag = 0, err = MATIO_E_NO_ERROR;
     enum matio_types packed_type = MAT_T_UNKNOWN;
@@ -9167,17 +9260,17 @@ Mat_VarReadNumeric5(mat_t *mat,matvar_t *matvar,void *data,size_t N)
             nBytes = (tag[0] & 0xffff0000) >> 16;
         } else {
             data_in_tag = 0;
-            err = Inflate(mat, matvar->internal->z, tag+1, 4, NULL);
+            err = Inflate(mat, matvar->internal->z, tag + 1, 4, NULL);
             if ( err ) {
                 return err;
             }
             if ( mat->byteswap )
-                (void)Mat_uint32Swap(tag+1);
+                (void)Mat_uint32Swap(tag + 1);
             nBytes = tag[1];
         }
 #endif
     } else {
-        err = Read(tag, 4, 1, (FILE*)mat->fp, NULL);
+        err = Read(tag, 4, 1, (FILE *)mat->fp, NULL);
         if ( err ) {
             return err;
         }
@@ -9189,12 +9282,12 @@ Mat_VarReadNumeric5(mat_t *mat,matvar_t *matvar,void *data,size_t N)
             nBytes = (tag[0] & 0xffff0000) >> 16;
         } else {
             data_in_tag = 0;
-            err = Read(tag+1, 4, 1, (FILE*)mat->fp, NULL);
+            err = Read(tag + 1, 4, 1, (FILE *)mat->fp, NULL);
             if ( err ) {
                 return err;
             }
             if ( mat->byteswap )
-                (void)Mat_uint32Swap(tag+1);
+                (void)Mat_uint32Swap(tag + 1);
             nBytes = tag[1];
         }
     }
@@ -9206,38 +9299,38 @@ Mat_VarReadNumeric5(mat_t *mat,matvar_t *matvar,void *data,size_t N)
     if ( matvar->compression == MAT_COMPRESSION_NONE ) {
         switch ( matvar->class_type ) {
             case MAT_C_DOUBLE:
-                nBytes = ReadDoubleData(mat,(double*)data,packed_type,N);
+                nBytes = ReadDoubleData(mat, (double *)data, packed_type, N);
                 break;
             case MAT_C_SINGLE:
-                nBytes = ReadSingleData(mat,(float*)data,packed_type,N);
+                nBytes = ReadSingleData(mat, (float *)data, packed_type, N);
                 break;
             case MAT_C_INT64:
 #ifdef HAVE_MATIO_INT64_T
-                nBytes = ReadInt64Data(mat,(mat_int64_t*)data,packed_type,N);
+                nBytes = ReadInt64Data(mat, (mat_int64_t *)data, packed_type, N);
 #endif
                 break;
             case MAT_C_UINT64:
 #ifdef HAVE_MATIO_UINT64_T
-                nBytes = ReadUInt64Data(mat,(mat_uint64_t*)data,packed_type,N);
+                nBytes = ReadUInt64Data(mat, (mat_uint64_t *)data, packed_type, N);
 #endif
                 break;
             case MAT_C_INT32:
-                nBytes = ReadInt32Data(mat,(mat_int32_t*)data,packed_type,N);
+                nBytes = ReadInt32Data(mat, (mat_int32_t *)data, packed_type, N);
                 break;
             case MAT_C_UINT32:
-                nBytes = ReadUInt32Data(mat,(mat_uint32_t*)data,packed_type,N);
+                nBytes = ReadUInt32Data(mat, (mat_uint32_t *)data, packed_type, N);
                 break;
             case MAT_C_INT16:
-                nBytes = ReadInt16Data(mat,(mat_int16_t*)data,packed_type,N);
+                nBytes = ReadInt16Data(mat, (mat_int16_t *)data, packed_type, N);
                 break;
             case MAT_C_UINT16:
-                nBytes = ReadUInt16Data(mat,(mat_uint16_t*)data,packed_type,N);
+                nBytes = ReadUInt16Data(mat, (mat_uint16_t *)data, packed_type, N);
                 break;
             case MAT_C_INT8:
-                nBytes = ReadInt8Data(mat,(mat_int8_t*)data,packed_type,N);
+                nBytes = ReadInt8Data(mat, (mat_int8_t *)data, packed_type, N);
                 break;
             case MAT_C_UINT8:
-                nBytes = ReadUInt8Data(mat,(mat_uint8_t*)data,packed_type,N);
+                nBytes = ReadUInt8Data(mat, (mat_uint8_t *)data, packed_type, N);
                 break;
             default:
                 break;
@@ -9248,55 +9341,55 @@ Mat_VarReadNumeric5(mat_t *mat,matvar_t *matvar,void *data,size_t N)
          * boundary so add 4 to make it an 8-byte
          */
         if ( data_in_tag )
-            nBytes+=4;
+            nBytes += 4;
         if ( (nBytes % 8) != 0 )
-            (void)fseek((FILE*)mat->fp,8-(nBytes % 8),SEEK_CUR);
+            (void)fseek((FILE *)mat->fp, 8 - (nBytes % 8), SEEK_CUR);
 #if HAVE_ZLIB
     } else if ( matvar->compression == MAT_COMPRESSION_ZLIB ) {
         switch ( matvar->class_type ) {
             case MAT_C_DOUBLE:
-                nBytes = ReadCompressedDoubleData(mat,matvar->internal->z,(double*)data,
-                                                  packed_type,N);
+                nBytes = ReadCompressedDoubleData(mat, matvar->internal->z, (double *)data,
+                                                  packed_type, N);
                 break;
             case MAT_C_SINGLE:
-                nBytes = ReadCompressedSingleData(mat,matvar->internal->z,(float*)data,
-                                                  packed_type,N);
+                nBytes = ReadCompressedSingleData(mat, matvar->internal->z, (float *)data,
+                                                  packed_type, N);
                 break;
             case MAT_C_INT64:
 #ifdef HAVE_MATIO_INT64_T
-                nBytes = ReadCompressedInt64Data(mat,matvar->internal->z,(mat_int64_t*)data,
-                                                 packed_type,N);
+                nBytes = ReadCompressedInt64Data(mat, matvar->internal->z, (mat_int64_t *)data,
+                                                 packed_type, N);
 #endif
                 break;
             case MAT_C_UINT64:
 #ifdef HAVE_MATIO_UINT64_T
-                nBytes = ReadCompressedUInt64Data(mat,matvar->internal->z,(mat_uint64_t*)data,
-                                                  packed_type,N);
+                nBytes = ReadCompressedUInt64Data(mat, matvar->internal->z, (mat_uint64_t *)data,
+                                                  packed_type, N);
 #endif
                 break;
             case MAT_C_INT32:
-                nBytes = ReadCompressedInt32Data(mat,matvar->internal->z,(mat_int32_t*)data,
-                                                 packed_type,N);
+                nBytes = ReadCompressedInt32Data(mat, matvar->internal->z, (mat_int32_t *)data,
+                                                 packed_type, N);
                 break;
             case MAT_C_UINT32:
-                nBytes = ReadCompressedUInt32Data(mat,matvar->internal->z,(mat_uint32_t*)data,
-                                                  packed_type,N);
+                nBytes = ReadCompressedUInt32Data(mat, matvar->internal->z, (mat_uint32_t *)data,
+                                                  packed_type, N);
                 break;
             case MAT_C_INT16:
-                nBytes = ReadCompressedInt16Data(mat,matvar->internal->z,(mat_int16_t*)data,
-                                                 packed_type,N);
+                nBytes = ReadCompressedInt16Data(mat, matvar->internal->z, (mat_int16_t *)data,
+                                                 packed_type, N);
                 break;
             case MAT_C_UINT16:
-                nBytes = ReadCompressedUInt16Data(mat,matvar->internal->z,(mat_uint16_t*)data,
-                                                  packed_type,N);
+                nBytes = ReadCompressedUInt16Data(mat, matvar->internal->z, (mat_uint16_t *)data,
+                                                  packed_type, N);
                 break;
             case MAT_C_INT8:
-                nBytes = ReadCompressedInt8Data(mat,matvar->internal->z,(mat_int8_t*)data,
-                                                packed_type,N);
+                nBytes = ReadCompressedInt8Data(mat, matvar->internal->z, (mat_int8_t *)data,
+                                                packed_type, N);
                 break;
             case MAT_C_UINT8:
-                nBytes = ReadCompressedUInt8Data(mat,matvar->internal->z,(mat_uint8_t*)data,
-                                                 packed_type,N);
+                nBytes = ReadCompressedUInt8Data(mat, matvar->internal->z, (mat_uint8_t *)data,
+                                                 packed_type, N);
                 break;
             default:
                 break;
@@ -9306,9 +9399,9 @@ Mat_VarReadNumeric5(mat_t *mat,matvar_t *matvar,void *data,size_t N)
          * boundary so add 4 to make it an 8-byte
          */
         if ( data_in_tag )
-            nBytes+=4;
+            nBytes += 4;
         if ( (nBytes % 8) != 0 )
-            err = InflateSkip(mat, matvar->internal->z, 8-(nBytes % 8), NULL);
+            err = InflateSkip(mat, matvar->internal->z, 8 - (nBytes % 8), NULL);
 #endif
     }
     return err;
@@ -9335,7 +9428,7 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
 
     if ( matvar == NULL )
         return MATIO_E_BAD_ARGUMENT;
-    else if ( matvar->rank == 0 )        /* An empty data set */
+    else if ( matvar->rank == 0 ) /* An empty data set */
         return MATIO_E_NO_ERROR;
 #if HAVE_ZLIB
     else if ( NULL != matvar->internal->data ) {
@@ -9345,7 +9438,7 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
         return MATIO_E_NO_ERROR;
     }
 #endif
-    fpos = ftell((FILE*)mat->fp);
+    fpos = ftell((FILE *)mat->fp);
     if ( fpos == -1L ) {
         Mat_Critical("Couldn't determine file position");
         return MATIO_E_GENERIC_READ_ERROR;
@@ -9365,64 +9458,64 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
             if ( NULL != matvar->dims ) {
                 free(matvar->dims);
             }
-            matvar->dims = (size_t*)calloc(matvar->rank, sizeof(*(matvar->dims)));
+            matvar->dims = (size_t *)calloc(matvar->rank, sizeof(*(matvar->dims)));
             break;
         case MAT_C_DOUBLE:
-            (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
             matvar->data_size = sizeof(double);
             matvar->data_type = MAT_T_DOUBLE;
             break;
         case MAT_C_SINGLE:
-            (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
             matvar->data_size = sizeof(float);
             matvar->data_type = MAT_T_SINGLE;
             break;
         case MAT_C_INT64:
 #ifdef HAVE_MATIO_INT64_T
-            (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
             matvar->data_size = sizeof(mat_int64_t);
             matvar->data_type = MAT_T_INT64;
 #endif
             break;
         case MAT_C_UINT64:
 #ifdef HAVE_MATIO_UINT64_T
-            (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
             matvar->data_size = sizeof(mat_uint64_t);
             matvar->data_type = MAT_T_UINT64;
 #endif
             break;
         case MAT_C_INT32:
-            (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
             matvar->data_size = sizeof(mat_int32_t);
             matvar->data_type = MAT_T_INT32;
             break;
         case MAT_C_UINT32:
-            (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
             matvar->data_size = sizeof(mat_uint32_t);
             matvar->data_type = MAT_T_UINT32;
             break;
         case MAT_C_INT16:
-            (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
             matvar->data_size = sizeof(mat_int16_t);
             matvar->data_type = MAT_T_INT16;
             break;
         case MAT_C_UINT16:
-            (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
             matvar->data_size = sizeof(mat_uint16_t);
             matvar->data_type = MAT_T_UINT16;
             break;
         case MAT_C_INT8:
-            (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
             matvar->data_size = sizeof(mat_int8_t);
             matvar->data_type = MAT_T_INT8;
             break;
         case MAT_C_UINT8:
-            (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
             matvar->data_size = sizeof(mat_uint8_t);
             matvar->data_type = MAT_T_UINT8;
             break;
         case MAT_C_CHAR:
-            (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
             if ( matvar->compression == MAT_COMPRESSION_ZLIB ) {
 #if HAVE_ZLIB
                 matvar->internal->z->avail_in = 0;
@@ -9438,12 +9531,12 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
                     nBytes = (tag[0] & 0xffff0000) >> 16;
                 } else {
                     data_in_tag = 0;
-                    err = Inflate(mat, matvar->internal->z, tag+1, 4, &bytesread);
+                    err = Inflate(mat, matvar->internal->z, tag + 1, 4, &bytesread);
                     if ( err ) {
                         break;
                     }
                     if ( byteswap )
-                        (void)Mat_uint32Swap(tag+1);
+                        (void)Mat_uint32Swap(tag + 1);
                     nBytes = tag[1];
                 }
 #endif
@@ -9451,7 +9544,7 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
                 matvar->data_size = Mat_SizeOf(matvar->data_type);
                 matvar->nbytes = nBytes;
             } else {
-                err = Read(tag, 4, 1, (FILE*)mat->fp, &bytesread);
+                err = Read(tag, 4, 1, (FILE *)mat->fp, &bytesread);
                 if ( err ) {
                     break;
                 }
@@ -9460,24 +9553,20 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
                 packed_type = TYPE_FROM_TAG(tag[0]);
                 if ( tag[0] & 0xffff0000 ) { /* Data is in the tag */
                     data_in_tag = 1;
-                    /* nBytes = (tag[0] & 0xffff0000) >> 16; */
+                    nBytes = (tag[0] & 0xffff0000) >> 16;
                 } else {
                     data_in_tag = 0;
-                    err = Read(tag+1, 4, 1, (FILE*)mat->fp, &bytesread);
+                    err = Read(tag + 1, 4, 1, (FILE *)mat->fp, &bytesread);
                     if ( err ) {
                         break;
                     }
                     if ( byteswap )
-                        (void)Mat_uint32Swap(tag+1);
-                    /* nBytes = tag[1]; */
+                        (void)Mat_uint32Swap(tag + 1);
+                    nBytes = tag[1];
                 }
-                matvar->data_type = MAT_T_UINT8;
-                matvar->data_size = Mat_SizeOf(MAT_T_UINT8);
-                err = Mul(&matvar->nbytes, nelems, matvar->data_size);
-                if ( err ) {
-                    Mat_Critical("Integer multiplication overflow");
-                    break;
-                }
+                matvar->data_type = packed_type;
+                matvar->data_size = Mat_SizeOf(matvar->data_type);
+                matvar->nbytes = nBytes;
             }
             if ( matvar->isComplex ) {
                 break;
@@ -9502,33 +9591,35 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
                     break;
                 }
             }
+            if ( matvar->data_type == MAT_T_UTF8 ) {
+                nelems = matvar->nbytes;
+            }
             if ( matvar->compression == MAT_COMPRESSION_NONE ) {
-                nBytes = ReadCharData(mat,(char*)matvar->data,packed_type,nelems);
+                nBytes = ReadCharData(mat, matvar->data, matvar->data_type, nelems);
                 /*
                  * If the data was in the tag we started on a 4-byte
                  * boundary so add 4 to make it an 8-byte
                  */
                 if ( data_in_tag )
-                    nBytes+=4;
+                    nBytes += 4;
                 if ( (nBytes % 8) != 0 )
-                    (void)fseek((FILE*)mat->fp,8-(nBytes % 8),SEEK_CUR);
+                    (void)fseek((FILE *)mat->fp, 8 - (nBytes % 8), SEEK_CUR);
 #if HAVE_ZLIB
             } else if ( matvar->compression == MAT_COMPRESSION_ZLIB ) {
-                nBytes = ReadCompressedCharData(mat,matvar->internal->z,
-                             (char*)matvar->data,packed_type,(int)nelems);
+                nBytes = ReadCompressedCharData(mat, matvar->internal->z, matvar->data,
+                                                matvar->data_type, nelems);
                 /*
                  * If the data was in the tag we started on a 4-byte
                  * boundary so add 4 to make it an 8-byte
                  */
                 if ( data_in_tag )
-                    nBytes+=4;
+                    nBytes += 4;
                 if ( (nBytes % 8) != 0 )
-                    InflateSkip(mat, matvar->internal->z, 8-(nBytes % 8), NULL);
+                    InflateSkip(mat, matvar->internal->z, 8 - (nBytes % 8), NULL);
 #endif
             }
             break;
-        case MAT_C_STRUCT:
-        {
+        case MAT_C_STRUCT: {
             matvar_t **fields;
             size_t i, nelems_x_nfields;
 
@@ -9539,20 +9630,19 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
             fields = (matvar_t **)matvar->data;
             for ( i = 0; i < nelems_x_nfields; i++ ) {
                 if ( NULL != fields[i] ) {
-                    err = Mat_VarRead5(mat,fields[i]);
-                    if (err )
+                    err = Mat_VarRead5(mat, fields[i]);
+                    if ( err )
                         break;
                 }
             }
             break;
         }
-        case MAT_C_CELL:
-        {
+        case MAT_C_CELL: {
             matvar_t **cells;
             size_t i;
 
             if ( NULL == matvar->data ) {
-                Mat_Critical("Data is NULL for cell array %s",matvar->name);
+                Mat_Critical("Data is NULL for cell array %s", matvar->name);
                 err = MATIO_E_FILE_FORMAT_VIOLATION;
                 break;
             }
@@ -9568,21 +9658,20 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
             matvar->data_type = MAT_T_CELL;
             break;
         }
-        case MAT_C_SPARSE:
-        {
+        case MAT_C_SPARSE: {
             mat_uint32_t N = 0;
             mat_sparse_t *sparse;
 
             matvar->data_size = sizeof(mat_sparse_t);
-            matvar->data      = calloc(1, matvar->data_size);
+            matvar->data = calloc(1, matvar->data_size);
             if ( matvar->data == NULL ) {
                 err = MATIO_E_OUT_OF_MEMORY;
                 Mat_Critical("Mat_VarRead5: Allocation of data pointer failed");
                 break;
             }
-            sparse = (mat_sparse_t*)matvar->data;
-            sparse->nzmax  = matvar->nbytes;
-            (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+            sparse = (mat_sparse_t *)matvar->data;
+            sparse->nzmax = matvar->nbytes;
+            (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
             /*  Read ir    */
             bytesread += ReadSparse(mat, matvar, &sparse->nir, &sparse->ir);
             /*  Read jc    */
@@ -9603,12 +9692,11 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
                     N = (tag[0] & 0xffff0000) >> 16;
                 } else {
                     data_in_tag = 0;
-                    (void)ReadCompressedUInt32Data(mat,matvar->internal->z,
-                             &N,MAT_T_UINT32,1);
+                    (void)ReadCompressedUInt32Data(mat, matvar->internal->z, &N, MAT_T_UINT32, 1);
                 }
 #endif
             } else {
-                err = Read(tag, 4, 1, (FILE*)mat->fp, &bytesread);
+                err = Read(tag, 4, 1, (FILE *)mat->fp, &bytesread);
                 if ( err ) {
                     break;
                 }
@@ -9620,7 +9708,7 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
                     N = (tag[0] & 0xffff0000) >> 16;
                 } else {
                     data_in_tag = 0;
-                    err = Read(&N, 4, 1, (FILE*)mat->fp, &bytesread);
+                    err = Read(&N, 4, 1, (FILE *)mat->fp, &bytesread);
                     if ( err ) {
                         break;
                     }
@@ -9663,65 +9751,66 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
 #if defined(EXTENDED_SPARSE)
                     switch ( matvar->data_type ) {
                         case MAT_T_DOUBLE:
-                            nBytes = ReadDoubleData(mat,(double*)complex_data->Re,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadDoubleData(mat, (double *)complex_data->Re, packed_type,
+                                                    sparse->ndata);
                             break;
                         case MAT_T_SINGLE:
-                            nBytes = ReadSingleData(mat,(float*)complex_data->Re,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadSingleData(mat, (float *)complex_data->Re, packed_type,
+                                                    sparse->ndata);
                             break;
                         case MAT_T_INT64:
 #ifdef HAVE_MATIO_INT64_T
-                            nBytes = ReadInt64Data(mat,(mat_int64_t*)complex_data->Re,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadInt64Data(mat, (mat_int64_t *)complex_data->Re,
+                                                   packed_type, sparse->ndata);
 #endif
                             break;
                         case MAT_T_UINT64:
 #ifdef HAVE_MATIO_UINT64_T
-                            nBytes = ReadUInt64Data(mat,(mat_uint64_t*)complex_data->Re,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadUInt64Data(mat, (mat_uint64_t *)complex_data->Re,
+                                                    packed_type, sparse->ndata);
 #endif
                             break;
                         case MAT_T_INT32:
-                            nBytes = ReadInt32Data(mat,(mat_int32_t*)complex_data->Re,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadInt32Data(mat, (mat_int32_t *)complex_data->Re,
+                                                   packed_type, sparse->ndata);
                             break;
                         case MAT_T_UINT32:
-                            nBytes = ReadUInt32Data(mat,(mat_uint32_t*)complex_data->Re,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadUInt32Data(mat, (mat_uint32_t *)complex_data->Re,
+                                                    packed_type, sparse->ndata);
                             break;
                         case MAT_T_INT16:
-                            nBytes = ReadInt16Data(mat,(mat_int16_t*)complex_data->Re,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadInt16Data(mat, (mat_int16_t *)complex_data->Re,
+                                                   packed_type, sparse->ndata);
                             break;
                         case MAT_T_UINT16:
-                            nBytes = ReadUInt16Data(mat,(mat_uint16_t*)complex_data->Re,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadUInt16Data(mat, (mat_uint16_t *)complex_data->Re,
+                                                    packed_type, sparse->ndata);
                             break;
                         case MAT_T_INT8:
-                            nBytes = ReadInt8Data(mat,(mat_int8_t*)complex_data->Re,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadInt8Data(mat, (mat_int8_t *)complex_data->Re, packed_type,
+                                                  sparse->ndata);
                             break;
                         case MAT_T_UINT8:
-                            nBytes = ReadUInt8Data(mat,(mat_uint8_t*)complex_data->Re,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadUInt8Data(mat, (mat_uint8_t *)complex_data->Re,
+                                                   packed_type, sparse->ndata);
                             break;
                         default:
                             break;
                     }
 #else
-                    nBytes = ReadDoubleData(mat,(double*)complex_data->Re,
-                                 packed_type,sparse->ndata);
+                    nBytes =
+                        ReadDoubleData(mat, (double *)complex_data->Re, packed_type, sparse->ndata);
 #endif
                     nBytes *= Mat_SizeOf(packed_type);
                     if ( data_in_tag )
-                        nBytes+=4;
+                        nBytes += 4;
                     if ( (nBytes % 8) != 0 )
-                        (void)fseek((FILE*)mat->fp,8-(nBytes % 8),SEEK_CUR);
+                        (void)fseek((FILE *)mat->fp, 8 - (nBytes % 8), SEEK_CUR);
 
                     /* Complex Data Tag */
-                    err = Read(tag, 4, 1, (FILE*)mat->fp, &bytesread);
+                    err = Read(tag, 4, 1, (FILE *)mat->fp, &bytesread);
                     if ( err ) {
+                        ComplexFree(complex_data);
                         break;
                     }
                     if ( byteswap )
@@ -9732,133 +9821,143 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
                         nBytes = (tag[0] & 0xffff0000) >> 16;
                     } else {
                         data_in_tag = 0;
-                        err = Read(tag+1, 4, 1, (FILE*)mat->fp, &bytesread);
+                        err = Read(tag + 1, 4, 1, (FILE *)mat->fp, &bytesread);
                         if ( err ) {
+                            ComplexFree(complex_data);
                             break;
                         }
                         if ( byteswap )
-                            (void)Mat_uint32Swap(tag+1);
+                            (void)Mat_uint32Swap(tag + 1);
                         nBytes = tag[1];
                     }
 #if defined(EXTENDED_SPARSE)
                     switch ( matvar->data_type ) {
                         case MAT_T_DOUBLE:
-                            nBytes = ReadDoubleData(mat,(double*)complex_data->Im,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadDoubleData(mat, (double *)complex_data->Im, packed_type,
+                                                    sparse->ndata);
                             break;
                         case MAT_T_SINGLE:
-                            nBytes = ReadSingleData(mat,(float*)complex_data->Im,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadSingleData(mat, (float *)complex_data->Im, packed_type,
+                                                    sparse->ndata);
                             break;
                         case MAT_T_INT64:
 #ifdef HAVE_MATIO_INT64_T
-                            nBytes = ReadInt64Data(mat,(mat_int64_t*)complex_data->Im,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadInt64Data(mat, (mat_int64_t *)complex_data->Im,
+                                                   packed_type, sparse->ndata);
 #endif
                             break;
                         case MAT_T_UINT64:
 #ifdef HAVE_MATIO_UINT64_T
-                            nBytes = ReadUInt64Data(mat,(mat_uint64_t*)complex_data->Im,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadUInt64Data(mat, (mat_uint64_t *)complex_data->Im,
+                                                    packed_type, sparse->ndata);
 #endif
                             break;
                         case MAT_T_INT32:
-                            nBytes = ReadInt32Data(mat,(mat_int32_t*)complex_data->Im,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadInt32Data(mat, (mat_int32_t *)complex_data->Im,
+                                                   packed_type, sparse->ndata);
                             break;
                         case MAT_T_UINT32:
-                            nBytes = ReadUInt32Data(mat,(mat_uint32_t*)complex_data->Im,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadUInt32Data(mat, (mat_uint32_t *)complex_data->Im,
+                                                    packed_type, sparse->ndata);
                             break;
                         case MAT_T_INT16:
-                            nBytes = ReadInt16Data(mat,(mat_int16_t*)complex_data->Im,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadInt16Data(mat, (mat_int16_t *)complex_data->Im,
+                                                   packed_type, sparse->ndata);
                             break;
                         case MAT_T_UINT16:
-                            nBytes = ReadUInt16Data(mat,(mat_uint16_t*)complex_data->Im,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadUInt16Data(mat, (mat_uint16_t *)complex_data->Im,
+                                                    packed_type, sparse->ndata);
                             break;
                         case MAT_T_INT8:
-                            nBytes = ReadInt8Data(mat,(mat_int8_t*)complex_data->Im,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadInt8Data(mat, (mat_int8_t *)complex_data->Im, packed_type,
+                                                  sparse->ndata);
                             break;
                         case MAT_T_UINT8:
-                            nBytes = ReadUInt8Data(mat,(mat_uint8_t*)complex_data->Im,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadUInt8Data(mat, (mat_uint8_t *)complex_data->Im,
+                                                   packed_type, sparse->ndata);
                             break;
                         default:
                             break;
                     }
 #else /* EXTENDED_SPARSE */
-                    nBytes = ReadDoubleData(mat,(double*)complex_data->Im,
-                                packed_type,sparse->ndata);
+                    nBytes =
+                        ReadDoubleData(mat, (double *)complex_data->Im, packed_type, sparse->ndata);
 #endif /* EXTENDED_SPARSE */
                     nBytes *= Mat_SizeOf(packed_type);
                     if ( data_in_tag )
-                        nBytes+=4;
+                        nBytes += 4;
                     if ( (nBytes % 8) != 0 )
-                        (void)fseek((FILE*)mat->fp,8-(nBytes % 8),SEEK_CUR);
+                        (void)fseek((FILE *)mat->fp, 8 - (nBytes % 8), SEEK_CUR);
 #if HAVE_ZLIB
                 } else if ( matvar->compression == MAT_COMPRESSION_ZLIB ) {
 #if defined(EXTENDED_SPARSE)
                     switch ( matvar->data_type ) {
                         case MAT_T_DOUBLE:
-                            nBytes = ReadCompressedDoubleData(mat,matvar->internal->z,
-                                 (double*)complex_data->Re,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedDoubleData(mat, matvar->internal->z,
+                                                              (double *)complex_data->Re,
+                                                              packed_type, sparse->ndata);
                             break;
                         case MAT_T_SINGLE:
-                            nBytes = ReadCompressedSingleData(mat,matvar->internal->z,
-                                 (float*)complex_data->Re,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedSingleData(mat, matvar->internal->z,
+                                                              (float *)complex_data->Re,
+                                                              packed_type, sparse->ndata);
                             break;
                         case MAT_T_INT64:
 #ifdef HAVE_MATIO_INT64_T
-                            nBytes = ReadCompressedInt64Data(mat,
-                                matvar->internal->z,(mat_int64_t*)complex_data->Re,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadCompressedInt64Data(mat, matvar->internal->z,
+                                                             (mat_int64_t *)complex_data->Re,
+                                                             packed_type, sparse->ndata);
 #endif
                             break;
                         case MAT_T_UINT64:
 #ifdef HAVE_MATIO_UINT64_T
-                            nBytes = ReadCompressedUInt64Data(mat,
-                                matvar->internal->z,(mat_uint64_t*)complex_data->Re,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadCompressedUInt64Data(mat, matvar->internal->z,
+                                                              (mat_uint64_t *)complex_data->Re,
+                                                              packed_type, sparse->ndata);
 #endif
                             break;
                         case MAT_T_INT32:
-                            nBytes = ReadCompressedInt32Data(mat,matvar->internal->z,
-                                 (mat_int32_t*)complex_data->Re,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedInt32Data(mat, matvar->internal->z,
+                                                             (mat_int32_t *)complex_data->Re,
+                                                             packed_type, sparse->ndata);
                             break;
                         case MAT_T_UINT32:
-                            nBytes = ReadCompressedUInt32Data(mat,matvar->internal->z,
-                                 (mat_uint32_t*)complex_data->Re,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedUInt32Data(mat, matvar->internal->z,
+                                                              (mat_uint32_t *)complex_data->Re,
+                                                              packed_type, sparse->ndata);
                             break;
                         case MAT_T_INT16:
-                            nBytes = ReadCompressedInt16Data(mat,matvar->internal->z,
-                                 (mat_int16_t*)complex_data->Re,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedInt16Data(mat, matvar->internal->z,
+                                                             (mat_int16_t *)complex_data->Re,
+                                                             packed_type, sparse->ndata);
                             break;
                         case MAT_T_UINT16:
-                            nBytes = ReadCompressedUInt16Data(mat,matvar->internal->z,
-                                 (mat_uint16_t*)complex_data->Re,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedUInt16Data(mat, matvar->internal->z,
+                                                              (mat_uint16_t *)complex_data->Re,
+                                                              packed_type, sparse->ndata);
                             break;
                         case MAT_T_INT8:
-                            nBytes = ReadCompressedInt8Data(mat,matvar->internal->z,
-                                 (mat_int8_t*)complex_data->Re,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedInt8Data(mat, matvar->internal->z,
+                                                            (mat_int8_t *)complex_data->Re,
+                                                            packed_type, sparse->ndata);
                             break;
                         case MAT_T_UINT8:
-                            nBytes = ReadCompressedUInt8Data(mat,matvar->internal->z,
-                                 (mat_uint8_t*)complex_data->Re,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedUInt8Data(mat, matvar->internal->z,
+                                                             (mat_uint8_t *)complex_data->Re,
+                                                             packed_type, sparse->ndata);
                             break;
                         default:
                             break;
                     }
-#else    /* EXTENDED_SPARSE */
-                    nBytes = ReadCompressedDoubleData(mat,matvar->internal->z,
-                                 (double*)complex_data->Re,packed_type,sparse->ndata);
-#endif    /* EXTENDED_SPARSE */
+#else /* EXTENDED_SPARSE */
+                    nBytes = ReadCompressedDoubleData(mat, matvar->internal->z,
+                                                      (double *)complex_data->Re, packed_type,
+                                                      sparse->ndata);
+#endif /* EXTENDED_SPARSE */
                     if ( data_in_tag )
-                        nBytes+=4;
+                        nBytes += 4;
                     if ( (nBytes % 8) != 0 )
-                        InflateSkip(mat,matvar->internal->z,8-(nBytes % 8), NULL);
+                        InflateSkip(mat, matvar->internal->z, 8 - (nBytes % 8), NULL);
 
                     /* Complex Data Tag */
                     err = Inflate(mat, matvar->internal->z, tag, 4, NULL);
@@ -9875,75 +9974,84 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
                         nBytes = (tag[0] & 0xffff0000) >> 16;
                     } else {
                         data_in_tag = 0;
-                        err = Inflate(mat, matvar->internal->z, tag+1, 4, NULL);
+                        err = Inflate(mat, matvar->internal->z, tag + 1, 4, NULL);
                         if ( err ) {
                             ComplexFree(complex_data);
                             break;
                         }
                         if ( byteswap )
-                            (void)Mat_uint32Swap(tag+1);
+                            (void)Mat_uint32Swap(tag + 1);
                         nBytes = tag[1];
                     }
 #if defined(EXTENDED_SPARSE)
                     switch ( matvar->data_type ) {
                         case MAT_T_DOUBLE:
-                            nBytes = ReadCompressedDoubleData(mat,matvar->internal->z,
-                                 (double*)complex_data->Im,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedDoubleData(mat, matvar->internal->z,
+                                                              (double *)complex_data->Im,
+                                                              packed_type, sparse->ndata);
                             break;
                         case MAT_T_SINGLE:
-                            nBytes = ReadCompressedSingleData(mat,matvar->internal->z,
-                                 (float*)complex_data->Im,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedSingleData(mat, matvar->internal->z,
+                                                              (float *)complex_data->Im,
+                                                              packed_type, sparse->ndata);
                             break;
                         case MAT_T_INT64:
 #ifdef HAVE_MATIO_INT64_T
-                            nBytes = ReadCompressedInt64Data(mat,
-                                matvar->internal->z,(mat_int64_t*)complex_data->Im,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadCompressedInt64Data(mat, matvar->internal->z,
+                                                             (mat_int64_t *)complex_data->Im,
+                                                             packed_type, sparse->ndata);
 #endif
                             break;
                         case MAT_T_UINT64:
 #ifdef HAVE_MATIO_UINT64_T
-                            nBytes = ReadCompressedUInt64Data(mat,
-                                matvar->internal->z,(mat_uint64_t*)complex_data->Im,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadCompressedUInt64Data(mat, matvar->internal->z,
+                                                              (mat_uint64_t *)complex_data->Im,
+                                                              packed_type, sparse->ndata);
 #endif
                             break;
                         case MAT_T_INT32:
-                            nBytes = ReadCompressedInt32Data(mat,matvar->internal->z,
-                                 (mat_int32_t*)complex_data->Im,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedInt32Data(mat, matvar->internal->z,
+                                                             (mat_int32_t *)complex_data->Im,
+                                                             packed_type, sparse->ndata);
                             break;
                         case MAT_T_UINT32:
-                            nBytes = ReadCompressedUInt32Data(mat,matvar->internal->z,
-                                 (mat_uint32_t*)complex_data->Im,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedUInt32Data(mat, matvar->internal->z,
+                                                              (mat_uint32_t *)complex_data->Im,
+                                                              packed_type, sparse->ndata);
                             break;
                         case MAT_T_INT16:
-                            nBytes = ReadCompressedInt16Data(mat,matvar->internal->z,
-                                 (mat_int16_t*)complex_data->Im,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedInt16Data(mat, matvar->internal->z,
+                                                             (mat_int16_t *)complex_data->Im,
+                                                             packed_type, sparse->ndata);
                             break;
                         case MAT_T_UINT16:
-                            nBytes = ReadCompressedUInt16Data(mat,matvar->internal->z,
-                                 (mat_uint16_t*)complex_data->Im,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedUInt16Data(mat, matvar->internal->z,
+                                                              (mat_uint16_t *)complex_data->Im,
+                                                              packed_type, sparse->ndata);
                             break;
                         case MAT_T_INT8:
-                            nBytes = ReadCompressedInt8Data(mat,matvar->internal->z,
-                                 (mat_int8_t*)complex_data->Im,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedInt8Data(mat, matvar->internal->z,
+                                                            (mat_int8_t *)complex_data->Im,
+                                                            packed_type, sparse->ndata);
                             break;
                         case MAT_T_UINT8:
-                            nBytes = ReadCompressedUInt8Data(mat,matvar->internal->z,
-                                 (mat_uint8_t*)complex_data->Im,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedUInt8Data(mat, matvar->internal->z,
+                                                             (mat_uint8_t *)complex_data->Im,
+                                                             packed_type, sparse->ndata);
                             break;
                         default:
                             break;
                     }
-#else    /* EXTENDED_SPARSE */
-                    nBytes = ReadCompressedDoubleData(mat,matvar->internal->z,
-                                 (double*)complex_data->Im,packed_type,sparse->ndata);
-#endif    /* EXTENDED_SPARSE */
+#else /* EXTENDED_SPARSE */
+                    nBytes = ReadCompressedDoubleData(mat, matvar->internal->z,
+                                                      (double *)complex_data->Im, packed_type,
+                                                      sparse->ndata);
+#endif /* EXTENDED_SPARSE */
                     if ( data_in_tag )
-                        nBytes+=4;
+                        nBytes += 4;
                     if ( (nBytes % 8) != 0 )
-                        err = InflateSkip(mat, matvar->internal->z, 8-(nBytes % 8), NULL);
-#endif    /* HAVE_ZLIB */
+                        err = InflateSkip(mat, matvar->internal->z, 8 - (nBytes % 8), NULL);
+#endif /* HAVE_ZLIB */
                 }
                 sparse->data = complex_data;
             } else { /* isComplex */
@@ -9963,129 +10071,137 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
 #if defined(EXTENDED_SPARSE)
                     switch ( matvar->data_type ) {
                         case MAT_T_DOUBLE:
-                            nBytes = ReadDoubleData(mat,(double*)sparse->data,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadDoubleData(mat, (double *)sparse->data, packed_type,
+                                                    sparse->ndata);
                             break;
                         case MAT_T_SINGLE:
-                            nBytes = ReadSingleData(mat,(float*)sparse->data,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadSingleData(mat, (float *)sparse->data, packed_type,
+                                                    sparse->ndata);
                             break;
                         case MAT_T_INT64:
 #ifdef HAVE_MATIO_INT64_T
-                            nBytes = ReadInt64Data(mat,(mat_int64_t*)sparse->data,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadInt64Data(mat, (mat_int64_t *)sparse->data, packed_type,
+                                                   sparse->ndata);
 #endif
                             break;
                         case MAT_T_UINT64:
 #ifdef HAVE_MATIO_UINT64_T
-                            nBytes = ReadUInt64Data(mat,(mat_uint64_t*)sparse->data,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadUInt64Data(mat, (mat_uint64_t *)sparse->data, packed_type,
+                                                    sparse->ndata);
 #endif
                             break;
                         case MAT_T_INT32:
-                            nBytes = ReadInt32Data(mat,(mat_int32_t*)sparse->data,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadInt32Data(mat, (mat_int32_t *)sparse->data, packed_type,
+                                                   sparse->ndata);
                             break;
                         case MAT_T_UINT32:
-                            nBytes = ReadUInt32Data(mat,(mat_uint32_t*)sparse->data,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadUInt32Data(mat, (mat_uint32_t *)sparse->data, packed_type,
+                                                    sparse->ndata);
                             break;
                         case MAT_T_INT16:
-                            nBytes = ReadInt16Data(mat,(mat_int16_t*)sparse->data,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadInt16Data(mat, (mat_int16_t *)sparse->data, packed_type,
+                                                   sparse->ndata);
                             break;
                         case MAT_T_UINT16:
-                            nBytes = ReadUInt16Data(mat,(mat_uint16_t*)sparse->data,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadUInt16Data(mat, (mat_uint16_t *)sparse->data, packed_type,
+                                                    sparse->ndata);
                             break;
                         case MAT_T_INT8:
-                            nBytes = ReadInt8Data(mat,(mat_int8_t*)sparse->data,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadInt8Data(mat, (mat_int8_t *)sparse->data, packed_type,
+                                                  sparse->ndata);
                             break;
                         case MAT_T_UINT8:
-                            nBytes = ReadUInt8Data(mat,(mat_uint8_t*)sparse->data,
-                                packed_type,sparse->ndata);
+                            nBytes = ReadUInt8Data(mat, (mat_uint8_t *)sparse->data, packed_type,
+                                                   sparse->ndata);
                             break;
                         default:
                             break;
                     }
 #else
-                    nBytes = ReadDoubleData(mat,(double*)sparse->data,packed_type,
-                                 sparse->ndata);
+                    nBytes =
+                        ReadDoubleData(mat, (double *)sparse->data, packed_type, sparse->ndata);
 #endif
                     nBytes *= Mat_SizeOf(packed_type);
                     if ( data_in_tag )
-                        nBytes+=4;
+                        nBytes += 4;
                     if ( (nBytes % 8) != 0 )
-                        (void)fseek((FILE*)mat->fp,8-(nBytes % 8),SEEK_CUR);
+                        (void)fseek((FILE *)mat->fp, 8 - (nBytes % 8), SEEK_CUR);
 #if HAVE_ZLIB
                 } else if ( matvar->compression == MAT_COMPRESSION_ZLIB ) {
 #if defined(EXTENDED_SPARSE)
                     switch ( matvar->data_type ) {
                         case MAT_T_DOUBLE:
-                            nBytes = ReadCompressedDoubleData(mat,matvar->internal->z,
-                                 (double*)sparse->data,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedDoubleData(mat, matvar->internal->z,
+                                                              (double *)sparse->data, packed_type,
+                                                              sparse->ndata);
                             break;
                         case MAT_T_SINGLE:
-                            nBytes = ReadCompressedSingleData(mat,matvar->internal->z,
-                                 (float*)sparse->data,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedSingleData(mat, matvar->internal->z,
+                                                              (float *)sparse->data, packed_type,
+                                                              sparse->ndata);
                             break;
                         case MAT_T_INT64:
 #ifdef HAVE_MATIO_INT64_T
-                            nBytes = ReadCompressedInt64Data(mat,
-                                matvar->internal->z,(mat_int64_t*)sparse->data,packed_type,
-                                sparse->ndata);
+                            nBytes = ReadCompressedInt64Data(mat, matvar->internal->z,
+                                                             (mat_int64_t *)sparse->data,
+                                                             packed_type, sparse->ndata);
 #endif
                             break;
                         case MAT_T_UINT64:
 #ifdef HAVE_MATIO_UINT64_T
-                            nBytes = ReadCompressedUInt64Data(mat,
-                                matvar->internal->z,(mat_uint64_t*)sparse->data,packed_type,
-                                sparse->ndata);
+                            nBytes = ReadCompressedUInt64Data(mat, matvar->internal->z,
+                                                              (mat_uint64_t *)sparse->data,
+                                                              packed_type, sparse->ndata);
 #endif
                             break;
                         case MAT_T_INT32:
-                            nBytes = ReadCompressedInt32Data(mat,matvar->internal->z,
-                                 (mat_int32_t*)sparse->data,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedInt32Data(mat, matvar->internal->z,
+                                                             (mat_int32_t *)sparse->data,
+                                                             packed_type, sparse->ndata);
                             break;
                         case MAT_T_UINT32:
-                            nBytes = ReadCompressedUInt32Data(mat,matvar->internal->z,
-                                 (mat_uint32_t*)sparse->data,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedUInt32Data(mat, matvar->internal->z,
+                                                              (mat_uint32_t *)sparse->data,
+                                                              packed_type, sparse->ndata);
                             break;
                         case MAT_T_INT16:
-                            nBytes = ReadCompressedInt16Data(mat,matvar->internal->z,
-                                 (mat_int16_t*)sparse->data,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedInt16Data(mat, matvar->internal->z,
+                                                             (mat_int16_t *)sparse->data,
+                                                             packed_type, sparse->ndata);
                             break;
                         case MAT_T_UINT16:
-                            nBytes = ReadCompressedUInt16Data(mat,matvar->internal->z,
-                                 (mat_uint16_t*)sparse->data,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedUInt16Data(mat, matvar->internal->z,
+                                                              (mat_uint16_t *)sparse->data,
+                                                              packed_type, sparse->ndata);
                             break;
                         case MAT_T_INT8:
-                            nBytes = ReadCompressedInt8Data(mat,matvar->internal->z,
-                                 (mat_int8_t*)sparse->data,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedInt8Data(mat, matvar->internal->z,
+                                                            (mat_int8_t *)sparse->data, packed_type,
+                                                            sparse->ndata);
                             break;
                         case MAT_T_UINT8:
-                            nBytes = ReadCompressedUInt8Data(mat,matvar->internal->z,
-                                 (mat_uint8_t*)sparse->data,packed_type,sparse->ndata);
+                            nBytes = ReadCompressedUInt8Data(mat, matvar->internal->z,
+                                                             (mat_uint8_t *)sparse->data,
+                                                             packed_type, sparse->ndata);
                             break;
                         default:
                             break;
                     }
-#else   /* EXTENDED_SPARSE */
-                    nBytes = ReadCompressedDoubleData(mat,matvar->internal->z,
-                                 (double*)sparse->data,packed_type,sparse->ndata);
-#endif   /* EXTENDED_SPARSE */
+#else /* EXTENDED_SPARSE */
+                    nBytes =
+                        ReadCompressedDoubleData(mat, matvar->internal->z, (double *)sparse->data,
+                                                 packed_type, sparse->ndata);
+#endif /* EXTENDED_SPARSE */
                     if ( data_in_tag )
-                        nBytes+=4;
+                        nBytes += 4;
                     if ( (nBytes % 8) != 0 )
-                        err = InflateSkip(mat, matvar->internal->z, 8-(nBytes % 8), NULL);
-#endif   /* HAVE_ZLIB */
+                        err = InflateSkip(mat, matvar->internal->z, 8 - (nBytes % 8), NULL);
+#endif /* HAVE_ZLIB */
                 }
             }
             break;
         }
-        case MAT_C_FUNCTION:
-        {
+        case MAT_C_FUNCTION: {
             matvar_t **functions;
             size_t nfunctions = 0;
 
@@ -10096,9 +10212,9 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
             if ( NULL != functions ) {
                 size_t i;
                 for ( i = 0; i < nfunctions; i++ ) {
-                   err = Mat_VarRead5(mat,functions[i]);
-                   if ( err)
-                       break;
+                    err = Mat_VarRead5(mat, functions[i]);
+                    if ( err )
+                        break;
                 }
             }
             /* FIXME: */
@@ -10144,19 +10260,19 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
                     break;
                 }
 
-                err = Mat_VarReadNumeric5(mat,matvar,complex_data->Re,nelems);
+                err = Mat_VarReadNumeric5(mat, matvar, complex_data->Re, nelems);
                 if ( err ) {
                     ComplexFree(complex_data);
                     break;
                 }
-                err = Mat_VarReadNumeric5(mat,matvar,complex_data->Im,nelems);
+                err = Mat_VarReadNumeric5(mat, matvar, complex_data->Im, nelems);
                 if ( err ) {
                     ComplexFree(complex_data);
                     break;
                 }
                 matvar->data = complex_data;
             } else {
-                void * data;
+                void *data;
                 err = Mul(&matvar->nbytes, nelems, matvar->data_size);
                 if ( err ) {
                     Mat_Critical("Integer multiplication overflow");
@@ -10169,7 +10285,7 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
                     Mat_Critical("Couldn't allocate memory for the data");
                     break;
                 }
-                err = Mat_VarReadNumeric5(mat,matvar,data,nelems);
+                err = Mat_VarReadNumeric5(mat, matvar, data, nelems);
                 if ( err ) {
                     free(data);
                     break;
@@ -10179,355 +10295,329 @@ Mat_VarRead5(mat_t *mat, matvar_t *matvar)
         default:
             break;
     }
-    (void)fseek((FILE*)mat->fp,fpos,SEEK_SET);
+    (void)fseek((FILE *)mat->fp, fpos, SEEK_SET);
 
     return err;
 }
 
 #if HAVE_ZLIB
-#define GET_DATA_SLABN_RANK_LOOP \
-    do { \
-        for ( j = 1; j < rank; j++ ) { \
-            cnt[j]++; \
-            if ( (cnt[j] % edge[j]) == 0 ) { \
-                cnt[j] = 0; \
-                if ( (I % dimp[j]) != 0 ) { \
-                    ptr_in += dimp[j]-(I % dimp[j])+dimp[j-1]*start[j]; \
-                    I += dimp[j]-(I % dimp[j]) + dimp[j-1]*start[j]; \
-                } else if ( start[j] ) { \
-                    ptr_in += dimp[j-1]*start[j]; \
-                    I += dimp[j-1]*start[j]; \
-                } \
-            } else { \
-                I += inc[j]; \
-                ptr_in += inc[j]; \
-                break; \
-            } \
-        } \
-    } while (0)
+#define GET_DATA_SLABN_RANK_LOOP                                                \
+    do {                                                                        \
+        for ( j = 1; j < rank; j++ ) {                                          \
+            cnt[j]++;                                                           \
+            if ( (cnt[j] % edge[j]) == 0 ) {                                    \
+                cnt[j] = 0;                                                     \
+                if ( (I % dimp[j]) != 0 ) {                                     \
+                    ptr_in += dimp[j] - (I % dimp[j]) + dimp[j - 1] * start[j]; \
+                    I += dimp[j] - (I % dimp[j]) + dimp[j - 1] * start[j];      \
+                } else if ( start[j] ) {                                        \
+                    ptr_in += dimp[j - 1] * start[j];                           \
+                    I += dimp[j - 1] * start[j];                                \
+                }                                                               \
+            } else {                                                            \
+                I += inc[j];                                                    \
+                ptr_in += inc[j];                                               \
+                break;                                                          \
+            }                                                                   \
+        }                                                                       \
+    } while ( 0 )
 
-#define GET_DATA_SLAB2(T) \
-    do { \
-        ptr_in += start[1]*dims[0] + start[0]; \
-        for ( i = 0; i < edge[1]; i++ ) { \
-            for ( j = 0; j < edge[0]; j++ ) { \
-                *ptr = (T)(*(ptr_in+j*stride[0])); \
-                ptr++; \
-            } \
-            ptr_in += stride[1]*dims[0]; \
-        } \
-    } while (0)
+#define GET_DATA_SLAB2(T)                              \
+    do {                                               \
+        ptr_in += start[1] * dims[0] + start[0];       \
+        for ( i = 0; i < edge[1]; i++ ) {              \
+            for ( j = 0; j < edge[0]; j++ ) {          \
+                *ptr = (T)(*(ptr_in + j * stride[0])); \
+                ptr++;                                 \
+            }                                          \
+            ptr_in += stride[1] * dims[0];             \
+        }                                              \
+    } while ( 0 )
 
-#define GET_DATA_SLABN(T) \
-    do { \
-        inc[0]  = stride[0]-1; \
-        dimp[0] = dims[0]; \
-        N       = edge[0]; \
-        I       = 0; /* start[0]; */ \
-        for ( i = 1; i < rank; i++ ) { \
-            inc[i]  = stride[i]-1; \
-            dimp[i] = dims[i-1]; \
-            for ( j = i; j--; ) { \
-                inc[i]  *= dims[j]; \
-                dimp[i] *= dims[j+1]; \
-            } \
-            N *= edge[i]; \
-            I += dimp[i-1]*start[i]; \
-        } \
-        ptr_in += I; \
-        if ( stride[0] == 1 ) { \
-            for ( i = 0; i < N; i+=edge[0] ) { \
-                int k; \
-                if ( start[0] ) { \
-                    ptr_in += start[0]; \
-                    I += start[0]; \
-                } \
-                for ( k = 0; k < edge[0]; k++ ) { \
-                    *(ptr+i+k) = (T)(*(ptr_in+k)); \
-                } \
-                I += dims[0]-start[0]; \
-                ptr_in += dims[0]-start[0]; \
-                GET_DATA_SLABN_RANK_LOOP; \
-            } \
-        } else { \
-            for ( i = 0; i < N; i+=edge[0] ) { \
-                if ( start[0] ) { \
-                    ptr_in += start[0]; \
-                    I += start[0]; \
-                } \
-                for ( j = 0; j < edge[0]; j++ ) { \
-                    *(ptr+i+j) = (T)(*ptr_in); \
-                    ptr_in += stride[0]; \
-                    I += stride[0]; \
-                } \
-                I += dims[0]-(ptrdiff_t)edge[0]*stride[0]-start[0]; \
-                ptr_in += dims[0]-(ptrdiff_t)edge[0]*stride[0]-start[0]; \
-                GET_DATA_SLABN_RANK_LOOP; \
-            } \
-        } \
-    } while (0)
+#define GET_DATA_SLABN(T)                                                      \
+    do {                                                                       \
+        inc[0] = stride[0] - 1;                                                \
+        dimp[0] = dims[0];                                                     \
+        N = edge[0];                                                           \
+        I = 0; /* start[0]; */                                                 \
+        for ( i = 1; i < rank; i++ ) {                                         \
+            inc[i] = stride[i] - 1;                                            \
+            dimp[i] = dims[i - 1];                                             \
+            for ( j = i; j--; ) {                                              \
+                inc[i] *= dims[j];                                             \
+                dimp[i] *= dims[j + 1];                                        \
+            }                                                                  \
+            N *= edge[i];                                                      \
+            I += dimp[i - 1] * start[i];                                       \
+        }                                                                      \
+        ptr_in += I;                                                           \
+        if ( stride[0] == 1 ) {                                                \
+            for ( i = 0; i < N; i += edge[0] ) {                               \
+                int k;                                                         \
+                if ( start[0] ) {                                              \
+                    ptr_in += start[0];                                        \
+                    I += start[0];                                             \
+                }                                                              \
+                for ( k = 0; k < edge[0]; k++ ) {                              \
+                    *(ptr + i + k) = (T)(*(ptr_in + k));                       \
+                }                                                              \
+                I += dims[0] - start[0];                                       \
+                ptr_in += dims[0] - start[0];                                  \
+                GET_DATA_SLABN_RANK_LOOP;                                      \
+            }                                                                  \
+        } else {                                                               \
+            for ( i = 0; i < N; i += edge[0] ) {                               \
+                if ( start[0] ) {                                              \
+                    ptr_in += start[0];                                        \
+                    I += start[0];                                             \
+                }                                                              \
+                for ( j = 0; j < edge[0]; j++ ) {                              \
+                    *(ptr + i + j) = (T)(*ptr_in);                             \
+                    ptr_in += stride[0];                                       \
+                    I += stride[0];                                            \
+                }                                                              \
+                I += dims[0] - (ptrdiff_t)edge[0] * stride[0] - start[0];      \
+                ptr_in += dims[0] - (ptrdiff_t)edge[0] * stride[0] - start[0]; \
+                GET_DATA_SLABN_RANK_LOOP;                                      \
+            }                                                                  \
+        }                                                                      \
+    } while ( 0 )
 
 #ifdef HAVE_MATIO_INT64_T
-#define GET_DATA_SLAB2_INT64(T) \
-    do { \
-        if ( MAT_T_INT64 == data_type ) { \
+#define GET_DATA_SLAB2_INT64(T)                           \
+    do {                                                  \
+        if ( MAT_T_INT64 == data_type ) {                 \
             mat_int64_t *ptr_in = (mat_int64_t *)data_in; \
-            GET_DATA_SLAB2(T); \
-            err = MATIO_E_NO_ERROR; \
-        } \
-    } while (0)
+            GET_DATA_SLAB2(T);                            \
+            err = MATIO_E_NO_ERROR;                       \
+        }                                                 \
+    } while ( 0 )
 #else
 #define GET_DATA_SLAB2_INT64(T)
 #endif /* HAVE_MATIO_INT64_T */
 
 #ifdef HAVE_MATIO_UINT64_T
-#define GET_DATA_SLAB2_UINT64(T) \
-    do { \
-        if ( MAT_T_UINT64 == data_type ) { \
+#define GET_DATA_SLAB2_UINT64(T)                            \
+    do {                                                    \
+        if ( MAT_T_UINT64 == data_type ) {                  \
             mat_uint64_t *ptr_in = (mat_uint64_t *)data_in; \
-            GET_DATA_SLAB2(T); \
-            err = MATIO_E_NO_ERROR; \
-        } \
-    } while (0)
+            GET_DATA_SLAB2(T);                              \
+            err = MATIO_E_NO_ERROR;                         \
+        }                                                   \
+    } while ( 0 )
 #else
 #define GET_DATA_SLAB2_UINT64(T)
 #endif /* HAVE_MATIO_UINT64_T */
 
-#define GET_DATA_SLAB2_TYPE(T) \
-    do { \
-        switch ( data_type ) { \
-            case MAT_T_DOUBLE: \
-            { \
-                double *ptr_in = (double *)data_in; \
-                GET_DATA_SLAB2(T); \
-                break; \
-            } \
-            case MAT_T_SINGLE: \
-            { \
-                float *ptr_in = (float *)data_in; \
-                GET_DATA_SLAB2(T); \
-                break; \
-            } \
-            case MAT_T_INT32: \
-            { \
-                mat_int32_t *ptr_in = (mat_int32_t *)data_in; \
-                GET_DATA_SLAB2(T); \
-                break; \
-            } \
-            case MAT_T_UINT32: \
-            { \
+#define GET_DATA_SLAB2_TYPE(T)                                  \
+    do {                                                        \
+        switch ( data_type ) {                                  \
+            case MAT_T_DOUBLE: {                                \
+                double *ptr_in = (double *)data_in;             \
+                GET_DATA_SLAB2(T);                              \
+                break;                                          \
+            }                                                   \
+            case MAT_T_SINGLE: {                                \
+                float *ptr_in = (float *)data_in;               \
+                GET_DATA_SLAB2(T);                              \
+                break;                                          \
+            }                                                   \
+            case MAT_T_INT32: {                                 \
+                mat_int32_t *ptr_in = (mat_int32_t *)data_in;   \
+                GET_DATA_SLAB2(T);                              \
+                break;                                          \
+            }                                                   \
+            case MAT_T_UINT32: {                                \
                 mat_uint32_t *ptr_in = (mat_uint32_t *)data_in; \
-                GET_DATA_SLAB2(T); \
-                break; \
-            } \
-            case MAT_T_INT16: \
-            { \
-                mat_int16_t *ptr_in = (mat_int16_t *)data_in; \
-                GET_DATA_SLAB2(T); \
-                break; \
-            } \
-            case MAT_T_UINT16: \
-            { \
+                GET_DATA_SLAB2(T);                              \
+                break;                                          \
+            }                                                   \
+            case MAT_T_INT16: {                                 \
+                mat_int16_t *ptr_in = (mat_int16_t *)data_in;   \
+                GET_DATA_SLAB2(T);                              \
+                break;                                          \
+            }                                                   \
+            case MAT_T_UINT16: {                                \
                 mat_uint16_t *ptr_in = (mat_uint16_t *)data_in; \
-                GET_DATA_SLAB2(T); \
-                break; \
-            } \
-            case MAT_T_INT8: \
-            { \
-                mat_int8_t *ptr_in = (mat_int8_t *)data_in; \
-                GET_DATA_SLAB2(T); \
-                break; \
-            } \
-            case MAT_T_UINT8: \
-            { \
-                mat_uint8_t *ptr_in = (mat_uint8_t *)data_in; \
-                GET_DATA_SLAB2(T); \
-                break; \
-            } \
-            default: \
-                err = MATIO_E_OPERATION_NOT_SUPPORTED; \
-                GET_DATA_SLAB2_INT64(T); \
-                GET_DATA_SLAB2_UINT64(T); \
-                break; \
-        } \
-    } while (0)
+                GET_DATA_SLAB2(T);                              \
+                break;                                          \
+            }                                                   \
+            case MAT_T_INT8: {                                  \
+                mat_int8_t *ptr_in = (mat_int8_t *)data_in;     \
+                GET_DATA_SLAB2(T);                              \
+                break;                                          \
+            }                                                   \
+            case MAT_T_UINT8: {                                 \
+                mat_uint8_t *ptr_in = (mat_uint8_t *)data_in;   \
+                GET_DATA_SLAB2(T);                              \
+                break;                                          \
+            }                                                   \
+            default:                                            \
+                err = MATIO_E_OPERATION_NOT_SUPPORTED;          \
+                GET_DATA_SLAB2_INT64(T);                        \
+                GET_DATA_SLAB2_UINT64(T);                       \
+                break;                                          \
+        }                                                       \
+    } while ( 0 )
 
 #ifdef HAVE_MATIO_INT64_T
-#define GET_DATA_SLABN_INT64(T) \
-    do { \
-        if ( MAT_T_INT64 == data_type ) { \
+#define GET_DATA_SLABN_INT64(T)                           \
+    do {                                                  \
+        if ( MAT_T_INT64 == data_type ) {                 \
             mat_int64_t *ptr_in = (mat_int64_t *)data_in; \
-            GET_DATA_SLABN(T); \
-            err = MATIO_E_NO_ERROR; \
-        } \
-    } while (0)
+            GET_DATA_SLABN(T);                            \
+            err = MATIO_E_NO_ERROR;                       \
+        }                                                 \
+    } while ( 0 )
 #else
 #define GET_DATA_SLABN_INT64(T)
 #endif /* HAVE_MATIO_INT64_T */
 
 #ifdef HAVE_MATIO_UINT64_T
-#define GET_DATA_SLABN_UINT64(T) \
-    do { \
-        if ( MAT_T_UINT64 == data_type ) { \
+#define GET_DATA_SLABN_UINT64(T)                            \
+    do {                                                    \
+        if ( MAT_T_UINT64 == data_type ) {                  \
             mat_uint64_t *ptr_in = (mat_uint64_t *)data_in; \
-            GET_DATA_SLABN(T); \
-            err = 0; \
-        } \
-    } while (0)
+            GET_DATA_SLABN(T);                              \
+            err = 0;                                        \
+        }                                                   \
+    } while ( 0 )
 #else
 #define GET_DATA_SLABN_UINT64(T)
 #endif /* HAVE_MATIO_UINT64_T */
 
-#define GET_DATA_SLABN_TYPE(T) \
-    do { \
-        switch ( data_type ) { \
-            case MAT_T_DOUBLE: \
-            { \
-                double *ptr_in = (double *)data_in; \
-                GET_DATA_SLABN(T); \
-                break; \
-            } \
-            case MAT_T_SINGLE: \
-            { \
-                float *ptr_in = (float *)data_in; \
-                GET_DATA_SLABN(T); \
-                break; \
-            } \
-            case MAT_T_INT32: \
-            { \
-                mat_int32_t *ptr_in = (mat_int32_t *)data_in; \
-                GET_DATA_SLABN(T); \
-                break; \
-            } \
-            case MAT_T_UINT32: \
-            { \
+#define GET_DATA_SLABN_TYPE(T)                                  \
+    do {                                                        \
+        switch ( data_type ) {                                  \
+            case MAT_T_DOUBLE: {                                \
+                double *ptr_in = (double *)data_in;             \
+                GET_DATA_SLABN(T);                              \
+                break;                                          \
+            }                                                   \
+            case MAT_T_SINGLE: {                                \
+                float *ptr_in = (float *)data_in;               \
+                GET_DATA_SLABN(T);                              \
+                break;                                          \
+            }                                                   \
+            case MAT_T_INT32: {                                 \
+                mat_int32_t *ptr_in = (mat_int32_t *)data_in;   \
+                GET_DATA_SLABN(T);                              \
+                break;                                          \
+            }                                                   \
+            case MAT_T_UINT32: {                                \
                 mat_uint32_t *ptr_in = (mat_uint32_t *)data_in; \
-                GET_DATA_SLABN(T); \
-                break; \
-            } \
-            case MAT_T_INT16: \
-            { \
-                mat_int16_t *ptr_in = (mat_int16_t *)data_in; \
-                GET_DATA_SLABN(T); \
-                break; \
-            } \
-            case MAT_T_UINT16: \
-            { \
+                GET_DATA_SLABN(T);                              \
+                break;                                          \
+            }                                                   \
+            case MAT_T_INT16: {                                 \
+                mat_int16_t *ptr_in = (mat_int16_t *)data_in;   \
+                GET_DATA_SLABN(T);                              \
+                break;                                          \
+            }                                                   \
+            case MAT_T_UINT16: {                                \
                 mat_uint16_t *ptr_in = (mat_uint16_t *)data_in; \
-                GET_DATA_SLABN(T); \
-                break; \
-            } \
-            case MAT_T_INT8: \
-            { \
-                mat_int8_t *ptr_in = (mat_int8_t *)data_in; \
-                GET_DATA_SLABN(T); \
-                break; \
-            } \
-            case MAT_T_UINT8: \
-            { \
-                mat_uint8_t *ptr_in = (mat_uint8_t *)data_in; \
-                GET_DATA_SLABN(T); \
-                break; \
-            } \
-            default: \
-                err = MATIO_E_OPERATION_NOT_SUPPORTED; \
-                GET_DATA_SLABN_INT64(T); \
-                GET_DATA_SLABN_UINT64(T); \
-                break; \
-        } \
-    } while (0)
+                GET_DATA_SLABN(T);                              \
+                break;                                          \
+            }                                                   \
+            case MAT_T_INT8: {                                  \
+                mat_int8_t *ptr_in = (mat_int8_t *)data_in;     \
+                GET_DATA_SLABN(T);                              \
+                break;                                          \
+            }                                                   \
+            case MAT_T_UINT8: {                                 \
+                mat_uint8_t *ptr_in = (mat_uint8_t *)data_in;   \
+                GET_DATA_SLABN(T);                              \
+                break;                                          \
+            }                                                   \
+            default:                                            \
+                err = MATIO_E_OPERATION_NOT_SUPPORTED;          \
+                GET_DATA_SLABN_INT64(T);                        \
+                GET_DATA_SLABN_UINT64(T);                       \
+                break;                                          \
+        }                                                       \
+    } while ( 0 )
 
 static int
 GetDataSlab(void *data_in, void *data_out, enum matio_classes class_type,
-    enum matio_types data_type, size_t *dims, int *start, int *stride, int *edge,
-    int rank, size_t nbytes)
+            enum matio_types data_type, size_t *dims, int *start, int *stride, int *edge, int rank,
+            size_t nbytes)
 {
     int err = MATIO_E_NO_ERROR;
     int same_type = 0;
-    if (( class_type == MAT_C_DOUBLE && data_type == MAT_T_DOUBLE ) ||
-        ( class_type == MAT_C_SINGLE && data_type == MAT_T_SINGLE ) ||
-        ( class_type == MAT_C_INT16 && data_type == MAT_T_INT16 ) ||
-        ( class_type == MAT_C_INT32 && data_type == MAT_T_INT32 ) ||
-        ( class_type == MAT_C_INT64 && data_type == MAT_T_INT64 ) ||
-        ( class_type == MAT_C_INT8 && data_type == MAT_T_INT8 ) ||
-        ( class_type == MAT_C_UINT16 && data_type == MAT_T_UINT16 ) ||
-        ( class_type == MAT_C_UINT32 && data_type == MAT_T_UINT32 ) ||
-        ( class_type == MAT_C_UINT64 && data_type == MAT_T_UINT64 ) ||
-        ( class_type == MAT_C_UINT8 && data_type == MAT_T_UINT8 ))
+    if ( (class_type == MAT_C_DOUBLE && data_type == MAT_T_DOUBLE) ||
+         (class_type == MAT_C_SINGLE && data_type == MAT_T_SINGLE) ||
+         (class_type == MAT_C_INT16 && data_type == MAT_T_INT16) ||
+         (class_type == MAT_C_INT32 && data_type == MAT_T_INT32) ||
+         (class_type == MAT_C_INT64 && data_type == MAT_T_INT64) ||
+         (class_type == MAT_C_INT8 && data_type == MAT_T_INT8) ||
+         (class_type == MAT_C_UINT16 && data_type == MAT_T_UINT16) ||
+         (class_type == MAT_C_UINT32 && data_type == MAT_T_UINT32) ||
+         (class_type == MAT_C_UINT64 && data_type == MAT_T_UINT64) ||
+         (class_type == MAT_C_UINT8 && data_type == MAT_T_UINT8) )
         same_type = 1;
 
     if ( rank == 2 ) {
-        if ( (size_t)stride[0]*(edge[0]-1)+start[0]+1 > dims[0] )
+        if ( (size_t)stride[0] * (edge[0] - 1) + start[0] + 1 > dims[0] )
             err = MATIO_E_BAD_ARGUMENT;
-        else if ( (size_t)stride[1]*(edge[1]-1)+start[1]+1 > dims[1] )
+        else if ( (size_t)stride[1] * (edge[1] - 1) + start[1] + 1 > dims[1] )
             err = MATIO_E_BAD_ARGUMENT;
-        else if ( ( stride[0] == 1 && (size_t)edge[0] == dims[0] ) &&
-                  ( stride[1] == 1 ) && ( same_type == 1 ) )
+        else if ( (stride[0] == 1 && (size_t)edge[0] == dims[0]) && (stride[1] == 1) &&
+                  (same_type == 1) )
             memcpy(data_out, data_in, nbytes);
         else {
             int i, j;
 
             switch ( class_type ) {
-                case MAT_C_DOUBLE:
-                {
+                case MAT_C_DOUBLE: {
                     double *ptr = (double *)data_out;
                     GET_DATA_SLAB2_TYPE(double);
                     break;
                 }
-                case MAT_C_SINGLE:
-                {
+                case MAT_C_SINGLE: {
                     float *ptr = (float *)data_out;
                     GET_DATA_SLAB2_TYPE(float);
                     break;
                 }
 #ifdef HAVE_MATIO_INT64_T
-                case MAT_C_INT64:
-                {
+                case MAT_C_INT64: {
                     mat_int64_t *ptr = (mat_int64_t *)data_out;
                     GET_DATA_SLAB2_TYPE(mat_int64_t);
                     break;
                 }
 #endif /* HAVE_MATIO_INT64_T */
 #ifdef HAVE_MATIO_UINT64_T
-                case MAT_C_UINT64:
-                {
+                case MAT_C_UINT64: {
                     mat_uint64_t *ptr = (mat_uint64_t *)data_out;
                     GET_DATA_SLAB2_TYPE(mat_uint64_t);
                     break;
                 }
 #endif /* HAVE_MATIO_UINT64_T */
-                case MAT_C_INT32:
-                {
+                case MAT_C_INT32: {
                     mat_int32_t *ptr = (mat_int32_t *)data_out;
                     GET_DATA_SLAB2_TYPE(mat_int32_t);
                     break;
                 }
-                case MAT_C_UINT32:
-                {
+                case MAT_C_UINT32: {
                     mat_uint32_t *ptr = (mat_uint32_t *)data_out;
                     GET_DATA_SLAB2_TYPE(mat_uint32_t);
                     break;
                 }
-                case MAT_C_INT16:
-                {
+                case MAT_C_INT16: {
                     mat_int16_t *ptr = (mat_int16_t *)data_out;
                     GET_DATA_SLAB2_TYPE(mat_int16_t);
                     break;
                 }
-                case MAT_C_UINT16:
-                {
+                case MAT_C_UINT16: {
                     mat_uint16_t *ptr = (mat_uint16_t *)data_out;
                     GET_DATA_SLAB2_TYPE(mat_uint16_t);
                     break;
                 }
-                case MAT_C_INT8:
-                {
+                case MAT_C_INT8: {
                     mat_int8_t *ptr = (mat_int8_t *)data_out;
                     GET_DATA_SLAB2_TYPE(mat_int8_t);
                     break;
                 }
-                case MAT_C_UINT8:
-                {
+                case MAT_C_UINT8: {
                     mat_uint8_t *ptr = (mat_uint8_t *)data_out;
                     GET_DATA_SLAB2_TYPE(mat_uint8_t);
                     break;
@@ -10539,69 +10629,61 @@ GetDataSlab(void *data_in, void *data_out, enum matio_classes class_type,
         }
     } else {
         int i, j, N, I = 0;
-        int inc[10] = {0,}, cnt[10] = {0,}, dimp[10] = {0,};
+        int inc[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        int cnt[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        int dimp[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
         switch ( class_type ) {
-            case MAT_C_DOUBLE:
-            {
+            case MAT_C_DOUBLE: {
                 double *ptr = (double *)data_out;
                 GET_DATA_SLABN_TYPE(double);
                 break;
             }
-            case MAT_C_SINGLE:
-            {
+            case MAT_C_SINGLE: {
                 float *ptr = (float *)data_out;
                 GET_DATA_SLABN_TYPE(float);
                 break;
             }
 #ifdef HAVE_MATIO_INT64_T
-            case MAT_C_INT64:
-            {
+            case MAT_C_INT64: {
                 mat_int64_t *ptr = (mat_int64_t *)data_out;
                 GET_DATA_SLABN_TYPE(mat_int64_t);
                 break;
             }
 #endif /* HAVE_MATIO_INT64_T */
 #ifdef HAVE_MATIO_UINT64_T
-            case MAT_C_UINT64:
-            {
+            case MAT_C_UINT64: {
                 mat_uint64_t *ptr = (mat_uint64_t *)data_out;
                 GET_DATA_SLABN_TYPE(mat_uint64_t);
                 break;
             }
 #endif /* HAVE_MATIO_UINT64_T */
-            case MAT_C_INT32:
-            {
+            case MAT_C_INT32: {
                 mat_int32_t *ptr = (mat_int32_t *)data_out;
                 GET_DATA_SLABN_TYPE(mat_int32_t);
                 break;
             }
-            case MAT_C_UINT32:
-            {
+            case MAT_C_UINT32: {
                 mat_uint32_t *ptr = (mat_uint32_t *)data_out;
                 GET_DATA_SLABN_TYPE(mat_uint32_t);
                 break;
             }
-            case MAT_C_INT16:
-            {
+            case MAT_C_INT16: {
                 mat_int16_t *ptr = (mat_int16_t *)data_out;
                 GET_DATA_SLABN_TYPE(mat_int16_t);
                 break;
             }
-            case MAT_C_UINT16:
-            {
+            case MAT_C_UINT16: {
                 mat_uint16_t *ptr = (mat_uint16_t *)data_out;
                 GET_DATA_SLABN_TYPE(mat_uint16_t);
                 break;
             }
-            case MAT_C_INT8:
-            {
+            case MAT_C_INT8: {
                 mat_int8_t *ptr = (mat_int8_t *)data_out;
                 GET_DATA_SLABN_TYPE(mat_int8_t);
                 break;
             }
-            case MAT_C_UINT8:
-            {
+            case MAT_C_UINT8: {
                 mat_uint8_t *ptr = (mat_uint8_t *)data_out;
                 GET_DATA_SLABN_TYPE(mat_uint8_t);
                 break;
@@ -10625,97 +10707,87 @@ GetDataSlab(void *data_in, void *data_out, enum matio_classes class_type,
 #undef GET_DATA_SLABN_UINT64
 #undef GET_DATA_SLABN_RANK_LOOP
 
-#define GET_DATA_LINEAR \
-    do { \
-        ptr_in += start; \
-        if ( !stride ) { \
-            memcpy(ptr, ptr_in, (size_t)edge*data_size); \
-        } else { \
-            int i; \
-            for ( i = 0; i < edge; i++ ) \
-                memcpy(ptr++, ptr_in+i*stride, data_size); \
-        } \
-    } while (0)
+#define GET_DATA_LINEAR                                        \
+    do {                                                       \
+        ptr_in += start;                                       \
+        if ( !stride ) {                                       \
+            memcpy(ptr, ptr_in, (size_t)edge *data_size);      \
+        } else {                                               \
+            int i;                                             \
+            for ( i = 0; i < edge; i++ )                       \
+                memcpy(ptr++, ptr_in + i * stride, data_size); \
+        }                                                      \
+    } while ( 0 )
 
 static int
 GetDataLinear(void *data_in, void *data_out, enum matio_classes class_type,
-    enum matio_types data_type, int start, int stride, int edge)
+              enum matio_types data_type, int start, int stride, int edge)
 {
     int err = MATIO_E_NO_ERROR;
     size_t data_size = Mat_SizeOf(data_type);
 
     switch ( class_type ) {
-        case MAT_C_DOUBLE:
-        {
+        case MAT_C_DOUBLE: {
             double *ptr = (double *)data_out;
-            double *ptr_in = (double*)data_in;
+            double *ptr_in = (double *)data_in;
             GET_DATA_LINEAR;
             break;
         }
-        case MAT_C_SINGLE:
-        {
+        case MAT_C_SINGLE: {
             float *ptr = (float *)data_out;
-            float *ptr_in = (float*)data_in;
+            float *ptr_in = (float *)data_in;
             GET_DATA_LINEAR;
             break;
         }
 #ifdef HAVE_MATIO_INT64_T
-        case MAT_C_INT64:
-        {
+        case MAT_C_INT64: {
             mat_int64_t *ptr = (mat_int64_t *)data_out;
-            mat_int64_t *ptr_in = (mat_int64_t*)data_in;
+            mat_int64_t *ptr_in = (mat_int64_t *)data_in;
             GET_DATA_LINEAR;
             break;
         }
 #endif /* HAVE_MATIO_INT64_T */
 #ifdef HAVE_MATIO_UINT64_T
-        case MAT_C_UINT64:
-        {
+        case MAT_C_UINT64: {
             mat_uint64_t *ptr = (mat_uint64_t *)data_out;
-            mat_uint64_t *ptr_in = (mat_uint64_t*)data_in;
+            mat_uint64_t *ptr_in = (mat_uint64_t *)data_in;
             GET_DATA_LINEAR;
             break;
         }
 #endif /* HAVE_MATIO_UINT64_T */
-        case MAT_C_INT32:
-        {
+        case MAT_C_INT32: {
             mat_int32_t *ptr = (mat_int32_t *)data_out;
-            mat_int32_t *ptr_in = (mat_int32_t*)data_in;
+            mat_int32_t *ptr_in = (mat_int32_t *)data_in;
             GET_DATA_LINEAR;
             break;
         }
-        case MAT_C_UINT32:
-        {
+        case MAT_C_UINT32: {
             mat_uint32_t *ptr = (mat_uint32_t *)data_out;
-            mat_uint32_t *ptr_in = (mat_uint32_t*)data_in;
+            mat_uint32_t *ptr_in = (mat_uint32_t *)data_in;
             GET_DATA_LINEAR;
             break;
         }
-        case MAT_C_INT16:
-        {
+        case MAT_C_INT16: {
             mat_int16_t *ptr = (mat_int16_t *)data_out;
-            mat_int16_t *ptr_in = (mat_int16_t*)data_in;
+            mat_int16_t *ptr_in = (mat_int16_t *)data_in;
             GET_DATA_LINEAR;
             break;
         }
-        case MAT_C_UINT16:
-        {
+        case MAT_C_UINT16: {
             mat_uint16_t *ptr = (mat_uint16_t *)data_out;
-            mat_uint16_t *ptr_in = (mat_uint16_t*)data_in;
+            mat_uint16_t *ptr_in = (mat_uint16_t *)data_in;
             GET_DATA_LINEAR;
             break;
         }
-        case MAT_C_INT8:
-        {
+        case MAT_C_INT8: {
             mat_int8_t *ptr = (mat_int8_t *)data_out;
-            mat_int8_t *ptr_in = (mat_int8_t*)data_in;
+            mat_int8_t *ptr_in = (mat_int8_t *)data_in;
             GET_DATA_LINEAR;
             break;
         }
-        case MAT_C_UINT8:
-        {
+        case MAT_C_UINT8: {
             mat_uint8_t *ptr = (mat_uint8_t *)data_out;
-            mat_uint8_t *ptr_in = (mat_uint8_t*)data_in;
+            mat_uint8_t *ptr_in = (mat_uint8_t *)data_in;
             GET_DATA_LINEAR;
             break;
         }
@@ -10745,8 +10817,7 @@ GetDataLinear(void *data_in, void *data_out, enum matio_classes class_type,
  * @endif
  */
 static int
-Mat_VarReadData5(mat_t *mat,matvar_t *matvar,void *data,
-    int *start,int *stride,int *edge)
+Mat_VarReadData5(mat_t *mat, matvar_t *matvar, void *data, int *start, int *stride, int *edge)
 {
     int err = MATIO_E_NO_ERROR, real_bytes = 0;
     mat_int32_t tag[2];
@@ -10754,22 +10825,22 @@ Mat_VarReadData5(mat_t *mat,matvar_t *matvar,void *data,
     z_stream z;
 #endif
 
-    (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+    (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
     if ( matvar->compression == MAT_COMPRESSION_NONE ) {
-        err = Read(tag, 4, 2, (FILE*)mat->fp, NULL);
+        err = Read(tag, 4, 2, (FILE *)mat->fp, NULL);
         if ( err ) {
             return err;
         }
         if ( mat->byteswap ) {
             (void)Mat_int32Swap(tag);
-            (void)Mat_int32Swap(tag+1);
+            (void)Mat_int32Swap(tag + 1);
         }
         matvar->data_type = TYPE_FROM_TAG(tag[0]);
         if ( tag[0] & 0xffff0000 ) { /* Data is packed in the tag */
-            (void)fseek((FILE*)mat->fp,-4,SEEK_CUR);
-            real_bytes = 4+(tag[0] >> 16);
+            (void)fseek((FILE *)mat->fp, -4, SEEK_CUR);
+            real_bytes = 4 + (tag[0] >> 16);
         } else {
-            real_bytes = 8+tag[1];
+            real_bytes = 8 + tag[1];
         }
 #if HAVE_ZLIB
     } else if ( matvar->compression == MAT_COMPRESSION_ZLIB ) {
@@ -10778,26 +10849,25 @@ Mat_VarReadData5(mat_t *mat,matvar_t *matvar,void *data,
             if ( matvar->isComplex ) {
                 mat_complex_split_t *ci, *co;
 
-                co = (mat_complex_split_t*)data;
-                ci = (mat_complex_split_t*)matvar->internal->data;
-                err = GetDataSlab(ci->Re, co->Re, matvar->class_type,
-                    matvar->data_type, matvar->dims, start, stride, edge,
-                    matvar->rank, matvar->nbytes);
+                co = (mat_complex_split_t *)data;
+                ci = (mat_complex_split_t *)matvar->internal->data;
+                err = GetDataSlab(ci->Re, co->Re, matvar->class_type, matvar->data_type,
+                                  matvar->dims, start, stride, edge, matvar->rank, matvar->nbytes);
                 if ( MATIO_E_NO_ERROR == err )
-                    err = GetDataSlab(ci->Im, co->Im, matvar->class_type,
-                        matvar->data_type, matvar->dims, start, stride, edge,
-                        matvar->rank, matvar->nbytes);
+                    err = GetDataSlab(ci->Im, co->Im, matvar->class_type, matvar->data_type,
+                                      matvar->dims, start, stride, edge, matvar->rank,
+                                      matvar->nbytes);
                 return err;
             } else {
                 return GetDataSlab(matvar->internal->data, data, matvar->class_type,
-                    matvar->data_type, matvar->dims, start, stride, edge,
-                    matvar->rank, matvar->nbytes);
+                                   matvar->data_type, matvar->dims, start, stride, edge,
+                                   matvar->rank, matvar->nbytes);
             }
         }
 
-        err = inflateCopy(&z,matvar->internal->z);
+        err = inflateCopy(&z, matvar->internal->z);
         if ( err != Z_OK ) {
-            Mat_Critical("inflateCopy returned error %s",zError(err));
+            Mat_Critical("inflateCopy returned error %s", zError(err));
             return MATIO_E_FILE_FORMAT_VIOLATION;
         }
         z.avail_in = 0;
@@ -10809,70 +10879,69 @@ Mat_VarReadData5(mat_t *mat,matvar_t *matvar,void *data,
             (void)Mat_int32Swap(tag);
         }
         matvar->data_type = TYPE_FROM_TAG(tag[0]);
-        if ( !(tag[0] & 0xffff0000) ) {/* Data is NOT packed in the tag */
-            err = Inflate(mat, &z, tag+1, 4, NULL);
+        if ( !(tag[0] & 0xffff0000) ) { /* Data is NOT packed in the tag */
+            err = Inflate(mat, &z, tag + 1, 4, NULL);
             if ( err ) {
                 return err;
             }
             if ( mat->byteswap ) {
-                (void)Mat_int32Swap(tag+1);
+                (void)Mat_int32Swap(tag + 1);
             }
-            real_bytes = 8+tag[1];
+            real_bytes = 8 + tag[1];
         } else {
-            real_bytes = 4+(tag[0] >> 16);
+            real_bytes = 4 + (tag[0] >> 16);
         }
 #endif
     }
     if ( real_bytes % 8 )
-        real_bytes += (8-(real_bytes % 8));
+        real_bytes += (8 - (real_bytes % 8));
 
     if ( matvar->rank == 2 ) {
-        if ( (size_t)stride[0]*(edge[0]-1)+start[0]+1 > matvar->dims[0] )
+        if ( (size_t)stride[0] * (edge[0] - 1) + start[0] + 1 > matvar->dims[0] )
             err = MATIO_E_BAD_ARGUMENT;
-        else if ( (size_t)stride[1]*(edge[1]-1)+start[1]+1 > matvar->dims[1] )
+        else if ( (size_t)stride[1] * (edge[1] - 1) + start[1] + 1 > matvar->dims[1] )
             err = MATIO_E_BAD_ARGUMENT;
         else if ( matvar->compression == MAT_COMPRESSION_NONE ) {
             if ( matvar->isComplex ) {
-                mat_complex_split_t *complex_data = (mat_complex_split_t*)data;
+                mat_complex_split_t *complex_data = (mat_complex_split_t *)data;
 
-                ReadDataSlab2(mat,complex_data->Re,matvar->class_type,
-                    matvar->data_type,matvar->dims,start,stride,edge);
-                (void)fseek((FILE*)mat->fp,matvar->internal->datapos+real_bytes,SEEK_SET);
-                err = Read(tag, 4, 2, (FILE*)mat->fp, NULL);
+                ReadDataSlab2(mat, complex_data->Re, matvar->class_type, matvar->data_type,
+                              matvar->dims, start, stride, edge);
+                (void)fseek((FILE *)mat->fp, matvar->internal->datapos + real_bytes, SEEK_SET);
+                err = Read(tag, 4, 2, (FILE *)mat->fp, NULL);
                 if ( err ) {
                     return err;
                 }
                 if ( mat->byteswap ) {
                     (void)Mat_int32Swap(tag);
-                    (void)Mat_int32Swap(tag+1);
+                    (void)Mat_int32Swap(tag + 1);
                 }
                 matvar->data_type = TYPE_FROM_TAG(tag[0]);
                 if ( tag[0] & 0xffff0000 ) { /* Data is packed in the tag */
-                    (void)fseek((FILE*)mat->fp,-4,SEEK_CUR);
+                    (void)fseek((FILE *)mat->fp, -4, SEEK_CUR);
                 }
-                ReadDataSlab2(mat,complex_data->Im,matvar->class_type,
-                              matvar->data_type,matvar->dims,start,stride,edge);
+                ReadDataSlab2(mat, complex_data->Im, matvar->class_type, matvar->data_type,
+                              matvar->dims, start, stride, edge);
             } else {
-                ReadDataSlab2(mat,data,matvar->class_type,
-                    matvar->data_type,matvar->dims,start,stride,edge);
+                ReadDataSlab2(mat, data, matvar->class_type, matvar->data_type, matvar->dims, start,
+                              stride, edge);
             }
         }
 #if HAVE_ZLIB
         else if ( matvar->compression == MAT_COMPRESSION_ZLIB ) {
             if ( matvar->isComplex ) {
-                mat_complex_split_t *complex_data = (mat_complex_split_t*)data;
+                mat_complex_split_t *complex_data = (mat_complex_split_t *)data;
 
-                ReadCompressedDataSlab2(mat,&z,complex_data->Re,
-                    matvar->class_type,matvar->data_type,matvar->dims,
-                    start,stride,edge);
+                ReadCompressedDataSlab2(mat, &z, complex_data->Re, matvar->class_type,
+                                        matvar->data_type, matvar->dims, start, stride, edge);
 
-                (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+                (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
 
                 /* Reset zlib knowledge to before reading real tag */
                 inflateEnd(&z);
-                err = inflateCopy(&z,matvar->internal->z);
+                err = inflateCopy(&z, matvar->internal->z);
                 if ( err != Z_OK ) {
-                    Mat_Critical("inflateCopy returned error %s",zError(err));
+                    Mat_Critical("inflateCopy returned error %s", zError(err));
                     return MATIO_E_FILE_FORMAT_VIOLATION;
                 }
                 InflateSkip(mat, &z, real_bytes, NULL);
@@ -10885,15 +10954,14 @@ Mat_VarReadData5(mat_t *mat,matvar_t *matvar,void *data,
                     (void)Mat_int32Swap(tag);
                 }
                 matvar->data_type = TYPE_FROM_TAG(tag[0]);
-                if ( !(tag[0] & 0xffff0000) ) {/*Data is NOT packed in the tag*/
+                if ( !(tag[0] & 0xffff0000) ) { /*Data is NOT packed in the tag*/
                     InflateSkip(mat, &z, 4, NULL);
                 }
-                ReadCompressedDataSlab2(mat,&z,complex_data->Im,
-                    matvar->class_type,matvar->data_type,matvar->dims,
-                    start,stride,edge);
+                ReadCompressedDataSlab2(mat, &z, complex_data->Im, matvar->class_type,
+                                        matvar->data_type, matvar->dims, start, stride, edge);
             } else {
-                ReadCompressedDataSlab2(mat,&z,data,matvar->class_type,
-                    matvar->data_type,matvar->dims,start,stride,edge);
+                ReadCompressedDataSlab2(mat, &z, data, matvar->class_type, matvar->data_type,
+                                        matvar->dims, start, stride, edge);
             }
             inflateEnd(&z);
         }
@@ -10901,48 +10969,46 @@ Mat_VarReadData5(mat_t *mat,matvar_t *matvar,void *data,
     } else {
         if ( matvar->compression == MAT_COMPRESSION_NONE ) {
             if ( matvar->isComplex ) {
-                mat_complex_split_t *complex_data = (mat_complex_split_t*)data;
+                mat_complex_split_t *complex_data = (mat_complex_split_t *)data;
 
-                ReadDataSlabN(mat,complex_data->Re,matvar->class_type,
-                    matvar->data_type,matvar->rank,matvar->dims,
-                    start,stride,edge);
+                ReadDataSlabN(mat, complex_data->Re, matvar->class_type, matvar->data_type,
+                              matvar->rank, matvar->dims, start, stride, edge);
 
-                (void)fseek((FILE*)mat->fp,matvar->internal->datapos+real_bytes,SEEK_SET);
-                err = Read(tag, 4, 2, (FILE*)mat->fp, NULL);
+                (void)fseek((FILE *)mat->fp, matvar->internal->datapos + real_bytes, SEEK_SET);
+                err = Read(tag, 4, 2, (FILE *)mat->fp, NULL);
                 if ( err ) {
                     return err;
                 }
                 if ( mat->byteswap ) {
                     (void)Mat_int32Swap(tag);
-                    (void)Mat_int32Swap(tag+1);
+                    (void)Mat_int32Swap(tag + 1);
                 }
                 matvar->data_type = TYPE_FROM_TAG(tag[0]);
                 if ( tag[0] & 0xffff0000 ) { /* Data is packed in the tag */
-                    (void)fseek((FILE*)mat->fp,-4,SEEK_CUR);
+                    (void)fseek((FILE *)mat->fp, -4, SEEK_CUR);
                 }
-                ReadDataSlabN(mat,complex_data->Im,matvar->class_type,
-                    matvar->data_type,matvar->rank,matvar->dims,
-                    start,stride,edge);
+                ReadDataSlabN(mat, complex_data->Im, matvar->class_type, matvar->data_type,
+                              matvar->rank, matvar->dims, start, stride, edge);
             } else {
-                ReadDataSlabN(mat,data,matvar->class_type,matvar->data_type,
-                    matvar->rank,matvar->dims,start,stride,edge);
+                ReadDataSlabN(mat, data, matvar->class_type, matvar->data_type, matvar->rank,
+                              matvar->dims, start, stride, edge);
             }
         }
 #if HAVE_ZLIB
         else if ( matvar->compression == MAT_COMPRESSION_ZLIB ) {
             if ( matvar->isComplex ) {
-                mat_complex_split_t *complex_data = (mat_complex_split_t*)data;
+                mat_complex_split_t *complex_data = (mat_complex_split_t *)data;
 
-                ReadCompressedDataSlabN(mat,&z,complex_data->Re,
-                    matvar->class_type,matvar->data_type,matvar->rank,
-                    matvar->dims,start,stride,edge);
+                ReadCompressedDataSlabN(mat, &z, complex_data->Re, matvar->class_type,
+                                        matvar->data_type, matvar->rank, matvar->dims, start,
+                                        stride, edge);
 
-                (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+                (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
                 /* Reset zlib knowledge to before reading real tag */
                 inflateEnd(&z);
-                err = inflateCopy(&z,matvar->internal->z);
+                err = inflateCopy(&z, matvar->internal->z);
                 if ( err != Z_OK ) {
-                    Mat_Critical("inflateCopy returned error %s",zError(err));
+                    Mat_Critical("inflateCopy returned error %s", zError(err));
                     return MATIO_E_FILE_FORMAT_VIOLATION;
                 }
                 InflateSkip(mat, &z, real_bytes, NULL);
@@ -10955,16 +11021,15 @@ Mat_VarReadData5(mat_t *mat,matvar_t *matvar,void *data,
                     (void)Mat_int32Swap(tag);
                 }
                 matvar->data_type = TYPE_FROM_TAG(tag[0]);
-                if ( !(tag[0] & 0xffff0000) ) {/*Data is NOT packed in the tag*/
+                if ( !(tag[0] & 0xffff0000) ) { /*Data is NOT packed in the tag*/
                     InflateSkip(mat, &z, 4, NULL);
                 }
-                ReadCompressedDataSlabN(mat,&z,complex_data->Im,
-                    matvar->class_type,matvar->data_type,matvar->rank,
-                    matvar->dims,start,stride,edge);
+                ReadCompressedDataSlabN(mat, &z, complex_data->Im, matvar->class_type,
+                                        matvar->data_type, matvar->rank, matvar->dims, start,
+                                        stride, edge);
             } else {
-                ReadCompressedDataSlabN(mat,&z,data,matvar->class_type,
-                    matvar->data_type,matvar->rank,matvar->dims,
-                    start,stride,edge);
+                ReadCompressedDataSlabN(mat, &z, data, matvar->class_type, matvar->data_type,
+                                        matvar->rank, matvar->dims, start, stride, edge);
             }
             inflateEnd(&z);
         }
@@ -10991,8 +11056,7 @@ Mat_VarReadData5(mat_t *mat,matvar_t *matvar,void *data,
  * @retval 0 on success
  */
 static int
-Mat_VarReadDataLinear5(mat_t *mat,matvar_t *matvar,void *data,int start,
-                      int stride,int edge)
+Mat_VarReadDataLinear5(mat_t *mat, matvar_t *matvar, void *data, int start, int stride, int edge)
 {
     int err = MATIO_E_NO_ERROR, real_bytes = 0;
     mat_int32_t tag[2];
@@ -11003,22 +11067,22 @@ Mat_VarReadDataLinear5(mat_t *mat,matvar_t *matvar,void *data,int start,
 
     if ( mat->version == MAT_FT_MAT4 )
         return -1;
-    (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+    (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
     if ( matvar->compression == MAT_COMPRESSION_NONE ) {
-        err = Read(tag, 4, 2, (FILE*)mat->fp, NULL);
+        err = Read(tag, 4, 2, (FILE *)mat->fp, NULL);
         if ( err ) {
             return err;
         }
         if ( mat->byteswap ) {
             (void)Mat_int32Swap(tag);
-            (void)Mat_int32Swap(tag+1);
+            (void)Mat_int32Swap(tag + 1);
         }
         matvar->data_type = (enum matio_types)(tag[0] & 0x000000ff);
         if ( tag[0] & 0xffff0000 ) { /* Data is packed in the tag */
-            (void)fseek((FILE*)mat->fp,-4,SEEK_CUR);
-            real_bytes = 4+(tag[0] >> 16);
+            (void)fseek((FILE *)mat->fp, -4, SEEK_CUR);
+            real_bytes = 4 + (tag[0] >> 16);
         } else {
-            real_bytes = 8+tag[1];
+            real_bytes = 8 + tag[1];
         }
 #if HAVE_ZLIB
     } else if ( matvar->compression == MAT_COMPRESSION_ZLIB ) {
@@ -11027,24 +11091,24 @@ Mat_VarReadDataLinear5(mat_t *mat,matvar_t *matvar,void *data,int start,
             if ( matvar->isComplex ) {
                 mat_complex_split_t *ci, *co;
 
-                co = (mat_complex_split_t*)data;
-                ci = (mat_complex_split_t*)matvar->internal->data;
-                err = GetDataLinear(ci->Re, co->Re, matvar->class_type,
-                    matvar->data_type, start, stride, edge);
+                co = (mat_complex_split_t *)data;
+                ci = (mat_complex_split_t *)matvar->internal->data;
+                err = GetDataLinear(ci->Re, co->Re, matvar->class_type, matvar->data_type, start,
+                                    stride, edge);
                 if ( err == MATIO_E_NO_ERROR )
-                    err = GetDataLinear(ci->Im, co->Im, matvar->class_type,
-                        matvar->data_type, start, stride, edge);
+                    err = GetDataLinear(ci->Im, co->Im, matvar->class_type, matvar->data_type,
+                                        start, stride, edge);
                 return err;
             } else {
                 return GetDataLinear(matvar->internal->data, data, matvar->class_type,
-                    matvar->data_type, start, stride, edge);
+                                     matvar->data_type, start, stride, edge);
             }
         }
 
         matvar->internal->z->avail_in = 0;
-        err = inflateCopy(&z,matvar->internal->z);
+        err = inflateCopy(&z, matvar->internal->z);
         if ( err != Z_OK ) {
-            Mat_Critical("inflateCopy returned error %s",zError(err));
+            Mat_Critical("inflateCopy returned error %s", zError(err));
             return MATIO_E_FILE_FORMAT_VIOLATION;
         }
         err = Inflate(mat, &z, tag, 4, NULL);
@@ -11053,25 +11117,25 @@ Mat_VarReadDataLinear5(mat_t *mat,matvar_t *matvar,void *data,int start,
         }
         if ( mat->byteswap ) {
             (void)Mat_int32Swap(tag);
-            (void)Mat_int32Swap(tag+1);
+            (void)Mat_int32Swap(tag + 1);
         }
         matvar->data_type = (enum matio_types)(tag[0] & 0x000000ff);
-        if ( !(tag[0] & 0xffff0000) ) {/* Data is NOT packed in the tag */
-            err = Inflate(mat, &z, tag+1, 4, NULL);
+        if ( !(tag[0] & 0xffff0000) ) { /* Data is NOT packed in the tag */
+            err = Inflate(mat, &z, tag + 1, 4, NULL);
             if ( err ) {
                 return err;
             }
             if ( mat->byteswap ) {
-                (void)Mat_int32Swap(tag+1);
+                (void)Mat_int32Swap(tag + 1);
             }
-            real_bytes = 8+tag[1];
+            real_bytes = 8 + tag[1];
         } else {
-            real_bytes = 4+(tag[0] >> 16);
+            real_bytes = 4 + (tag[0] >> 16);
         }
 #endif
     }
     if ( real_bytes % 8 )
-        real_bytes += (8-(real_bytes % 8));
+        real_bytes += (8 - (real_bytes % 8));
 
     err = Mat_MulDims(matvar, &nelems);
     if ( err ) {
@@ -11079,48 +11143,47 @@ Mat_VarReadDataLinear5(mat_t *mat,matvar_t *matvar,void *data,int start,
         return err;
     }
 
-    if ( (size_t)stride*(edge-1)+start+1 > nelems ) {
+    if ( (size_t)stride * (edge - 1) + start + 1 > nelems ) {
         err = MATIO_E_BAD_ARGUMENT;
     } else if ( matvar->compression == MAT_COMPRESSION_NONE ) {
         if ( matvar->isComplex ) {
-            mat_complex_split_t *complex_data = (mat_complex_split_t*)data;
+            mat_complex_split_t *complex_data = (mat_complex_split_t *)data;
 
-            ReadDataSlab1(mat,complex_data->Re,matvar->class_type,
-                          matvar->data_type,start,stride,edge);
-            (void)fseek((FILE*)mat->fp,matvar->internal->datapos+real_bytes,SEEK_SET);
-            err = Read(tag, 4, 2, (FILE*)mat->fp, NULL);
+            ReadDataSlab1(mat, complex_data->Re, matvar->class_type, matvar->data_type, start,
+                          stride, edge);
+            (void)fseek((FILE *)mat->fp, matvar->internal->datapos + real_bytes, SEEK_SET);
+            err = Read(tag, 4, 2, (FILE *)mat->fp, NULL);
             if ( err ) {
                 return err;
             }
             if ( mat->byteswap ) {
                 (void)Mat_int32Swap(tag);
-                (void)Mat_int32Swap(tag+1);
+                (void)Mat_int32Swap(tag + 1);
             }
             matvar->data_type = (enum matio_types)(tag[0] & 0x000000ff);
             if ( tag[0] & 0xffff0000 ) { /* Data is packed in the tag */
-                (void)fseek((FILE*)mat->fp,-4,SEEK_CUR);
+                (void)fseek((FILE *)mat->fp, -4, SEEK_CUR);
             }
-            ReadDataSlab1(mat,complex_data->Im,matvar->class_type,
-                          matvar->data_type,start,stride,edge);
+            ReadDataSlab1(mat, complex_data->Im, matvar->class_type, matvar->data_type, start,
+                          stride, edge);
         } else {
-            ReadDataSlab1(mat,data,matvar->class_type,
-                          matvar->data_type,start,stride,edge);
+            ReadDataSlab1(mat, data, matvar->class_type, matvar->data_type, start, stride, edge);
         }
 #if HAVE_ZLIB
     } else if ( matvar->compression == MAT_COMPRESSION_ZLIB ) {
         if ( matvar->isComplex ) {
-            mat_complex_split_t *complex_data = (mat_complex_split_t*)data;
+            mat_complex_split_t *complex_data = (mat_complex_split_t *)data;
 
-            ReadCompressedDataSlab1(mat,&z,complex_data->Re,
-                matvar->class_type,matvar->data_type,start,stride,edge);
+            ReadCompressedDataSlab1(mat, &z, complex_data->Re, matvar->class_type,
+                                    matvar->data_type, start, stride, edge);
 
-            (void)fseek((FILE*)mat->fp,matvar->internal->datapos,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, matvar->internal->datapos, SEEK_SET);
 
             /* Reset zlib knowledge to before reading real tag */
             inflateEnd(&z);
             err = inflateCopy(&z, matvar->internal->z);
             if ( err != Z_OK ) {
-                Mat_Critical("inflateCopy returned error %s",zError(err));
+                Mat_Critical("inflateCopy returned error %s", zError(err));
                 return MATIO_E_FILE_FORMAT_VIOLATION;
             }
             InflateSkip(mat, &z, real_bytes, NULL);
@@ -11133,14 +11196,14 @@ Mat_VarReadDataLinear5(mat_t *mat,matvar_t *matvar,void *data,int start,
                 (void)Mat_int32Swap(tag);
             }
             matvar->data_type = (enum matio_types)(tag[0] & 0x000000ff);
-            if ( !(tag[0] & 0xffff0000) ) {/*Data is NOT packed in the tag*/
+            if ( !(tag[0] & 0xffff0000) ) { /*Data is NOT packed in the tag*/
                 InflateSkip(mat, &z, 4, NULL);
             }
-            ReadCompressedDataSlab1(mat,&z,complex_data->Im,
-                matvar->class_type,matvar->data_type,start,stride,edge);
+            ReadCompressedDataSlab1(mat, &z, complex_data->Im, matvar->class_type,
+                                    matvar->data_type, start, stride, edge);
         } else {
-            ReadCompressedDataSlab1(mat,&z,data,matvar->class_type,
-                matvar->data_type,start,stride,edge);
+            ReadCompressedDataSlab1(mat, &z, data, matvar->class_type, matvar->data_type, start,
+                                    stride, edge);
         }
         inflateEnd(&z);
 #endif
@@ -11164,7 +11227,7 @@ Mat_VarReadDataLinear5(mat_t *mat,matvar_t *matvar,void *data,int start,
  * @endif
  */
 static int
-Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
+Mat_VarWrite5(mat_t *mat, matvar_t *matvar, int compress)
 {
     mat_uint32_t array_flags;
     int array_flags_type = MAT_T_UINT32, dims_array_type = MAT_T_INT32;
@@ -11177,7 +11240,7 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
         return MATIO_E_BAD_ARGUMENT;
 
     /* FIXME: SEEK_END is not Guaranteed by the C standard */
-    (void)fseek((FILE*)mat->fp,0,SEEK_END);         /* Always write at end of file */
+    (void)fseek((FILE *)mat->fp, 0, SEEK_END); /* Always write at end of file */
 
     if ( NULL == matvar || NULL == matvar->name )
         return MATIO_E_BAD_ARGUMENT;
@@ -11187,9 +11250,9 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
 #else
     {
 #endif
-        fwrite(&matrix_type,4,1,(FILE*)mat->fp);
-        fwrite(&pad4,4,1,(FILE*)mat->fp);
-        start = ftell((FILE*)mat->fp);
+        fwrite(&matrix_type, 4, 1, (FILE *)mat->fp);
+        fwrite(&pad4, 4, 1, (FILE *)mat->fp);
+        start = ftell((FILE *)mat->fp);
 
         /* Array Flags */
         array_flags = matvar->class_type & CLASS_TYPE_MASK;
@@ -11202,46 +11265,46 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
         if ( matvar->class_type == MAT_C_SPARSE )
             nzmax = ((mat_sparse_t *)matvar->data)->nzmax;
 
-        fwrite(&array_flags_type,4,1,(FILE*)mat->fp);
-        fwrite(&array_flags_size,4,1,(FILE*)mat->fp);
-        fwrite(&array_flags,4,1,(FILE*)mat->fp);
-        fwrite(&nzmax,4,1,(FILE*)mat->fp);
+        fwrite(&array_flags_type, 4, 1, (FILE *)mat->fp);
+        fwrite(&array_flags_size, 4, 1, (FILE *)mat->fp);
+        fwrite(&array_flags, 4, 1, (FILE *)mat->fp);
+        fwrite(&nzmax, 4, 1, (FILE *)mat->fp);
         /* Rank and Dimension */
         nBytes = matvar->rank * 4;
-        fwrite(&dims_array_type,4,1,(FILE*)mat->fp);
-        fwrite(&nBytes,4,1,(FILE*)mat->fp);
+        fwrite(&dims_array_type, 4, 1, (FILE *)mat->fp);
+        fwrite(&nBytes, 4, 1, (FILE *)mat->fp);
         for ( i = 0; i < matvar->rank; i++ ) {
             mat_int32_t dim;
             dim = matvar->dims[i];
-            fwrite(&dim,4,1,(FILE*)mat->fp);
+            fwrite(&dim, 4, 1, (FILE *)mat->fp);
         }
         if ( matvar->rank % 2 != 0 )
-            fwrite(&pad4,4,1,(FILE*)mat->fp);
+            fwrite(&pad4, 4, 1, (FILE *)mat->fp);
         /* Name of variable */
         if ( strlen(matvar->name) <= 4 ) {
             mat_uint32_t array_name_type = MAT_T_INT8;
             const mat_uint32_t array_name_len = (mat_uint32_t)strlen(matvar->name);
-            const mat_uint8_t  pad1 = 0;
+            const mat_uint8_t pad1 = 0;
             array_name_type |= array_name_len << 16;
-            fwrite(&array_name_type,4,1,(FILE*)mat->fp);
-            fwrite(matvar->name,1,array_name_len,(FILE*)mat->fp);
+            fwrite(&array_name_type, 4, 1, (FILE *)mat->fp);
+            fwrite(matvar->name, 1, array_name_len, (FILE *)mat->fp);
             for ( i = array_name_len; i < 4; i++ )
-                fwrite(&pad1,1,1,(FILE*)mat->fp);
+                fwrite(&pad1, 1, 1, (FILE *)mat->fp);
         } else {
             const mat_uint32_t array_name_type = MAT_T_INT8;
             const mat_uint32_t array_name_len = (mat_uint32_t)strlen(matvar->name);
-            const mat_uint8_t  pad1 = 0;
+            const mat_uint8_t pad1 = 0;
 
-            fwrite(&array_name_type,4,1,(FILE*)mat->fp);
-            fwrite(&array_name_len,4,1,(FILE*)mat->fp);
-            fwrite(matvar->name,1,array_name_len,(FILE*)mat->fp);
+            fwrite(&array_name_type, 4, 1, (FILE *)mat->fp);
+            fwrite(&array_name_len, 4, 1, (FILE *)mat->fp);
+            fwrite(matvar->name, 1, array_name_len, (FILE *)mat->fp);
             if ( array_name_len % 8 )
                 for ( i = array_name_len % 8; i < 8; i++ )
-                    fwrite(&pad1,1,1,(FILE*)mat->fp);
+                    fwrite(&pad1, 1, 1, (FILE *)mat->fp);
         }
 
         if ( NULL != matvar->internal ) {
-            matvar->internal->datapos = ftell((FILE*)mat->fp);
+            matvar->internal->datapos = ftell((FILE *)mat->fp);
             if ( matvar->internal->datapos == -1L ) {
                 Mat_Critical("Couldn't determine file position");
                 return MATIO_E_GENERIC_READ_ERROR;
@@ -11250,29 +11313,29 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
             /* Must be empty */
             matvar->class_type = MAT_C_EMPTY;
         }
-        WriteType(mat,matvar);
+        WriteType(mat, matvar);
 #if HAVE_ZLIB
     } else if ( compress == MAT_COMPRESSION_ZLIB ) {
         mat_uint32_t comp_buf[512];
-        mat_uint32_t uncomp_buf[512] = {0,};
+        mat_uint32_t uncomp_buf[512];
         int buf_size = 512, err;
         size_t byteswritten = 0, matrix_max_buf_size;
         z_streamp z;
 
-        z = (z_streamp)calloc(1,sizeof(*z));
+        z = (z_streamp)calloc(1, sizeof(*z));
         if ( z == NULL )
             return MATIO_E_OUT_OF_MEMORY;
-        err = deflateInit(z,Z_DEFAULT_COMPRESSION);
+        err = deflateInit(z, Z_DEFAULT_COMPRESSION);
         if ( err != Z_OK ) {
             free(z);
-            Mat_Critical("deflateInit returned %s",zError(err));
+            Mat_Critical("deflateInit returned %s", zError(err));
             return MATIO_E_FILE_FORMAT_VIOLATION;
         }
 
         matrix_type = MAT_T_COMPRESSED;
-        fwrite(&matrix_type,4,1,(FILE*)mat->fp);
-        fwrite(&pad4,4,1,(FILE*)mat->fp);
-        start = ftell((FILE*)mat->fp);
+        fwrite(&matrix_type, 4, 1, (FILE *)mat->fp);
+        fwrite(&pad4, 4, 1, (FILE *)mat->fp);
+        start = ftell((FILE *)mat->fp);
 
         /* Array Flags */
         array_flags = matvar->class_type & CLASS_TYPE_MASK;
@@ -11285,6 +11348,7 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
         if ( matvar->class_type == MAT_C_SPARSE )
             nzmax = ((mat_sparse_t *)matvar->data)->nzmax;
 
+        memset(&uncomp_buf, 0, sizeof(uncomp_buf));
         uncomp_buf[0] = MAT_T_MATRIX;
         err = GetMatrixMaxBufSize(matvar, &matrix_max_buf_size);
         if ( err ) {
@@ -11296,14 +11360,14 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
             return MATIO_E_INDEX_TOO_BIG;
         }
         uncomp_buf[1] = matrix_max_buf_size;
-        z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+        z->next_in = ZLIB_BYTE_PTR(uncomp_buf);
         z->avail_in = 8;
         do {
-            z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-            z->avail_out = buf_size*sizeof(*comp_buf);
-            deflate(z,Z_NO_FLUSH);
-            byteswritten += fwrite(comp_buf,1,
-                buf_size*sizeof(*comp_buf)-z->avail_out,(FILE*)mat->fp);
+            z->next_out = ZLIB_BYTE_PTR(comp_buf);
+            z->avail_out = buf_size * sizeof(*comp_buf);
+            deflate(z, Z_NO_FLUSH);
+            byteswritten +=
+                fwrite(comp_buf, 1, buf_size * sizeof(*comp_buf) - z->avail_out, (FILE *)mat->fp);
         } while ( z->avail_out == 0 );
         uncomp_buf[0] = array_flags_type;
         uncomp_buf[1] = array_flags_size;
@@ -11316,64 +11380,64 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
         for ( i = 0; i < matvar->rank; i++ ) {
             mat_int32_t dim;
             dim = matvar->dims[i];
-            uncomp_buf[6+i] = dim;
+            uncomp_buf[6 + i] = dim;
         }
         if ( matvar->rank % 2 != 0 ) {
-            uncomp_buf[6+i] = pad4;
+            uncomp_buf[6 + i] = pad4;
             i++;
         }
 
-        z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
-        z->avail_in = (6+i)*sizeof(*uncomp_buf);
+        z->next_in = ZLIB_BYTE_PTR(uncomp_buf);
+        z->avail_in = (6 + i) * sizeof(*uncomp_buf);
         do {
-            z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-            z->avail_out = buf_size*sizeof(*comp_buf);
-            deflate(z,Z_NO_FLUSH);
-            byteswritten += fwrite(comp_buf,1,
-                buf_size*sizeof(*comp_buf)-z->avail_out,(FILE*)mat->fp);
+            z->next_out = ZLIB_BYTE_PTR(comp_buf);
+            z->avail_out = buf_size * sizeof(*comp_buf);
+            deflate(z, Z_NO_FLUSH);
+            byteswritten +=
+                fwrite(comp_buf, 1, buf_size * sizeof(*comp_buf) - z->avail_out, (FILE *)mat->fp);
         } while ( z->avail_out == 0 );
         /* Name of variable */
         if ( strlen(matvar->name) <= 4 ) {
             mat_uint32_t array_name_len = (mat_uint32_t)strlen(matvar->name);
             const mat_uint32_t array_name_type = MAT_T_INT8;
 
-            memset(uncomp_buf,0,8);
+            memset(uncomp_buf, 0, 8);
             uncomp_buf[0] = (array_name_len << 16) | array_name_type;
-            memcpy(uncomp_buf+1,matvar->name,array_name_len);
+            memcpy(uncomp_buf + 1, matvar->name, array_name_len);
             if ( array_name_len % 4 )
-                array_name_len += 4-(array_name_len % 4);
+                array_name_len += 4 - (array_name_len % 4);
 
-            z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+            z->next_in = ZLIB_BYTE_PTR(uncomp_buf);
             z->avail_in = 8;
             do {
-                z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-                z->avail_out = buf_size*sizeof(*comp_buf);
-                deflate(z,Z_NO_FLUSH);
-                byteswritten += fwrite(comp_buf,1,
-                    buf_size*sizeof(*comp_buf)-z->avail_out,(FILE*)mat->fp);
+                z->next_out = ZLIB_BYTE_PTR(comp_buf);
+                z->avail_out = buf_size * sizeof(*comp_buf);
+                deflate(z, Z_NO_FLUSH);
+                byteswritten += fwrite(comp_buf, 1, buf_size * sizeof(*comp_buf) - z->avail_out,
+                                       (FILE *)mat->fp);
             } while ( z->avail_out == 0 );
         } else {
             mat_uint32_t array_name_len = (mat_uint32_t)strlen(matvar->name);
             const mat_uint32_t array_name_type = MAT_T_INT8;
 
-            memset(uncomp_buf,0,buf_size*sizeof(*uncomp_buf));
+            memset(uncomp_buf, 0, buf_size * sizeof(*uncomp_buf));
             uncomp_buf[0] = array_name_type;
             uncomp_buf[1] = array_name_len;
-            memcpy(uncomp_buf+2,matvar->name,array_name_len);
+            memcpy(uncomp_buf + 2, matvar->name, array_name_len);
             if ( array_name_len % 8 )
-                array_name_len += 8-(array_name_len % 8);
-            z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
-            z->avail_in = 8+array_name_len;
+                array_name_len += 8 - (array_name_len % 8);
+            z->next_in = ZLIB_BYTE_PTR(uncomp_buf);
+            z->avail_in = 8 + array_name_len;
             do {
-                z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-                z->avail_out = buf_size*sizeof(*comp_buf);
-                deflate(z,Z_NO_FLUSH);
-                byteswritten += fwrite(comp_buf,1,
-                    buf_size*sizeof(*comp_buf)-z->avail_out,(FILE*)mat->fp);
+                z->next_out = ZLIB_BYTE_PTR(comp_buf);
+                z->avail_out = buf_size * sizeof(*comp_buf);
+                deflate(z, Z_NO_FLUSH);
+                byteswritten += fwrite(comp_buf, 1, buf_size * sizeof(*comp_buf) - z->avail_out,
+                                       (FILE *)mat->fp);
             } while ( z->avail_out == 0 );
         }
         if ( NULL != matvar->internal ) {
-            matvar->internal->datapos = ftell((FILE*)mat->fp);
+            matvar->internal->datapos = ftell((FILE *)mat->fp);
             if ( matvar->internal->datapos == -1L ) {
                 free(z);
                 Mat_Critical("Couldn't determine file position");
@@ -11383,26 +11447,26 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
             /* Must be empty */
             matvar->class_type = MAT_C_EMPTY;
         }
-        WriteCompressedType(mat,matvar,z);
-        z->next_in  = NULL;
+        WriteCompressedType(mat, matvar, z);
+        z->next_in = NULL;
         z->avail_in = 0;
         do {
-            z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-            z->avail_out = buf_size*sizeof(*comp_buf);
-            err = deflate(z,Z_FINISH);
-            byteswritten += fwrite(comp_buf,1,
-                buf_size*sizeof(*comp_buf)-z->avail_out,(FILE*)mat->fp);
+            z->next_out = ZLIB_BYTE_PTR(comp_buf);
+            z->avail_out = buf_size * sizeof(*comp_buf);
+            err = deflate(z, Z_FINISH);
+            byteswritten +=
+                fwrite(comp_buf, 1, buf_size * sizeof(*comp_buf) - z->avail_out, (FILE *)mat->fp);
         } while ( err != Z_STREAM_END && z->avail_out == 0 );
         (void)deflateEnd(z);
         free(z);
 #endif
     }
-    end = ftell((FILE*)mat->fp);
+    end = ftell((FILE *)mat->fp);
     if ( start != -1L && end != -1L ) {
-        nBytes = (int)(end-start);
-        (void)fseek((FILE*)mat->fp,(long)-(nBytes+4),SEEK_CUR);
-        fwrite(&nBytes,4,1,(FILE*)mat->fp);
-        (void)fseek((FILE*)mat->fp,end,SEEK_SET);
+        nBytes = (int)(end - start);
+        (void)fseek((FILE *)mat->fp, (long)-(nBytes + 4), SEEK_CUR);
+        fwrite(&nBytes, 4, 1, (FILE *)mat->fp);
+        (void)fseek((FILE *)mat->fp, end, SEEK_SET);
     } else {
         Mat_Critical("Couldn't determine file position");
     }
@@ -11419,45 +11483,45 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
  * @endif
  */
 static matvar_t *
-Mat_VarReadNextInfo5( mat_t *mat )
+Mat_VarReadNextInfo5(mat_t *mat)
 {
     int err;
-    mat_int32_t data_type, nBytes;
+    mat_uint32_t data_type, array_flags, nBytes;
     long fpos;
     matvar_t *matvar = NULL;
-    mat_uint32_t array_flags;
 
     if ( mat == NULL || mat->fp == NULL )
         return NULL;
 
-    fpos = ftell((FILE*)mat->fp);
-    if ( fpos == -1L ) {
-        Mat_Critical("Couldn't determine file position");
+    if ( IsEndOfFile((FILE *)mat->fp, &fpos) )
         return NULL;
-    }
+
+    if ( fpos == -1L )
+        return NULL;
+
     {
         size_t nbytes = 0;
-        err = Read(&data_type, sizeof(mat_int32_t), 1, (FILE*)mat->fp, &nbytes);
+        err = Read(&data_type, sizeof(mat_uint32_t), 1, (FILE *)mat->fp, &nbytes);
         if ( err || 0 == nbytes )
             return NULL;
     }
-    err = Read(&nBytes, 4, 1, (FILE*)mat->fp, NULL);
+    err = Read(&nBytes, sizeof(mat_uint32_t), 1, (FILE *)mat->fp, NULL);
     if ( err )
         return NULL;
     if ( mat->byteswap ) {
-        (void)Mat_int32Swap(&data_type);
-        (void)Mat_int32Swap(&nBytes);
+        (void)Mat_uint32Swap(&data_type);
+        (void)Mat_uint32Swap(&nBytes);
     }
-    if ( nBytes > INT32_MAX - 8 - fpos )
+    if ( nBytes > INT32_MAX - 8 - (mat_uint32_t)fpos )
         return NULL;
     switch ( data_type ) {
-        case MAT_T_COMPRESSED:
-        {
+        case MAT_T_COMPRESSED: {
 #if HAVE_ZLIB
-            mat_uint32_t uncomp_buf[16] = {0,};
+            mat_uint32_t uncomp_buf[16];
             int nbytes;
             size_t bytesread = 0;
 
+            memset(&uncomp_buf, 0, sizeof(uncomp_buf));
             matvar = Mat_VarCalloc();
             if ( NULL == matvar ) {
                 Mat_Critical("Couldn't allocate memory");
@@ -11465,12 +11529,12 @@ Mat_VarReadNextInfo5( mat_t *mat )
             }
 
             matvar->compression = MAT_COMPRESSION_ZLIB;
-            matvar->internal->z = (z_streamp)calloc(1,sizeof(z_stream));
+            matvar->internal->z = (z_streamp)calloc(1, sizeof(z_stream));
             err = inflateInit(matvar->internal->z);
             if ( err != Z_OK ) {
                 Mat_VarFree(matvar);
                 matvar = NULL;
-                Mat_Critical("inflateInit returned %s",zError(err));
+                Mat_Critical("inflateInit returned %s", zError(err));
                 break;
             }
 
@@ -11478,11 +11542,11 @@ Mat_VarReadNextInfo5( mat_t *mat )
             err = Inflate(mat, matvar->internal->z, uncomp_buf, 8, &bytesread);
             if ( mat->byteswap ) {
                 (void)Mat_uint32Swap(uncomp_buf);
-                (void)Mat_uint32Swap(uncomp_buf+1);
+                (void)Mat_uint32Swap(uncomp_buf + 1);
             }
             nbytes = uncomp_buf[1];
             if ( uncomp_buf[0] != MAT_T_MATRIX ) {
-                (void)fseek((FILE*)mat->fp,nBytes-bytesread,SEEK_CUR);
+                (void)fseek((FILE *)mat->fp, (long)(nBytes - bytesread), SEEK_CUR);
                 Mat_VarFree(matvar);
                 matvar = NULL;
                 Mat_Critical("Uncompressed type not MAT_T_MATRIX");
@@ -11497,25 +11561,26 @@ Mat_VarReadNextInfo5( mat_t *mat )
             }
             if ( mat->byteswap ) {
                 (void)Mat_uint32Swap(uncomp_buf);
-                (void)Mat_uint32Swap(uncomp_buf+2);
-                (void)Mat_uint32Swap(uncomp_buf+3);
+                (void)Mat_uint32Swap(uncomp_buf + 2);
+                (void)Mat_uint32Swap(uncomp_buf + 3);
             }
             /* Array flags */
             if ( uncomp_buf[0] == MAT_T_UINT32 ) {
                 array_flags = uncomp_buf[2];
                 matvar->class_type = CLASS_FROM_ARRAY_FLAGS(array_flags);
-                matvar->isComplex  = (array_flags & MAT_F_COMPLEX);
-                matvar->isGlobal   = (array_flags & MAT_F_GLOBAL);
-                matvar->isLogical  = (array_flags & MAT_F_LOGICAL);
+                matvar->isComplex = (array_flags & MAT_F_COMPLEX);
+                matvar->isGlobal = (array_flags & MAT_F_GLOBAL);
+                matvar->isLogical = (array_flags & MAT_F_LOGICAL);
                 if ( matvar->class_type == MAT_C_SPARSE ) {
                     /* Need to find a more appropriate place to store nzmax */
                     matvar->nbytes = uncomp_buf[3];
                 }
             }
             if ( matvar->class_type != MAT_C_OPAQUE ) {
-                mat_uint32_t* dims = NULL;
+                mat_uint32_t *dims = NULL;
                 int do_clean = 0;
-                err = InflateRankDims(mat, matvar->internal->z, uncomp_buf, sizeof(uncomp_buf), &dims, &bytesread);
+                err = InflateRankDims(mat, matvar->internal->z, uncomp_buf, sizeof(uncomp_buf),
+                                      &dims, &bytesread);
                 if ( NULL == dims ) {
                     dims = uncomp_buf + 2;
                 } else {
@@ -11531,7 +11596,7 @@ Mat_VarReadNextInfo5( mat_t *mat )
                 }
                 if ( mat->byteswap ) {
                     (void)Mat_uint32Swap(uncomp_buf);
-                    (void)Mat_uint32Swap(uncomp_buf+1);
+                    (void)Mat_uint32Swap(uncomp_buf + 1);
                 }
                 /* Rank and dimension */
                 if ( uncomp_buf[0] == MAT_T_INT32 ) {
@@ -11550,17 +11615,17 @@ Mat_VarReadNextInfo5( mat_t *mat )
                         if ( do_clean ) {
                             free(dims);
                         }
-                        (void)fseek((FILE*)mat->fp,nBytes-bytesread,SEEK_CUR);
+                        (void)fseek((FILE *)mat->fp, (long)(nBytes - bytesread), SEEK_CUR);
                         Mat_VarFree(matvar);
                         matvar = NULL;
                         Mat_Critical("Integer multiplication overflow");
                         break;
                     }
-                    matvar->dims = (size_t*)malloc(size);
+                    matvar->dims = (size_t *)malloc(size);
                     if ( NULL == matvar->dims ) {
                         if ( do_clean )
                             free(dims);
-                        (void)fseek((FILE*)mat->fp,nBytes-bytesread,SEEK_CUR);
+                        (void)fseek((FILE *)mat->fp, (long)(nBytes - bytesread), SEEK_CUR);
                         Mat_VarFree(matvar);
                         matvar = NULL;
                         Mat_Critical("Couldn't allocate memory");
@@ -11587,10 +11652,10 @@ Mat_VarReadNextInfo5( mat_t *mat )
                 if ( mat->byteswap )
                     (void)Mat_uint32Swap(uncomp_buf);
                 /* Name of variable */
-                if ( uncomp_buf[0] == MAT_T_INT8 ) {    /* Name not in tag */
+                if ( uncomp_buf[0] == MAT_T_INT8 ) { /* Name not in tag */
                     mat_uint32_t len, len_pad;
                     if ( mat->byteswap )
-                        len = Mat_uint32Swap(uncomp_buf+1);
+                        len = Mat_uint32Swap(uncomp_buf + 1);
                     else
                         len = uncomp_buf[1];
 
@@ -11603,11 +11668,11 @@ Mat_VarReadNextInfo5( mat_t *mat )
                         matvar = NULL;
                         break;
                     }
-                    matvar->name = (char*)malloc(len_pad + 1);
+                    matvar->name = (char *)malloc(len_pad + 1);
                     if ( NULL != matvar->name ) {
                         /* Variable name */
                         err = Inflate(mat, matvar->internal->z, matvar->name, len_pad, &bytesread);
-                        if ( err )  {
+                        if ( err ) {
                             Mat_VarFree(matvar);
                             matvar = NULL;
                             break;
@@ -11618,49 +11683,50 @@ Mat_VarReadNextInfo5( mat_t *mat )
                     mat_uint32_t len = (uncomp_buf[0] & 0xffff0000) >> 16;
                     if ( ((uncomp_buf[0] & 0x0000ffff) == MAT_T_INT8) && len > 0 && len <= 4 ) {
                         /* Name packed in tag */
-                        matvar->name = (char*)malloc(len+1);
+                        matvar->name = (char *)malloc(len + 1);
                         if ( NULL != matvar->name ) {
-                            memcpy(matvar->name,uncomp_buf+1,len);
+                            memcpy(matvar->name, uncomp_buf + 1, len);
                             matvar->name[len] = '\0';
                         }
                     }
                 }
                 if ( matvar->class_type == MAT_C_STRUCT )
-                    (void)ReadNextStructField(mat,matvar);
+                    (void)ReadNextStructField(mat, matvar);
                 else if ( matvar->class_type == MAT_C_CELL )
-                    (void)ReadNextCell(mat,matvar);
-                (void)fseek((FILE*)mat->fp,-(int)matvar->internal->z->avail_in,SEEK_CUR);
-                matvar->internal->datapos = ftell((FILE*)mat->fp);
+                    (void)ReadNextCell(mat, matvar);
+                (void)fseek((FILE *)mat->fp, -(int)matvar->internal->z->avail_in, SEEK_CUR);
+                matvar->internal->datapos = ftell((FILE *)mat->fp);
                 if ( matvar->internal->datapos == -1L ) {
                     Mat_Critical("Couldn't determine file position");
                 }
             }
-            (void)fseek((FILE*)mat->fp,nBytes+8+fpos,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, nBytes + 8 + fpos, SEEK_SET);
             break;
 #else
-            Mat_Critical("Compressed variable found in \"%s\", but matio was "
-                         "built without zlib support",mat->filename);
-            (void)fseek((FILE*)mat->fp,nBytes+8+fpos,SEEK_SET);
+            Mat_Critical(
+                "Compressed variable found in \"%s\", but matio was "
+                "built without zlib support",
+                mat->filename);
+            (void)fseek((FILE *)mat->fp, nBytes + 8 + fpos, SEEK_SET);
             return NULL;
 #endif
         }
-        case MAT_T_MATRIX:
-        {
+        case MAT_T_MATRIX: {
             mat_uint32_t buf[6];
 
             /* Read array flags and the dimensions tag */
-            err = Read(buf, 4, 6, (FILE*)mat->fp, NULL);
+            err = Read(buf, 4, 6, (FILE *)mat->fp, NULL);
             if ( err ) {
-                (void)fseek((FILE*)mat->fp, fpos, SEEK_SET);
+                (void)fseek((FILE *)mat->fp, fpos, SEEK_SET);
                 break;
             }
             if ( mat->byteswap ) {
                 (void)Mat_uint32Swap(buf);
-                (void)Mat_uint32Swap(buf+1);
-                (void)Mat_uint32Swap(buf+2);
-                (void)Mat_uint32Swap(buf+3);
-                (void)Mat_uint32Swap(buf+4);
-                (void)Mat_uint32Swap(buf+5);
+                (void)Mat_uint32Swap(buf + 1);
+                (void)Mat_uint32Swap(buf + 2);
+                (void)Mat_uint32Swap(buf + 3);
+                (void)Mat_uint32Swap(buf + 4);
+                (void)Mat_uint32Swap(buf + 5);
             }
 
             matvar = Mat_VarCalloc();
@@ -11671,42 +11737,42 @@ Mat_VarReadNextInfo5( mat_t *mat )
 
             /* Array flags */
             if ( buf[0] == MAT_T_UINT32 || buf[0] == MAT_T_INT32 ) { /* Also allow INT32 for SWAN */
-               array_flags = buf[2];
-               matvar->class_type = CLASS_FROM_ARRAY_FLAGS(array_flags);
-               matvar->isComplex  = (array_flags & MAT_F_COMPLEX);
-               matvar->isGlobal   = (array_flags & MAT_F_GLOBAL);
-               matvar->isLogical  = (array_flags & MAT_F_LOGICAL);
-               if ( matvar->class_type == MAT_C_SPARSE ) {
-                   /* Need to find a more appropriate place to store nzmax */
-                   matvar->nbytes = buf[3];
-               }
+                array_flags = buf[2];
+                matvar->class_type = CLASS_FROM_ARRAY_FLAGS(array_flags);
+                matvar->isComplex = (array_flags & MAT_F_COMPLEX);
+                matvar->isGlobal = (array_flags & MAT_F_GLOBAL);
+                matvar->isLogical = (array_flags & MAT_F_LOGICAL);
+                if ( matvar->class_type == MAT_C_SPARSE ) {
+                    /* Need to find a more appropriate place to store nzmax */
+                    matvar->nbytes = buf[3];
+                }
             }
             /* Rank and dimension */
             {
                 size_t nbytes = 0;
                 err = ReadRankDims(mat, matvar, (enum matio_types)buf[4], buf[5], &nbytes);
-                if ( 0 == nbytes && 0 < matvar->rank ) {
+                if ( err ) {
                     Mat_VarFree(matvar);
                     matvar = NULL;
-                    (void)fseek((FILE*)mat->fp, fpos, SEEK_SET);
+                    (void)fseek((FILE *)mat->fp, fpos, SEEK_SET);
                     break;
                 }
             }
             /* Variable name tag */
-            err = Read(buf, 4, 2, (FILE*)mat->fp, NULL);
+            err = Read(buf, 4, 2, (FILE *)mat->fp, NULL);
             if ( err ) {
                 Mat_VarFree(matvar);
                 matvar = NULL;
-                (void)fseek((FILE*)mat->fp, fpos, SEEK_SET);
+                (void)fseek((FILE *)mat->fp, fpos, SEEK_SET);
                 break;
             }
             if ( mat->byteswap )
                 (void)Mat_uint32Swap(buf);
             /* Name of variable */
-            if ( buf[0] == MAT_T_INT8 ) {    /* Name not in tag */
+            if ( buf[0] == MAT_T_INT8 ) { /* Name not in tag */
                 mat_uint32_t len, len_pad;
                 if ( mat->byteswap )
-                    len = Mat_uint32Swap(buf+1);
+                    len = Mat_uint32Swap(buf + 1);
                 else
                     len = buf[1];
                 if ( len % 8 == 0 )
@@ -11716,18 +11782,18 @@ Mat_VarReadNextInfo5( mat_t *mat )
                 else {
                     Mat_VarFree(matvar);
                     matvar = NULL;
-                    (void)fseek((FILE*)mat->fp, fpos, SEEK_SET);
+                    (void)fseek((FILE *)mat->fp, fpos, SEEK_SET);
                     break;
                 }
-                matvar->name = (char*)malloc(len_pad + 1);
+                matvar->name = (char *)malloc(len_pad + 1);
                 if ( NULL != matvar->name ) {
-                    err = Read(matvar->name, 1, len_pad, (FILE*)mat->fp, NULL);
+                    err = Read(matvar->name, 1, len_pad, (FILE *)mat->fp, NULL);
                     if ( MATIO_E_NO_ERROR == err ) {
                         matvar->name[len] = '\0';
                     } else {
                         Mat_VarFree(matvar);
                         matvar = NULL;
-                        (void)fseek((FILE*)mat->fp, fpos, SEEK_SET);
+                        (void)fseek((FILE *)mat->fp, fpos, SEEK_SET);
                         break;
                     }
                 }
@@ -11735,29 +11801,28 @@ Mat_VarReadNextInfo5( mat_t *mat )
                 mat_uint32_t len = (buf[0] & 0xffff0000) >> 16;
                 if ( ((buf[0] & 0x0000ffff) == MAT_T_INT8) && len > 0 && len <= 4 ) {
                     /* Name packed in tag */
-                    matvar->name = (char*)malloc(len+1);
+                    matvar->name = (char *)malloc(len + 1);
                     if ( NULL != matvar->name ) {
-                        memcpy(matvar->name, buf+1, len);
+                        memcpy(matvar->name, buf + 1, len);
                         matvar->name[len] = '\0';
                     }
                 }
             }
             if ( matvar->class_type == MAT_C_STRUCT )
-                (void)ReadNextStructField(mat,matvar);
+                (void)ReadNextStructField(mat, matvar);
             else if ( matvar->class_type == MAT_C_CELL )
-                (void)ReadNextCell(mat,matvar);
+                (void)ReadNextCell(mat, matvar);
             else if ( matvar->class_type == MAT_C_FUNCTION )
-                (void)ReadNextFunctionHandle(mat,matvar);
-            matvar->internal->datapos = ftell((FILE*)mat->fp);
+                (void)ReadNextFunctionHandle(mat, matvar);
+            matvar->internal->datapos = ftell((FILE *)mat->fp);
             if ( matvar->internal->datapos == -1L ) {
                 Mat_Critical("Couldn't determine file position");
             }
-            (void)fseek((FILE*)mat->fp,nBytes+8+fpos,SEEK_SET);
+            (void)fseek((FILE *)mat->fp, nBytes + 8 + fpos, SEEK_SET);
             break;
         }
         default:
-            Mat_Critical("%d is not valid (MAT_T_MATRIX or MAT_T_COMPRESSED)",
-                         data_type);
+            Mat_Critical("%d is not valid (MAT_T_MATRIX or MAT_T_COMPRESSED)", data_type);
             return NULL;
     }
 
@@ -11775,51 +11840,41 @@ Mat_VarReadNextInfo5( mat_t *mat )
 
 #if HAVE_HDF5
 
-static const char *ClassNames[] = {
-    "",
-    "cell",
-    "struct",
-    "object",
-    "char",
-    "sparse",
-    "double",
-    "single",
-    "int8",
-    "uint8",
-    "int16",
-    "uint16",
-    "int32",
-    "uint32",
-    "int64",
-    "uint64",
-    "function"
-};
+static const char *ClassNames[] = {"",       "cell",   "struct", "object", "char",    "sparse",
+                                   "double", "single", "int8",   "uint8",  "int16",   "uint16",
+                                   "int32",  "uint32", "int64",  "uint64", "function"};
 
-struct ReadNextIterData {
+struct ReadNextIterData
+{
     mat_t *mat;
     matvar_t *matvar;
 };
 
-struct ReadGroupInfoIterData {
+struct ReadGroupInfoIterData
+{
     hsize_t nfields;
     matvar_t *matvar;
 };
 
-#if H5_VERSION_GE(1,10,0)
-#define H5RDEREFERENCE(obj_id, ref_type, _ref) H5Rdereference2((obj_id), H5P_DATASET_ACCESS_DEFAULT, (ref_type), (_ref))
+#if H5_VERSION_GE(1, 10, 0)
+#define H5RDEREFERENCE(obj_id, ref_type, _ref) \
+    H5Rdereference2((obj_id), H5P_DATASET_ACCESS_DEFAULT, (ref_type), (_ref))
 #else
 #define H5RDEREFERENCE(obj_id, ref_type, _ref) H5Rdereference((obj_id), (ref_type), (_ref))
 #endif
 
-#if H5_VERSION_GE(1,12,0)
+#if H5_VERSION_GE(1, 12, 0)
 #define H5O_INFO_T H5O_info2_t
-#define H5OGET_INFO_BY_NAME(loc_id, name, oinfo, lapl_id) H5Oget_info_by_name3((loc_id), (name), (oinfo), H5O_INFO_BASIC, (lapl_id));
-#elif H5_VERSION_GE(1,10,3)
+#define H5OGET_INFO_BY_NAME(loc_id, name, oinfo, lapl_id) \
+    H5Oget_info_by_name3((loc_id), (name), (oinfo), H5O_INFO_BASIC, (lapl_id));
+#elif H5_VERSION_GE(1, 10, 3)
 #define H5O_INFO_T H5O_info_t
-#define H5OGET_INFO_BY_NAME(loc_id, name, oinfo, lapl_id) H5Oget_info_by_name2((loc_id), (name), (oinfo), H5O_INFO_BASIC, (lapl_id));
+#define H5OGET_INFO_BY_NAME(loc_id, name, oinfo, lapl_id) \
+    H5Oget_info_by_name2((loc_id), (name), (oinfo), H5O_INFO_BASIC, (lapl_id));
 #else
 #define H5O_INFO_T H5O_info_t
-#define H5OGET_INFO_BY_NAME(loc_id, name, oinfo, lapl_id) H5Oget_info_by_name((loc_id), (name), (oinfo), (lapl_id));
+#define H5OGET_INFO_BY_NAME(loc_id, name, oinfo, lapl_id) \
+    H5Oget_info_by_name((loc_id), (name), (oinfo), (lapl_id));
 #endif
 
 #if !defined(MAX_RANK)
@@ -11833,55 +11888,53 @@ struct ReadGroupInfoIterData {
  */
 static enum matio_classes ClassStr2ClassType(const char *name);
 static enum matio_classes DataType2ClassType(enum matio_types type);
-static hid_t   ClassType2H5T(enum matio_classes class_type);
-static hid_t   DataType2H5T(enum matio_types data_type);
-static hid_t   SizeType2H5T(void);
-static hid_t   DataType(hid_t h5_type, int isComplex);
-static void    Mat_H5GetChunkSize(size_t rank,hsize_t *dims,hsize_t *chunk_dims);
-static void    Mat_H5ReadVarInfo(matvar_t *matvar,hid_t dset_id);
-static size_t* Mat_H5ReadDims(hid_t dset_id, hsize_t *nelems, int *rank);
-static void    Mat_H5ReadFieldNames(matvar_t *matvar, hid_t dset_id, hsize_t *nfields);
-static void    Mat_H5ReadDatasetInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id);
-static void    Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id);
-static void    Mat_H5ReadNextReferenceInfo(hid_t ref_id,matvar_t *matvar,mat_t *mat);
-static void    Mat_H5ReadNextReferenceData(hid_t ref_id,matvar_t *matvar,mat_t *mat);
-static int     Mat_VarWriteEmpty(hid_t id,matvar_t *matvar,const char *name,
-                   const char* class_name);
-static int     Mat_VarWriteCell73(hid_t id,matvar_t *matvar,const char *name,
-                   hid_t *refs_id,hsize_t *dims);
-static int     Mat_VarWriteChar73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims);
-static int     Mat_WriteEmptyVariable73(hid_t id,const char *name,hsize_t rank,
-                   size_t *dims);
-static int     Mat_VarWriteLogical73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims);
-static int     Mat_VarWriteNumeric73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims,
-                   hsize_t* max_dims);
-static int     Mat_VarWriteAppendNumeric73(hid_t id,matvar_t *matvar,const char *name,
-                   hsize_t *dims,int dim);
-static int     Mat_VarWriteSparse73(hid_t id,matvar_t *matvar,const char *name);
-static int     Mat_VarWriteStruct73(hid_t id,matvar_t *matvar,const char *name,
-                   hid_t *refs_id,hsize_t *dims,hsize_t* max_dims);
-static int     Mat_VarWriteAppendStruct73(hid_t id,matvar_t *matvar,const char *name,
-                   hid_t *refs_id,hsize_t *dims,int dim);
-static int     Mat_VarWriteNext73(hid_t id,matvar_t *matvar,const char *name,
-                   hid_t *refs_id);
-static int     Mat_VarWriteAppendNext73(hid_t id,matvar_t *matvar,const char *name,
-                   hid_t *refs_id,int dim);
-static int     Mat_VarWriteNextType73(hid_t id,matvar_t *matvar,const char *name,
-                   hid_t *refs_id,hsize_t *dims);
-static int     Mat_VarWriteAppendNextType73(hid_t id,matvar_t *matvar,const char *name,
-                   hid_t *refs_id,hsize_t *dims,int dim);
-static herr_t  Mat_VarReadNextInfoIterate(hid_t id, const char *name,
-                   const H5L_info_t *info, void *op_data);
-static herr_t  Mat_H5ReadGroupInfoIterate(hid_t dset_id, const char *name,
-                   const H5L_info_t *info, void *op_data);
-static void    Mat_H5ReadData(hid_t dset_id, hid_t h5_type, hid_t mem_space, hid_t dset_space,
-                   int isComplex, void *data);
-static int     Mat_H5WriteData(hid_t dset_id, hid_t h5_type, hid_t mem_space, hid_t dset_space,
-                   int isComplex, void *data);
-static int     Mat_H5WriteAppendData(hid_t id, hid_t h5_type, int mrank, const char *name,
-                   const size_t* mdims, hsize_t *dims, int dim, int isComplex, void* data);
-static int     Mat_VarWriteRef(hid_t id, matvar_t* matvar, enum matio_compression compression,
-                   hid_t *refs_id, hobj_ref_t* ref);
+static hid_t ClassType2H5T(enum matio_classes class_type);
+static hid_t DataType2H5T(enum matio_types data_type);
+static hid_t SizeType2H5T(void);
+static hid_t DataType(hid_t h5_type, int isComplex);
+static void Mat_H5GetChunkSize(size_t rank, hsize_t *dims, hsize_t *chunk_dims);
+static int Mat_H5ReadVarInfo(matvar_t *matvar, hid_t dset_id);
+static size_t *Mat_H5ReadDims(hid_t dset_id, hsize_t *nelems, int *rank);
+static int Mat_H5ReadFieldNames(matvar_t *matvar, hid_t dset_id, hsize_t *nfields);
+static int Mat_H5ReadDatasetInfo(mat_t *mat, matvar_t *matvar, hid_t dset_id);
+static int Mat_H5ReadGroupInfo(mat_t *mat, matvar_t *matvar, hid_t dset_id);
+static int Mat_H5ReadNextReferenceInfo(hid_t ref_id, matvar_t *matvar, mat_t *mat);
+static int Mat_H5ReadNextReferenceData(hid_t ref_id, matvar_t *matvar, mat_t *mat);
+static int Mat_VarWriteEmpty(hid_t id, matvar_t *matvar, const char *name, const char *class_name);
+static int Mat_VarWriteCell73(hid_t id, matvar_t *matvar, const char *name, hid_t *refs_id,
+                              hsize_t *dims);
+static int Mat_VarWriteChar73(hid_t id, matvar_t *matvar, const char *name, hsize_t *dims);
+static int Mat_WriteEmptyVariable73(hid_t id, const char *name, hsize_t rank, size_t *dims);
+static int Mat_VarWriteLogical73(hid_t id, matvar_t *matvar, const char *name, hsize_t *dims);
+static int Mat_VarWriteNumeric73(hid_t id, matvar_t *matvar, const char *name, hsize_t *dims,
+                                 hsize_t *max_dims);
+static int Mat_VarWriteAppendNumeric73(hid_t id, matvar_t *matvar, const char *name, hsize_t *dims,
+                                       int dim);
+static int Mat_VarWriteSparse73(hid_t id, matvar_t *matvar, const char *name);
+static int Mat_VarWriteStruct73(hid_t id, matvar_t *matvar, const char *name, hid_t *refs_id,
+                                hsize_t *dims, hsize_t *max_dims);
+static int Mat_VarWriteAppendStruct73(hid_t id, matvar_t *matvar, const char *name, hid_t *refs_id,
+                                      hsize_t *dims, int dim);
+static int Mat_VarWriteNext73(hid_t id, matvar_t *matvar, const char *name, hid_t *refs_id);
+static int Mat_VarWriteAppendNext73(hid_t id, matvar_t *matvar, const char *name, hid_t *refs_id,
+                                    int dim);
+static int Mat_VarWriteNextType73(hid_t id, matvar_t *matvar, const char *name, hid_t *refs_id,
+                                  hsize_t *dims);
+static int Mat_VarWriteAppendNextType73(hid_t id, matvar_t *matvar, const char *name,
+                                        hid_t *refs_id, hsize_t *dims, int dim);
+static herr_t Mat_VarReadNextInfoIterate(hid_t id, const char *name, const H5L_info_t *info,
+                                         void *op_data);
+static herr_t Mat_H5ReadGroupInfoIterate(hid_t dset_id, const char *name, const H5L_info_t *info,
+                                         void *op_data);
+static int Mat_H5ReadData(hid_t dset_id, hid_t h5_type, hid_t mem_space, hid_t dset_space,
+                          int isComplex, void *data);
+static int Mat_H5WriteData(hid_t dset_id, hid_t h5_type, hid_t mem_space, hid_t dset_space,
+                           int isComplex, void *data);
+static int Mat_H5WriteAppendData(hid_t id, hid_t h5_type, int mrank, const char *name,
+                                 const size_t *mdims, hsize_t *dims, int dim, int isComplex,
+                                 void *data);
+static int Mat_VarWriteRef(hid_t id, matvar_t *matvar, enum matio_compression compression,
+                           hid_t *refs_id, hobj_ref_t *ref);
 
 static enum matio_classes
 ClassStr2ClassType(const char *name)
@@ -11890,7 +11943,7 @@ ClassStr2ClassType(const char *name)
     if ( NULL != name ) {
         int k;
         for ( k = 1; k < 17; k++ ) {
-            if ( 0 == strcmp(name,ClassNames[k]) ) {
+            if ( 0 == strcmp(name, ClassNames[k]) ) {
                 id = (enum matio_classes)k;
                 break;
             }
@@ -11942,74 +11995,74 @@ ClassType2H5T(enum matio_classes class_type)
         case MAT_C_SINGLE:
             return H5T_NATIVE_FLOAT;
         case MAT_C_INT64:
-            if ( CHAR_BIT*sizeof(long long) == 64 )
+            if ( CHAR_BIT * sizeof(long long) == 64 )
                 return H5T_NATIVE_LLONG;
-            else if ( CHAR_BIT*sizeof(long) == 64 )
+            else if ( CHAR_BIT * sizeof(long) == 64 )
                 return H5T_NATIVE_LONG;
-            else if ( CHAR_BIT*sizeof(int) == 64 )
+            else if ( CHAR_BIT * sizeof(int) == 64 )
                 return H5T_NATIVE_INT;
-            else if ( CHAR_BIT*sizeof(short) == 64 )
+            else if ( CHAR_BIT * sizeof(short) == 64 )
                 return H5T_NATIVE_SHORT;
             else
                 return -1;
         case MAT_C_UINT64:
-            if ( CHAR_BIT*sizeof(long long) == 64 )
+            if ( CHAR_BIT * sizeof(long long) == 64 )
                 return H5T_NATIVE_ULLONG;
-            else if ( CHAR_BIT*sizeof(long) == 64 )
+            else if ( CHAR_BIT * sizeof(long) == 64 )
                 return H5T_NATIVE_ULONG;
-            else if ( CHAR_BIT*sizeof(int) == 64 )
+            else if ( CHAR_BIT * sizeof(int) == 64 )
                 return H5T_NATIVE_UINT;
-            if ( CHAR_BIT*sizeof(short) == 64 )
+            if ( CHAR_BIT * sizeof(short) == 64 )
                 return H5T_NATIVE_USHORT;
             else
                 return -1;
         case MAT_C_INT32:
-            if ( CHAR_BIT*sizeof(int) == 32 )
+            if ( CHAR_BIT * sizeof(int) == 32 )
                 return H5T_NATIVE_INT;
-            else if ( CHAR_BIT*sizeof(short) == 32 )
+            else if ( CHAR_BIT * sizeof(short) == 32 )
                 return H5T_NATIVE_SHORT;
-            else if ( CHAR_BIT*sizeof(long) == 32 )
+            else if ( CHAR_BIT * sizeof(long) == 32 )
                 return H5T_NATIVE_LONG;
-            else if ( CHAR_BIT*sizeof(long long) == 32 )
+            else if ( CHAR_BIT * sizeof(long long) == 32 )
                 return H5T_NATIVE_LLONG;
             else if ( CHAR_BIT == 32 )
                 return H5T_NATIVE_SCHAR;
             else
                 return -1;
         case MAT_C_UINT32:
-            if ( CHAR_BIT*sizeof(int) == 32 )
+            if ( CHAR_BIT * sizeof(int) == 32 )
                 return H5T_NATIVE_UINT;
-            else if ( CHAR_BIT*sizeof(short) == 32 )
+            else if ( CHAR_BIT * sizeof(short) == 32 )
                 return H5T_NATIVE_USHORT;
-            else if ( CHAR_BIT*sizeof(long) == 32 )
+            else if ( CHAR_BIT * sizeof(long) == 32 )
                 return H5T_NATIVE_ULONG;
-            else if ( CHAR_BIT*sizeof(long long) == 32 )
+            else if ( CHAR_BIT * sizeof(long long) == 32 )
                 return H5T_NATIVE_ULLONG;
             else if ( CHAR_BIT == 32 )
                 return H5T_NATIVE_UCHAR;
             else
                 return -1;
         case MAT_C_INT16:
-            if ( CHAR_BIT*sizeof(short) == 16 )
+            if ( CHAR_BIT * sizeof(short) == 16 )
                 return H5T_NATIVE_SHORT;
-            else if ( CHAR_BIT*sizeof(int) == 16 )
+            else if ( CHAR_BIT * sizeof(int) == 16 )
                 return H5T_NATIVE_INT;
-            else if ( CHAR_BIT*sizeof(long) == 16 )
+            else if ( CHAR_BIT * sizeof(long) == 16 )
                 return H5T_NATIVE_LONG;
-            else if ( CHAR_BIT*sizeof(long long) == 16 )
+            else if ( CHAR_BIT * sizeof(long long) == 16 )
                 return H5T_NATIVE_LLONG;
             else if ( CHAR_BIT == 16 )
                 return H5T_NATIVE_SCHAR;
             else
                 return -1;
         case MAT_C_UINT16:
-            if ( CHAR_BIT*sizeof(short) == 16 )
+            if ( CHAR_BIT * sizeof(short) == 16 )
                 return H5T_NATIVE_USHORT;
-            else if ( CHAR_BIT*sizeof(int) == 16 )
+            else if ( CHAR_BIT * sizeof(int) == 16 )
                 return H5T_NATIVE_UINT;
-            else if ( CHAR_BIT*sizeof(long) == 16 )
+            else if ( CHAR_BIT * sizeof(long) == 16 )
                 return H5T_NATIVE_ULONG;
-            else if ( CHAR_BIT*sizeof(long long) == 16 )
+            else if ( CHAR_BIT * sizeof(long long) == 16 )
                 return H5T_NATIVE_ULLONG;
             else if ( CHAR_BIT == 16 )
                 return H5T_NATIVE_UCHAR;
@@ -12018,26 +12071,26 @@ ClassType2H5T(enum matio_classes class_type)
         case MAT_C_INT8:
             if ( CHAR_BIT == 8 )
                 return H5T_NATIVE_SCHAR;
-            else if ( CHAR_BIT*sizeof(short) == 8 )
+            else if ( CHAR_BIT * sizeof(short) == 8 )
                 return H5T_NATIVE_SHORT;
-            else if ( CHAR_BIT*sizeof(int) == 8 )
+            else if ( CHAR_BIT * sizeof(int) == 8 )
                 return H5T_NATIVE_INT;
-            else if ( CHAR_BIT*sizeof(long) == 8 )
+            else if ( CHAR_BIT * sizeof(long) == 8 )
                 return H5T_NATIVE_LONG;
-            else if ( CHAR_BIT*sizeof(long long) == 8 )
+            else if ( CHAR_BIT * sizeof(long long) == 8 )
                 return H5T_NATIVE_LLONG;
             else
                 return -1;
         case MAT_C_UINT8:
             if ( CHAR_BIT == 8 )
                 return H5T_NATIVE_UCHAR;
-            else if ( CHAR_BIT*sizeof(short) == 8 )
+            else if ( CHAR_BIT * sizeof(short) == 8 )
                 return H5T_NATIVE_USHORT;
-            else if ( CHAR_BIT*sizeof(int) == 8 )
+            else if ( CHAR_BIT * sizeof(int) == 8 )
                 return H5T_NATIVE_UINT;
-            else if ( CHAR_BIT*sizeof(long) == 8 )
+            else if ( CHAR_BIT * sizeof(long) == 8 )
                 return H5T_NATIVE_ULONG;
-            else if ( CHAR_BIT*sizeof(long long) == 8 )
+            else if ( CHAR_BIT * sizeof(long long) == 8 )
                 return H5T_NATIVE_ULLONG;
             else
                 return -1;
@@ -12055,74 +12108,74 @@ DataType2H5T(enum matio_types data_type)
         case MAT_T_SINGLE:
             return H5T_NATIVE_FLOAT;
         case MAT_T_INT64:
-            if ( CHAR_BIT*sizeof(long long) == 64 )
+            if ( CHAR_BIT * sizeof(long long) == 64 )
                 return H5T_NATIVE_LLONG;
-            else if ( CHAR_BIT*sizeof(long) == 64 )
+            else if ( CHAR_BIT * sizeof(long) == 64 )
                 return H5T_NATIVE_LONG;
-            else if ( CHAR_BIT*sizeof(int) == 64 )
+            else if ( CHAR_BIT * sizeof(int) == 64 )
                 return H5T_NATIVE_INT;
-            else if ( CHAR_BIT*sizeof(short) == 64 )
+            else if ( CHAR_BIT * sizeof(short) == 64 )
                 return H5T_NATIVE_SHORT;
             else
                 return -1;
         case MAT_T_UINT64:
-            if ( CHAR_BIT*sizeof(long long) == 64 )
+            if ( CHAR_BIT * sizeof(long long) == 64 )
                 return H5T_NATIVE_ULLONG;
-            else if ( CHAR_BIT*sizeof(long) == 64 )
+            else if ( CHAR_BIT * sizeof(long) == 64 )
                 return H5T_NATIVE_ULONG;
-            else if ( CHAR_BIT*sizeof(int) == 64 )
+            else if ( CHAR_BIT * sizeof(int) == 64 )
                 return H5T_NATIVE_UINT;
-            else if ( CHAR_BIT*sizeof(short) == 64 )
+            else if ( CHAR_BIT * sizeof(short) == 64 )
                 return H5T_NATIVE_USHORT;
             else
                 return -1;
         case MAT_T_INT32:
-            if ( CHAR_BIT*sizeof(int) == 32 )
+            if ( CHAR_BIT * sizeof(int) == 32 )
                 return H5T_NATIVE_INT;
-            else if ( CHAR_BIT*sizeof(short) == 32 )
+            else if ( CHAR_BIT * sizeof(short) == 32 )
                 return H5T_NATIVE_SHORT;
-            else if ( CHAR_BIT*sizeof(long) == 32 )
+            else if ( CHAR_BIT * sizeof(long) == 32 )
                 return H5T_NATIVE_LONG;
-            else if ( CHAR_BIT*sizeof(long long) == 32 )
+            else if ( CHAR_BIT * sizeof(long long) == 32 )
                 return H5T_NATIVE_LLONG;
             else if ( CHAR_BIT == 32 )
                 return H5T_NATIVE_SCHAR;
             else
                 return -1;
         case MAT_T_UINT32:
-            if ( CHAR_BIT*sizeof(int) == 32 )
+            if ( CHAR_BIT * sizeof(int) == 32 )
                 return H5T_NATIVE_UINT;
-            else if ( CHAR_BIT*sizeof(short) == 32 )
+            else if ( CHAR_BIT * sizeof(short) == 32 )
                 return H5T_NATIVE_USHORT;
-            else if ( CHAR_BIT*sizeof(long) == 32 )
+            else if ( CHAR_BIT * sizeof(long) == 32 )
                 return H5T_NATIVE_ULONG;
-            else if ( CHAR_BIT*sizeof(long long) == 32 )
+            else if ( CHAR_BIT * sizeof(long long) == 32 )
                 return H5T_NATIVE_ULLONG;
             else if ( CHAR_BIT == 32 )
                 return H5T_NATIVE_UCHAR;
             else
                 return -1;
         case MAT_T_INT16:
-            if ( CHAR_BIT*sizeof(short) == 16 )
+            if ( CHAR_BIT * sizeof(short) == 16 )
                 return H5T_NATIVE_SHORT;
-            else if ( CHAR_BIT*sizeof(int) == 16 )
+            else if ( CHAR_BIT * sizeof(int) == 16 )
                 return H5T_NATIVE_INT;
-            else if ( CHAR_BIT*sizeof(long) == 16 )
+            else if ( CHAR_BIT * sizeof(long) == 16 )
                 return H5T_NATIVE_LONG;
-            else if ( CHAR_BIT*sizeof(long long) == 16 )
+            else if ( CHAR_BIT * sizeof(long long) == 16 )
                 return H5T_NATIVE_LLONG;
             else if ( CHAR_BIT == 16 )
                 return H5T_NATIVE_SCHAR;
             else
                 return -1;
         case MAT_T_UINT16:
-            if ( CHAR_BIT*sizeof(short) == 16 )
+            if ( CHAR_BIT * sizeof(short) == 16 )
                 return H5T_NATIVE_USHORT;
-            else if ( CHAR_BIT*sizeof(int) == 16 )
+            else if ( CHAR_BIT * sizeof(int) == 16 )
                 return H5T_NATIVE_UINT;
-            else if ( CHAR_BIT*sizeof(long) == 16 )
+            else if ( CHAR_BIT * sizeof(long) == 16 )
                 return H5T_NATIVE_ULONG;
-            else if ( CHAR_BIT*sizeof(long long) == 16 )
+            else if ( CHAR_BIT * sizeof(long long) == 16 )
                 return H5T_NATIVE_ULLONG;
             else if ( CHAR_BIT == 16 )
                 return H5T_NATIVE_UCHAR;
@@ -12131,26 +12184,26 @@ DataType2H5T(enum matio_types data_type)
         case MAT_T_INT8:
             if ( CHAR_BIT == 8 )
                 return H5T_NATIVE_SCHAR;
-            else if ( CHAR_BIT*sizeof(short) == 8 )
+            else if ( CHAR_BIT * sizeof(short) == 8 )
                 return H5T_NATIVE_SHORT;
-            else if ( CHAR_BIT*sizeof(int) == 8 )
+            else if ( CHAR_BIT * sizeof(int) == 8 )
                 return H5T_NATIVE_INT;
-            else if ( CHAR_BIT*sizeof(long) == 8 )
+            else if ( CHAR_BIT * sizeof(long) == 8 )
                 return H5T_NATIVE_LONG;
-            else if ( CHAR_BIT*sizeof(long long) == 8 )
+            else if ( CHAR_BIT * sizeof(long long) == 8 )
                 return H5T_NATIVE_LLONG;
             else
                 return -1;
         case MAT_T_UINT8:
             if ( CHAR_BIT == 8 )
                 return H5T_NATIVE_UCHAR;
-            else if ( CHAR_BIT*sizeof(short) == 8 )
+            else if ( CHAR_BIT * sizeof(short) == 8 )
                 return H5T_NATIVE_USHORT;
-            else if ( CHAR_BIT*sizeof(int) == 8 )
+            else if ( CHAR_BIT * sizeof(int) == 8 )
                 return H5T_NATIVE_UINT;
-            else if ( CHAR_BIT*sizeof(long) == 8 )
+            else if ( CHAR_BIT * sizeof(long) == 8 )
                 return H5T_NATIVE_ULONG;
-            else if ( CHAR_BIT*sizeof(long long) == 8 )
+            else if ( CHAR_BIT * sizeof(long long) == 8 )
                 return H5T_NATIVE_ULLONG;
             else
                 return -1;
@@ -12184,9 +12237,9 @@ DataType(hid_t h5_type, int isComplex)
     hid_t h5_dtype;
     if ( isComplex ) {
         size_t h5_size = H5Tget_size(h5_type);
-        h5_dtype = H5Tcreate(H5T_COMPOUND, 2*h5_size);
-        H5Tinsert(h5_dtype,"real",0,h5_type);
-        H5Tinsert(h5_dtype,"imag",h5_size,h5_type);
+        h5_dtype = H5Tcreate(H5T_COMPOUND, 2 * h5_size);
+        H5Tinsert(h5_dtype, "real", 0, h5_type);
+        H5Tinsert(h5_dtype, "imag", h5_size, h5_type);
     } else {
         h5_dtype = H5Tcopy(h5_type);
     }
@@ -12194,13 +12247,13 @@ DataType(hid_t h5_type, int isComplex)
 }
 
 static void
-Mat_H5GetChunkSize(size_t rank,hsize_t *dims,hsize_t *chunk_dims)
+Mat_H5GetChunkSize(size_t rank, hsize_t *dims, hsize_t *chunk_dims)
 {
     hsize_t i, j, chunk_size = 1;
 
     for ( i = 0; i < rank; i++ ) {
         chunk_dims[i] = 1;
-        for ( j = 4096/chunk_size; j > 1; j >>= 1 ) {
+        for ( j = 4096 / chunk_size; j > 1; j >>= 1 ) {
             if ( dims[i] >= j ) {
                 chunk_dims[i] = j;
                 break;
@@ -12210,39 +12263,54 @@ Mat_H5GetChunkSize(size_t rank,hsize_t *dims,hsize_t *chunk_dims)
     }
 }
 
-static void
-Mat_H5ReadVarInfo(matvar_t *matvar,hid_t dset_id)
+static int
+Mat_H5ReadVarInfo(matvar_t *matvar, hid_t dset_id)
 {
     hid_t attr_id, type_id;
     ssize_t name_len;
+    int err = MATIO_E_NO_ERROR;
 
     /* Get the HDF5 name of the variable */
-    name_len = H5Iget_name(dset_id,NULL,0);
+    name_len = H5Iget_name(dset_id, NULL, 0);
     if ( name_len > 0 ) {
-        matvar->internal->hdf5_name = (char*)malloc(name_len+1);
-        (void)H5Iget_name(dset_id,matvar->internal->hdf5_name,name_len+1);
+        matvar->internal->hdf5_name = (char *)malloc(name_len + 1);
+        (void)H5Iget_name(dset_id, matvar->internal->hdf5_name, name_len + 1);
     } else {
         /* Can not get an internal name, so leave the identifier open */
         matvar->internal->id = dset_id;
     }
 
-    attr_id = H5Aopen_by_name(dset_id,".","MATLAB_class",H5P_DEFAULT,H5P_DEFAULT);
-    type_id  = H5Aget_type(attr_id);
+    attr_id = H5Aopen_by_name(dset_id, ".", "MATLAB_class", H5P_DEFAULT, H5P_DEFAULT);
+    type_id = H5Aget_type(attr_id);
     if ( H5T_STRING == H5Tget_class(type_id) ) {
-        char *class_str = (char*)calloc(H5Tget_size(type_id)+1,1);
+        char *class_str = (char *)calloc(H5Tget_size(type_id) + 1, 1);
         if ( NULL != class_str ) {
+            herr_t herr;
             hid_t class_id = H5Tcopy(H5T_C_S1);
-            H5Tset_size(class_id,H5Tget_size(type_id));
-            H5Aread(attr_id,class_id,class_str);
+            H5Tset_size(class_id, H5Tget_size(type_id));
+            herr = H5Aread(attr_id, class_id, class_str);
             H5Tclose(class_id);
+            if ( herr < 0 ) {
+                free(class_str);
+                H5Tclose(type_id);
+                H5Aclose(attr_id);
+                return MATIO_E_GENERIC_READ_ERROR;
+            }
             matvar->class_type = ClassStr2ClassType(class_str);
             if ( MAT_C_EMPTY == matvar->class_type || MAT_C_CHAR == matvar->class_type ) {
                 int int_decode = 0;
-                if ( H5Aexists_by_name(dset_id,".","MATLAB_int_decode",H5P_DEFAULT) ) {
-                    hid_t attr_id2 = H5Aopen_by_name(dset_id,".","MATLAB_int_decode",H5P_DEFAULT,H5P_DEFAULT);
+                if ( H5Aexists_by_name(dset_id, ".", "MATLAB_int_decode", H5P_DEFAULT) ) {
+                    hid_t attr_id2 = H5Aopen_by_name(dset_id, ".", "MATLAB_int_decode", H5P_DEFAULT,
+                                                     H5P_DEFAULT);
                     /* FIXME: Check that dataspace is scalar */
-                    H5Aread(attr_id2,H5T_NATIVE_INT,&int_decode);
+                    herr = H5Aread(attr_id2, H5T_NATIVE_INT, &int_decode);
                     H5Aclose(attr_id2);
+                    if ( herr < 0 ) {
+                        free(class_str);
+                        H5Tclose(type_id);
+                        H5Aclose(attr_id);
+                        return MATIO_E_GENERIC_READ_ERROR;
+                    }
                 }
                 switch ( int_decode ) {
                     case 2:
@@ -12271,25 +12339,37 @@ Mat_H5ReadVarInfo(matvar_t *matvar,hid_t dset_id)
                 matvar->data_type = ClassType2DataType(matvar->class_type);
             }
             free(class_str);
+        } else {
+            err = MATIO_E_OUT_OF_MEMORY;
         }
     }
     H5Tclose(type_id);
     H5Aclose(attr_id);
 
-    /* Check if the variable is global */
-    if ( H5Aexists_by_name(dset_id,".","MATLAB_global",H5P_DEFAULT) ) {
-        attr_id = H5Aopen_by_name(dset_id,".","MATLAB_global",H5P_DEFAULT,H5P_DEFAULT);
-        /* FIXME: Check that dataspace is scalar */
-        H5Aread(attr_id,H5T_NATIVE_INT,&matvar->isGlobal);
-        H5Aclose(attr_id);
+    if ( err ) {
+        return err;
     }
+
+    /* Check if the variable is global */
+    if ( H5Aexists_by_name(dset_id, ".", "MATLAB_global", H5P_DEFAULT) ) {
+        herr_t herr;
+        attr_id = H5Aopen_by_name(dset_id, ".", "MATLAB_global", H5P_DEFAULT, H5P_DEFAULT);
+        /* FIXME: Check that dataspace is scalar */
+        herr = H5Aread(attr_id, H5T_NATIVE_INT, &matvar->isGlobal);
+        H5Aclose(attr_id);
+        if ( herr < 0 ) {
+            return MATIO_E_GENERIC_READ_ERROR;
+        }
+    }
+
+    return err;
 }
 
-static size_t*
+static size_t *
 Mat_H5ReadDims(hid_t dset_id, hsize_t *nelems, int *rank)
 {
     hid_t space_id;
-    size_t* perm_dims;
+    size_t *perm_dims;
 
     *nelems = 0;
     space_id = H5Dget_space(dset_id);
@@ -12299,14 +12379,14 @@ Mat_H5ReadDims(hid_t dset_id, hsize_t *nelems, int *rank)
         H5Sclose(space_id);
         return NULL;
     }
-    perm_dims = (size_t*)malloc(*rank*sizeof(*perm_dims));
+    perm_dims = (size_t *)malloc(*rank * sizeof(*perm_dims));
     if ( NULL != perm_dims ) {
         int err = 0;
         if ( MAX_RANK >= *rank ) {
             hsize_t dims[MAX_RANK];
             int k;
             size_t tmp = 1;
-            (void)H5Sget_simple_extent_dims(space_id,dims,NULL);
+            (void)H5Sget_simple_extent_dims(space_id, dims, NULL);
             /* Permute dimensions */
             for ( k = 0; k < *rank; k++ ) {
                 perm_dims[k] = (size_t)dims[*rank - k - 1];
@@ -12321,11 +12401,11 @@ Mat_H5ReadDims(hid_t dset_id, hsize_t *nelems, int *rank)
             *nelems = (hsize_t)tmp;
             H5Sclose(space_id);
         } else {
-            hsize_t* dims = (hsize_t*)malloc(*rank*sizeof(hsize_t));
+            hsize_t *dims = (hsize_t *)malloc(*rank * sizeof(hsize_t));
             if ( NULL != dims ) {
                 int k;
                 size_t tmp = 1;
-                (void)H5Sget_simple_extent_dims(space_id,dims,NULL);
+                (void)H5Sget_simple_extent_dims(space_id, dims, NULL);
                 /* Permute dimensions */
                 for ( k = 0; k < *rank; k++ ) {
                     perm_dims[k] = (size_t)dims[*rank - k - 1];
@@ -12357,155 +12437,244 @@ Mat_H5ReadDims(hid_t dset_id, hsize_t *nelems, int *rank)
     return perm_dims;
 }
 
-static void
+static int
 Mat_H5ReadFieldNames(matvar_t *matvar, hid_t dset_id, hsize_t *nfields)
 {
-    hsize_t  i;
-    hid_t    field_id, attr_id, space_id;
-    hvl_t   *fieldnames_vl;
+    hsize_t i;
+    hid_t field_id, attr_id, space_id;
+    hvl_t *fieldnames_vl;
+    herr_t herr;
+    int err;
 
-    attr_id = H5Aopen_by_name(dset_id,".","MATLAB_fields",H5P_DEFAULT,H5P_DEFAULT);
+    attr_id = H5Aopen_by_name(dset_id, ".", "MATLAB_fields", H5P_DEFAULT, H5P_DEFAULT);
     space_id = H5Aget_space(attr_id);
-    (void)H5Sget_simple_extent_dims(space_id,nfields,NULL);
+    err = H5Sget_simple_extent_dims(space_id, nfields, NULL);
+    if ( err < 0 ) {
+        H5Sclose(space_id);
+        H5Aclose(attr_id);
+        return MATIO_E_GENERIC_READ_ERROR;
+    } else {
+        err = MATIO_E_NO_ERROR;
+    }
+    fieldnames_vl = (hvl_t *)calloc((size_t)(*nfields), sizeof(*fieldnames_vl));
+    if ( fieldnames_vl == NULL ) {
+        H5Sclose(space_id);
+        H5Aclose(attr_id);
+        return MATIO_E_OUT_OF_MEMORY;
+    }
     field_id = H5Aget_type(attr_id);
-    fieldnames_vl = (hvl_t*)malloc((size_t)(*nfields)*sizeof(*fieldnames_vl));
-    H5Aread(attr_id,field_id,fieldnames_vl);
-
-    matvar->internal->num_fields = (unsigned int)*nfields;
-    matvar->internal->fieldnames =
-        (char**)malloc((size_t)(*nfields)*sizeof(*matvar->internal->fieldnames));
-    for ( i = 0; i < *nfields; i++ ) {
-        matvar->internal->fieldnames[i] =
-            (char*)calloc(fieldnames_vl[i].len+1,1);
-        memcpy(matvar->internal->fieldnames[i],fieldnames_vl[i].p,
-            fieldnames_vl[i].len);
+    herr = H5Aread(attr_id, field_id, fieldnames_vl);
+    if ( herr >= 0 ) {
+        matvar->internal->num_fields = (unsigned int)*nfields;
+        matvar->internal->fieldnames =
+            (char **)calloc((size_t)(*nfields), sizeof(*matvar->internal->fieldnames));
+        if ( matvar->internal->fieldnames != NULL ) {
+            for ( i = 0; i < *nfields; i++ ) {
+                matvar->internal->fieldnames[i] = (char *)calloc(fieldnames_vl[i].len + 1, 1);
+                if ( matvar->internal->fieldnames[i] != NULL ) {
+                    if ( fieldnames_vl[i].p != NULL ) {
+                        memcpy(matvar->internal->fieldnames[i], fieldnames_vl[i].p,
+                               fieldnames_vl[i].len);
+                    }
+                } else {
+                    err = MATIO_E_OUT_OF_MEMORY;
+                    break;
+                }
+            }
+        } else {
+            err = MATIO_E_OUT_OF_MEMORY;
+        }
+#if H5_VERSION_GE(1, 12, 0)
+        H5Treclaim(field_id, space_id, H5P_DEFAULT, fieldnames_vl);
+#else
+        H5Dvlen_reclaim(field_id, space_id, H5P_DEFAULT, fieldnames_vl);
+#endif
+    } else {
+        err = MATIO_E_GENERIC_READ_ERROR;
     }
 
-#if H5_VERSION_GE(1,12,0)
-    H5Treclaim(field_id,space_id,H5P_DEFAULT,fieldnames_vl);
-#else
-    H5Dvlen_reclaim(field_id,space_id,H5P_DEFAULT,fieldnames_vl);
-#endif
     H5Sclose(space_id);
     H5Tclose(field_id);
     H5Aclose(attr_id);
     free(fieldnames_vl);
+
+    return err;
 }
 
-static void
-Mat_H5ReadDatasetInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
+static int
+Mat_H5ReadDatasetInfo(mat_t *mat, matvar_t *matvar, hid_t dset_id)
 {
-    int err = 0;
-    hid_t   attr_id,type_id;
+    int err;
     hsize_t nelems;
 
-    Mat_H5ReadVarInfo(matvar, dset_id);
+    err = Mat_H5ReadVarInfo(matvar, dset_id);
+    if ( err ) {
+        return err;
+    }
 
     matvar->dims = Mat_H5ReadDims(dset_id, &nelems, &matvar->rank);
     if ( NULL == matvar->dims ) {
-        return;
+        return MATIO_E_UNKNOWN_ERROR;
     }
 
     /* Check for attribute that indicates an empty array */
-    if ( H5Aexists_by_name(dset_id,".","MATLAB_empty",H5P_DEFAULT) ) {
+    if ( H5Aexists_by_name(dset_id, ".", "MATLAB_empty", H5P_DEFAULT) ) {
         int empty = 0;
-        attr_id = H5Aopen_by_name(dset_id,".","MATLAB_empty",H5P_DEFAULT,H5P_DEFAULT);
+        herr_t herr;
+        hid_t attr_id = H5Aopen_by_name(dset_id, ".", "MATLAB_empty", H5P_DEFAULT, H5P_DEFAULT);
         /* FIXME: Check that dataspace is scalar */
-        H5Aread(attr_id,H5T_NATIVE_INT,&empty);
+        herr = H5Aread(attr_id, H5T_NATIVE_INT, &empty);
         H5Aclose(attr_id);
-        if ( empty ) {
-            matvar->rank = matvar->dims[0];
+        if ( herr < 0 ) {
+            err = MATIO_E_GENERIC_READ_ERROR;
+        } else if ( empty ) {
+            matvar->rank = (int)matvar->dims[0];
             free(matvar->dims);
-            matvar->dims = (size_t*)calloc(matvar->rank,sizeof(*matvar->dims));
-            H5Dread(dset_id,SizeType2H5T(),H5S_ALL,H5S_ALL,H5P_DEFAULT,matvar->dims);
-            {
-                size_t tmp = 1;
-                err = Mat_MulDims(matvar, &tmp);
-                nelems = (hsize_t)tmp;
+            matvar->dims = (size_t *)calloc(matvar->rank, sizeof(*matvar->dims));
+            if ( matvar->dims == NULL ) {
+                err = MATIO_E_OUT_OF_MEMORY;
+            } else {
+                herr =
+                    H5Dread(dset_id, SizeType2H5T(), H5S_ALL, H5S_ALL, H5P_DEFAULT, matvar->dims);
+                if ( herr < 0 ) {
+                    err = MATIO_E_GENERIC_READ_ERROR;
+                } else {
+                    size_t tmp = 1;
+                    err = Mat_MulDims(matvar, &tmp);
+                    nelems = (hsize_t)tmp;
+                }
             }
+        }
+        if ( err ) {
+            return err;
         }
     }
 
     /* Test if dataset type is compound and if so if it's complex */
-    type_id = H5Dget_type(dset_id);
-    if ( H5T_COMPOUND == H5Tget_class(type_id) ) {
-        /* FIXME: Any more checks? */
-        matvar->isComplex = MAT_F_COMPLEX;
+    {
+        hid_t type_id = H5Dget_type(dset_id);
+        if ( H5T_COMPOUND == H5Tget_class(type_id) ) {
+            /* FIXME: Any more checks? */
+            matvar->isComplex = MAT_F_COMPLEX;
+        }
+        H5Tclose(type_id);
     }
-    H5Tclose(type_id);
+
+    /* Test if dataset is deflated */
+    {
+        hid_t plist_id = H5Dget_create_plist(dset_id);
+        if ( plist_id > 0 ) {
+            const int nFilters = H5Pget_nfilters(plist_id);
+            int i;
+            for ( i = 0; i < nFilters; i++ ) {
+                const H5Z_filter_t filterType =
+                    H5Pget_filter2(plist_id, i, NULL, NULL, 0, 0, NULL, NULL);
+                if ( H5Z_FILTER_DEFLATE == filterType ) {
+                    matvar->compression = MAT_COMPRESSION_ZLIB;
+                    break;
+                }
+            }
+            H5Pclose(plist_id);
+        }
+    }
 
     /* If the dataset is a cell array read the info of the cells */
     if ( MAT_C_CELL == matvar->class_type ) {
         matvar_t **cells;
-        hobj_ref_t *ref_ids;
 
-        matvar->data_size = sizeof(matvar_t**);
-        err |= Mul(&matvar->nbytes, nelems, matvar->data_size);
+        matvar->data_size = sizeof(matvar_t **);
+        err = Mul(&matvar->nbytes, nelems, matvar->data_size);
         if ( err ) {
             Mat_Critical("Integer multiplication overflow");
-            return;
+            return err;
         }
-        matvar->data = malloc(matvar->nbytes);
+        matvar->data = calloc(matvar->nbytes, 1);
         if ( NULL == matvar->data ) {
             Mat_Critical("Couldn't allocate memory for the data");
-            return;
+            return MATIO_E_OUT_OF_MEMORY;
         }
-        cells = (matvar_t**)matvar->data;
+        cells = (matvar_t **)matvar->data;
 
         if ( nelems ) {
-            size_t i;
-            ref_ids = (hobj_ref_t*)malloc(nelems*sizeof(*ref_ids));
-            H5Dread(dset_id,H5T_STD_REF_OBJ,H5S_ALL,H5S_ALL,H5P_DEFAULT,ref_ids);
-            for ( i = 0; i < nelems; i++ ) {
-                hid_t ref_id;
-                cells[i] = Mat_VarCalloc();
-                cells[i]->internal->hdf5_ref = ref_ids[i];
-                /* Closing of ref_id is done in Mat_H5ReadNextReferenceInfo */
-                ref_id = H5RDEREFERENCE(dset_id,H5R_OBJECT,ref_ids+i);
-                cells[i]->internal->id = ref_id;
-                Mat_H5ReadNextReferenceInfo(ref_id,cells[i],mat);
+            hobj_ref_t *ref_ids = (hobj_ref_t *)calloc(nelems, sizeof(*ref_ids));
+            if ( ref_ids != NULL ) {
+                size_t i;
+                herr_t herr =
+                    H5Dread(dset_id, H5T_STD_REF_OBJ, H5S_ALL, H5S_ALL, H5P_DEFAULT, ref_ids);
+                if ( herr < 0 ) {
+                    free(ref_ids);
+                    return MATIO_E_GENERIC_READ_ERROR;
+                }
+                for ( i = 0; i < nelems; i++ ) {
+                    hid_t ref_id;
+                    cells[i] = Mat_VarCalloc();
+                    cells[i]->internal->hdf5_ref = ref_ids[i];
+                    /* Closing of ref_id is done in Mat_H5ReadNextReferenceInfo */
+                    ref_id = H5RDEREFERENCE(dset_id, H5R_OBJECT, ref_ids + i);
+                    if ( ref_id < 0 ) {
+                        err = MATIO_E_GENERIC_READ_ERROR;
+                    } else {
+                        cells[i]->internal->id = ref_id;
+                        err = Mat_H5ReadNextReferenceInfo(ref_id, cells[i], mat);
+                    }
+                    if ( err ) {
+                        break;
+                    }
+                }
+                free(ref_ids);
+            } else {
+                err = MATIO_E_OUT_OF_MEMORY;
             }
-            free(ref_ids);
         }
     } else if ( MAT_C_STRUCT == matvar->class_type ) {
         /* Empty structures can be a dataset */
 
         /* Check if the structure defines its fields in MATLAB_fields */
-        if ( H5Aexists_by_name(dset_id,".","MATLAB_fields",H5P_DEFAULT) ) {
+        if ( H5Aexists_by_name(dset_id, ".", "MATLAB_fields", H5P_DEFAULT) ) {
             hsize_t nfields;
-            Mat_H5ReadFieldNames(matvar, dset_id, &nfields);
+            err = Mat_H5ReadFieldNames(matvar, dset_id, &nfields);
         }
     }
+
+    return err;
 }
 
-static void
-Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
+static int
+Mat_H5ReadGroupInfo(mat_t *mat, matvar_t *matvar, hid_t dset_id)
 {
-    int      fields_are_variables = 1;
-    hsize_t  nfields=0,nelems;
-    hid_t    attr_id,field_id;
+    int fields_are_variables = 1;
+    hsize_t nfields = 0, nelems;
+    hid_t attr_id, field_id;
     matvar_t **fields;
     H5O_type_t obj_type;
+    int err;
 
-    Mat_H5ReadVarInfo(matvar,dset_id);
+    err = Mat_H5ReadVarInfo(matvar, dset_id);
+    if ( err < 0 ) {
+        return err;
+    }
 
     /* Check if the variable is sparse */
-    if ( H5Aexists_by_name(dset_id,".","MATLAB_sparse",H5P_DEFAULT) ) {
+    if ( H5Aexists_by_name(dset_id, ".", "MATLAB_sparse", H5P_DEFAULT) ) {
+        herr_t herr;
         hid_t sparse_dset_id;
         unsigned nrows = 0;
 
-        attr_id = H5Aopen_by_name(dset_id,".","MATLAB_sparse",H5P_DEFAULT,H5P_DEFAULT);
-        H5Aread(attr_id,H5T_NATIVE_UINT,&nrows);
+        attr_id = H5Aopen_by_name(dset_id, ".", "MATLAB_sparse", H5P_DEFAULT, H5P_DEFAULT);
+        herr = H5Aread(attr_id, H5T_NATIVE_UINT, &nrows);
         H5Aclose(attr_id);
+        if ( herr < 0 ) {
+            return MATIO_E_GENERIC_READ_ERROR;
+        }
 
         matvar->class_type = MAT_C_SPARSE;
 
-        sparse_dset_id = H5Dopen(dset_id,"jc",H5P_DEFAULT);
+        sparse_dset_id = H5Dopen(dset_id, "jc", H5P_DEFAULT);
         matvar->dims = Mat_H5ReadDims(sparse_dset_id, &nelems, &matvar->rank);
         H5Dclose(sparse_dset_id);
         if ( NULL != matvar->dims ) {
             if ( 1 == matvar->rank ) {
-                size_t* dims = (size_t*)realloc(matvar->dims, 2*sizeof(*matvar->dims));
+                size_t *dims = (size_t *)realloc(matvar->dims, 2 * sizeof(*matvar->dims));
                 if ( NULL != dims ) {
                     matvar->rank = 2;
                     matvar->dims = dims;
@@ -12516,13 +12685,13 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
                 matvar->dims[0] = nrows;
             }
         } else {
-            return;
+            return MATIO_E_UNKNOWN_ERROR;
         }
 
         /* Test if dataset type is compound and if so if it's complex */
-        if ( H5Lexists(dset_id,"data",H5P_DEFAULT) ) {
+        if ( H5Lexists(dset_id, "data", H5P_DEFAULT) ) {
             hid_t type_id;
-            sparse_dset_id = H5Dopen(dset_id,"data",H5P_DEFAULT);
+            sparse_dset_id = H5Dopen(dset_id, "data", H5P_DEFAULT);
             type_id = H5Dget_type(sparse_dset_id);
             if ( H5T_COMPOUND == H5Tget_class(type_id) ) {
                 /* FIXME: Any more checks? */
@@ -12531,34 +12700,42 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
             H5Tclose(type_id);
             H5Dclose(sparse_dset_id);
         }
-        return;
+        return MATIO_E_NO_ERROR;
+    }
+
+    if ( MAT_C_STRUCT != matvar->class_type ) {
+        return MATIO_E_GENERIC_READ_ERROR;
     }
 
     /* Check if the structure defines its fields in MATLAB_fields */
-    if ( H5Aexists_by_name(dset_id,".","MATLAB_fields",H5P_DEFAULT) ) {
-        Mat_H5ReadFieldNames(matvar, dset_id, &nfields);
+    if ( H5Aexists_by_name(dset_id, ".", "MATLAB_fields", H5P_DEFAULT) ) {
+        err = Mat_H5ReadFieldNames(matvar, dset_id, &nfields);
+        if ( err ) {
+            return err;
+        }
     } else {
+        herr_t herr;
         H5G_info_t group_info;
         matvar->internal->num_fields = 0;
-        H5Gget_info(dset_id, &group_info);
-        if ( group_info.nlinks > 0 ) {
+        group_info.nlinks = 0;
+        herr = H5Gget_info(dset_id, &group_info);
+        if ( herr >= 0 && group_info.nlinks > 0 ) {
             struct ReadGroupInfoIterData group_data = {0, NULL};
-            herr_t herr;
 
             /* First iteration to retrieve number of relevant links */
             herr = H5Literate_by_name(dset_id, matvar->internal->hdf5_name, H5_INDEX_NAME,
-                H5_ITER_NATIVE, NULL, Mat_H5ReadGroupInfoIterate,
-                (void *)&group_data, H5P_DEFAULT);
+                                      H5_ITER_NATIVE, NULL, Mat_H5ReadGroupInfoIterate,
+                                      (void *)&group_data, H5P_DEFAULT);
             if ( herr > 0 && group_data.nfields > 0 ) {
-                matvar->internal->fieldnames =
-                    (char**)calloc((size_t)(group_data.nfields),sizeof(*matvar->internal->fieldnames));
+                matvar->internal->fieldnames = (char **)calloc(
+                    (size_t)(group_data.nfields), sizeof(*matvar->internal->fieldnames));
                 group_data.nfields = 0;
                 group_data.matvar = matvar;
                 if ( matvar->internal->fieldnames != NULL ) {
                     /* Second iteration to fill fieldnames */
                     H5Literate_by_name(dset_id, matvar->internal->hdf5_name, H5_INDEX_NAME,
-                        H5_ITER_NATIVE, NULL, Mat_H5ReadGroupInfoIterate,
-                        (void *)&group_data, H5P_DEFAULT);
+                                       H5_ITER_NATIVE, NULL, Mat_H5ReadGroupInfoIterate,
+                                       (void *)&group_data, H5P_DEFAULT);
                 }
                 matvar->internal->num_fields = (unsigned)group_data.nfields;
                 nfields = group_data.nfields;
@@ -12568,6 +12745,7 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
 
     if ( nfields > 0 ) {
         H5O_INFO_T object_info;
+        object_info.type = H5O_TYPE_UNKNOWN;
         H5OGET_INFO_BY_NAME(dset_id, matvar->internal->fieldnames[0], &object_info, H5P_DEFAULT);
         obj_type = object_info.type;
     } else {
@@ -12575,16 +12753,16 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
     }
     if ( obj_type == H5O_TYPE_DATASET ) {
         hid_t field_type_id;
-        field_id = H5Dopen(dset_id,matvar->internal->fieldnames[0],H5P_DEFAULT);
+        field_id = H5Dopen(dset_id, matvar->internal->fieldnames[0], H5P_DEFAULT);
         field_type_id = H5Dget_type(field_id);
         if ( H5T_REFERENCE == H5Tget_class(field_type_id) ) {
             /* Check if the field has the MATLAB_class attribute. If so, it
              * means the structure is a scalar. Otherwise, the dimensions of
              * the field dataset is the dimensions of the structure
              */
-            if ( H5Aexists_by_name(field_id,".","MATLAB_class",H5P_DEFAULT) ) {
+            if ( H5Aexists_by_name(field_id, ".", "MATLAB_class", H5P_DEFAULT) ) {
                 matvar->rank = 2;
-                matvar->dims = (size_t*)malloc(2*sizeof(*matvar->dims));
+                matvar->dims = (size_t *)malloc(2 * sizeof(*matvar->dims));
                 if ( NULL != matvar->dims ) {
                     matvar->dims[0] = 1;
                     matvar->dims[1] = 1;
@@ -12593,7 +12771,7 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
                     H5Tclose(field_type_id);
                     H5Dclose(field_id);
                     Mat_Critical("Error allocating memory for matvar->dims");
-                    return;
+                    return MATIO_E_OUT_OF_MEMORY;
                 }
             } else {
                 matvar->dims = Mat_H5ReadDims(field_id, &nelems, &matvar->rank);
@@ -12602,13 +12780,13 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
                 } else {
                     H5Tclose(field_type_id);
                     H5Dclose(field_id);
-                    return;
+                    return MATIO_E_UNKNOWN_ERROR;
                 }
             }
         } else {
             /* Structure should be a scalar */
             matvar->rank = 2;
-            matvar->dims = (size_t*)malloc(2*sizeof(*matvar->dims));
+            matvar->dims = (size_t *)malloc(2 * sizeof(*matvar->dims));
             if ( NULL != matvar->dims ) {
                 matvar->dims[0] = 1;
                 matvar->dims[1] = 1;
@@ -12617,7 +12795,7 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
                 H5Tclose(field_type_id);
                 H5Dclose(field_id);
                 Mat_Critical("Error allocating memory for matvar->dims");
-                return;
+                return MATIO_E_UNKNOWN_ERROR;
             }
         }
         H5Tclose(field_type_id);
@@ -12625,89 +12803,112 @@ Mat_H5ReadGroupInfo(mat_t *mat,matvar_t *matvar,hid_t dset_id)
     } else {
         /* Structure should be a scalar */
         matvar->rank = 2;
-        matvar->dims = (size_t*)malloc(2*sizeof(*matvar->dims));
+        matvar->dims = (size_t *)malloc(2 * sizeof(*matvar->dims));
         if ( NULL != matvar->dims ) {
             matvar->dims[0] = 1;
             matvar->dims[1] = 1;
             nelems = 1;
         } else {
             Mat_Critical("Error allocating memory for matvar->dims");
-            return;
+            return MATIO_E_OUT_OF_MEMORY;
         }
     }
 
     if ( nelems < 1 || nfields < 1 )
-        return;
+        return err;
 
     matvar->data_size = sizeof(*fields);
     {
-        int err;
         size_t nelems_x_nfields;
         err = Mul(&nelems_x_nfields, nelems, nfields);
         err |= Mul(&matvar->nbytes, nelems_x_nfields, matvar->data_size);
         if ( err ) {
             Mat_Critical("Integer multiplication overflow");
             matvar->nbytes = 0;
-            return;
+            return err;
         }
     }
-    fields = (matvar_t**)malloc(matvar->nbytes);
+    fields = (matvar_t **)calloc(matvar->nbytes, 1);
     matvar->data = fields;
     if ( NULL != fields ) {
         hsize_t k;
         for ( k = 0; k < nfields; k++ ) {
             H5O_INFO_T object_info;
             fields[k] = NULL;
-            H5OGET_INFO_BY_NAME(dset_id, matvar->internal->fieldnames[k], &object_info, H5P_DEFAULT);
+            object_info.type = H5O_TYPE_UNKNOWN;
+            H5OGET_INFO_BY_NAME(dset_id, matvar->internal->fieldnames[k], &object_info,
+                                H5P_DEFAULT);
             if ( object_info.type == H5O_TYPE_DATASET ) {
-                field_id = H5Dopen(dset_id,matvar->internal->fieldnames[k],
-                                   H5P_DEFAULT);
+                field_id = H5Dopen(dset_id, matvar->internal->fieldnames[k], H5P_DEFAULT);
                 if ( !fields_are_variables ) {
-                    hsize_t l;
-                    hobj_ref_t *ref_ids = (hobj_ref_t*)malloc((size_t)nelems*sizeof(*ref_ids));
-                    H5Dread(field_id,H5T_STD_REF_OBJ,H5S_ALL,H5S_ALL,
-                            H5P_DEFAULT,ref_ids);
-                    for ( l = 0; l < nelems; l++ ) {
-                        hid_t ref_id;
-                        fields[l*nfields+k] = Mat_VarCalloc();
-                        fields[l*nfields+k]->name =
-                            Mat_strdup(matvar->internal->fieldnames[k]);
-                        fields[l*nfields+k]->internal->hdf5_ref=ref_ids[l];
-                        /* Closing of ref_id is done in Mat_H5ReadNextReferenceInfo */
-                        ref_id = H5RDEREFERENCE(field_id,H5R_OBJECT,ref_ids+l);
-                        fields[l*nfields+k]->internal->id = ref_id;
-                        Mat_H5ReadNextReferenceInfo(ref_id,fields[l*nfields+k],mat);
+                    hobj_ref_t *ref_ids = (hobj_ref_t *)calloc((size_t)nelems, sizeof(*ref_ids));
+                    if ( ref_ids != NULL ) {
+                        hsize_t l;
+                        herr_t herr = H5Dread(field_id, H5T_STD_REF_OBJ, H5S_ALL, H5S_ALL,
+                                              H5P_DEFAULT, ref_ids);
+                        if ( herr < 0 ) {
+                            err = MATIO_E_GENERIC_READ_ERROR;
+                        } else {
+                            for ( l = 0; l < nelems; l++ ) {
+                                hid_t ref_id;
+                                fields[l * nfields + k] = Mat_VarCalloc();
+                                fields[l * nfields + k]->name =
+                                    Mat_strdup(matvar->internal->fieldnames[k]);
+                                fields[l * nfields + k]->internal->hdf5_ref = ref_ids[l];
+                                /* Closing of ref_id is done in Mat_H5ReadNextReferenceInfo */
+                                ref_id = H5RDEREFERENCE(field_id, H5R_OBJECT, ref_ids + l);
+                                if ( ref_id < 0 ) {
+                                    err = MATIO_E_GENERIC_READ_ERROR;
+                                } else {
+                                    fields[l * nfields + k]->internal->id = ref_id;
+                                    err = Mat_H5ReadNextReferenceInfo(ref_id,
+                                                                      fields[l * nfields + k], mat);
+                                }
+                                if ( err ) {
+                                    break;
+                                }
+                            }
+                        }
+                        free(ref_ids);
+                    } else {
+                        err = MATIO_E_OUT_OF_MEMORY;
                     }
-                    free(ref_ids);
                 } else {
                     fields[k] = Mat_VarCalloc();
                     fields[k]->name = Mat_strdup(matvar->internal->fieldnames[k]);
-                    Mat_H5ReadDatasetInfo(mat,fields[k],field_id);
+                    err = Mat_H5ReadDatasetInfo(mat, fields[k], field_id);
                 }
                 H5Dclose(field_id);
             } else if ( object_info.type == H5O_TYPE_GROUP ) {
-                field_id = H5Gopen(dset_id,matvar->internal->fieldnames[k],
-                                   H5P_DEFAULT);
+                field_id = H5Gopen(dset_id, matvar->internal->fieldnames[k], H5P_DEFAULT);
                 if ( -1 < field_id ) {
                     fields[k] = Mat_VarCalloc();
                     fields[k]->name = Mat_strdup(matvar->internal->fieldnames[k]);
-                    Mat_H5ReadGroupInfo(mat,fields[k],field_id);
+                    err = Mat_H5ReadGroupInfo(mat, fields[k], field_id);
                     H5Gclose(field_id);
                 }
             }
+            if ( err ) {
+                break;
+            }
         }
+    } else {
+        err = MATIO_E_OUT_OF_MEMORY;
     }
+
+    return err;
 }
 
 static herr_t
 Mat_H5ReadGroupInfoIterate(hid_t dset_id, const char *name, const H5L_info_t *info, void *op_data)
 {
-    matvar_t  *matvar;
+    matvar_t *matvar;
     H5O_INFO_T object_info;
     struct ReadGroupInfoIterData *group_data;
 
     /* FIXME: follow symlinks, datatypes? */
 
+    object_info.type = H5O_TYPE_UNKNOWN;
     H5OGET_INFO_BY_NAME(dset_id, name, &object_info, H5P_DEFAULT);
     if ( H5O_TYPE_DATASET != object_info.type && H5O_TYPE_GROUP != object_info.type )
         return 0;
@@ -12720,7 +12921,7 @@ Mat_H5ReadGroupInfoIterate(hid_t dset_id, const char *name, const H5L_info_t *in
     switch ( object_info.type ) {
         case H5O_TYPE_GROUP:
             /* Check that this is not the /#refs# group */
-            if ( 0 == strcmp(name,"#refs#") )
+            if ( 0 == strcmp(name, "#refs#") )
                 return 0;
             /* Fall through */
         case H5O_TYPE_DATASET:
@@ -12737,15 +12938,16 @@ Mat_H5ReadGroupInfoIterate(hid_t dset_id, const char *name, const H5L_info_t *in
     return 1;
 }
 
-static void
-Mat_H5ReadNextReferenceInfo(hid_t ref_id,matvar_t *matvar,mat_t *mat)
+static int
+Mat_H5ReadNextReferenceInfo(hid_t ref_id, matvar_t *matvar, mat_t *mat)
 {
+    int err;
     if ( ref_id < 0 || matvar == NULL )
-        return;
+        return MATIO_E_NO_ERROR;
 
     switch ( H5Iget_type(ref_id) ) {
         case H5I_DATASET:
-            Mat_H5ReadDatasetInfo(mat,matvar,ref_id);
+            err = Mat_H5ReadDatasetInfo(mat, matvar, ref_id);
             if ( matvar->internal->id != ref_id ) {
                 /* Close dataset and increment count */
                 H5Dclose(ref_id);
@@ -12755,47 +12957,61 @@ Mat_H5ReadNextReferenceInfo(hid_t ref_id,matvar_t *matvar,mat_t *mat)
             break;
 
         case H5I_GROUP:
-            Mat_H5ReadGroupInfo(mat,matvar,ref_id);
+            err = Mat_H5ReadGroupInfo(mat, matvar, ref_id);
             break;
 
         default:
+            err = MATIO_E_NO_ERROR;
             break;
     }
 
-    return;
+    return err;
 }
 
-static void
-Mat_H5ReadData(hid_t dset_id, hid_t h5_type, hid_t mem_space, hid_t dset_space, int isComplex, void *data)
+static int
+Mat_H5ReadData(hid_t dset_id, hid_t h5_type, hid_t mem_space, hid_t dset_space, int isComplex,
+               void *data)
 {
+    herr_t herr;
+
     if ( !isComplex ) {
-        H5Dread(dset_id,h5_type,mem_space,dset_space,H5P_DEFAULT,data);
+        herr = H5Dread(dset_id, h5_type, mem_space, dset_space, H5P_DEFAULT, data);
+        if ( herr < 0 ) {
+            return MATIO_E_GENERIC_READ_ERROR;
+        }
     } else {
-        mat_complex_split_t *complex_data = (mat_complex_split_t*)data;
+        mat_complex_split_t *complex_data = (mat_complex_split_t *)data;
         hid_t h5_complex;
         size_t h5_size = H5Tget_size(h5_type);
 
         h5_complex = H5Tcreate(H5T_COMPOUND, h5_size);
-        H5Tinsert(h5_complex,"real",0,h5_type);
-        H5Dread(dset_id,h5_complex,mem_space,dset_space,H5P_DEFAULT,
-                complex_data->Re);
+        H5Tinsert(h5_complex, "real", 0, h5_type);
+        herr = H5Dread(dset_id, h5_complex, mem_space, dset_space, H5P_DEFAULT, complex_data->Re);
         H5Tclose(h5_complex);
+        if ( herr < 0 ) {
+            return MATIO_E_GENERIC_READ_ERROR;
+        }
 
         h5_complex = H5Tcreate(H5T_COMPOUND, h5_size);
-        H5Tinsert(h5_complex,"imag",0,h5_type);
-        H5Dread(dset_id,h5_complex,mem_space,dset_space,H5P_DEFAULT,
-                complex_data->Im);
+        H5Tinsert(h5_complex, "imag", 0, h5_type);
+        herr = H5Dread(dset_id, h5_complex, mem_space, dset_space, H5P_DEFAULT, complex_data->Im);
         H5Tclose(h5_complex);
+        if ( herr < 0 ) {
+            return MATIO_E_GENERIC_READ_ERROR;
+        }
     }
+
+    return MATIO_E_NO_ERROR;
 }
 
-static void
-Mat_H5ReadNextReferenceData(hid_t ref_id,matvar_t *matvar,mat_t *mat)
+static int
+Mat_H5ReadNextReferenceData(hid_t ref_id, matvar_t *matvar, mat_t *mat)
 {
+    int err = MATIO_E_NO_ERROR;
     size_t nelems = 1;
 
     if ( ref_id < 0 || matvar == NULL )
-        return;
+        return err;
 
     /* If the datatype with references is a cell, we've already read info into
      * the variable data, so just loop over each cell element and call
@@ -12803,31 +13019,40 @@ Mat_H5ReadNextReferenceData(hid_t ref_id,matvar_t *matvar,mat_t *mat)
      */
     if ( MAT_C_CELL == matvar->class_type ) {
         size_t i;
-        matvar_t **cells = (matvar_t**)matvar->data;
-        int err = Mat_MulDims(matvar, &nelems);
-        if ( err )
-            return;
+        matvar_t **cells;
 
-        for ( i = 0; i < nelems; i++ )
-            Mat_H5ReadNextReferenceData(cells[i]->internal->id,cells[i],mat);
-        return;
+        if ( NULL == matvar->data ) {
+            return err;
+        }
+        err = Mat_MulDims(matvar, &nelems);
+        if ( err ) {
+            return err;
+        }
+        cells = (matvar_t **)matvar->data;
+        for ( i = 0; i < nelems; i++ ) {
+            if ( NULL != cells[i] ) {
+                err = Mat_H5ReadNextReferenceData(cells[i]->internal->id, cells[i], mat);
+            }
+            if ( err ) {
+                break;
+            }
+        }
+        return err;
     }
 
     switch ( H5Iget_type(ref_id) ) {
-        case H5I_DATASET:
-        {
-            int err;
+        case H5I_DATASET: {
             hid_t data_type_id, dset_id;
             if ( MAT_C_CHAR == matvar->class_type ) {
                 matvar->data_type = MAT_T_UINT8;
-                matvar->data_size = Mat_SizeOf(MAT_T_UINT8);
-                data_type_id      = DataType2H5T(MAT_T_UINT8);
+                matvar->data_size = (int)Mat_SizeOf(MAT_T_UINT8);
+                data_type_id = DataType2H5T(MAT_T_UINT8);
             } else if ( MAT_C_STRUCT == matvar->class_type ) {
                 /* Empty structure array */
                 break;
             } else {
-                matvar->data_size = Mat_SizeOfClass(matvar->class_type);
-                data_type_id      = ClassType2H5T(matvar->class_type);
+                matvar->data_size = (int)Mat_SizeOfClass(matvar->class_type);
+                data_type_id = ClassType2H5T(matvar->class_type);
             }
 
             err = Mat_MulDims(matvar, &nelems);
@@ -12845,16 +13070,15 @@ Mat_H5ReadNextReferenceData(hid_t ref_id,matvar_t *matvar,mat_t *mat)
                 matvar->data = ComplexMalloc(matvar->nbytes);
             }
             if ( NULL != matvar->data ) {
-                Mat_H5ReadData(dset_id, data_type_id,
-                    H5S_ALL, H5S_ALL, matvar->isComplex, matvar->data);
+                err = Mat_H5ReadData(dset_id, data_type_id, H5S_ALL, H5S_ALL, matvar->isComplex,
+                                     matvar->data);
             }
             H5Dclose(dset_id);
             break;
         }
-        case H5I_GROUP:
-        {
+        case H5I_GROUP: {
             if ( MAT_C_SPARSE == matvar->class_type ) {
-                Mat_VarRead73(mat,matvar);
+                err = Mat_VarRead73(mat, matvar);
             } else {
                 matvar_t **fields;
                 size_t i;
@@ -12862,15 +13086,17 @@ Mat_H5ReadNextReferenceData(hid_t ref_id,matvar_t *matvar,mat_t *mat)
                 if ( !matvar->nbytes || !matvar->data_size || NULL == matvar->data )
                     break;
                 nelems = matvar->nbytes / matvar->data_size;
-                fields  = (matvar_t**)matvar->data;
+                fields = (matvar_t **)matvar->data;
                 for ( i = 0; i < nelems; i++ ) {
-                    if ( NULL != fields[i] &&
-                          0 < fields[i]->internal->hdf5_ref &&
+                    if ( NULL != fields[i] && 0 < fields[i]->internal->hdf5_ref &&
                          -1 < fields[i]->internal->id ) {
                         /* Dataset of references */
-                        Mat_H5ReadNextReferenceData(fields[i]->internal->id,fields[i],mat);
+                        err = Mat_H5ReadNextReferenceData(fields[i]->internal->id, fields[i], mat);
                     } else {
-                        Mat_VarRead73(mat,fields[i]);
+                        err = Mat_VarRead73(mat, fields[i]);
+                    }
+                    if ( err ) {
+                        break;
                     }
                 }
             }
@@ -12880,19 +13106,20 @@ Mat_H5ReadNextReferenceData(hid_t ref_id,matvar_t *matvar,mat_t *mat)
             break;
     }
 
-    return;
+    return err;
 }
 
 static int
-Mat_H5WriteData(hid_t dset_id, hid_t h5_type, hid_t mem_space, hid_t dset_space, int isComplex, void *data)
+Mat_H5WriteData(hid_t dset_id, hid_t h5_type, hid_t mem_space, hid_t dset_space, int isComplex,
+                void *data)
 {
     int err = MATIO_E_NO_ERROR;
 
     if ( !isComplex ) {
-        if ( 0 > H5Dwrite(dset_id,h5_type,mem_space,dset_space,H5P_DEFAULT,data) )
+        if ( 0 > H5Dwrite(dset_id, h5_type, mem_space, dset_space, H5P_DEFAULT, data) )
             err = MATIO_E_GENERIC_WRITE_ERROR;
     } else {
-        mat_complex_split_t *complex_data = (mat_complex_split_t*)data;
+        mat_complex_split_t *complex_data = (mat_complex_split_t *)data;
         hid_t h5_complex;
         size_t h5_size = H5Tget_size(h5_type);
 
@@ -12904,7 +13131,7 @@ Mat_H5WriteData(hid_t dset_id, hid_t h5_type, hid_t mem_space, hid_t dset_space,
 
         /* Write imaginary part of dataset */
         h5_complex = H5Tcreate(H5T_COMPOUND, h5_size);
-        H5Tinsert(h5_complex,"imag", 0, h5_type);
+        H5Tinsert(h5_complex, "imag", 0, h5_type);
         err += Mat_H5WriteData(dset_id, h5_complex, mem_space, dset_space, 0, complex_data->Im);
         H5Tclose(h5_complex);
     }
@@ -12913,7 +13140,8 @@ Mat_H5WriteData(hid_t dset_id, hid_t h5_type, hid_t mem_space, hid_t dset_space,
 }
 
 static int
-Mat_H5WriteAppendData(hid_t id, hid_t h5_type, int mrank, const char *name, const size_t* mdims, hsize_t *dims, int dim, int isComplex, void* data)
+Mat_H5WriteAppendData(hid_t id, hid_t h5_type, int mrank, const char *name, const size_t *mdims,
+                      hsize_t *dims, int dim, int isComplex, void *data)
 {
     int err = MATIO_E_NO_ERROR;
     hid_t dset_id, space_id;
@@ -12926,14 +13154,14 @@ Mat_H5WriteAppendData(hid_t id, hid_t h5_type, int mrank, const char *name, cons
     space_id = H5Dget_space(dset_id);
     rank = H5Sget_simple_extent_ndims(space_id);
     if ( rank == mrank ) {
-        hsize_t* size_offset_dims;
-        size_offset_dims = (hsize_t*)malloc(rank*sizeof(*size_offset_dims));
+        hsize_t *size_offset_dims;
+        size_offset_dims = (hsize_t *)malloc(rank * sizeof(*size_offset_dims));
         if ( NULL != size_offset_dims ) {
             hsize_t offset;
             hid_t mspace_id;
             int k;
 
-            (void)H5Sget_simple_extent_dims(space_id,size_offset_dims,NULL);
+            (void)H5Sget_simple_extent_dims(space_id, size_offset_dims, NULL);
             offset = size_offset_dims[rank - dim];
             size_offset_dims[rank - dim] += mdims[dim - 1];
             H5Dset_extent(dset_id, size_offset_dims);
@@ -12944,8 +13172,7 @@ Mat_H5WriteAppendData(hid_t id, hid_t h5_type, int mrank, const char *name, cons
             /* Need to reopen */
             H5Sclose(space_id);
             space_id = H5Dget_space(dset_id);
-            H5Sselect_hyperslab(space_id, H5S_SELECT_SET, size_offset_dims,
-                                NULL, dims, NULL);
+            H5Sselect_hyperslab(space_id, H5S_SELECT_SET, size_offset_dims, NULL, dims, NULL);
             free(size_offset_dims);
             mspace_id = H5Screate_simple(rank, dims, NULL);
             err = Mat_H5WriteData(dset_id, h5_type, mspace_id, space_id, isComplex, data);
@@ -12963,39 +13190,44 @@ Mat_H5WriteAppendData(hid_t id, hid_t h5_type, int mrank, const char *name, cons
 }
 
 static int
-Mat_VarWriteRef(hid_t id, matvar_t* matvar, enum matio_compression compression, hid_t *refs_id, hobj_ref_t* ref)
+Mat_VarWriteRef(hid_t id, matvar_t *matvar, enum matio_compression compression, hid_t *refs_id,
+                hobj_ref_t *ref)
 {
     int err;
+    herr_t herr;
     char obj_name[64];
     H5G_info_t group_info;
 
-    H5Gget_info(*refs_id, &group_info);
-    sprintf(obj_name,"%llu", group_info.nlinks);
-    if ( NULL != matvar )
-        matvar->compression = compression;
-    err = Mat_VarWriteNext73(*refs_id, matvar, obj_name, refs_id);
-    sprintf(obj_name, "/#refs#/%llu", group_info.nlinks);
-    H5Rcreate(ref, id, obj_name, H5R_OBJECT, -1);
-
+    group_info.nlinks = 0;
+    herr = H5Gget_info(*refs_id, &group_info);
+    if ( herr < 0 ) {
+        err = MATIO_E_BAD_ARGUMENT;
+    } else {
+        sprintf(obj_name, "%llu", group_info.nlinks);
+        if ( NULL != matvar )
+            matvar->compression = compression;
+        err = Mat_VarWriteNext73(*refs_id, matvar, obj_name, refs_id);
+        sprintf(obj_name, "/#refs#/%llu", group_info.nlinks);
+        H5Rcreate(ref, id, obj_name, H5R_OBJECT, -1);
+    }
     return err;
 }
 
 static int
-Mat_VarWriteEmpty(hid_t id,matvar_t *matvar,const char *name,const char* class_name)
+Mat_VarWriteEmpty(hid_t id, matvar_t *matvar, const char *name, const char *class_name)
 {
-    int      err = MATIO_E_NO_ERROR;
-    hsize_t  rank = matvar->rank;
+    int err = MATIO_E_NO_ERROR;
+    hsize_t rank = matvar->rank;
     unsigned empty = 1;
-    hid_t    mspace_id, dset_id, attr_type_id, aspace_id, attr_id;
+    hid_t mspace_id, dset_id, attr_type_id, aspace_id, attr_id;
 
-    mspace_id = H5Screate_simple(1,&rank,NULL);
-    dset_id = H5Dcreate(id,name,H5T_NATIVE_HSIZE,mspace_id,
-                        H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
+    mspace_id = H5Screate_simple(1, &rank, NULL);
+    dset_id =
+        H5Dcreate(id, name, H5T_NATIVE_HSIZE, mspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     attr_type_id = H5Tcopy(H5T_C_S1);
     H5Tset_size(attr_type_id, strlen(class_name));
     aspace_id = H5Screate(H5S_SCALAR);
-    attr_id = H5Acreate(dset_id,"MATLAB_class",attr_type_id,
-                        aspace_id,H5P_DEFAULT,H5P_DEFAULT);
+    attr_id = H5Acreate(dset_id, "MATLAB_class", attr_type_id, aspace_id, H5P_DEFAULT, H5P_DEFAULT);
     if ( 0 > H5Awrite(attr_id, attr_type_id, class_name) )
         err = MATIO_E_GENERIC_WRITE_ERROR;
     H5Sclose(aspace_id);
@@ -13007,23 +13239,22 @@ Mat_VarWriteEmpty(hid_t id,matvar_t *matvar,const char *name,const char* class_n
             /* Write the fields attribute */
             hsize_t nfields = matvar->internal->num_fields;
             if ( nfields ) {
-                hvl_t *fieldnames = (hvl_t*)malloc((size_t)nfields*sizeof(*fieldnames));
+                hvl_t *fieldnames = (hvl_t *)malloc((size_t)nfields * sizeof(*fieldnames));
                 if ( NULL != fieldnames ) {
-                    hid_t str_type_id,fieldnames_id;
+                    hid_t str_type_id, fieldnames_id;
                     hsize_t k;
 
                     str_type_id = H5Tcopy(H5T_C_S1);
                     for ( k = 0; k < nfields; k++ ) {
-                        fieldnames[k].len =
-                            strlen(matvar->internal->fieldnames[k]);
-                        fieldnames[k].p   = matvar->internal->fieldnames[k];
+                        fieldnames[k].len = strlen(matvar->internal->fieldnames[k]);
+                        fieldnames[k].p = matvar->internal->fieldnames[k];
                     }
-                    H5Tset_size(str_type_id,1);
+                    H5Tset_size(str_type_id, 1);
                     fieldnames_id = H5Tvlen_create(str_type_id);
-                    aspace_id     = H5Screate_simple(1,&nfields,NULL);
-                    attr_id = H5Acreate(dset_id,"MATLAB_fields",fieldnames_id,
-                                        aspace_id,H5P_DEFAULT,H5P_DEFAULT);
-                    if ( 0 > H5Awrite(attr_id,fieldnames_id,fieldnames) )
+                    aspace_id = H5Screate_simple(1, &nfields, NULL);
+                    attr_id = H5Acreate(dset_id, "MATLAB_fields", fieldnames_id, aspace_id,
+                                        H5P_DEFAULT, H5P_DEFAULT);
+                    if ( 0 > H5Awrite(attr_id, fieldnames_id, fieldnames) )
                         err = MATIO_E_GENERIC_WRITE_ERROR;
                     H5Aclose(attr_id);
                     H5Sclose(aspace_id);
@@ -13038,9 +13269,9 @@ Mat_VarWriteEmpty(hid_t id,matvar_t *matvar,const char *name,const char* class_n
             /* Write the MATLAB_int_decode attribute */
             int int_decode = 1;
             aspace_id = H5Screate(H5S_SCALAR);
-            attr_id = H5Acreate(dset_id,"MATLAB_int_decode",H5T_NATIVE_INT,
-                                aspace_id,H5P_DEFAULT,H5P_DEFAULT);
-            if ( 0 > H5Awrite(attr_id,H5T_NATIVE_INT,&int_decode) )
+            attr_id = H5Acreate(dset_id, "MATLAB_int_decode", H5T_NATIVE_INT, aspace_id,
+                                H5P_DEFAULT, H5P_DEFAULT);
+            if ( 0 > H5Awrite(attr_id, H5T_NATIVE_INT, &int_decode) )
                 err = MATIO_E_GENERIC_WRITE_ERROR;
             H5Sclose(aspace_id);
             H5Aclose(attr_id);
@@ -13049,9 +13280,9 @@ Mat_VarWriteEmpty(hid_t id,matvar_t *matvar,const char *name,const char* class_n
         if ( MATIO_E_NO_ERROR == err ) {
             /* Write the empty attribute */
             aspace_id = H5Screate(H5S_SCALAR);
-            attr_id = H5Acreate(dset_id,"MATLAB_empty",H5T_NATIVE_UINT,
-                                aspace_id,H5P_DEFAULT,H5P_DEFAULT);
-            if ( 0 > H5Awrite(attr_id,H5T_NATIVE_UINT,&empty) )
+            attr_id = H5Acreate(dset_id, "MATLAB_empty", H5T_NATIVE_UINT, aspace_id, H5P_DEFAULT,
+                                H5P_DEFAULT);
+            if ( 0 > H5Awrite(attr_id, H5T_NATIVE_UINT, &empty) )
                 err = MATIO_E_GENERIC_WRITE_ERROR;
             H5Sclose(aspace_id);
             H5Aclose(attr_id);
@@ -13059,8 +13290,8 @@ Mat_VarWriteEmpty(hid_t id,matvar_t *matvar,const char *name,const char* class_n
 
         if ( MATIO_E_NO_ERROR == err ) {
             /* Write the dimensions as the data */
-            if ( 0 > H5Dwrite(dset_id,SizeType2H5T(),H5S_ALL,H5S_ALL,
-                              H5P_DEFAULT,matvar->dims) )
+            if ( 0 >
+                 H5Dwrite(dset_id, SizeType2H5T(), H5S_ALL, H5S_ALL, H5P_DEFAULT, matvar->dims) )
                 err = MATIO_E_GENERIC_WRITE_ERROR;
         }
     }
@@ -13084,14 +13315,14 @@ Mat_VarWriteEmpty(hid_t id,matvar_t *matvar,const char *name,const char* class_n
  * @endif
  */
 static int
-Mat_VarWriteCell73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id,hsize_t *dims)
+Mat_VarWriteCell73(hid_t id, matvar_t *matvar, const char *name, hid_t *refs_id, hsize_t *dims)
 {
-    int        k;
-    hsize_t    nelems = 1, l;
+    int k;
+    hsize_t nelems = 1, l;
     matvar_t **cells;
-    int        err = MATIO_E_NO_ERROR;
+    int err = MATIO_E_NO_ERROR;
 
-    cells = (matvar_t**)matvar->data;
+    cells = (matvar_t **)matvar->data;
     for ( k = 0; k < matvar->rank; k++ )
         nelems *= dims[k];
 
@@ -13099,38 +13330,35 @@ Mat_VarWriteCell73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id,hsi
         err = Mat_VarWriteEmpty(id, matvar, name, ClassNames[matvar->class_type]);
     } else {
         if ( *refs_id < 0 ) {
-            if ( H5Lexists(id,"/#refs#",H5P_DEFAULT) ) {
-                *refs_id = H5Gopen(id,"/#refs#",H5P_DEFAULT);
+            if ( H5Lexists(id, "/#refs#", H5P_DEFAULT) ) {
+                *refs_id = H5Gopen(id, "/#refs#", H5P_DEFAULT);
             } else {
-                *refs_id = H5Gcreate(id,"/#refs#",H5P_DEFAULT,
-                                     H5P_DEFAULT,H5P_DEFAULT);
+                *refs_id = H5Gcreate(id, "/#refs#", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
             }
         }
         if ( *refs_id > -1 ) {
-            hobj_ref_t *refs = (hobj_ref_t*)malloc((size_t)nelems*sizeof(*refs));
+            hobj_ref_t *refs = (hobj_ref_t *)malloc((size_t)nelems * sizeof(*refs));
             if ( NULL != refs ) {
-                hid_t mspace_id = H5Screate_simple(matvar->rank,dims,NULL);
-                hid_t dset_id = H5Dcreate(id,name,H5T_STD_REF_OBJ,mspace_id,
-                                    H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
+                hid_t mspace_id = H5Screate_simple(matvar->rank, dims, NULL);
+                hid_t dset_id = H5Dcreate(id, name, H5T_STD_REF_OBJ, mspace_id, H5P_DEFAULT,
+                                          H5P_DEFAULT, H5P_DEFAULT);
 
                 for ( l = 0; l < nelems; l++ ) {
-                    err = Mat_VarWriteRef(id, cells[l], matvar->compression,
-                                           refs_id, refs+l);
+                    err = Mat_VarWriteRef(id, cells[l], matvar->compression, refs_id, refs + l);
                     if ( err )
                         break;
                 }
                 if ( MATIO_E_NO_ERROR == err ) {
-                    err = Mat_H5WriteData(dset_id, H5T_STD_REF_OBJ, H5S_ALL, H5S_ALL,
-                                           0, refs);
+                    err = Mat_H5WriteData(dset_id, H5T_STD_REF_OBJ, H5S_ALL, H5S_ALL, 0, refs);
 
-                    if (  MATIO_E_NO_ERROR == err ) {
-                        hid_t attr_id,aspace_id;
+                    if ( MATIO_E_NO_ERROR == err ) {
+                        hid_t attr_id, aspace_id;
                         hid_t str_type_id = H5Tcopy(H5T_C_S1);
-                        H5Tset_size(str_type_id,4);
+                        H5Tset_size(str_type_id, 4);
                         aspace_id = H5Screate(H5S_SCALAR);
-                        attr_id = H5Acreate(dset_id,"MATLAB_class",str_type_id,
-                                            aspace_id,H5P_DEFAULT,H5P_DEFAULT);
-                        if ( 0 > H5Awrite(attr_id,str_type_id,"cell") )
+                        attr_id = H5Acreate(dset_id, "MATLAB_class", str_type_id, aspace_id,
+                                            H5P_DEFAULT, H5P_DEFAULT);
+                        if ( 0 > H5Awrite(attr_id, str_type_id, "cell") )
                             err = MATIO_E_GENERIC_WRITE_ERROR;
                         H5Aclose(attr_id);
                         H5Sclose(aspace_id);
@@ -13164,10 +13392,12 @@ Mat_VarWriteCell73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id,hsi
  * @endif
  */
 static int
-Mat_VarWriteChar73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims)
+Mat_VarWriteChar73(hid_t id, matvar_t *matvar, const char *name, hsize_t *dims)
 {
-    int     err = MATIO_E_NO_ERROR, k;
+    int err = MATIO_E_NO_ERROR, k;
     hsize_t nelems = 1;
+    mat_uint16_t *u16 = NULL;
+    hid_t h5type;
 
     for ( k = 0; k < matvar->rank; k++ ) {
         nelems *= dims[k];
@@ -13176,19 +13406,17 @@ Mat_VarWriteChar73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims)
     if ( 0 == nelems || NULL == matvar->data ) {
         err = Mat_VarWriteEmpty(id, matvar, name, ClassNames[matvar->class_type]);
     } else {
-        int   matlab_int_decode = 2;
-        hid_t mspace_id,dset_id,attr_type_id,attr_id,aspace_id;
+        int matlab_int_decode = 2;
+        hid_t mspace_id, dset_id, attr_type_id, attr_id, aspace_id;
 
-        mspace_id = H5Screate_simple(matvar->rank,dims,NULL);
+        mspace_id = H5Screate_simple(matvar->rank, dims, NULL);
         switch ( matvar->data_type ) {
             case MAT_T_UTF32:
             case MAT_T_INT32:
             case MAT_T_UINT32:
                 /* Not sure matlab will actually handle this */
-                dset_id = H5Dcreate(id,name,
-                                    ClassType2H5T(MAT_C_UINT32),
-                                    mspace_id,H5P_DEFAULT,H5P_DEFAULT,
-                                    H5P_DEFAULT);
+                dset_id = H5Dcreate(id, name, ClassType2H5T(MAT_C_UINT32), mspace_id, H5P_DEFAULT,
+                                    H5P_DEFAULT, H5P_DEFAULT);
                 break;
             case MAT_T_UTF16:
             case MAT_T_UTF8:
@@ -13196,10 +13424,8 @@ Mat_VarWriteChar73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims)
             case MAT_T_UINT16:
             case MAT_T_INT8:
             case MAT_T_UINT8:
-                dset_id = H5Dcreate(id,name,
-                                    ClassType2H5T(MAT_C_UINT16),
-                                    mspace_id,H5P_DEFAULT,H5P_DEFAULT,
-                                    H5P_DEFAULT);
+                dset_id = H5Dcreate(id, name, ClassType2H5T(MAT_C_UINT16), mspace_id, H5P_DEFAULT,
+                                    H5P_DEFAULT, H5P_DEFAULT);
                 break;
             default:
                 H5Sclose(mspace_id);
@@ -13208,29 +13434,66 @@ Mat_VarWriteChar73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims)
         attr_type_id = H5Tcopy(H5T_C_S1);
         H5Tset_size(attr_type_id, strlen(ClassNames[matvar->class_type]));
         aspace_id = H5Screate(H5S_SCALAR);
-        attr_id = H5Acreate(dset_id,"MATLAB_class",attr_type_id,
-                            aspace_id,H5P_DEFAULT,H5P_DEFAULT);
-        if ( 0 > H5Awrite(attr_id,attr_type_id,ClassNames[matvar->class_type]) )
+        attr_id =
+            H5Acreate(dset_id, "MATLAB_class", attr_type_id, aspace_id, H5P_DEFAULT, H5P_DEFAULT);
+        if ( 0 > H5Awrite(attr_id, attr_type_id, ClassNames[matvar->class_type]) )
             err = MATIO_E_GENERIC_WRITE_ERROR;
         H5Aclose(attr_id);
         H5Tclose(attr_type_id);
 
         if ( MATIO_E_NO_ERROR == err ) {
             attr_type_id = H5Tcopy(H5T_NATIVE_INT);
-            attr_id = H5Acreate(dset_id,"MATLAB_int_decode",attr_type_id,
-                                aspace_id,H5P_DEFAULT,H5P_DEFAULT);
-            if ( 0 > H5Awrite(attr_id,attr_type_id,&matlab_int_decode) )
+            attr_id = H5Acreate(dset_id, "MATLAB_int_decode", attr_type_id, aspace_id, H5P_DEFAULT,
+                                H5P_DEFAULT);
+            if ( 0 > H5Awrite(attr_id, attr_type_id, &matlab_int_decode) )
                 err = MATIO_E_GENERIC_WRITE_ERROR;
             H5Aclose(attr_id);
             H5Tclose(attr_type_id);
         }
         H5Sclose(aspace_id);
 
+        h5type = DataType2H5T(matvar->data_type);
+        if ( MATIO_E_NO_ERROR == err && matvar->data_type == MAT_T_UTF8 ) {
+            /* Convert to UTF-16 */
+            h5type = H5T_NATIVE_UINT16;
+            u16 = (mat_uint16_t *)calloc(nelems, sizeof(mat_uint16_t));
+            if ( u16 != NULL ) {
+                mat_uint8_t *data = (mat_uint8_t *)matvar->data;
+                size_t i, j = 0;
+                for ( i = 0; i < matvar->nbytes; i++ ) {
+                    const mat_uint8_t c = data[i];
+                    if ( c <= 0x7F ) { /* ASCII */
+                        u16[j] = (mat_uint16_t)c;
+                    } else if ( c < 0xE0 && i + 1 < matvar->nbytes ) { /* Extended ASCII */
+                        const mat_uint16_t _a = (mat_uint16_t)(c & 0x1F);
+                        const mat_uint16_t _b = (mat_uint16_t)(data[i + 1] & 0x3F);
+                        u16[j] = (_a << 6) | _b;
+                        i = i + 1;
+                    } else if ( (c & 0xF0) == 0xE0 && i + 2 < matvar->nbytes ) { /* BMP */
+                        const mat_uint16_t _a = (mat_uint16_t)(c & 0xF);
+                        const mat_uint16_t _b = (mat_uint16_t)(data[i + 1] & 0x3C) >> 2;
+                        const mat_uint16_t _c = (mat_uint16_t)(data[i + 1] & 0x3);
+                        const mat_uint16_t _d = (mat_uint16_t)(data[i + 2] & 0x30) >> 4;
+                        const mat_uint16_t _e = (mat_uint16_t)(data[i + 2] & 0xF);
+                        u16[j] = (_a << 12) | (_b << 8) | (_c << 6) | (_d << 4) | _e;
+                        i = i + 2;
+                    } else { /* Full UTF-8 */
+                        err = MATIO_E_OPERATION_NOT_SUPPORTED;
+                        break;
+                    }
+                    j++;
+                }
+            } else {
+                err = MATIO_E_OUT_OF_MEMORY;
+            }
+        }
+
         if ( MATIO_E_NO_ERROR == err ) {
-            if ( 0 > H5Dwrite(dset_id,DataType2H5T(matvar->data_type),
-                              H5S_ALL,H5S_ALL,H5P_DEFAULT,matvar->data) )
+            void *data = matvar->data_type == MAT_T_UTF8 ? u16 : matvar->data;
+            if ( 0 > H5Dwrite(dset_id, h5type, H5S_ALL, H5S_ALL, H5P_DEFAULT, (void *)data) )
                 err = MATIO_E_GENERIC_WRITE_ERROR;
         }
+        free(u16);
         H5Dclose(dset_id);
         H5Sclose(mspace_id);
     }
@@ -13239,24 +13502,24 @@ Mat_VarWriteChar73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims)
 }
 
 static int
-Mat_WriteEmptyVariable73(hid_t id,const char *name,hsize_t rank,size_t *dims)
+Mat_WriteEmptyVariable73(hid_t id, const char *name, hsize_t rank, size_t *dims)
 {
     int err = MATIO_E_NO_ERROR;
     unsigned empty = 1;
-    hid_t mspace_id,dset_id;
+    hid_t mspace_id, dset_id;
 
-    mspace_id = H5Screate_simple(1,&rank,NULL);
-    dset_id = H5Dcreate(id,name,H5T_NATIVE_HSIZE,mspace_id,
-                        H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
+    mspace_id = H5Screate_simple(1, &rank, NULL);
+    dset_id =
+        H5Dcreate(id, name, H5T_NATIVE_HSIZE, mspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     if ( dset_id > -1 ) {
-        hid_t attr_type_id,attr_id,aspace_id;
+        hid_t attr_type_id, attr_id, aspace_id;
 
         attr_type_id = H5Tcopy(H5T_C_S1);
-        H5Tset_size(attr_type_id,6);
+        H5Tset_size(attr_type_id, 6);
         aspace_id = H5Screate(H5S_SCALAR);
-        attr_id = H5Acreate(dset_id,"MATLAB_class",attr_type_id,
-                            aspace_id,H5P_DEFAULT,H5P_DEFAULT);
-        if ( 0 > H5Awrite(attr_id,attr_type_id,"double") )
+        attr_id =
+            H5Acreate(dset_id, "MATLAB_class", attr_type_id, aspace_id, H5P_DEFAULT, H5P_DEFAULT);
+        if ( 0 > H5Awrite(attr_id, attr_type_id, "double") )
             err = MATIO_E_GENERIC_WRITE_ERROR;
         H5Sclose(aspace_id);
         H5Aclose(attr_id);
@@ -13264,9 +13527,9 @@ Mat_WriteEmptyVariable73(hid_t id,const char *name,hsize_t rank,size_t *dims)
 
         if ( MATIO_E_NO_ERROR == err ) {
             aspace_id = H5Screate(H5S_SCALAR);
-            attr_id = H5Acreate(dset_id,"MATLAB_empty",H5T_NATIVE_UINT,
-                                aspace_id,H5P_DEFAULT,H5P_DEFAULT);
-            if ( 0 > H5Awrite(attr_id,H5T_NATIVE_UINT,&empty) )
+            attr_id = H5Acreate(dset_id, "MATLAB_empty", H5T_NATIVE_UINT, aspace_id, H5P_DEFAULT,
+                                H5P_DEFAULT);
+            if ( 0 > H5Awrite(attr_id, H5T_NATIVE_UINT, &empty) )
                 err = MATIO_E_GENERIC_WRITE_ERROR;
             H5Sclose(aspace_id);
             H5Aclose(attr_id);
@@ -13274,8 +13537,7 @@ Mat_WriteEmptyVariable73(hid_t id,const char *name,hsize_t rank,size_t *dims)
 
         if ( MATIO_E_NO_ERROR == err ) {
             /* Write the dimensions as the data */
-            if ( 0 > H5Dwrite(dset_id,SizeType2H5T(),H5S_ALL,H5S_ALL,
-                              H5P_DEFAULT,dims) )
+            if ( 0 > H5Dwrite(dset_id, SizeType2H5T(), H5S_ALL, H5S_ALL, H5P_DEFAULT, dims) )
                 err = MATIO_E_GENERIC_WRITE_ERROR;
         }
         H5Dclose(dset_id);
@@ -13300,11 +13562,11 @@ Mat_WriteEmptyVariable73(hid_t id,const char *name,hsize_t rank,size_t *dims)
  * @endif
  */
 static int
-Mat_VarWriteLogical73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims)
+Mat_VarWriteLogical73(hid_t id, matvar_t *matvar, const char *name, hsize_t *dims)
 {
-    int     err = MATIO_E_NO_ERROR, k;
+    int err = MATIO_E_NO_ERROR, k;
     hsize_t nelems = 1;
-    hid_t   plist;
+    hid_t plist;
 
     for ( k = 0; k < matvar->rank; k++ ) {
         nelems *= dims[k];
@@ -13317,7 +13579,7 @@ Mat_VarWriteLogical73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims)
             Mat_H5GetChunkSize(matvar->rank, dims, chunk_dims);
             H5Pset_chunk(plist, matvar->rank, chunk_dims);
         } else {
-            hsize_t *chunk_dims = (hsize_t*)malloc(matvar->rank*sizeof(hsize_t));
+            hsize_t *chunk_dims = (hsize_t *)malloc(matvar->rank * sizeof(hsize_t));
             if ( NULL != chunk_dims ) {
                 Mat_H5GetChunkSize(matvar->rank, dims, chunk_dims);
                 H5Pset_chunk(plist, matvar->rank, chunk_dims);
@@ -13335,20 +13597,19 @@ Mat_VarWriteLogical73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims)
     if ( 0 == nelems || NULL == matvar->data ) {
         err = Mat_VarWriteEmpty(id, matvar, name, "logical");
     } else {
-        int   int_decode = 1;
-        hid_t mspace_id,dset_id,attr_type_id,attr_id,aspace_id;
+        int int_decode = 1;
+        hid_t mspace_id, dset_id, attr_type_id, attr_id, aspace_id;
 
-        mspace_id = H5Screate_simple(matvar->rank,dims,NULL);
+        mspace_id = H5Screate_simple(matvar->rank, dims, NULL);
         /* Note that MATLAB only recognizes uint8 as logical */
-        dset_id = H5Dcreate(id,name,
-                            ClassType2H5T(MAT_C_UINT8),
-                            mspace_id,H5P_DEFAULT,plist,H5P_DEFAULT);
+        dset_id = H5Dcreate(id, name, ClassType2H5T(MAT_C_UINT8), mspace_id, H5P_DEFAULT, plist,
+                            H5P_DEFAULT);
         attr_type_id = H5Tcopy(H5T_C_S1);
-        H5Tset_size(attr_type_id,7);
+        H5Tset_size(attr_type_id, 7);
         aspace_id = H5Screate(H5S_SCALAR);
-        attr_id = H5Acreate(dset_id,"MATLAB_class",attr_type_id,
-                            aspace_id,H5P_DEFAULT,H5P_DEFAULT);
-        if ( 0 > H5Awrite(attr_id,attr_type_id,"logical") )
+        attr_id =
+            H5Acreate(dset_id, "MATLAB_class", attr_type_id, aspace_id, H5P_DEFAULT, H5P_DEFAULT);
+        if ( 0 > H5Awrite(attr_id, attr_type_id, "logical") )
             err = MATIO_E_GENERIC_WRITE_ERROR;
         H5Sclose(aspace_id);
         H5Aclose(attr_id);
@@ -13357,17 +13618,17 @@ Mat_VarWriteLogical73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims)
         if ( MATIO_E_NO_ERROR == err ) {
             /* Write the MATLAB_int_decode attribute */
             aspace_id = H5Screate(H5S_SCALAR);
-            attr_id = H5Acreate(dset_id,"MATLAB_int_decode",H5T_NATIVE_INT,
-                                aspace_id,H5P_DEFAULT,H5P_DEFAULT);
-            if ( 0 > H5Awrite(attr_id,H5T_NATIVE_INT,&int_decode) )
+            attr_id = H5Acreate(dset_id, "MATLAB_int_decode", H5T_NATIVE_INT, aspace_id,
+                                H5P_DEFAULT, H5P_DEFAULT);
+            if ( 0 > H5Awrite(attr_id, H5T_NATIVE_INT, &int_decode) )
                 err = MATIO_E_GENERIC_WRITE_ERROR;
             H5Sclose(aspace_id);
             H5Aclose(attr_id);
         }
 
         if ( MATIO_E_NO_ERROR == err ) {
-            if ( 0 > H5Dwrite(dset_id,DataType2H5T(matvar->data_type),
-                              H5S_ALL,H5S_ALL,H5P_DEFAULT,matvar->data) )
+            if ( 0 > H5Dwrite(dset_id, DataType2H5T(matvar->data_type), H5S_ALL, H5S_ALL,
+                              H5P_DEFAULT, matvar->data) )
                 err = MATIO_E_GENERIC_WRITE_ERROR;
         }
         H5Dclose(dset_id);
@@ -13394,7 +13655,8 @@ Mat_VarWriteLogical73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims)
  * @endif
  */
 static int
-Mat_VarWriteNumeric73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims,hsize_t* max_dims)
+Mat_VarWriteNumeric73(hid_t id, matvar_t *matvar, const char *name, hsize_t *dims,
+                      hsize_t *max_dims)
 {
     int err = MATIO_E_NO_ERROR, k;
     hsize_t nelems = 1;
@@ -13411,7 +13673,7 @@ Mat_VarWriteNumeric73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims,h
             Mat_H5GetChunkSize(matvar->rank, dims, chunk_dims);
             H5Pset_chunk(plist, matvar->rank, chunk_dims);
         } else {
-            hsize_t *chunk_dims = (hsize_t*)malloc(matvar->rank*sizeof(hsize_t));
+            hsize_t *chunk_dims = (hsize_t *)malloc(matvar->rank * sizeof(hsize_t));
             if ( NULL != chunk_dims ) {
                 Mat_H5GetChunkSize(matvar->rank, dims, chunk_dims);
                 H5Pset_chunk(plist, matvar->rank, chunk_dims);
@@ -13430,18 +13692,17 @@ Mat_VarWriteNumeric73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims,h
     if ( 0 == nelems || NULL == matvar->data ) {
         err = Mat_VarWriteEmpty(id, matvar, name, ClassNames[matvar->class_type]);
     } else {
-        hid_t mspace_id,dset_id,attr_type_id,attr_id,aspace_id;
+        hid_t mspace_id, dset_id, attr_type_id, attr_id, aspace_id;
         hid_t h5_type = ClassType2H5T(matvar->class_type);
         hid_t h5_dtype = DataType(h5_type, matvar->isComplex);
 
-        mspace_id = H5Screate_simple(matvar->rank,dims,max_dims);
-        dset_id = H5Dcreate(id,name,h5_dtype,mspace_id,
-                            H5P_DEFAULT,plist,H5P_DEFAULT);
+        mspace_id = H5Screate_simple(matvar->rank, dims, max_dims);
+        dset_id = H5Dcreate(id, name, h5_dtype, mspace_id, H5P_DEFAULT, plist, H5P_DEFAULT);
         attr_type_id = H5Tcopy(H5T_C_S1);
         H5Tset_size(attr_type_id, strlen(ClassNames[matvar->class_type]));
         aspace_id = H5Screate(H5S_SCALAR);
-        attr_id = H5Acreate(dset_id,"MATLAB_class",attr_type_id,
-                            aspace_id,H5P_DEFAULT,H5P_DEFAULT);
+        attr_id =
+            H5Acreate(dset_id, "MATLAB_class", attr_type_id, aspace_id, H5P_DEFAULT, H5P_DEFAULT);
         if ( 0 > H5Awrite(attr_id, attr_type_id, ClassNames[matvar->class_type]) )
             err = MATIO_E_GENERIC_WRITE_ERROR;
         H5Sclose(aspace_id);
@@ -13449,8 +13710,8 @@ Mat_VarWriteNumeric73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims,h
         H5Tclose(attr_type_id);
         H5Tclose(h5_dtype);
         if ( MATIO_E_NO_ERROR == err ) {
-            err = Mat_H5WriteData(dset_id, h5_type, H5S_ALL, H5S_ALL,
-                                   matvar->isComplex, matvar->data);
+            err = Mat_H5WriteData(dset_id, h5_type, H5S_ALL, H5S_ALL, matvar->isComplex,
+                                  matvar->data);
         }
         H5Dclose(dset_id);
         H5Sclose(mspace_id);
@@ -13476,7 +13737,7 @@ Mat_VarWriteNumeric73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims,h
  * @endif
  */
 static int
-Mat_VarWriteAppendNumeric73(hid_t id,matvar_t *matvar,const char *name,hsize_t *dims,int dim)
+Mat_VarWriteAppendNumeric73(hid_t id, matvar_t *matvar, const char *name, hsize_t *dims, int dim)
 {
     int err = MATIO_E_NO_ERROR, k;
     hsize_t nelems = 1;
@@ -13488,7 +13749,8 @@ Mat_VarWriteAppendNumeric73(hid_t id,matvar_t *matvar,const char *name,hsize_t *
     if ( 0 != nelems && NULL != matvar->data ) {
         if ( H5Lexists(id, matvar->name, H5P_DEFAULT) ) {
             err = Mat_H5WriteAppendData(id, ClassType2H5T(matvar->class_type), matvar->rank,
-                matvar->name, matvar->dims, dims, dim, matvar->isComplex, matvar->data);
+                                        matvar->name, matvar->dims, dims, dim, matvar->isComplex,
+                                        matvar->data);
         } else {
             /* Create with unlimited number of dimensions */
             if ( MAX_RANK >= matvar->rank ) {
@@ -13498,7 +13760,7 @@ Mat_VarWriteAppendNumeric73(hid_t id,matvar_t *matvar,const char *name,hsize_t *
                 }
                 err = Mat_VarWriteNumeric73(id, matvar, name, dims, max_dims);
             } else {
-                hsize_t* max_dims = (hsize_t*)malloc(matvar->rank*sizeof(hsize_t));
+                hsize_t *max_dims = (hsize_t *)malloc(matvar->rank * sizeof(hsize_t));
                 if ( NULL != max_dims ) {
                     for ( k = 0; k < matvar->rank; k++ ) {
                         max_dims[k] = H5S_UNLIMITED;
@@ -13529,32 +13791,30 @@ Mat_VarWriteAppendNumeric73(hid_t id,matvar_t *matvar,const char *name,hsize_t *
  * @endif
  */
 static int
-Mat_VarWriteSparse73(hid_t id,matvar_t *matvar,const char *name)
+Mat_VarWriteSparse73(hid_t id, matvar_t *matvar, const char *name)
 {
     int err = MATIO_E_NO_ERROR;
     hid_t sparse_id;
 
-    sparse_id = H5Gcreate(id,name,H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
+    sparse_id = H5Gcreate(id, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     if ( sparse_id < 0 ) {
-        Mat_Critical("Error creating group for sparse array %s",
-                     matvar->name);
+        Mat_Critical("Error creating group for sparse array %s", matvar->name);
         err = MATIO_E_OUTPUT_BAD_DATA;
     } else {
-        hid_t size_type_id,h5_type,h5_dtype;
-        hid_t mspace_id,dset_id,attr_type_id,attr_id,aspace_id;
+        hid_t size_type_id, h5_type, h5_dtype;
+        hid_t mspace_id, dset_id, attr_type_id, attr_id, aspace_id;
         mat_sparse_t *sparse;
         hsize_t nir, njc, ndata;
         mat_uint64_t sparse_attr_value;
         enum matio_classes class_type;
 
-        sparse = (mat_sparse_t*)matvar->data;
+        sparse = (mat_sparse_t *)matvar->data;
         class_type = DataType2ClassType(matvar->data_type);
         attr_type_id = H5Tcopy(H5T_C_S1);
-        H5Tset_size(attr_type_id,
-                    matvar->isLogical ? 7 : strlen(ClassNames[class_type]));
+        H5Tset_size(attr_type_id, matvar->isLogical ? 7 : strlen(ClassNames[class_type]));
         aspace_id = H5Screate(H5S_SCALAR);
-        attr_id = H5Acreate(sparse_id,"MATLAB_class",attr_type_id,
-                            aspace_id,H5P_DEFAULT,H5P_DEFAULT);
+        attr_id =
+            H5Acreate(sparse_id, "MATLAB_class", attr_type_id, aspace_id, H5P_DEFAULT, H5P_DEFAULT);
         if ( 0 > H5Awrite(attr_id, attr_type_id,
                           matvar->isLogical ? "logical" : ClassNames[class_type]) )
             err = MATIO_E_GENERIC_WRITE_ERROR;
@@ -13567,8 +13827,8 @@ Mat_VarWriteSparse73(hid_t id,matvar_t *matvar,const char *name)
                 /* Write the MATLAB_int_decode attribute */
                 int int_decode = 1;
                 aspace_id = H5Screate(H5S_SCALAR);
-                attr_id = H5Acreate(sparse_id, "MATLAB_int_decode", H5T_NATIVE_INT,
-                                    aspace_id, H5P_DEFAULT, H5P_DEFAULT);
+                attr_id = H5Acreate(sparse_id, "MATLAB_int_decode", H5T_NATIVE_INT, aspace_id,
+                                    H5P_DEFAULT, H5P_DEFAULT);
                 if ( 0 > H5Awrite(attr_id, H5T_NATIVE_INT, &int_decode) )
                     err = MATIO_E_GENERIC_WRITE_ERROR;
                 H5Sclose(aspace_id);
@@ -13580,9 +13840,9 @@ Mat_VarWriteSparse73(hid_t id,matvar_t *matvar,const char *name)
             sparse_attr_value = matvar->dims[0];
             size_type_id = ClassType2H5T(MAT_C_UINT64);
             aspace_id = H5Screate(H5S_SCALAR);
-            attr_id = H5Acreate(sparse_id,"MATLAB_sparse",size_type_id,
-                                aspace_id,H5P_DEFAULT,H5P_DEFAULT);
-            if ( 0 > H5Awrite(attr_id,size_type_id,&sparse_attr_value) )
+            attr_id = H5Acreate(sparse_id, "MATLAB_sparse", size_type_id, aspace_id, H5P_DEFAULT,
+                                H5P_DEFAULT);
+            if ( 0 > H5Awrite(attr_id, size_type_id, &sparse_attr_value) )
                 err = MATIO_E_GENERIC_WRITE_ERROR;
             H5Sclose(aspace_id);
             H5Aclose(attr_id);
@@ -13592,34 +13852,32 @@ Mat_VarWriteSparse73(hid_t id,matvar_t *matvar,const char *name)
             ndata = sparse->ndata;
             h5_type = DataType2H5T(matvar->data_type);
             h5_dtype = DataType(h5_type, matvar->isComplex);
-            mspace_id = H5Screate_simple(1,&ndata,NULL);
-            dset_id = H5Dcreate(sparse_id,"data",h5_dtype,mspace_id,
-                                H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
+            mspace_id = H5Screate_simple(1, &ndata, NULL);
+            dset_id = H5Dcreate(sparse_id, "data", h5_dtype, mspace_id, H5P_DEFAULT, H5P_DEFAULT,
+                                H5P_DEFAULT);
             H5Tclose(h5_dtype);
-            err = Mat_H5WriteData(dset_id, h5_type, H5S_ALL, H5S_ALL,
-                                   matvar->isComplex, sparse->data);
+            err = Mat_H5WriteData(dset_id, h5_type, H5S_ALL, H5S_ALL, matvar->isComplex,
+                                  sparse->data);
             H5Dclose(dset_id);
             H5Sclose(mspace_id);
         }
 
         if ( MATIO_E_NO_ERROR == err ) {
             nir = sparse->nir;
-            mspace_id = H5Screate_simple(1,&nir,NULL);
-            dset_id = H5Dcreate(sparse_id,"ir",size_type_id,mspace_id,
-                                H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
-            err = Mat_H5WriteData(dset_id, H5T_NATIVE_UINT, H5S_ALL, H5S_ALL,
-                                   0, sparse->ir);
+            mspace_id = H5Screate_simple(1, &nir, NULL);
+            dset_id = H5Dcreate(sparse_id, "ir", size_type_id, mspace_id, H5P_DEFAULT, H5P_DEFAULT,
+                                H5P_DEFAULT);
+            err = Mat_H5WriteData(dset_id, H5T_NATIVE_UINT, H5S_ALL, H5S_ALL, 0, sparse->ir);
             H5Dclose(dset_id);
             H5Sclose(mspace_id);
         }
 
         if ( MATIO_E_NO_ERROR == err ) {
             njc = sparse->njc;
-            mspace_id = H5Screate_simple(1,&njc,NULL);
-            dset_id = H5Dcreate(sparse_id,"jc",size_type_id,mspace_id,
-                                H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
-            err = Mat_H5WriteData(dset_id, H5T_NATIVE_UINT, H5S_ALL, H5S_ALL,
-                                   0, sparse->jc);
+            mspace_id = H5Screate_simple(1, &njc, NULL);
+            dset_id = H5Dcreate(sparse_id, "jc", size_type_id, mspace_id, H5P_DEFAULT, H5P_DEFAULT,
+                                H5P_DEFAULT);
+            err = Mat_H5WriteData(dset_id, H5T_NATIVE_UINT, H5S_ALL, H5S_ALL, 0, sparse->jc);
             H5Dclose(dset_id);
             H5Sclose(mspace_id);
         }
@@ -13644,9 +13902,10 @@ Mat_VarWriteSparse73(hid_t id,matvar_t *matvar,const char *name)
  * @endif
  */
 static int
-Mat_VarWriteStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id,hsize_t *dims,hsize_t* max_dims)
+Mat_VarWriteStruct73(hid_t id, matvar_t *matvar, const char *name, hid_t *refs_id, hsize_t *dims,
+                     hsize_t *max_dims)
 {
-    int     err;
+    int err;
     hsize_t nelems;
 
     {
@@ -13658,22 +13917,22 @@ Mat_VarWriteStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id,h
     if ( err || 0 == nelems || NULL == matvar->data ) {
         err = Mat_VarWriteEmpty(id, matvar, name, ClassNames[matvar->class_type]);
     } else {
-        hid_t struct_id = H5Gcreate(id,name,H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
+        hid_t struct_id = H5Gcreate(id, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         if ( struct_id < 0 ) {
-            Mat_Critical("Error creating group for struct %s",name);
+            Mat_Critical("Error creating group for struct %s", name);
             err = MATIO_E_OUTPUT_BAD_DATA;
         } else {
-            hid_t attr_id,aspace_id;
+            hid_t attr_id, aspace_id;
             hid_t str_type_id;
-            matvar_t **fields = (matvar_t**)matvar->data;
-            hsize_t    nfields = matvar->internal->num_fields, k;
+            matvar_t **fields = (matvar_t **)matvar->data;
+            hsize_t nfields = matvar->internal->num_fields, k;
 
             str_type_id = H5Tcopy(H5T_C_S1);
-            H5Tset_size(str_type_id,6);
+            H5Tset_size(str_type_id, 6);
             aspace_id = H5Screate(H5S_SCALAR);
-            attr_id = H5Acreate(struct_id,"MATLAB_class",str_type_id,
-                                aspace_id,H5P_DEFAULT,H5P_DEFAULT);
-            if ( 0 > H5Awrite(attr_id,str_type_id,"struct") )
+            attr_id = H5Acreate(struct_id, "MATLAB_class", str_type_id, aspace_id, H5P_DEFAULT,
+                                H5P_DEFAULT);
+            if ( 0 > H5Awrite(attr_id, str_type_id, "struct") )
                 err = MATIO_E_GENERIC_WRITE_ERROR;
             H5Aclose(attr_id);
             H5Sclose(aspace_id);
@@ -13686,20 +13945,19 @@ Mat_VarWriteStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id,h
             }
 
             if ( MATIO_E_NO_ERROR == err ) {
-                hvl_t *fieldnames = (hvl_t*)malloc((size_t)nfields*sizeof(*fieldnames));
+                hvl_t *fieldnames = (hvl_t *)malloc((size_t)nfields * sizeof(*fieldnames));
                 if ( NULL != fieldnames ) {
                     hid_t fieldnames_id;
                     for ( k = 0; k < nfields; k++ ) {
-                        fieldnames[k].len =
-                            strlen(matvar->internal->fieldnames[k]);
-                        fieldnames[k].p   = matvar->internal->fieldnames[k];
+                        fieldnames[k].len = strlen(matvar->internal->fieldnames[k]);
+                        fieldnames[k].p = matvar->internal->fieldnames[k];
                     }
-                    H5Tset_size(str_type_id,1);
+                    H5Tset_size(str_type_id, 1);
                     fieldnames_id = H5Tvlen_create(str_type_id);
-                    aspace_id     = H5Screate_simple(1,&nfields,NULL);
-                    attr_id = H5Acreate(struct_id,"MATLAB_fields",fieldnames_id,
-                                        aspace_id,H5P_DEFAULT,H5P_DEFAULT);
-                    if ( 0 > H5Awrite(attr_id,fieldnames_id,fieldnames) )
+                    aspace_id = H5Screate_simple(1, &nfields, NULL);
+                    attr_id = H5Acreate(struct_id, "MATLAB_fields", fieldnames_id, aspace_id,
+                                        H5P_DEFAULT, H5P_DEFAULT);
+                    if ( 0 > H5Awrite(attr_id, fieldnames_id, fieldnames) )
                         err = MATIO_E_GENERIC_WRITE_ERROR;
                     H5Aclose(attr_id);
                     H5Sclose(aspace_id);
@@ -13716,25 +13974,25 @@ Mat_VarWriteStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id,h
                     for ( k = 0; k < nfields; k++ ) {
                         if ( NULL != fields[k] )
                             fields[k]->compression = matvar->compression;
-                        err = Mat_VarWriteNext73(struct_id,fields[k],
-                            matvar->internal->fieldnames[k],refs_id);
+                        err = Mat_VarWriteNext73(struct_id, fields[k],
+                                                 matvar->internal->fieldnames[k], refs_id);
                     }
                 } else {
                     if ( *refs_id < 0 ) {
-                        if ( H5Lexists(id,"/#refs#",H5P_DEFAULT) ) {
-                            *refs_id = H5Gopen(id,"/#refs#",H5P_DEFAULT);
+                        if ( H5Lexists(id, "/#refs#", H5P_DEFAULT) ) {
+                            *refs_id = H5Gopen(id, "/#refs#", H5P_DEFAULT);
                         } else {
-                            *refs_id = H5Gcreate(id,"/#refs#",H5P_DEFAULT,
-                                                 H5P_DEFAULT,H5P_DEFAULT);
+                            *refs_id =
+                                H5Gcreate(id, "/#refs#", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
                         }
                     }
                     if ( *refs_id > -1 ) {
                         hid_t plist = H5P_DEFAULT;
-                        hobj_ref_t **refs = (hobj_ref_t**)calloc((size_t)nfields, sizeof(*refs));
+                        hobj_ref_t **refs = (hobj_ref_t **)calloc((size_t)nfields, sizeof(*refs));
                         if ( NULL != refs ) {
                             hsize_t l;
                             for ( l = 0; l < nfields; l++ ) {
-                                refs[l] = (hobj_ref_t*)calloc((size_t)nelems, sizeof(*refs[l]));
+                                refs[l] = (hobj_ref_t *)calloc((size_t)nelems, sizeof(*refs[l]));
                                 if ( NULL == refs[l] ) {
                                     err = MATIO_E_OUT_OF_MEMORY;
                                     break;
@@ -13744,8 +14002,9 @@ Mat_VarWriteStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id,h
                             if ( MATIO_E_NO_ERROR == err ) {
                                 for ( k = 0; k < nelems; k++ ) {
                                     for ( l = 0; l < nfields; l++ ) {
-                                        err = Mat_VarWriteRef(id, fields[k*nfields+l], matvar->compression,
-                                                               refs_id, refs[l]+k);
+                                        err = Mat_VarWriteRef(id, fields[k * nfields + l],
+                                                              matvar->compression, refs_id,
+                                                              refs[l] + k);
                                         if ( err )
                                             break;
                                     }
@@ -13762,7 +14021,8 @@ Mat_VarWriteStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id,h
                                         Mat_H5GetChunkSize(matvar->rank, dims, chunk_dims);
                                         H5Pset_chunk(plist, matvar->rank, chunk_dims);
                                     } else {
-                                        hsize_t *chunk_dims = (hsize_t*)malloc(matvar->rank*sizeof(hsize_t));
+                                        hsize_t *chunk_dims =
+                                            (hsize_t *)malloc(matvar->rank * sizeof(hsize_t));
                                         if ( NULL != chunk_dims ) {
                                             Mat_H5GetChunkSize(matvar->rank, dims, chunk_dims);
                                             H5Pset_chunk(plist, matvar->rank, chunk_dims);
@@ -13779,14 +14039,13 @@ Mat_VarWriteStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id,h
                             }
 
                             if ( MATIO_E_NO_ERROR == err ) {
-                                hid_t mspace_id = H5Screate_simple(matvar->rank,dims,max_dims);
+                                hid_t mspace_id = H5Screate_simple(matvar->rank, dims, max_dims);
                                 for ( l = 0; l < nfields; l++ ) {
-                                    hid_t dset_id = H5Dcreate(struct_id,
-                                                        matvar->internal->fieldnames[l],
-                                                        H5T_STD_REF_OBJ,mspace_id,
-                                                        H5P_DEFAULT,plist,H5P_DEFAULT);
+                                    hid_t dset_id = H5Dcreate(
+                                        struct_id, matvar->internal->fieldnames[l], H5T_STD_REF_OBJ,
+                                        mspace_id, H5P_DEFAULT, plist, H5P_DEFAULT);
                                     err = Mat_H5WriteData(dset_id, H5T_STD_REF_OBJ, H5S_ALL,
-                                                           H5S_ALL, 0, refs[l]);
+                                                          H5S_ALL, 0, refs[l]);
                                     H5Dclose(dset_id);
                                     if ( err )
                                         break;
@@ -13814,7 +14073,8 @@ Mat_VarWriteStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id,h
 }
 
 static int
-Mat_VarWriteAppendStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id,hsize_t *dims,int dim)
+Mat_VarWriteAppendStruct73(hid_t id, matvar_t *matvar, const char *name, hid_t *refs_id,
+                           hsize_t *dims, int dim)
 {
     int err = MATIO_E_NO_ERROR;
     hsize_t nelems = 1;
@@ -13830,16 +14090,16 @@ Mat_VarWriteAppendStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *ref
         if ( H5Lexists(id, name, H5P_DEFAULT) ) {
             hobj_ref_t **refs;
             hsize_t nfields = matvar->internal->num_fields;
-            matvar_t** fields = (matvar_t**)matvar->data;
+            matvar_t **fields = (matvar_t **)matvar->data;
 
             if ( *refs_id <= -1 )
                 return MATIO_E_OUTPUT_BAD_DATA;
 
-            refs = (hobj_ref_t**)calloc((size_t)nfields, sizeof(*refs));
-            if ( NULL != refs) {
+            refs = (hobj_ref_t **)calloc((size_t)nfields, sizeof(*refs));
+            if ( NULL != refs ) {
                 hsize_t l;
                 for ( l = 0; l < nfields; l++ ) {
-                    refs[l] = (hobj_ref_t*)calloc((size_t)nelems, sizeof(*refs[l]));
+                    refs[l] = (hobj_ref_t *)calloc((size_t)nelems, sizeof(*refs[l]));
                     if ( NULL == refs[l] ) {
                         err = MATIO_E_OUT_OF_MEMORY;
                         break;
@@ -13850,8 +14110,8 @@ Mat_VarWriteAppendStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *ref
                     hsize_t k;
                     for ( k = 0; k < nelems; k++ ) {
                         for ( l = 0; l < nfields; l++ ) {
-                            err = Mat_VarWriteRef(id, fields[k*nfields+l], matvar->compression,
-                                                   refs_id, refs[l]+k);
+                            err = Mat_VarWriteRef(id, fields[k * nfields + l], matvar->compression,
+                                                  refs_id, refs[l] + k);
                             if ( err )
                                 break;
                         }
@@ -13864,7 +14124,8 @@ Mat_VarWriteAppendStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *ref
                     hid_t struct_id = H5Gopen(id, name, H5P_DEFAULT);
                     for ( l = 0; l < nfields; l++ ) {
                         err = Mat_H5WriteAppendData(struct_id, H5T_STD_REF_OBJ, matvar->rank,
-                            matvar->internal->fieldnames[l], matvar->dims, dims, dim, 0, refs[l]);
+                                                    matvar->internal->fieldnames[l], matvar->dims,
+                                                    dims, dim, 0, refs[l]);
                         if ( err )
                             break;
                     }
@@ -13882,15 +14143,15 @@ Mat_VarWriteAppendStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *ref
                 for ( k = 0; k < matvar->rank; k++ ) {
                     max_dims[k] = H5S_UNLIMITED;
                 }
-                err = Mat_VarWriteStruct73(id,matvar,name,refs_id,dims,max_dims);
+                err = Mat_VarWriteStruct73(id, matvar, name, refs_id, dims, max_dims);
             } else {
-                hsize_t* max_dims = (hsize_t*)malloc(matvar->rank*sizeof(hsize_t));
+                hsize_t *max_dims = (hsize_t *)malloc(matvar->rank * sizeof(hsize_t));
                 if ( NULL != max_dims ) {
                     int k;
                     for ( k = 0; k < matvar->rank; k++ ) {
                         max_dims[k] = H5S_UNLIMITED;
                     }
-                    err = Mat_VarWriteStruct73(id,matvar,name,refs_id,dims,max_dims);
+                    err = Mat_VarWriteStruct73(id, matvar, name, refs_id, dims, max_dims);
                     free(max_dims);
                 } else {
                     err = MATIO_E_OUT_OF_MEMORY;
@@ -13903,20 +14164,20 @@ Mat_VarWriteAppendStruct73(hid_t id,matvar_t *matvar,const char *name,hid_t *ref
 }
 
 static int
-Mat_VarWriteNext73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id)
+Mat_VarWriteNext73(hid_t id, matvar_t *matvar, const char *name, hid_t *refs_id)
 {
     int err;
 
     if ( NULL == matvar ) {
-        size_t dims[2] = {0,0};
-        return Mat_WriteEmptyVariable73(id,name,2,dims);
+        size_t dims[2] = {0, 0};
+        return Mat_WriteEmptyVariable73(id, name, 2, dims);
     }
 
     if ( MAX_RANK >= matvar->rank ) {
         hsize_t perm_dims[MAX_RANK];
         err = Mat_VarWriteNextType73(id, matvar, name, refs_id, perm_dims);
     } else {
-        hsize_t *perm_dims = (hsize_t*)malloc(matvar->rank*sizeof(hsize_t));
+        hsize_t *perm_dims = (hsize_t *)malloc(matvar->rank * sizeof(hsize_t));
         if ( NULL != perm_dims ) {
             err = Mat_VarWriteNextType73(id, matvar, name, refs_id, perm_dims);
             free(perm_dims);
@@ -13929,7 +14190,7 @@ Mat_VarWriteNext73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id)
 }
 
 static int
-Mat_VarWriteAppendNext73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id,int dim)
+Mat_VarWriteAppendNext73(hid_t id, matvar_t *matvar, const char *name, hid_t *refs_id, int dim)
 {
     int err;
 
@@ -13937,7 +14198,7 @@ Mat_VarWriteAppendNext73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_
         hsize_t perm_dims[MAX_RANK];
         err = Mat_VarWriteAppendNextType73(id, matvar, name, refs_id, perm_dims, dim);
     } else {
-        hsize_t *perm_dims = (hsize_t*)malloc(matvar->rank*sizeof(hsize_t));
+        hsize_t *perm_dims = (hsize_t *)malloc(matvar->rank * sizeof(hsize_t));
         if ( NULL != perm_dims ) {
             err = Mat_VarWriteAppendNextType73(id, matvar, name, refs_id, perm_dims, dim);
             free(perm_dims);
@@ -13950,7 +14211,7 @@ Mat_VarWriteAppendNext73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_
 }
 
 static int
-Mat_VarWriteNextType73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id,hsize_t *dims)
+Mat_VarWriteNextType73(hid_t id, matvar_t *matvar, const char *name, hid_t *refs_id, hsize_t *dims)
 {
     int err, k;
 
@@ -13960,7 +14221,7 @@ Mat_VarWriteNextType73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id
     }
 
     if ( matvar->isLogical && matvar->class_type != MAT_C_SPARSE ) {
-        err = Mat_VarWriteLogical73(id,matvar,name,dims);
+        err = Mat_VarWriteLogical73(id, matvar, name, dims);
     } else {
         switch ( matvar->class_type ) {
             case MAT_C_DOUBLE:
@@ -13973,22 +14234,22 @@ Mat_VarWriteNextType73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id
             case MAT_C_UINT16:
             case MAT_C_INT8:
             case MAT_C_UINT8:
-                err = Mat_VarWriteNumeric73(id,matvar,name,dims,NULL);
+                err = Mat_VarWriteNumeric73(id, matvar, name, dims, NULL);
                 break;
             case MAT_C_CHAR:
-                err = Mat_VarWriteChar73(id,matvar,name,dims);
+                err = Mat_VarWriteChar73(id, matvar, name, dims);
                 break;
             case MAT_C_STRUCT:
-                err = Mat_VarWriteStruct73(id,matvar,name,refs_id,dims,NULL);
+                err = Mat_VarWriteStruct73(id, matvar, name, refs_id, dims, NULL);
                 break;
             case MAT_C_CELL:
-                err = Mat_VarWriteCell73(id,matvar,name,refs_id,dims);
+                err = Mat_VarWriteCell73(id, matvar, name, refs_id, dims);
                 break;
             case MAT_C_SPARSE:
-                err = Mat_VarWriteSparse73(id,matvar,name);
+                err = Mat_VarWriteSparse73(id, matvar, name);
                 break;
             case MAT_C_EMPTY:
-                err = Mat_WriteEmptyVariable73(id,name,matvar->rank,matvar->dims);
+                err = Mat_WriteEmptyVariable73(id, name, matvar->rank, matvar->dims);
                 break;
             case MAT_C_FUNCTION:
             case MAT_C_OBJECT:
@@ -14005,7 +14266,8 @@ Mat_VarWriteNextType73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id
 }
 
 static int
-Mat_VarWriteAppendNextType73(hid_t id,matvar_t *matvar,const char *name,hid_t *refs_id,hsize_t *dims,int dim)
+Mat_VarWriteAppendNextType73(hid_t id, matvar_t *matvar, const char *name, hid_t *refs_id,
+                             hsize_t *dims, int dim)
 {
     int err, k;
 
@@ -14026,10 +14288,10 @@ Mat_VarWriteAppendNextType73(hid_t id,matvar_t *matvar,const char *name,hid_t *r
             case MAT_C_UINT16:
             case MAT_C_INT8:
             case MAT_C_UINT8:
-                err = Mat_VarWriteAppendNumeric73(id,matvar,name,dims,dim);
+                err = Mat_VarWriteAppendNumeric73(id, matvar, name, dims, dim);
                 break;
             case MAT_C_STRUCT:
-                err = Mat_VarWriteAppendStruct73(id,matvar,name,refs_id,dims,dim);
+                err = Mat_VarWriteAppendStruct73(id, matvar, name, refs_id, dims, dim);
                 break;
             case MAT_C_EMPTY:
             case MAT_C_CHAR:
@@ -14038,7 +14300,7 @@ Mat_VarWriteAppendNextType73(hid_t id,matvar_t *matvar,const char *name,hid_t *r
             case MAT_C_FUNCTION:
             case MAT_C_OBJECT:
             case MAT_C_OPAQUE:
-                err = Mat_VarWriteNextType73(id,matvar,name,refs_id,dims);
+                err = Mat_VarWriteNextType73(id, matvar, name, refs_id, dims);
                 break;
             default:
                 err = MATIO_E_OUTPUT_BAD_DATA;
@@ -14068,28 +14330,28 @@ Mat_VarWriteAppendNextType73(hid_t id,matvar_t *matvar,const char *name,hid_t *r
  * @endif
  */
 static mat_t *
-Mat_Create73(const char *matname,const char *hdr_str)
+Mat_Create73(const char *matname, const char *hdr_str)
 {
     FILE *fp = NULL;
     mat_int16_t endian = 0, version;
     mat_t *mat = NULL;
     size_t err;
     time_t t;
-    hid_t plist_id,fid,plist_ap;
+    hid_t plist_id, fid, plist_ap;
 
     plist_id = H5Pcreate(H5P_FILE_CREATE);
-    H5Pset_userblock(plist_id,512);
+    H5Pset_userblock(plist_id, 512);
     plist_ap = H5Pcreate(H5P_FILE_ACCESS);
-#if H5_VERSION_GE(1,10,2)
-    H5Pset_libver_bounds(plist_ap,H5F_LIBVER_EARLIEST,H5F_LIBVER_V18);
+#if H5_VERSION_GE(1, 10, 2)
+    H5Pset_libver_bounds(plist_ap, H5F_LIBVER_EARLIEST, H5F_LIBVER_V18);
 #endif
-    fid = H5Fcreate(matname,H5F_ACC_TRUNC,plist_id,plist_ap);
+    fid = H5Fcreate(matname, H5F_ACC_TRUNC, plist_id, plist_ap);
     H5Fclose(fid);
     H5Pclose(plist_id);
 
-#if defined(_WIN32) && defined(_MSC_VER) && H5_VERSION_GE(1,11,6)
+#if defined(_WIN32) && defined(_MSC_VER) && H5_VERSION_GE(1, 11, 6)
     {
-        wchar_t* wname = utf82u(matname);
+        wchar_t *wname = utf82u(matname);
         if ( NULL != wname ) {
             fp = _wfopen(wname, L"r+b");
             free(wname);
@@ -14103,63 +14365,64 @@ Mat_Create73(const char *matname,const char *hdr_str)
         return NULL;
     }
 
-    (void)fseek(fp,0,SEEK_SET);
+    (void)fseek(fp, 0, SEEK_SET);
 
-    mat = (mat_t*)malloc(sizeof(*mat));
+    mat = (mat_t *)malloc(sizeof(*mat));
     if ( mat == NULL ) {
         fclose(fp);
         H5Pclose(plist_ap);
         return NULL;
     }
 
-    mat->fp            = NULL;
-    mat->header        = NULL;
+    mat->fp = NULL;
+    mat->header = NULL;
     mat->subsys_offset = NULL;
-    mat->filename      = NULL;
-    mat->version       = 0;
-    mat->byteswap      = 0;
-    mat->mode          = 0;
-    mat->bof           = 128;
-    mat->next_index    = 0;
-    mat->num_datasets  = 0;
-    mat->refs_id       = -1;
-    mat->dir           = NULL;
+    mat->filename = NULL;
+    mat->version = 0;
+    mat->byteswap = 0;
+    mat->mode = 0;
+    mat->bof = 128;
+    mat->next_index = 0;
+    mat->num_datasets = 0;
+    mat->refs_id = -1;
+    mat->dir = NULL;
 
     t = time(NULL);
     mat->filename = Mat_strdup(matname);
-    mat->mode     = MAT_ACC_RDWR;
+    mat->mode = MAT_ACC_RDWR;
     mat->byteswap = 0;
-    mat->header   = (char*)malloc(128*sizeof(char));
-    mat->subsys_offset = (char*)malloc(8*sizeof(char));
-    memset(mat->header,' ',128);
+    mat->header = (char *)malloc(128 * sizeof(char));
+    mat->subsys_offset = (char *)malloc(8 * sizeof(char));
+    memset(mat->header, ' ', 128);
     if ( hdr_str == NULL ) {
-        err = mat_snprintf(mat->header,116,"MATLAB 7.3 MAT-file, Platform: %s, "
-                "Created by: libmatio v%d.%d.%d on %s HDF5 schema 0.5",
-                MATIO_PLATFORM, MATIO_MAJOR_VERSION, MATIO_MINOR_VERSION,
-                MATIO_RELEASE_LEVEL, ctime(&t));
+        err = mat_snprintf(mat->header, 116,
+                           "MATLAB 7.3 MAT-file, Platform: %s, "
+                           "Created by: libmatio v%d.%d.%d on %s HDF5 schema 0.5",
+                           MATIO_PLATFORM, MATIO_MAJOR_VERSION, MATIO_MINOR_VERSION,
+                           MATIO_RELEASE_LEVEL, ctime(&t));
     } else {
-        err = mat_snprintf(mat->header,116,"%s",hdr_str);
+        err = mat_snprintf(mat->header, 116, "%s", hdr_str);
     }
     if ( err >= 116 )
         mat->header[115] = '\0'; /* Just to make sure it's NULL terminated */
-    memset(mat->subsys_offset,' ',8);
+    memset(mat->subsys_offset, ' ', 8);
     mat->version = (int)0x0200;
     endian = 0x4d49;
 
     version = 0x0200;
 
-    fwrite(mat->header,1,116,fp);
-    fwrite(mat->subsys_offset,1,8,fp);
-    fwrite(&version,2,1,fp);
-    fwrite(&endian,2,1,fp);
+    fwrite(mat->header, 1, 116, fp);
+    fwrite(mat->subsys_offset, 1, 8, fp);
+    fwrite(&version, 2, 1, fp);
+    fwrite(&endian, 2, 1, fp);
 
     fclose(fp);
 
-    fid = H5Fopen(matname,H5F_ACC_RDWR,plist_ap);
+    fid = H5Fopen(matname, H5F_ACC_RDWR, plist_ap);
     H5Pclose(plist_ap);
 
     mat->fp = malloc(sizeof(hid_t));
-    *(hid_t*)mat->fp = fid;
+    *(hid_t *)mat->fp = fid;
 
     return mat;
 }
@@ -14178,7 +14441,7 @@ Mat_Close73(mat_t *mat)
     int err = MATIO_E_NO_ERROR;
     if ( mat->refs_id > -1 )
         H5Gclose(mat->refs_id);
-    if ( 0 > H5Fclose(*(hid_t*)mat->fp) )
+    if ( 0 > H5Fclose(*(hid_t *)mat->fp) )
         err = MATIO_E_FILESYSTEM_ERROR_ON_CLOSE;
     free(mat->fp);
     mat->fp = NULL;
@@ -14195,17 +14458,17 @@ Mat_Close73(mat_t *mat)
  * @endif
  */
 static int
-Mat_VarRead73(mat_t *mat,matvar_t *matvar)
+Mat_VarRead73(mat_t *mat, matvar_t *matvar)
 {
     int err = MATIO_E_NO_ERROR;
-    hid_t fid,dset_id,ref_id;
+    hid_t fid, dset_id, ref_id;
 
     if ( NULL == mat || NULL == matvar )
         return MATIO_E_BAD_ARGUMENT;
     else if ( NULL == matvar->internal->hdf5_name && 0 > matvar->internal->id )
         return MATIO_E_READ_VARIABLE_DOES_NOT_EXIST;
 
-    fid = *(hid_t*)mat->fp;
+    fid = *(hid_t *)mat->fp;
 
     switch ( matvar->class_type ) {
         case MAT_C_DOUBLE:
@@ -14217,10 +14480,9 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
         case MAT_C_INT16:
         case MAT_C_UINT16:
         case MAT_C_INT8:
-        case MAT_C_UINT8:
-        {
+        case MAT_C_UINT8: {
             size_t nelems = 1;
-            matvar->data_size = Mat_SizeOfClass(matvar->class_type);
+            matvar->data_size = (int)Mat_SizeOfClass(matvar->class_type);
             err = Mat_MulDims(matvar, &nelems);
             if ( err ) {
                 Mat_Critical("Integer multiplication overflow");
@@ -14236,13 +14498,13 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
                 break;
 
             if ( NULL != matvar->internal->hdf5_name ) {
-                ref_id = H5Dopen(fid,matvar->internal->hdf5_name,H5P_DEFAULT);
+                ref_id = H5Dopen(fid, matvar->internal->hdf5_name, H5P_DEFAULT);
             } else {
                 ref_id = matvar->internal->id;
                 H5Iinc_ref(ref_id);
             }
             if ( 0 < matvar->internal->hdf5_ref ) {
-                dset_id = H5RDEREFERENCE(ref_id,H5R_OBJECT,&matvar->internal->hdf5_ref);
+                dset_id = H5RDEREFERENCE(ref_id, H5R_OBJECT, &matvar->internal->hdf5_ref);
             } else {
                 dset_id = ref_id;
                 H5Iinc_ref(dset_id);
@@ -14254,17 +14516,16 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
                 matvar->data = ComplexMalloc(matvar->nbytes);
             }
             if ( NULL != matvar->data ) {
-                Mat_H5ReadData(dset_id, ClassType2H5T(matvar->class_type),
-                    H5S_ALL, H5S_ALL, matvar->isComplex, matvar->data);
+                err = Mat_H5ReadData(dset_id, ClassType2H5T(matvar->class_type), H5S_ALL, H5S_ALL,
+                                     matvar->isComplex, matvar->data);
             }
             H5Dclose(dset_id);
             H5Dclose(ref_id);
             break;
         }
-        case MAT_C_CHAR:
-        {
+        case MAT_C_CHAR: {
             size_t nelems = 1;
-            matvar->data_size = Mat_SizeOf(matvar->data_type);
+            matvar->data_size = (int)Mat_SizeOf(matvar->data_type);
             err = Mat_MulDims(matvar, &nelems);
             if ( err ) {
                 Mat_Critical("Integer multiplication overflow");
@@ -14277,7 +14538,7 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
             }
 
             if ( NULL != matvar->internal->hdf5_name ) {
-                dset_id = H5Dopen(fid,matvar->internal->hdf5_name,H5P_DEFAULT);
+                dset_id = H5Dopen(fid, matvar->internal->hdf5_name, H5P_DEFAULT);
             } else {
                 dset_id = matvar->internal->id;
                 H5Iinc_ref(dset_id);
@@ -14285,15 +14546,19 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
             if ( matvar->nbytes > 0 ) {
                 matvar->data = malloc(matvar->nbytes);
                 if ( NULL != matvar->data ) {
-                    H5Dread(dset_id,DataType2H5T(matvar->data_type),
-                            H5S_ALL,H5S_ALL,H5P_DEFAULT,matvar->data);
+                    herr_t herr = H5Dread(dset_id, DataType2H5T(matvar->data_type), H5S_ALL,
+                                          H5S_ALL, H5P_DEFAULT, matvar->data);
+                    if ( herr < 0 ) {
+                        err = MATIO_E_GENERIC_READ_ERROR;
+                    }
+                } else {
+                    err = MATIO_E_OUT_OF_MEMORY;
                 }
             }
             H5Dclose(dset_id);
             break;
         }
-        case MAT_C_STRUCT:
-        {
+        case MAT_C_STRUCT: {
             matvar_t **fields;
             size_t i, nelems_x_nfields, nelems = 1;
 
@@ -14311,23 +14576,22 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
                 return err;
             }
 
-            fields = (matvar_t**)matvar->data;
+            fields = (matvar_t **)matvar->data;
             for ( i = 0; i < nelems_x_nfields; i++ ) {
-                if ( NULL != fields[i] &&
-                      0 < fields[i]->internal->hdf5_ref &&
+                if ( NULL != fields[i] && 0 < fields[i]->internal->hdf5_ref &&
                      -1 < fields[i]->internal->id ) {
                     /* Dataset of references */
-                    Mat_H5ReadNextReferenceData(fields[i]->internal->id,fields[i],mat);
+                    err = Mat_H5ReadNextReferenceData(fields[i]->internal->id, fields[i], mat);
                 } else {
-                    err = Mat_VarRead73(mat,fields[i]);
-                    if ( err )
-                        break;
+                    err = Mat_VarRead73(mat, fields[i]);
+                }
+                if ( err ) {
+                    break;
                 }
             }
             break;
         }
-        case MAT_C_CELL:
-        {
+        case MAT_C_CELL: {
             matvar_t **cells;
             size_t i, nelems;
 
@@ -14337,37 +14601,38 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
                 break;
             }
             nelems = matvar->nbytes / matvar->data_size;
-            cells  = (matvar_t**)matvar->data;
+            cells = (matvar_t **)matvar->data;
             for ( i = 0; i < nelems; i++ ) {
                 if ( NULL != cells[i] ) {
-                    Mat_H5ReadNextReferenceData(cells[i]->internal->id,cells[i],mat);
+                    err = Mat_H5ReadNextReferenceData(cells[i]->internal->id, cells[i], mat);
+                }
+                if ( err ) {
+                    break;
                 }
             }
             break;
         }
-        case MAT_C_SPARSE:
-        {
+        case MAT_C_SPARSE: {
             hid_t sparse_dset_id;
-            mat_sparse_t *sparse_data = (mat_sparse_t *)calloc(1,
-                sizeof(*sparse_data));
+            mat_sparse_t *sparse_data = (mat_sparse_t *)calloc(1, sizeof(*sparse_data));
 
             if ( NULL != matvar->internal->hdf5_name ) {
-                dset_id = H5Gopen(fid,matvar->internal->hdf5_name,H5P_DEFAULT);
+                dset_id = H5Gopen(fid, matvar->internal->hdf5_name, H5P_DEFAULT);
             } else {
                 dset_id = matvar->internal->id;
                 H5Iinc_ref(dset_id);
             }
 
-            if ( H5Lexists(dset_id,"ir",H5P_DEFAULT) ) {
+            if ( H5Lexists(dset_id, "ir", H5P_DEFAULT) ) {
                 size_t *dims;
                 hsize_t nelems;
                 int rank;
 
-                sparse_dset_id = H5Dopen(dset_id,"ir",H5P_DEFAULT);
+                sparse_dset_id = H5Dopen(dset_id, "ir", H5P_DEFAULT);
                 dims = Mat_H5ReadDims(sparse_dset_id, &nelems, &rank);
                 if ( NULL != dims ) {
                     size_t nbytes;
-                    sparse_data->nir = dims[0];
+                    sparse_data->nir = (mat_uint32_t)dims[0];
                     free(dims);
                     err = Mul(&nbytes, sparse_data->nir, sizeof(mat_uint32_t));
                     if ( err ) {
@@ -14377,23 +14642,37 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
                         Mat_Critical("Integer multiplication overflow");
                         return err;
                     }
-                    sparse_data->ir = (mat_uint32_t*)malloc(nbytes);
-                    H5Dread(sparse_dset_id,H5T_NATIVE_UINT,
-                            H5S_ALL,H5S_ALL,H5P_DEFAULT,sparse_data->ir);
+                    sparse_data->ir = (mat_uint32_t *)malloc(nbytes);
+                    if ( sparse_data->ir != NULL ) {
+                        herr_t herr = H5Dread(sparse_dset_id, H5T_NATIVE_UINT, H5S_ALL, H5S_ALL,
+                                              H5P_DEFAULT, sparse_data->ir);
+                        if ( herr < 0 ) {
+                            err = MATIO_E_GENERIC_READ_ERROR;
+                        }
+                    } else {
+                        err = MATIO_E_OUT_OF_MEMORY;
+                    }
+                } else {
+                    err = MATIO_E_UNKNOWN_ERROR;
                 }
                 H5Dclose(sparse_dset_id);
+                if ( err ) {
+                    H5Gclose(dset_id);
+                    free(sparse_data);
+                    return err;
+                }
             }
 
-            if ( H5Lexists(dset_id,"jc",H5P_DEFAULT) ) {
+            if ( H5Lexists(dset_id, "jc", H5P_DEFAULT) ) {
                 size_t *dims;
                 hsize_t nelems;
                 int rank;
 
-                sparse_dset_id = H5Dopen(dset_id,"jc",H5P_DEFAULT);
+                sparse_dset_id = H5Dopen(dset_id, "jc", H5P_DEFAULT);
                 dims = Mat_H5ReadDims(sparse_dset_id, &nelems, &rank);
                 if ( NULL != dims ) {
                     size_t nbytes;
-                    sparse_data->njc = dims[0];
+                    sparse_data->njc = (mat_uint32_t)dims[0];
                     free(dims);
                     err = Mul(&nbytes, sparse_data->njc, sizeof(mat_uint32_t));
                     if ( err ) {
@@ -14403,24 +14682,38 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
                         Mat_Critical("Integer multiplication overflow");
                         return err;
                     }
-                    sparse_data->jc = (mat_uint32_t*)malloc(nbytes);
-                    H5Dread(sparse_dset_id,H5T_NATIVE_UINT,
-                            H5S_ALL,H5S_ALL,H5P_DEFAULT,sparse_data->jc);
+                    sparse_data->jc = (mat_uint32_t *)malloc(nbytes);
+                    if ( sparse_data->jc != NULL ) {
+                        herr_t herr = H5Dread(sparse_dset_id, H5T_NATIVE_UINT, H5S_ALL, H5S_ALL,
+                                              H5P_DEFAULT, sparse_data->jc);
+                        if ( herr < 0 ) {
+                            err = MATIO_E_GENERIC_READ_ERROR;
+                        }
+                    } else {
+                        err = MATIO_E_OUT_OF_MEMORY;
+                    }
+                } else {
+                    err = MATIO_E_UNKNOWN_ERROR;
                 }
                 H5Dclose(sparse_dset_id);
+                if ( err ) {
+                    H5Gclose(dset_id);
+                    free(sparse_data);
+                    return err;
+                }
             }
 
-            if ( H5Lexists(dset_id,"data",H5P_DEFAULT) ) {
+            if ( H5Lexists(dset_id, "data", H5P_DEFAULT) ) {
                 size_t *dims;
                 hsize_t nelems;
                 int rank;
 
-                sparse_dset_id = H5Dopen(dset_id,"data",H5P_DEFAULT);
+                sparse_dset_id = H5Dopen(dset_id, "data", H5P_DEFAULT);
                 dims = Mat_H5ReadDims(sparse_dset_id, &nelems, &rank);
                 if ( NULL != dims ) {
                     size_t ndata_bytes;
-                    sparse_data->nzmax = dims[0];
-                    sparse_data->ndata = dims[0];
+                    sparse_data->nzmax = (mat_uint32_t)dims[0];
+                    sparse_data->ndata = (mat_uint32_t)dims[0];
                     free(dims);
                     err = Mul(&ndata_bytes, sparse_data->nzmax, Mat_SizeOf(matvar->data_type));
                     if ( err ) {
@@ -14431,15 +14724,18 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
                         return err;
                     }
                     matvar->data_size = sizeof(mat_sparse_t);
-                    matvar->nbytes    = matvar->data_size;
+                    matvar->nbytes = matvar->data_size;
                     if ( !matvar->isComplex ) {
                         sparse_data->data = malloc(ndata_bytes);
                     } else {
                         sparse_data->data = ComplexMalloc(ndata_bytes);
                     }
                     if ( NULL != sparse_data->data ) {
-                        Mat_H5ReadData(sparse_dset_id, DataType2H5T(matvar->data_type),
-                            H5S_ALL, H5S_ALL, matvar->isComplex, sparse_data->data);
+                        err =
+                            Mat_H5ReadData(sparse_dset_id, DataType2H5T(matvar->data_type), H5S_ALL,
+                                           H5S_ALL, matvar->isComplex, sparse_data->data);
+                    } else {
+                        err = MATIO_E_OUT_OF_MEMORY;
                     }
                 }
                 H5Dclose(sparse_dset_id);
@@ -14475,34 +14771,33 @@ Mat_VarRead73(mat_t *mat,matvar_t *matvar)
  * @endif
  */
 static int
-Mat_VarReadData73(mat_t *mat,matvar_t *matvar,void *data,
-          int *start,int *stride,int *edge)
+Mat_VarReadData73(mat_t *mat, matvar_t *matvar, void *data, int *start, int *stride, int *edge)
 {
     int err = MATIO_E_NO_ERROR, k;
-    hid_t fid,dset_id,ref_id,dset_space,mem_space;
+    hid_t fid, dset_id, ref_id, dset_space, mem_space;
     hsize_t *dset_start_stride_edge;
     hsize_t *dset_start, *dset_stride, *dset_edge;
 
-    if ( NULL == mat || NULL == matvar || NULL == data || NULL == start ||
-         NULL == stride || NULL == edge )
-         return MATIO_E_BAD_ARGUMENT;
+    if ( NULL == mat || NULL == matvar || NULL == data || NULL == start || NULL == stride ||
+         NULL == edge )
+        return MATIO_E_BAD_ARGUMENT;
     else if ( NULL == matvar->internal->hdf5_name && 0 > matvar->internal->id )
         return MATIO_E_FAIL_TO_IDENTIFY;
 
-    fid = *(hid_t*)mat->fp;
+    fid = *(hid_t *)mat->fp;
 
-    dset_start_stride_edge = (hsize_t*)malloc(matvar->rank*3*sizeof(hsize_t));
+    dset_start_stride_edge = (hsize_t *)malloc(matvar->rank * 3 * sizeof(hsize_t));
     if ( NULL == dset_start_stride_edge ) {
         return MATIO_E_OUT_OF_MEMORY;
     }
-    dset_start  = &dset_start_stride_edge[0];
+    dset_start = &dset_start_stride_edge[0];
     dset_stride = &dset_start_stride_edge[matvar->rank];
-    dset_edge   = &dset_start_stride_edge[2*matvar->rank];
+    dset_edge = &dset_start_stride_edge[2 * matvar->rank];
 
     for ( k = 0; k < matvar->rank; k++ ) {
-        dset_start[k]  = start[matvar->rank-k-1];
-        dset_stride[k] = stride[matvar->rank-k-1];
-        dset_edge[k]   = edge[matvar->rank-k-1];
+        dset_start[k] = start[matvar->rank - k - 1];
+        dset_stride[k] = stride[matvar->rank - k - 1];
+        dset_edge[k] = edge[matvar->rank - k - 1];
     }
     mem_space = H5Screate_simple(matvar->rank, dset_edge, NULL);
 
@@ -14518,23 +14813,23 @@ Mat_VarReadData73(mat_t *mat,matvar_t *matvar,void *data,
         case MAT_C_INT8:
         case MAT_C_UINT8:
             if ( NULL != matvar->internal->hdf5_name ) {
-                ref_id = H5Dopen(fid,matvar->internal->hdf5_name,H5P_DEFAULT);
+                ref_id = H5Dopen(fid, matvar->internal->hdf5_name, H5P_DEFAULT);
             } else {
                 ref_id = matvar->internal->id;
                 H5Iinc_ref(ref_id);
             }
             if ( 0 < matvar->internal->hdf5_ref ) {
-                dset_id = H5RDEREFERENCE(ref_id,H5R_OBJECT,&matvar->internal->hdf5_ref);
+                dset_id = H5RDEREFERENCE(ref_id, H5R_OBJECT, &matvar->internal->hdf5_ref);
             } else {
                 dset_id = ref_id;
                 H5Iinc_ref(dset_id);
             }
 
             dset_space = H5Dget_space(dset_id);
-            H5Sselect_hyperslab(dset_space, H5S_SELECT_SET, dset_start,
-                                dset_stride, dset_edge, NULL);
-            Mat_H5ReadData(dset_id, ClassType2H5T(matvar->class_type), mem_space,
-                dset_space, matvar->isComplex, data);
+            H5Sselect_hyperslab(dset_space, H5S_SELECT_SET, dset_start, dset_stride, dset_edge,
+                                NULL);
+            err = Mat_H5ReadData(dset_id, ClassType2H5T(matvar->class_type), mem_space, dset_space,
+                                 matvar->isComplex, data);
             H5Sclose(dset_space);
             H5Dclose(dset_id);
             H5Dclose(ref_id);
@@ -14566,11 +14861,10 @@ Mat_VarReadData73(mat_t *mat,matvar_t *matvar,void *data,
  * @endif
  */
 static int
-Mat_VarReadDataLinear73(mat_t *mat,matvar_t *matvar,void *data,
-    int start,int stride,int edge)
+Mat_VarReadDataLinear73(mat_t *mat, matvar_t *matvar, void *data, int start, int stride, int edge)
 {
     int err = MATIO_E_NO_ERROR, k;
-    hid_t fid,dset_id,dset_space,mem_space;
+    hid_t fid, dset_id, dset_space, mem_space;
     hsize_t *points, dset_edge, *dimp;
 
     if ( NULL == mat || NULL == matvar || NULL == data )
@@ -14578,7 +14872,7 @@ Mat_VarReadDataLinear73(mat_t *mat,matvar_t *matvar,void *data,
     else if ( NULL == matvar->internal->hdf5_name && 0 > matvar->internal->id )
         return MATIO_E_FAIL_TO_IDENTIFY;
 
-    fid = *(hid_t*)mat->fp;
+    fid = *(hid_t *)mat->fp;
 
     dset_edge = edge;
     mem_space = H5Screate_simple(1, &dset_edge, NULL);
@@ -14594,12 +14888,12 @@ Mat_VarReadDataLinear73(mat_t *mat,matvar_t *matvar,void *data,
         case MAT_C_UINT16:
         case MAT_C_INT8:
         case MAT_C_UINT8:
-            points = (hsize_t*)malloc(matvar->rank*(size_t)dset_edge*sizeof(*points));
+            points = (hsize_t *)malloc(matvar->rank * (size_t)dset_edge * sizeof(*points));
             if ( NULL == points ) {
                 err = MATIO_E_OUT_OF_MEMORY;
                 break;
             }
-            dimp = (hsize_t*)malloc(matvar->rank*sizeof(hsize_t));
+            dimp = (hsize_t *)malloc(matvar->rank * sizeof(hsize_t));
             if ( NULL == dimp ) {
                 err = MATIO_E_OUT_OF_MEMORY;
                 free(points);
@@ -14607,29 +14901,29 @@ Mat_VarReadDataLinear73(mat_t *mat,matvar_t *matvar,void *data,
             }
             dimp[0] = 1;
             for ( k = 1; k < matvar->rank; k++ )
-                dimp[k] = dimp[k-1]*matvar->dims[k-1];
+                dimp[k] = dimp[k - 1] * matvar->dims[k - 1];
             for ( k = 0; k < edge; k++ ) {
                 size_t l, coord;
-                coord = (size_t)(start + k*stride);
+                coord = (size_t)(start + k * stride);
                 for ( l = matvar->rank; l--; ) {
                     size_t idx = (size_t)(coord / dimp[l]);
-                    points[matvar->rank*(k+1)-1-l] = idx;
-                    coord -= idx*(size_t)dimp[l];
+                    points[matvar->rank * (k + 1) - 1 - l] = idx;
+                    coord -= idx * (size_t)dimp[l];
                 }
             }
             free(dimp);
 
             if ( NULL != matvar->internal->hdf5_name ) {
-                dset_id = H5Dopen(fid,matvar->internal->hdf5_name,H5P_DEFAULT);
+                dset_id = H5Dopen(fid, matvar->internal->hdf5_name, H5P_DEFAULT);
             } else {
                 dset_id = matvar->internal->id;
                 H5Iinc_ref(dset_id);
             }
             dset_space = H5Dget_space(dset_id);
-            H5Sselect_elements(dset_space,H5S_SELECT_SET,(size_t)dset_edge,points);
+            H5Sselect_elements(dset_space, H5S_SELECT_SET, (size_t)dset_edge, points);
             free(points);
-            Mat_H5ReadData(dset_id, ClassType2H5T(matvar->class_type), mem_space,
-                dset_space, matvar->isComplex, data);
+            err = Mat_H5ReadData(dset_id, ClassType2H5T(matvar->class_type), mem_space, dset_space,
+                                 matvar->isComplex, data);
             H5Sclose(dset_space);
             H5Dclose(dset_id);
             break;
@@ -14651,11 +14945,11 @@ Mat_VarReadDataLinear73(mat_t *mat,matvar_t *matvar,void *data,
  * @endif
  */
 static matvar_t *
-Mat_VarReadNextInfo73( mat_t *mat )
+Mat_VarReadNextInfo73(mat_t *mat)
 {
-    hid_t   id;
+    hid_t id;
     hsize_t idx;
-    herr_t  herr;
+    herr_t herr;
     struct ReadNextIterData mat_data;
 
     if ( mat == NULL )
@@ -14664,11 +14958,12 @@ Mat_VarReadNextInfo73( mat_t *mat )
     if ( mat->next_index >= mat->num_datasets )
         return NULL;
 
-    id = *(hid_t*)mat->fp;
+    id = *(hid_t *)mat->fp;
     idx = (hsize_t)mat->next_index;
     mat_data.mat = mat;
     mat_data.matvar = NULL;
-    herr = H5Literate(id, H5_INDEX_NAME, H5_ITER_NATIVE, &idx, Mat_VarReadNextInfoIterate, (void*)&mat_data);
+    herr = H5Literate(id, H5_INDEX_NAME, H5_ITER_NATIVE, &idx, Mat_VarReadNextInfoIterate,
+                      (void *)&mat_data);
     if ( herr > 0 )
         mat->next_index = (size_t)idx;
     return mat_data.matvar;
@@ -14678,7 +14973,6 @@ static herr_t
 Mat_VarReadNextInfoIterate(hid_t id, const char *name, const H5L_info_t *info, void *op_data)
 {
     mat_t *mat;
-    matvar_t *matvar;
     H5O_INFO_T object_info;
     struct ReadNextIterData *mat_data;
 
@@ -14688,6 +14982,7 @@ Mat_VarReadNextInfoIterate(hid_t id, const char *name, const H5L_info_t *info, v
     if ( 0 == strcmp(name, "#refs#") || 0 == strcmp(name, "#subsystem#") )
         return 0;
 
+    object_info.type = H5O_TYPE_UNKNOWN;
     H5OGET_INFO_BY_NAME(id, name, &object_info, H5P_DEFAULT);
     if ( H5O_TYPE_DATASET != object_info.type && H5O_TYPE_GROUP != object_info.type )
         return 0;
@@ -14697,35 +14992,53 @@ Mat_VarReadNextInfoIterate(hid_t id, const char *name, const H5L_info_t *info, v
         return -1;
     mat = mat_data->mat;
 
-    matvar = Mat_VarCalloc();
-    if ( NULL == matvar )
-        return -1;
-
-    matvar->name = Mat_strdup(name);
-    if ( NULL == matvar->name ) {
-        Mat_VarFree(matvar);
-        return -1;
-    }
-
     switch ( object_info.type ) {
-        case H5O_TYPE_DATASET:
-        {
-            hid_t dset_id = H5Dopen(id,matvar->name,H5P_DEFAULT);
+        case H5O_TYPE_DATASET: {
+            int err;
+            hid_t dset_id;
+            matvar_t *matvar = Mat_VarCalloc();
+            if ( NULL == matvar )
+                return -1;
 
-            Mat_H5ReadDatasetInfo(mat,matvar,dset_id);
+            matvar->name = Mat_strdup(name);
+            if ( NULL == matvar->name ) {
+                Mat_VarFree(matvar);
+                return -1;
+            }
+
+            dset_id = H5Dopen(id, name, H5P_DEFAULT);
+            err = Mat_H5ReadDatasetInfo(mat, matvar, dset_id);
             if ( matvar->internal->id != dset_id ) {
                 /* Close dataset and increment count */
                 H5Dclose(dset_id);
             }
+            if ( err ) {
+                Mat_VarFree(matvar);
+                return -1;
+            }
             mat_data->matvar = matvar;
             break;
         }
-        case H5O_TYPE_GROUP:
-        {
-            hid_t dset_id = H5Gopen(id,matvar->name,H5P_DEFAULT);
+        case H5O_TYPE_GROUP: {
+            int err;
+            hid_t dset_id;
+            matvar_t *matvar = Mat_VarCalloc();
+            if ( NULL == matvar )
+                return -1;
 
-            Mat_H5ReadGroupInfo(mat,matvar,dset_id);
+            matvar->name = Mat_strdup(name);
+            if ( NULL == matvar->name ) {
+                Mat_VarFree(matvar);
+                return -1;
+            }
+
+            dset_id = H5Gopen(id, name, H5P_DEFAULT);
+            err = Mat_H5ReadGroupInfo(mat, matvar, dset_id);
             H5Gclose(dset_id);
+            if ( err ) {
+                Mat_VarFree(matvar);
+                return -1;
+            }
             mat_data->matvar = matvar;
             break;
         }
@@ -14748,7 +15061,7 @@ Mat_VarReadNextInfoIterate(hid_t id, const char *name, const H5L_info_t *info, v
  * @endif
  */
 static int
-Mat_VarWrite73(mat_t *mat,matvar_t *matvar,int compress)
+Mat_VarWrite73(mat_t *mat, matvar_t *matvar, int compress)
 {
     hid_t id;
 
@@ -14757,8 +15070,8 @@ Mat_VarWrite73(mat_t *mat,matvar_t *matvar,int compress)
 
     matvar->compression = (enum matio_compression)compress;
 
-    id = *(hid_t*)mat->fp;
-    return Mat_VarWriteNext73(id,matvar,matvar->name,&(mat->refs_id));
+    id = *(hid_t *)mat->fp;
+    return Mat_VarWriteNext73(id, matvar, matvar->name, &(mat->refs_id));
 }
 
 /** @if mat_devman
@@ -14775,7 +15088,7 @@ Mat_VarWrite73(mat_t *mat,matvar_t *matvar,int compress)
  * @endif
  */
 static int
-Mat_VarWriteAppend73(mat_t *mat,matvar_t *matvar,int compress,int dim)
+Mat_VarWriteAppend73(mat_t *mat, matvar_t *matvar, int compress, int dim)
 {
     hid_t id;
 
@@ -14784,8 +15097,8 @@ Mat_VarWriteAppend73(mat_t *mat,matvar_t *matvar,int compress,int dim)
 
     matvar->compression = (enum matio_compression)compress;
 
-    id = *(hid_t*)mat->fp;
-    return Mat_VarWriteAppendNext73(id,matvar,matvar->name,&(mat->refs_id),dim);
+    id = *(hid_t *)mat->fp;
+    return Mat_VarWriteAppendNext73(id, matvar, matvar->name, &(mat->refs_id), dim);
 }
 
 #endif
@@ -14805,7 +15118,7 @@ Mat_VarWriteAppend73(mat_t *mat,matvar_t *matvar,int compress,int dim)
  * @return Pointer to the Cell Array Field on success, NULL on error
  */
 matvar_t *
-Mat_VarGetCell(matvar_t *matvar,int index)
+Mat_VarGetCell(matvar_t *matvar, int index)
 {
     size_t nelems = 1;
     matvar_t *cell = NULL;
@@ -14844,10 +15157,20 @@ Mat_VarGetCell(matvar_t *matvar,int index)
  * @returns an array of pointers to the cells
  */
 matvar_t **
-Mat_VarGetCells(matvar_t *matvar,int *start,int *stride,int *edge)
+Mat_VarGetCells(matvar_t *matvar, int *start, int *stride, int *edge)
 {
     int i, j, N, I;
-    size_t idx[10] = {0,}, cnt[10] = {0,}, dimp[10] = {0,};
+    size_t idx[10] =
+        {
+            0,
+        },
+           cnt[10] =
+               {
+                   0,
+               },
+           dimp[10] = {
+               0,
+           };
     matvar_t **cells;
 
     if ( matvar == NULL || start == NULL || stride == NULL || edge == NULL ) {
@@ -14861,15 +15184,15 @@ Mat_VarGetCells(matvar_t *matvar,int *start,int *stride,int *edge)
     I = start[0];
     idx[0] = start[0];
     for ( i = 1; i < matvar->rank; i++ ) {
-        idx[i]  = start[i];
-        dimp[i] = dimp[i-1]*matvar->dims[i];
+        idx[i] = start[i];
+        dimp[i] = dimp[i - 1] * matvar->dims[i];
         N *= edge[i];
-        I += start[i]*dimp[i-1];
+        I += start[i] * dimp[i - 1];
     }
-    cells = (matvar_t**)malloc(N*sizeof(matvar_t *));
-    for ( i = 0; i < N; i+=edge[0] ) {
+    cells = (matvar_t **)malloc(N * sizeof(matvar_t *));
+    for ( i = 0; i < N; i += edge[0] ) {
         for ( j = 0; j < edge[0]; j++ ) {
-            cells[i+j] = *((matvar_t **)matvar->data + I);
+            cells[i + j] = *((matvar_t **)matvar->data + I);
             I += stride[0];
         }
         idx[0] = start[0];
@@ -14881,11 +15204,11 @@ Mat_VarGetCells(matvar_t *matvar,int *start,int *stride,int *edge)
                 cnt[j] = 0;
                 idx[j] = start[j];
                 if ( j < matvar->rank - 1 ) {
-                    cnt[j+1]++;
-                    idx[j+1] += stride[j+1];
+                    cnt[j + 1]++;
+                    idx[j + 1] += stride[j + 1];
                 }
             }
-            I += idx[j]*dimp[j-1];
+            I += idx[j] * dimp[j - 1];
         }
     }
     return cells;
@@ -14906,13 +15229,13 @@ Mat_VarGetCells(matvar_t *matvar,int *start,int *stride,int *edge)
  * @returns an array of pointers to the cells
  */
 matvar_t **
-Mat_VarGetCellsLinear(matvar_t *matvar,int start,int stride,int edge)
+Mat_VarGetCellsLinear(matvar_t *matvar, int start, int stride, int edge)
 {
     matvar_t **cells = NULL;
 
     if ( matvar != NULL ) {
         int i, I;
-        cells = (matvar_t**)malloc(edge*sizeof(matvar_t *));
+        cells = (matvar_t **)malloc(edge * sizeof(matvar_t *));
         I = start;
         for ( i = 0; i < edge; i++ ) {
             cells[i] = *((matvar_t **)matvar->data + I);
@@ -14933,7 +15256,7 @@ Mat_VarGetCellsLinear(matvar_t *matvar,int start,int stride,int edge)
 *          previous cell element or error.
  */
 matvar_t *
-Mat_VarSetCell(matvar_t *matvar,int index,matvar_t *cell)
+Mat_VarSetCell(matvar_t *matvar, int index, matvar_t *cell)
 {
     size_t nelems = 1;
     matvar_t **cells, *old_cell = NULL;
@@ -14946,7 +15269,7 @@ Mat_VarSetCell(matvar_t *matvar,int index,matvar_t *cell)
     if ( err )
         return NULL;
 
-    cells = (matvar_t**)matvar->data;
+    cells = (matvar_t **)matvar->data;
     if ( 0 <= index && (size_t)index < nelems ) {
         old_cell = cells[index];
         cells[index] = cell;
@@ -14971,8 +15294,7 @@ Mat_VarSetCell(matvar_t *matvar,int index,matvar_t *cell)
  * @return Pointer to the new structure MATLAB variable on success, NULL on error
  */
 matvar_t *
-Mat_VarCreateStruct(const char *name,int rank,size_t *dims,const char **fields,
-    unsigned nfields)
+Mat_VarCreateStruct(const char *name, int rank, size_t *dims, const char **fields, unsigned nfields)
 {
     size_t nelems = 1;
     int j;
@@ -14989,20 +15311,20 @@ Mat_VarCreateStruct(const char *name,int rank,size_t *dims,const char **fields,
     if ( NULL != name )
         matvar->name = Mat_strdup(name);
     matvar->rank = rank;
-    matvar->dims = (size_t*)malloc(matvar->rank*sizeof(*matvar->dims));
+    matvar->dims = (size_t *)malloc(matvar->rank * sizeof(*matvar->dims));
     for ( j = 0; j < matvar->rank; j++ ) {
         matvar->dims[j] = dims[j];
         nelems *= dims[j];
     }
     matvar->class_type = MAT_C_STRUCT;
-    matvar->data_type  = MAT_T_STRUCT;
+    matvar->data_type = MAT_T_STRUCT;
 
     matvar->data_size = sizeof(matvar_t *);
 
     if ( nfields ) {
         matvar->internal->num_fields = nfields;
         matvar->internal->fieldnames =
-            (char**)malloc(nfields*sizeof(*matvar->internal->fieldnames));
+            (char **)malloc(nfields * sizeof(*matvar->internal->fieldnames));
         if ( NULL == matvar->internal->fieldnames ) {
             Mat_VarFree(matvar);
             matvar = NULL;
@@ -15044,13 +15366,13 @@ Mat_VarCreateStruct(const char *name,int rank,size_t *dims,const char **fields,
  * @retval 0 on success
  */
 int
-Mat_VarAddStructField(matvar_t *matvar,const char *fieldname)
+Mat_VarAddStructField(matvar_t *matvar, const char *fieldname)
 {
     int err;
     int cnt = 0;
     size_t i, nfields, nelems = 1;
     matvar_t **new_data, **old_data;
-    char     **fieldnames;
+    char **fieldnames;
 
     if ( matvar == NULL || fieldname == NULL )
         return -1;
@@ -15061,12 +15383,12 @@ Mat_VarAddStructField(matvar_t *matvar,const char *fieldname)
 
     matvar->internal->num_fields++;
     nfields = matvar->internal->num_fields;
-    fieldnames = (char**)realloc(matvar->internal->fieldnames,
-        nfields*sizeof(*matvar->internal->fieldnames));
+    fieldnames = (char **)realloc(matvar->internal->fieldnames,
+                                  nfields * sizeof(*matvar->internal->fieldnames));
     if ( NULL == fieldnames )
         return -1;
     matvar->internal->fieldnames = fieldnames;
-    matvar->internal->fieldnames[nfields-1] = Mat_strdup(fieldname);
+    matvar->internal->fieldnames[nfields - 1] = Mat_strdup(fieldname);
 
     {
         size_t nelems_x_nfields;
@@ -15077,17 +15399,17 @@ Mat_VarAddStructField(matvar_t *matvar,const char *fieldname)
             return -1;
         }
     }
-    new_data = (matvar_t**)malloc(matvar->nbytes);
+    new_data = (matvar_t **)malloc(matvar->nbytes);
     if ( new_data == NULL ) {
         matvar->nbytes = 0;
         return -1;
     }
 
-    old_data = (matvar_t**)matvar->data;
+    old_data = (matvar_t **)matvar->data;
     for ( i = 0; i < nelems; i++ ) {
         size_t f;
-        for ( f = 0; f < nfields-1; f++ )
-            new_data[cnt++] = old_data[i*(nfields-1)+f];
+        for ( f = 0; f < nfields - 1; f++ )
+            new_data[cnt++] = old_data[i * (nfields - 1) + f];
         new_data[cnt++] = NULL;
     }
 
@@ -15108,8 +15430,7 @@ unsigned
 Mat_VarGetNumberOfFields(matvar_t *matvar)
 {
     int nfields;
-    if ( matvar == NULL || matvar->class_type != MAT_C_STRUCT   ||
-        NULL == matvar->internal ) {
+    if ( matvar == NULL || matvar->class_type != MAT_C_STRUCT || NULL == matvar->internal ) {
         nfields = 0;
     } else {
         nfields = matvar->internal->num_fields;
@@ -15125,11 +15446,10 @@ Mat_VarGetNumberOfFields(matvar_t *matvar)
  * @param matvar Structure matlab variable
  * @returns Array of fieldnames
  */
-char * const *
+char *const *
 Mat_VarGetStructFieldnames(const matvar_t *matvar)
 {
-    if ( matvar == NULL || matvar->class_type != MAT_C_STRUCT   ||
-        NULL == matvar->internal ) {
+    if ( matvar == NULL || matvar->class_type != MAT_C_STRUCT || NULL == matvar->internal ) {
         return NULL;
     } else {
         return matvar->internal->fieldnames;
@@ -15146,14 +15466,13 @@ Mat_VarGetStructFieldnames(const matvar_t *matvar)
  * @return Pointer to the structure field on success, NULL on error
  */
 matvar_t *
-Mat_VarGetStructFieldByIndex(matvar_t *matvar,size_t field_index,size_t index)
+Mat_VarGetStructFieldByIndex(matvar_t *matvar, size_t field_index, size_t index)
 {
     int err;
     matvar_t *field = NULL;
     size_t nelems = 1, nfields;
 
-    if ( matvar == NULL || matvar->class_type != MAT_C_STRUCT ||
-        matvar->data_size == 0 )
+    if ( matvar == NULL || matvar->class_type != MAT_C_STRUCT || matvar->data_size == 0 )
         return NULL;
 
     err = Mat_MulDims(matvar, &nelems);
@@ -15168,7 +15487,7 @@ Mat_VarGetStructFieldByIndex(matvar_t *matvar,size_t field_index,size_t index)
         if ( field_index > nfields ) {
             Mat_Critical("Mat_VarGetStructField: field index out of bounds");
         } else {
-            field = *((matvar_t **)matvar->data+index*nfields+field_index);
+            field = *((matvar_t **)matvar->data + index * nfields + field_index);
         }
     }
 
@@ -15185,15 +15504,13 @@ Mat_VarGetStructFieldByIndex(matvar_t *matvar,size_t field_index,size_t index)
  * @return Pointer to the structure field on success, NULL on error
  */
 matvar_t *
-Mat_VarGetStructFieldByName(matvar_t *matvar,const char *field_name,
-                            size_t index)
+Mat_VarGetStructFieldByName(matvar_t *matvar, const char *field_name, size_t index)
 {
     int i, nfields, field_index, err;
     matvar_t *field = NULL;
     size_t nelems = 1;
 
-    if ( matvar == NULL || matvar->class_type != MAT_C_STRUCT   ||
-        matvar->data_size == 0 )
+    if ( matvar == NULL || matvar->class_type != MAT_C_STRUCT || matvar->data_size == 0 )
         return NULL;
 
     err = Mat_MulDims(matvar, &nelems);
@@ -15203,7 +15520,7 @@ Mat_VarGetStructFieldByName(matvar_t *matvar,const char *field_name,
     nfields = matvar->internal->num_fields;
     field_index = -1;
     for ( i = 0; i < nfields; i++ ) {
-        if ( !strcmp(matvar->internal->fieldnames[i],field_name) ) {
+        if ( !strcmp(matvar->internal->fieldnames[i], field_name) ) {
             field_index = i;
             break;
         }
@@ -15212,7 +15529,7 @@ Mat_VarGetStructFieldByName(matvar_t *matvar,const char *field_name,
     if ( index >= nelems ) {
         Mat_Critical("Mat_VarGetStructField: structure index out of bounds");
     } else if ( field_index >= 0 ) {
-        field = *((matvar_t **)matvar->data+index*nfields+field_index);
+        field = *((matvar_t **)matvar->data + index * nfields + field_index);
     }
 
     return field;
@@ -15232,7 +15549,7 @@ Mat_VarGetStructFieldByName(matvar_t *matvar,const char *field_name,
  * @return Pointer to the Structure Field on success, NULL on error
  */
 matvar_t *
-Mat_VarGetStructField(matvar_t *matvar,void *name_or_index,int opt,int index)
+Mat_VarGetStructField(matvar_t *matvar, void *name_or_index, int opt, int index)
 {
     int err, nfields;
     matvar_t *field = NULL;
@@ -15240,7 +15557,7 @@ Mat_VarGetStructField(matvar_t *matvar,void *name_or_index,int opt,int index)
 
     err = Mat_MulDims(matvar, &nelems);
     nfields = matvar->internal->num_fields;
-    if ( index < 0 || (nelems > 0 && (size_t)index >= nelems ))
+    if ( index < 0 || (nelems > 0 && (size_t)index >= nelems) )
         err = 1;
     else if ( nfields < 1 )
         err = 1;
@@ -15248,9 +15565,9 @@ Mat_VarGetStructField(matvar_t *matvar,void *name_or_index,int opt,int index)
     if ( !err && (opt == MAT_BY_INDEX) ) {
         size_t field_index = *(int *)name_or_index;
         if ( field_index > 0 )
-            field = Mat_VarGetStructFieldByIndex(matvar,field_index-1,index);
+            field = Mat_VarGetStructFieldByIndex(matvar, field_index - 1, index);
     } else if ( !err && (opt == MAT_BY_NAME) ) {
-        field = Mat_VarGetStructFieldByName(matvar,(const char*)name_or_index,index);
+        field = Mat_VarGetStructFieldByName(matvar, (const char *)name_or_index, index);
     }
 
     return field;
@@ -15279,10 +15596,20 @@ Mat_VarGetStructField(matvar_t *matvar,void *name_or_index,int opt,int index)
  * @returns A new structure array with fields indexed from @c matvar.
  */
 matvar_t *
-Mat_VarGetStructs(matvar_t *matvar,int *start,int *stride,int *edge,
-    int copy_fields)
+Mat_VarGetStructs(matvar_t *matvar, int *start, int *stride, int *edge, int copy_fields)
 {
-    size_t i,N,I,nfields,field,idx[10] = {0,},cnt[10] = {0,},dimp[10] = {0,};
+    size_t i, N, I, nfields, field,
+        idx[10] =
+            {
+                0,
+            },
+        cnt[10] =
+            {
+                0,
+            },
+        dimp[10] = {
+            0,
+        };
     matvar_t **fields, *struct_slab;
     int j;
 
@@ -15294,7 +15621,7 @@ Mat_VarGetStructs(matvar_t *matvar,int *start,int *stride,int *edge,
         return NULL;
     }
 
-    struct_slab = Mat_VarDuplicate(matvar,0);
+    struct_slab = Mat_VarDuplicate(matvar, 0);
     if ( !copy_fields )
         struct_slab->mem_conserve = 1;
 
@@ -15306,32 +15633,31 @@ Mat_VarGetStructs(matvar_t *matvar,int *start,int *stride,int *edge,
     struct_slab->dims[0] = edge[0];
     idx[0] = start[0];
     for ( j = 1; j < matvar->rank; j++ ) {
-        idx[j]  = start[j];
-        dimp[j] = dimp[j-1]*matvar->dims[j];
+        idx[j] = start[j];
+        dimp[j] = dimp[j - 1] * matvar->dims[j];
         N *= edge[j];
-        I += start[j]*dimp[j-1];
+        I += start[j] * dimp[j - 1];
         struct_slab->dims[j] = edge[j];
     }
     I *= nfields;
-    struct_slab->nbytes = N*nfields*sizeof(matvar_t *);
+    struct_slab->nbytes = N * nfields * sizeof(matvar_t *);
     struct_slab->data = malloc(struct_slab->nbytes);
     if ( struct_slab->data == NULL ) {
         Mat_VarFree(struct_slab);
         return NULL;
     }
-    fields = (matvar_t**)struct_slab->data;
-    for ( i = 0; i < N; i+=edge[0] ) {
+    fields = (matvar_t **)struct_slab->data;
+    for ( i = 0; i < N; i += edge[0] ) {
         for ( j = 0; j < edge[0]; j++ ) {
             for ( field = 0; field < nfields; field++ ) {
                 if ( copy_fields )
-                    fields[(i+j)*nfields+field] =
-                         Mat_VarDuplicate(*((matvar_t **)matvar->data + I),1);
+                    fields[(i + j) * nfields + field] =
+                        Mat_VarDuplicate(*((matvar_t **)matvar->data + I), 1);
                 else
-                    fields[(i+j)*nfields+field] =
-                        *((matvar_t **)matvar->data + I);
+                    fields[(i + j) * nfields + field] = *((matvar_t **)matvar->data + I);
                 I++;
             }
-            I += (stride[0]-1)*nfields;
+            I += (stride[0] - 1) * nfields;
         }
         idx[0] = start[0];
         I = idx[0];
@@ -15342,11 +15668,11 @@ Mat_VarGetStructs(matvar_t *matvar,int *start,int *stride,int *edge,
                 cnt[j] = 0;
                 idx[j] = start[j];
                 if ( j < matvar->rank - 1 ) {
-                    cnt[j+1]++;
-                    idx[j+1] += stride[j+1];
+                    cnt[j + 1]++;
+                    idx[j + 1] += stride[j + 1];
                 }
             }
-            I += idx[j]*dimp[j-1];
+            I += idx[j] * dimp[j - 1];
         }
         I *= nfields;
     }
@@ -15371,24 +15697,23 @@ Mat_VarGetStructs(matvar_t *matvar,int *start,int *stride,int *edge,
  * @returns A new structure with fields indexed from matvar
  */
 matvar_t *
-Mat_VarGetStructsLinear(matvar_t *matvar,int start,int stride,int edge,
-    int copy_fields)
+Mat_VarGetStructsLinear(matvar_t *matvar, int start, int stride, int edge, int copy_fields)
 {
     matvar_t *struct_slab;
 
     if ( matvar == NULL || matvar->rank > 10 ) {
-       struct_slab = NULL;
+        struct_slab = NULL;
     } else {
         int i, I, field, nfields;
         matvar_t **fields;
 
-        struct_slab = Mat_VarDuplicate(matvar,0);
+        struct_slab = Mat_VarDuplicate(matvar, 0);
         if ( !copy_fields )
             struct_slab->mem_conserve = 1;
 
         nfields = matvar->internal->num_fields;
 
-        struct_slab->nbytes = (size_t)edge*nfields*sizeof(matvar_t *);
+        struct_slab->nbytes = (size_t)edge * nfields * sizeof(matvar_t *);
         struct_slab->data = malloc(struct_slab->nbytes);
         if ( struct_slab->data == NULL ) {
             Mat_VarFree(struct_slab);
@@ -15396,22 +15721,22 @@ Mat_VarGetStructsLinear(matvar_t *matvar,int start,int stride,int edge,
         }
         struct_slab->dims[0] = edge;
         struct_slab->dims[1] = 1;
-        fields = (matvar_t**)struct_slab->data;
-        I = start*nfields;
+        fields = (matvar_t **)struct_slab->data;
+        I = start * nfields;
         for ( i = 0; i < edge; i++ ) {
             if ( copy_fields ) {
                 for ( field = 0; field < nfields; field++ ) {
-                    fields[i*nfields+field] =
-                        Mat_VarDuplicate(*((matvar_t **)matvar->data+I),1);
+                    fields[i * nfields + field] =
+                        Mat_VarDuplicate(*((matvar_t **)matvar->data + I), 1);
                     I++;
                 }
             } else {
                 for ( field = 0; field < nfields; field++ ) {
-                    fields[i*nfields+field] = *((matvar_t **)matvar->data + I);
+                    fields[i * nfields + field] = *((matvar_t **)matvar->data + I);
                     I++;
                 }
             }
-            I += (stride-1)*nfields;
+            I += (stride - 1) * nfields;
         }
     }
     return struct_slab;
@@ -15430,15 +15755,13 @@ Mat_VarGetStructsLinear(matvar_t *matvar,int start,int stride,int edge,
  * @return Pointer to the previous field (NULL if no previous field)
  */
 matvar_t *
-Mat_VarSetStructFieldByIndex(matvar_t *matvar,size_t field_index,size_t index,
-    matvar_t *field)
+Mat_VarSetStructFieldByIndex(matvar_t *matvar, size_t field_index, size_t index, matvar_t *field)
 {
     int err;
     matvar_t *old_field = NULL;
     size_t nelems = 1, nfields;
 
-    if ( matvar == NULL || matvar->class_type != MAT_C_STRUCT ||
-        matvar->data == NULL )
+    if ( matvar == NULL || matvar->class_type != MAT_C_STRUCT || matvar->data == NULL )
         return NULL;
 
     err = Mat_MulDims(matvar, &nelems);
@@ -15448,9 +15771,9 @@ Mat_VarSetStructFieldByIndex(matvar_t *matvar,size_t field_index,size_t index,
     nfields = matvar->internal->num_fields;
 
     if ( index < nelems && field_index < nfields ) {
-        matvar_t **fields = (matvar_t**)matvar->data;
-        old_field = fields[index*nfields+field_index];
-        fields[index*nfields+field_index] = field;
+        matvar_t **fields = (matvar_t **)matvar->data;
+        old_field = fields[index * nfields + field_index];
+        fields[index * nfields + field_index] = field;
         if ( NULL != field->name ) {
             free(field->name);
         }
@@ -15472,15 +15795,13 @@ Mat_VarSetStructFieldByIndex(matvar_t *matvar,size_t field_index,size_t index,
  * @return Pointer to the previous field (NULL if no previous field)
  */
 matvar_t *
-Mat_VarSetStructFieldByName(matvar_t *matvar,const char *field_name,
-    size_t index,matvar_t *field)
+Mat_VarSetStructFieldByName(matvar_t *matvar, const char *field_name, size_t index, matvar_t *field)
 {
     int err, i, nfields, field_index;
     matvar_t *old_field = NULL;
     size_t nelems = 1;
 
-    if ( matvar == NULL || matvar->class_type != MAT_C_STRUCT ||
-         matvar->data == NULL )
+    if ( matvar == NULL || matvar->class_type != MAT_C_STRUCT || matvar->data == NULL )
         return NULL;
 
     err = Mat_MulDims(matvar, &nelems);
@@ -15490,16 +15811,16 @@ Mat_VarSetStructFieldByName(matvar_t *matvar,const char *field_name,
     nfields = matvar->internal->num_fields;
     field_index = -1;
     for ( i = 0; i < nfields; i++ ) {
-        if ( !strcmp(matvar->internal->fieldnames[i],field_name) ) {
+        if ( !strcmp(matvar->internal->fieldnames[i], field_name) ) {
             field_index = i;
             break;
         }
     }
 
     if ( index < nelems && field_index >= 0 ) {
-        matvar_t **fields = (matvar_t**)matvar->data;
-        old_field = fields[index*nfields+field_index];
-        fields[index*nfields+field_index] = field;
+        matvar_t **fields = (matvar_t **)matvar->data;
+        old_field = fields[index * nfields + field_index];
+        fields[index * nfields + field_index] = field;
         if ( NULL != field->name ) {
             free(field->name);
         }

--- a/Modelica/Resources/C-Sources/ModelicaMatIO.h
+++ b/Modelica/Resources/C-Sources/ModelicaMatIO.h
@@ -1,6 +1,6 @@
 /* ModelicaMatIO.h - MAT file I/O functions header
 
-   Copyright (C) 2013-2020, Modelica Association and contributors
+   Copyright (C) 2013-2021, Modelica Association and contributors
    Copyright (C) 2005-2013, Christopher C. Hulbert
    All rights reserved.
 
@@ -54,13 +54,13 @@
 #define MATIO_MINOR_VERSION 5
 
 /* Matio release level number */
-#define MATIO_RELEASE_LEVEL 19
+#define MATIO_RELEASE_LEVEL 21
 
 /* Matio version number */
-#define MATIO_VERSION 1519
+#define MATIO_VERSION 1521
 
 /* Matio version string */
-#define MATIO_VERSION_STR "1.5.19"
+#define MATIO_VERSION_STR "1.5.21"
 
 /* Default file format */
 #define MAT_FT_DEFAULT MAT_FT_MAT5
@@ -182,9 +182,10 @@ typedef uint8_t mat_uint8_t;
  * @ingroup MAT
  * MAT file access types
  */
-enum mat_acc {
-    MAT_ACC_RDONLY = 0,  /**< @brief Read only file access                */
-    MAT_ACC_RDWR   = 1   /**< @brief Read/Write file access               */
+enum mat_acc
+{
+    MAT_ACC_RDONLY = 0, /**< @brief Read only file access                */
+    MAT_ACC_RDWR = 1    /**< @brief Read/Write file access               */
 };
 
 /** @brief MAT file versions
@@ -192,11 +193,12 @@ enum mat_acc {
  * @ingroup MAT
  * MAT file versions
  */
-enum mat_ft {
-    MAT_FT_MAT73  = 0x0200,   /**< @brief Matlab version 7.3 file             */
-    MAT_FT_MAT5   = 0x0100,   /**< @brief Matlab version 5 file               */
-    MAT_FT_MAT4   = 0x0010,   /**< @brief Matlab version 4 file               */
-    MAT_FT_UNDEFINED =   0    /**< @brief Undefined version                   */
+enum mat_ft
+{
+    MAT_FT_MAT73 = 0x0200, /**< @brief Matlab version 7.3 file             */
+    MAT_FT_MAT5 = 0x0100,  /**< @brief Matlab version 5 file               */
+    MAT_FT_MAT4 = 0x0010,  /**< @brief Matlab version 4 file               */
+    MAT_FT_UNDEFINED = 0   /**< @brief Undefined version                   */
 };
 
 /** @brief Matlab data types
@@ -204,29 +206,30 @@ enum mat_ft {
  * @ingroup MAT
  * Matlab data types
  */
-enum matio_types {
-    MAT_T_UNKNOWN    =  0,    /**< @brief UNKNOWN data type                   */
-    MAT_T_INT8       =  1,    /**< @brief 8-bit signed integer data type      */
-    MAT_T_UINT8      =  2,    /**< @brief 8-bit unsigned integer data type    */
-    MAT_T_INT16      =  3,    /**< @brief 16-bit signed integer data type     */
-    MAT_T_UINT16     =  4,    /**< @brief 16-bit unsigned integer data type   */
-    MAT_T_INT32      =  5,    /**< @brief 32-bit signed integer data type     */
-    MAT_T_UINT32     =  6,    /**< @brief 32-bit unsigned integer data type   */
-    MAT_T_SINGLE     =  7,    /**< @brief IEEE 754 single precision data type */
-    MAT_T_DOUBLE     =  9,    /**< @brief IEEE 754 double precision data type */
-    MAT_T_INT64      = 12,    /**< @brief 64-bit signed integer data type     */
-    MAT_T_UINT64     = 13,    /**< @brief 64-bit unsigned integer data type   */
-    MAT_T_MATRIX     = 14,    /**< @brief matrix data type                    */
-    MAT_T_COMPRESSED = 15,    /**< @brief compressed data type                */
-    MAT_T_UTF8       = 16,    /**< @brief 8-bit Unicode text data type        */
-    MAT_T_UTF16      = 17,    /**< @brief 16-bit Unicode text data type       */
-    MAT_T_UTF32      = 18,    /**< @brief 32-bit Unicode text data type       */
+enum matio_types
+{
+    MAT_T_UNKNOWN = 0,     /**< @brief UNKNOWN data type                   */
+    MAT_T_INT8 = 1,        /**< @brief 8-bit signed integer data type      */
+    MAT_T_UINT8 = 2,       /**< @brief 8-bit unsigned integer data type    */
+    MAT_T_INT16 = 3,       /**< @brief 16-bit signed integer data type     */
+    MAT_T_UINT16 = 4,      /**< @brief 16-bit unsigned integer data type   */
+    MAT_T_INT32 = 5,       /**< @brief 32-bit signed integer data type     */
+    MAT_T_UINT32 = 6,      /**< @brief 32-bit unsigned integer data type   */
+    MAT_T_SINGLE = 7,      /**< @brief IEEE 754 single precision data type */
+    MAT_T_DOUBLE = 9,      /**< @brief IEEE 754 double precision data type */
+    MAT_T_INT64 = 12,      /**< @brief 64-bit signed integer data type     */
+    MAT_T_UINT64 = 13,     /**< @brief 64-bit unsigned integer data type   */
+    MAT_T_MATRIX = 14,     /**< @brief matrix data type                    */
+    MAT_T_COMPRESSED = 15, /**< @brief compressed data type                */
+    MAT_T_UTF8 = 16,       /**< @brief 8-bit Unicode text data type        */
+    MAT_T_UTF16 = 17,      /**< @brief 16-bit Unicode text data type       */
+    MAT_T_UTF32 = 18,      /**< @brief 32-bit Unicode text data type       */
 
-    MAT_T_STRING     = 20,    /**< @brief String data type                    */
-    MAT_T_CELL       = 21,    /**< @brief Cell array data type                */
-    MAT_T_STRUCT     = 22,    /**< @brief Structure data type                 */
-    MAT_T_ARRAY      = 23,    /**< @brief Array data type                     */
-    MAT_T_FUNCTION   = 24     /**< @brief Function data type                  */
+    MAT_T_STRING = 20,  /**< @brief String data type                    */
+    MAT_T_CELL = 21,    /**< @brief Cell array data type                */
+    MAT_T_STRUCT = 22,  /**< @brief Structure data type                 */
+    MAT_T_ARRAY = 23,   /**< @brief Array data type                     */
+    MAT_T_FUNCTION = 24 /**< @brief Function data type                  */
 };
 
 /** @brief Matlab variable classes
@@ -234,25 +237,26 @@ enum matio_types {
  * @ingroup MAT
  * Matlab variable classes
  */
-enum matio_classes {
-    MAT_C_EMPTY    =  0, /**< @brief Empty array                           */
-    MAT_C_CELL     =  1, /**< @brief Matlab cell array class               */
-    MAT_C_STRUCT   =  2, /**< @brief Matlab structure class                */
-    MAT_C_OBJECT   =  3, /**< @brief Matlab object class                   */
-    MAT_C_CHAR     =  4, /**< @brief Matlab character array class          */
-    MAT_C_SPARSE   =  5, /**< @brief Matlab sparse array class             */
-    MAT_C_DOUBLE   =  6, /**< @brief Matlab double-precision class         */
-    MAT_C_SINGLE   =  7, /**< @brief Matlab single-precision class         */
-    MAT_C_INT8     =  8, /**< @brief Matlab signed 8-bit integer class     */
-    MAT_C_UINT8    =  9, /**< @brief Matlab unsigned 8-bit integer class   */
-    MAT_C_INT16    = 10, /**< @brief Matlab signed 16-bit integer class    */
-    MAT_C_UINT16   = 11, /**< @brief Matlab unsigned 16-bit integer class  */
-    MAT_C_INT32    = 12, /**< @brief Matlab signed 32-bit integer class    */
-    MAT_C_UINT32   = 13, /**< @brief Matlab unsigned 32-bit integer class  */
-    MAT_C_INT64    = 14, /**< @brief Matlab signed 64-bit integer class    */
-    MAT_C_UINT64   = 15, /**< @brief Matlab unsigned 64-bit integer class  */
+enum matio_classes
+{
+    MAT_C_EMPTY = 0,     /**< @brief Empty array                           */
+    MAT_C_CELL = 1,      /**< @brief Matlab cell array class               */
+    MAT_C_STRUCT = 2,    /**< @brief Matlab structure class                */
+    MAT_C_OBJECT = 3,    /**< @brief Matlab object class                   */
+    MAT_C_CHAR = 4,      /**< @brief Matlab character array class          */
+    MAT_C_SPARSE = 5,    /**< @brief Matlab sparse array class             */
+    MAT_C_DOUBLE = 6,    /**< @brief Matlab double-precision class         */
+    MAT_C_SINGLE = 7,    /**< @brief Matlab single-precision class         */
+    MAT_C_INT8 = 8,      /**< @brief Matlab signed 8-bit integer class     */
+    MAT_C_UINT8 = 9,     /**< @brief Matlab unsigned 8-bit integer class   */
+    MAT_C_INT16 = 10,    /**< @brief Matlab signed 16-bit integer class    */
+    MAT_C_UINT16 = 11,   /**< @brief Matlab unsigned 16-bit integer class  */
+    MAT_C_INT32 = 12,    /**< @brief Matlab signed 32-bit integer class    */
+    MAT_C_UINT32 = 13,   /**< @brief Matlab unsigned 32-bit integer class  */
+    MAT_C_INT64 = 14,    /**< @brief Matlab signed 64-bit integer class    */
+    MAT_C_UINT64 = 15,   /**< @brief Matlab unsigned 64-bit integer class  */
     MAT_C_FUNCTION = 16, /**< @brief Matlab function class                 */
-    MAT_C_OPAQUE   = 17  /**< @brief Matlab opaque class                   */
+    MAT_C_OPAQUE = 17    /**< @brief Matlab opaque class                   */
 };
 
 /** @brief Matlab array flags
@@ -260,11 +264,12 @@ enum matio_classes {
  * @ingroup MAT
  * Matlab array flags
  */
-enum matio_flags {
-    MAT_F_COMPLEX        = 0x0800, /**< @brief Complex bit flag */
-    MAT_F_GLOBAL         = 0x0400, /**< @brief Global bit flag */
-    MAT_F_LOGICAL        = 0x0200, /**< @brief Logical bit flag */
-    MAT_F_DONT_COPY_DATA = 0x0001  /**< Don't copy data, use keep the pointer */
+enum matio_flags
+{
+    MAT_F_COMPLEX = 0x0800,       /**< @brief Complex bit flag */
+    MAT_F_GLOBAL = 0x0400,        /**< @brief Global bit flag */
+    MAT_F_LOGICAL = 0x0200,       /**< @brief Logical bit flag */
+    MAT_F_DONT_COPY_DATA = 0x0001 /**< Don't copy data, use keep the pointer */
 };
 
 /** @brief MAT file compression options
@@ -272,9 +277,10 @@ enum matio_flags {
  * This option is only used on version 5 MAT files
  * @ingroup MAT
  */
-enum matio_compression {
-    MAT_COMPRESSION_NONE = 0,   /**< @brief No compression */
-    MAT_COMPRESSION_ZLIB = 1    /**< @brief zlib compression */
+enum matio_compression
+{
+    MAT_COMPRESSION_NONE = 0, /**< @brief No compression */
+    MAT_COMPRESSION_ZLIB = 1  /**< @brief zlib compression */
 };
 
 /** @brief matio lookup type
@@ -282,9 +288,10 @@ enum matio_compression {
  * @ingroup MAT
  * matio lookup type
  */
-enum {
-    MAT_BY_NAME  = 1, /**< Lookup by name */
-    MAT_BY_INDEX = 2  /**< Lookup by index */
+enum
+{
+    MAT_BY_NAME = 1, /**< Lookup by name */
+    MAT_BY_INDEX = 2 /**< Lookup by index */
 };
 
 /** @brief Complex data type using split storage
@@ -292,7 +299,8 @@ enum {
  * Complex data type using split real/imaginary pointers
  * @ingroup MAT
  */
-typedef struct mat_complex_split_t {
+typedef struct mat_complex_split_t
+{
     void *Re; /**< Pointer to the real part */
     void *Im; /**< Pointer to the imaginary part */
 } mat_complex_split_t;
@@ -312,21 +320,22 @@ struct matvar_internal;
  * Contains information about a Matlab variable
  * @ingroup MAT
  */
-typedef struct matvar_t {
-    size_t nbytes;                    /**< Number of bytes for the MAT variable */
-    int    rank;                      /**< Rank (Number of dimensions) of the data */
-    enum matio_types   data_type;     /**< Data type (MAT_T_*) */
-    int   data_size;                  /**< Bytes / element for the data */
-    enum matio_classes class_type;    /**< Class type in Matlab (MAT_C_DOUBLE, etc) */
-    int   isComplex;                  /**< non-zero if the data is complex, 0 if real */
-    int   isGlobal;                   /**< non-zero if the variable is global */
-    int   isLogical;                  /**< non-zero if the variable is logical */
-    size_t *dims;                     /**< Array of lengths for each dimension */
-    char *name;                       /**< Name of the variable */
-    void *data;                       /**< Pointer to the data */
-    int   mem_conserve;               /**< 1 if Memory was conserved with data */
-    enum matio_compression  compression; /**< Variable compression type */
-    struct matvar_internal *internal;    /**< matio internal data */
+typedef struct matvar_t
+{
+    size_t nbytes;                      /**< Number of bytes for the MAT variable */
+    int rank;                           /**< Rank (Number of dimensions) of the data */
+    enum matio_types data_type;         /**< Data type (MAT_T_*) */
+    int data_size;                      /**< Bytes / element for the data */
+    enum matio_classes class_type;      /**< Class type in Matlab (MAT_C_DOUBLE, etc) */
+    int isComplex;                      /**< non-zero if the data is complex, 0 if real */
+    int isGlobal;                       /**< non-zero if the variable is global */
+    int isLogical;                      /**< non-zero if the variable is logical */
+    size_t *dims;                       /**< Array of lengths for each dimension */
+    char *name;                         /**< Name of the variable */
+    void *data;                         /**< Pointer to the data */
+    int mem_conserve;                   /**< 1 if Memory was conserved with data */
+    enum matio_compression compression; /**< Variable compression type */
+    struct matvar_internal *internal;   /**< matio internal data */
 } matvar_t;
 
 /** @brief sparse data information
@@ -334,21 +343,21 @@ typedef struct matvar_t {
  * Contains information and data for a sparse matrix
  * @ingroup MAT
  */
-typedef struct mat_sparse_t {
-    mat_uint32_t  nzmax;     /**< Maximum number of non-zero elements */
-    mat_uint32_t *ir;        /**< Array of size nzmax where ir[k] is the row of
+typedef struct mat_sparse_t
+{
+    mat_uint32_t nzmax; /**< Maximum number of non-zero elements */
+    mat_uint32_t *ir;   /**< Array of size nzmax where ir[k] is the row of
                                *  data[k].  0 <= k <= nzmax
                                */
-    mat_uint32_t  nir;       /**< number of elements in ir */
-    mat_uint32_t *jc;        /**< Array size N+1 (N is number of columns) with
+    mat_uint32_t nir;   /**< number of elements in ir */
+    mat_uint32_t *jc;   /**< Array size N+1 (N is number of columns) with
                                *  jc[k] being the index into ir/data of the
                                *  first non-zero element for row k.
                                */
-    mat_uint32_t  njc;       /**< Number of elements in jc */
-    mat_uint32_t  ndata;     /**< Number of complex/real data values */
-    void *data;              /**< Array of data elements */
+    mat_uint32_t njc;   /**< Number of elements in jc */
+    mat_uint32_t ndata; /**< Number of complex/real data values */
+    void *data;         /**< Array of data elements */
 } mat_sparse_t;
-
 
 /** @cond 0 */
 #define MATIO_E_NO_ERROR 0
@@ -375,82 +384,79 @@ typedef struct mat_sparse_t {
 /** @endcond */
 
 /* Library function */
-MATIO_EXTERN void Mat_GetLibraryVersion(int *major,int *minor,int *release);
+MATIO_EXTERN void Mat_GetLibraryVersion(int *major, int *minor, int *release);
 
 /* io.c */
-MATIO_EXTERN void   Mat_Critical(const char *format, ...) MATIO_FORMATATTR_PRINTF1;
-MATIO_EXTERN void   Mat_Warning(const char *format, ...) MATIO_FORMATATTR_PRINTF1;
+MATIO_EXTERN void Mat_Critical(const char *format, ...) MATIO_FORMATATTR_PRINTF1;
+MATIO_EXTERN void Mat_Warning(const char *format, ...) MATIO_FORMATATTR_PRINTF1;
 MATIO_EXTERN size_t Mat_SizeOf(enum matio_types data_type);
 MATIO_EXTERN size_t Mat_SizeOfClass(int class_type);
 
 /* MAT File functions */
-#define                  Mat_Create(a,b) Mat_CreateVer(a,b,MAT_FT_DEFAULT)
-MATIO_EXTERN mat_t      *Mat_CreateVer(const char *matname,const char *hdr_str,
-                             enum mat_ft mat_file_ver);
-MATIO_EXTERN int         Mat_Close(mat_t *mat);
-MATIO_EXTERN mat_t      *Mat_Open(const char *matname,int mode);
+#define Mat_Create(a, b) Mat_CreateVer(a, b, MAT_FT_DEFAULT)
+MATIO_EXTERN mat_t *Mat_CreateVer(const char *matname, const char *hdr_str,
+                                  enum mat_ft mat_file_ver);
+MATIO_EXTERN int Mat_Close(mat_t *mat);
+MATIO_EXTERN mat_t *Mat_Open(const char *matname, int mode);
 MATIO_EXTERN const char *Mat_GetFilename(mat_t *mat);
 MATIO_EXTERN const char *Mat_GetHeader(mat_t *mat);
 MATIO_EXTERN enum mat_ft Mat_GetVersion(mat_t *mat);
-MATIO_EXTERN char      **Mat_GetDir(mat_t *mat, size_t *n);
-MATIO_EXTERN int         Mat_Rewind(mat_t *mat);
+MATIO_EXTERN char **Mat_GetDir(mat_t *mat, size_t *n);
+MATIO_EXTERN int Mat_Rewind(mat_t *mat);
 
 /* MAT variable functions */
-MATIO_EXTERN matvar_t  *Mat_VarCalloc(void);
-MATIO_EXTERN matvar_t  *Mat_VarCreate(const char *name,enum matio_classes class_type,
-                            enum matio_types data_type,int rank,size_t *dims,
-                            void *data,int opt);
-MATIO_EXTERN matvar_t  *Mat_VarCreateStruct(const char *name,int rank,size_t *dims,
-                            const char **fields,unsigned nfields);
-MATIO_EXTERN int        Mat_VarDelete(mat_t *mat, const char *name);
-MATIO_EXTERN matvar_t  *Mat_VarDuplicate(const matvar_t *in, int opt);
-MATIO_EXTERN void       Mat_VarFree(matvar_t *matvar);
-MATIO_EXTERN matvar_t  *Mat_VarGetCell(matvar_t *matvar,int index);
-MATIO_EXTERN matvar_t **Mat_VarGetCells(matvar_t *matvar,int *start,int *stride,
-                            int *edge);
-MATIO_EXTERN matvar_t **Mat_VarGetCellsLinear(matvar_t *matvar,int start,int stride,
-                            int edge);
-MATIO_EXTERN size_t     Mat_VarGetSize(matvar_t *matvar);
-MATIO_EXTERN unsigned   Mat_VarGetNumberOfFields(matvar_t *matvar);
-MATIO_EXTERN int        Mat_VarAddStructField(matvar_t *matvar,const char *fieldname);
-MATIO_EXTERN char * const *Mat_VarGetStructFieldnames(const matvar_t *matvar);
-MATIO_EXTERN matvar_t  *Mat_VarGetStructFieldByIndex(matvar_t *matvar,
-                            size_t field_index,size_t index);
-MATIO_EXTERN matvar_t  *Mat_VarGetStructFieldByName(matvar_t *matvar,
-                            const char *field_name,size_t index);
-MATIO_EXTERN matvar_t  *Mat_VarGetStructField(matvar_t *matvar,void *name_or_index,
-                            int opt,int index);
-MATIO_EXTERN matvar_t  *Mat_VarGetStructs(matvar_t *matvar,int *start,int *stride,
-                            int *edge,int copy_fields);
-MATIO_EXTERN matvar_t  *Mat_VarGetStructsLinear(matvar_t *matvar,int start,int stride,
-                            int edge,int copy_fields);
-MATIO_EXTERN void       Mat_VarPrint(matvar_t *matvar, int printdata);
-MATIO_EXTERN matvar_t  *Mat_VarRead(mat_t *mat, const char *name);
-MATIO_EXTERN int        Mat_VarReadData(mat_t *mat,matvar_t *matvar,void *data,
-                            int *start,int *stride,int *edge);
-MATIO_EXTERN int        Mat_VarReadDataAll(mat_t *mat,matvar_t *matvar);
-MATIO_EXTERN int        Mat_VarReadDataLinear(mat_t *mat,matvar_t *matvar,void *data,
-                            int start,int stride,int edge);
-MATIO_EXTERN matvar_t  *Mat_VarReadInfo(mat_t *mat, const char *name);
-MATIO_EXTERN matvar_t  *Mat_VarReadNext(mat_t *mat);
-MATIO_EXTERN matvar_t  *Mat_VarReadNextInfo(mat_t *mat);
-MATIO_EXTERN matvar_t  *Mat_VarSetCell(matvar_t *matvar,int index,matvar_t *cell);
-MATIO_EXTERN matvar_t  *Mat_VarSetStructFieldByIndex(matvar_t *matvar,
-                            size_t field_index,size_t index,matvar_t *field);
-MATIO_EXTERN matvar_t  *Mat_VarSetStructFieldByName(matvar_t *matvar,
-                            const char *field_name,size_t index,matvar_t *field);
-MATIO_EXTERN int        Mat_VarWrite(mat_t *mat,matvar_t *matvar,
-                            enum matio_compression compress);
-MATIO_EXTERN int        Mat_VarWriteAppend(mat_t *mat,matvar_t *matvar,
-                            enum matio_compression compress,int dim);
-MATIO_EXTERN int        Mat_VarWriteInfo(mat_t *mat,matvar_t *matvar);
-MATIO_EXTERN int        Mat_VarWriteData(mat_t *mat,matvar_t *matvar,void *data,
-                            int *start,int *stride,int *edge);
+MATIO_EXTERN matvar_t *Mat_VarCalloc(void);
+MATIO_EXTERN matvar_t *Mat_VarCreate(const char *name, enum matio_classes class_type,
+                                     enum matio_types data_type, int rank, size_t *dims, void *data,
+                                     int opt);
+MATIO_EXTERN matvar_t *Mat_VarCreateStruct(const char *name, int rank, size_t *dims,
+                                           const char **fields, unsigned nfields);
+MATIO_EXTERN int Mat_VarDelete(mat_t *mat, const char *name);
+MATIO_EXTERN matvar_t *Mat_VarDuplicate(const matvar_t *in, int opt);
+MATIO_EXTERN void Mat_VarFree(matvar_t *matvar);
+MATIO_EXTERN matvar_t *Mat_VarGetCell(matvar_t *matvar, int index);
+MATIO_EXTERN matvar_t **Mat_VarGetCells(matvar_t *matvar, int *start, int *stride, int *edge);
+MATIO_EXTERN matvar_t **Mat_VarGetCellsLinear(matvar_t *matvar, int start, int stride, int edge);
+MATIO_EXTERN size_t Mat_VarGetSize(matvar_t *matvar);
+MATIO_EXTERN unsigned Mat_VarGetNumberOfFields(matvar_t *matvar);
+MATIO_EXTERN int Mat_VarAddStructField(matvar_t *matvar, const char *fieldname);
+MATIO_EXTERN char *const *Mat_VarGetStructFieldnames(const matvar_t *matvar);
+MATIO_EXTERN matvar_t *Mat_VarGetStructFieldByIndex(matvar_t *matvar, size_t field_index,
+                                                    size_t index);
+MATIO_EXTERN matvar_t *Mat_VarGetStructFieldByName(matvar_t *matvar, const char *field_name,
+                                                   size_t index);
+MATIO_EXTERN matvar_t *Mat_VarGetStructField(matvar_t *matvar, void *name_or_index, int opt,
+                                             int index);
+MATIO_EXTERN matvar_t *Mat_VarGetStructs(matvar_t *matvar, int *start, int *stride, int *edge,
+                                         int copy_fields);
+MATIO_EXTERN matvar_t *Mat_VarGetStructsLinear(matvar_t *matvar, int start, int stride, int edge,
+                                               int copy_fields);
+MATIO_EXTERN void Mat_VarPrint(matvar_t *matvar, int printdata);
+MATIO_EXTERN matvar_t *Mat_VarRead(mat_t *mat, const char *name);
+MATIO_EXTERN int Mat_VarReadData(mat_t *mat, matvar_t *matvar, void *data, int *start, int *stride,
+                                 int *edge);
+MATIO_EXTERN int Mat_VarReadDataAll(mat_t *mat, matvar_t *matvar);
+MATIO_EXTERN int Mat_VarReadDataLinear(mat_t *mat, matvar_t *matvar, void *data, int start,
+                                       int stride, int edge);
+MATIO_EXTERN matvar_t *Mat_VarReadInfo(mat_t *mat, const char *name);
+MATIO_EXTERN matvar_t *Mat_VarReadNext(mat_t *mat);
+MATIO_EXTERN matvar_t *Mat_VarReadNextInfo(mat_t *mat);
+MATIO_EXTERN matvar_t *Mat_VarSetCell(matvar_t *matvar, int index, matvar_t *cell);
+MATIO_EXTERN matvar_t *Mat_VarSetStructFieldByIndex(matvar_t *matvar, size_t field_index,
+                                                    size_t index, matvar_t *field);
+MATIO_EXTERN matvar_t *Mat_VarSetStructFieldByName(matvar_t *matvar, const char *field_name,
+                                                   size_t index, matvar_t *field);
+MATIO_EXTERN int Mat_VarWrite(mat_t *mat, matvar_t *matvar, enum matio_compression compress);
+MATIO_EXTERN int Mat_VarWriteAppend(mat_t *mat, matvar_t *matvar, enum matio_compression compress,
+                                    int dim);
+MATIO_EXTERN int Mat_VarWriteInfo(mat_t *mat, matvar_t *matvar);
+MATIO_EXTERN int Mat_VarWriteData(mat_t *mat, matvar_t *matvar, void *data, int *start, int *stride,
+                                  int *edge);
 
 /* Other functions */
-MATIO_EXTERN int     Mat_CalcSingleSubscript(int rank,int *dims,int *subs);
-MATIO_EXTERN int     Mat_CalcSingleSubscript2(int rank,size_t *dims,size_t *subs,size_t *index);
-MATIO_EXTERN int    *Mat_CalcSubscripts(int rank,int *dims,int index);
-MATIO_EXTERN size_t *Mat_CalcSubscripts2(int rank,size_t *dims,size_t index);
+MATIO_EXTERN int Mat_CalcSingleSubscript(int rank, int *dims, int *subs);
+MATIO_EXTERN int Mat_CalcSingleSubscript2(int rank, size_t *dims, size_t *subs, size_t *index);
+MATIO_EXTERN int *Mat_CalcSubscripts(int rank, int *dims, int index);
+MATIO_EXTERN size_t *Mat_CalcSubscripts2(int rank, size_t *dims, size_t index);
 
 #endif /* MODELICAMATIO_H */

--- a/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt
+++ b/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2013-2020, Modelica Association and contributors
+Copyright (C) 2013-2021, Modelica Association and contributors
 Copyright (C) 2005-2013, Christopher C. Hulbert
 All rights reserved.
 


### PR DESCRIPTION
This updates ModelicaMatIO to the latest version 1.5.21 of the underlying matio library.

I can provide the new binaries for testing in a separate commit using a dedicated branch.