### PR TITLE
Rotational coupling

### DIFF
--- a/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Drive.mo
+++ b/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Drive.mo
@@ -119,7 +119,7 @@ equation
   annotation (experiment(StopTime=2.0, Interval=1E-4, Tolerance=1E-6), Documentation(
         info="<html>
 <p>
-This example demonstrate how to use a <a href=\"modelica://Modelica.Mechanics.Rotational.Components.Coupling\">coupling</a> 
+This example demonstrates how to use a <a href=\"modelica://Modelica.Mechanics.Rotational.Components.Coupling\">coupling</a> 
 to implement a drive consisting if two permanent magnet DC machines. 
 Note that <code>dcpm1</code> is turning in positive direction, whereas <code>dcpm2</code> is turning in the opposite direction. 
 Therefore the armature of <code>dcpm2</code> is connected reversed to the source.
@@ -128,7 +128,7 @@ Therefore the armature of <code>dcpm2</code> is connected reversed to the source
 Machine <code>dcpm1</code> starts the drive with a voltage ramp up to half of the no-load speed, the armature of <code>dcpm2</code> is not connected. 
 Since the induced voltage of <code>dcpm2</code> is the same as that of <code>dcdcInverter2</code>, the <code>switch</code> is closed without any transient. 
 After that, the armature voltage of <code>dcpm2</code> is slightly increased, causing <code>dcpm2</code> to drive as motor and <code>dcpm1</code> to brake as generator. 
-Therefore the common speed increases. 
+Therefore the speed <code>coupling.w</code> increases. 
 </p>
 <p>
 Note that in stationary operation the <code>battery</code> only delivers the losses of both machines, since power is exchanged directly between both machines. 

--- a/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Drive.mo
+++ b/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Drive.mo
@@ -122,13 +122,13 @@ equation
 This example demonstrates how to use a <a href=\"modelica://Modelica.Mechanics.Rotational.Components.Coupling\">coupling</a> 
 to implement a drive consisting if two permanent magnet DC machines. 
 Note that <code>dcpm1</code> is turning in positive direction, whereas <code>dcpm2</code> is turning in the opposite direction. 
-Therefore the armature of <code>dcpm2</code> is connected reversed to the source.
+Therefore, the armature of <code>dcpm2</code> is connected reversed to the source.
 </p>
 <p>
 Machine <code>dcpm1</code> starts the drive with a voltage ramp up to half of the no-load speed, the armature of <code>dcpm2</code> is not connected. 
 Since the induced voltage of <code>dcpm2</code> is the same as that of <code>dcdcInverter2</code>, the <code>switch</code> is closed without any transient. 
 After that, the armature voltage of <code>dcpm2</code> is slightly increased, causing <code>dcpm2</code> to drive as motor and <code>dcpm1</code> to brake as generator. 
-Therefore the speed <code>coupling.w</code> increases. 
+Therefore, the speed <code>coupling.w</code> increases. 
 </p>
 <p>
 Note that in stationary operation the <code>battery</code> only delivers the losses of both machines, since power is exchanged directly between both machines. 

--- a/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Drive.mo
+++ b/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Drive.mo
@@ -1,0 +1,141 @@
+within Modelica.Electrical.Machines.Examples.DCMachines;
+model DCPM_Drive
+  "Test example: drive with 2 permanent magnet DC machines"
+  extends Modelica.Icons.Example;
+  parameter Utilities.ParameterRecords.DcPermanentMagnetData dcpmData "DC machine data"
+    annotation (Placement(transformation(extent={{-10,-90},{10,-70}})));
+  Machines.BasicMachines.DCMachines.DC_PermanentMagnet dcpm1(
+    VaNominal=dcpmData.VaNominal,
+    IaNominal=dcpmData.IaNominal,
+    wNominal=dcpmData.wNominal,
+    TaNominal=dcpmData.TaNominal,
+    Ra=dcpmData.Ra,
+    TaRef=dcpmData.TaRef,
+    La=dcpmData.La,
+    Jr=dcpmData.Jr,
+    useSupport=false,
+    Js=dcpmData.Js,
+    frictionParameters=dcpmData.frictionParameters,
+    coreParameters=dcpmData.coreParameters,
+    strayLoadParameters=dcpmData.strayLoadParameters,
+    brushParameters=dcpmData.brushParameters,
+    TaOperational=293.15,
+    alpha20a=dcpmData.alpha20a,
+    phiMechanical(fixed=true),
+    wMechanical(fixed=true),
+    ia(fixed=true))
+    annotation (Placement(transformation(extent={{-50,-70},{-30,-50}})));
+  BasicMachines.DCMachines.DC_PermanentMagnet dcpm2(
+    VaNominal=dcpmData.VaNominal,
+    IaNominal=dcpmData.IaNominal,
+    wNominal=dcpmData.wNominal,
+    TaNominal=dcpmData.TaNominal,
+    Ra=dcpmData.Ra,
+    TaRef=dcpmData.TaRef,
+    La=dcpmData.La,
+    Jr=dcpmData.Jr,
+    useSupport=false,
+    Js=dcpmData.Js,
+    frictionParameters=dcpmData.frictionParameters,
+    coreParameters=dcpmData.coreParameters,
+    strayLoadParameters=dcpmData.strayLoadParameters,
+    brushParameters=dcpmData.brushParameters,
+    TaOperational=293.15,
+    alpha20a=dcpmData.alpha20a,
+    phiMechanical(fixed=false),
+    wMechanical(fixed=false),
+    ia(fixed=true))
+    annotation (Placement(transformation(extent={{50,-70},{30,-50}})));
+  Mechanics.Rotational.Components.Coupling coupling
+    annotation (Placement(transformation(extent={{-10,-70},{10,-50}})));
+  ControlledDCDrives.Utilities.DcdcInverter dcdcInverter1(fS=1000, VMax=
+        dcpmData.VaNominal)
+    annotation (Placement(transformation(extent={{-50,-10},{-30,10}})));
+  ControlledDCDrives.Utilities.DcdcInverter dcdcInverter2(fS=1000, VMax=
+        dcpmData.VaNominal)
+    annotation (Placement(transformation(extent={{30,-10},{50,10}})));
+  Modelica.Blocks.Sources.Ramp ramp1(
+    duration=0.5,
+    height=0.5*dcpmData.VaNominal,
+    offset=0,
+    startTime=0.25)
+    annotation (Placement(transformation(extent={{-90,-10},{-70,10}})));
+  Blocks.Sources.Ramp ramp2(
+    duration=0.5,
+    height=0.1*dcpmData.VaNominal,
+    offset=0.5*dcpmData.VaNominal,
+    startTime=1.25)
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+  Analog.Ideal.IdealClosingSwitch switch annotation (Placement(transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=270,
+        origin={30,-30})));
+  Blocks.Sources.BooleanStep booleanStep(startTime=1)
+    annotation (Placement(transformation(extent={{-10,-40},{10,-20}})));
+  ControlledDCDrives.Utilities.Battery battery(V0=dcpmData.VaNominal, INominal=1000)
+    annotation (Placement(transformation(
+        extent={{10,10},{-10,-10}},
+        rotation=180,
+        origin={0,30})));
+  Analog.Sensors.MultiSensor multiSensor annotation (Placement(transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=90,
+        origin={10,70})));
+equation
+  connect(dcpm1.flange, coupling.flange_a)
+    annotation (Line(points={{-30,-60},{-10,-60}}, color={0,0,0}));
+  connect(dcpm2.flange, coupling.flange_b)
+    annotation (Line(points={{30,-60},{10,-60}}, color={0,0,0}));
+  connect(booleanStep.y, switch.control)
+    annotation (Line(points={{11,-30},{18,-30}}, color={255,0,255}));
+  connect(ramp2.y, dcdcInverter2.vRef)
+    annotation (Line(points={{11,0},{28,0}}, color={0,0,127}));
+  connect(dcdcInverter1.vRef, ramp1.y)
+    annotation (Line(points={{-52,0},{-69,0}}, color={0,0,127}));
+  connect(dcpm1.pin_ap, dcdcInverter1.pin_pMot) annotation (Line(points={{-34,-50},
+          {-30,-50},{-30,-20},{-34,-20},{-34,-10}}, color={0,0,255}));
+  connect(dcdcInverter1.pin_nMot, dcpm1.pin_an) annotation (Line(points={{-46,-10},
+          {-46,-20},{-50,-20},{-50,-50},{-46,-50}}, color={0,0,255}));
+  connect(switch.n, dcpm2.pin_ap)
+    annotation (Line(points={{30,-40},{30,-50},{34,-50}}, color={0,0,255}));
+  connect(switch.p, dcdcInverter2.pin_nMot)
+    annotation (Line(points={{30,-20},{34,-20},{34,-10}}, color={0,0,255}));
+  connect(dcdcInverter2.pin_pMot, dcpm2.pin_an) annotation (Line(points={{46,-10},
+          {46,-20},{50,-20},{50,-50},{46,-50}}, color={0,0,255}));
+  connect(battery.pin_n, dcdcInverter1.pin_nBat) annotation (Line(points={{-6,40},
+          {-10,40},{-10,50},{-46,50},{-46,10}}, color={0,0,255}));
+  connect(multiSensor.nc, dcdcInverter2.pin_pBat) annotation (Line(points={{10,80},
+          {10,90},{46,90},{46,10}}, color={0,0,255}));
+  connect(multiSensor.nc, dcdcInverter1.pin_pBat) annotation (Line(points={{10,80},
+          {10,90},{-34,90},{-34,10}}, color={0,0,255}));
+  connect(multiSensor.pc, multiSensor.pv)
+    annotation (Line(points={{10,60},{20,60},{20,70}}, color={0,0,255}));
+  connect(battery.pin_n, multiSensor.nv) annotation (Line(points={{-6,40},{-10,40},
+          {-10,70},{0,70}}, color={0,0,255}));
+  connect(battery.pin_n, dcdcInverter2.pin_nBat) annotation (Line(points={{-6,40},
+          {-10,40},{-10,50},{34,50},{34,10}}, color={0,0,255}));
+  connect(battery.pin_p, multiSensor.pc)
+    annotation (Line(points={{6,40},{10,40},{10,60}}, color={0,0,255}));
+  annotation (experiment(StopTime=2.0, Interval=1E-4, Tolerance=1E-6), Documentation(
+        info="<html>
+<p>
+This example demonstrate how to use a <a href=\"modelica://Modelica.Mechanics.Rotational.Components.Coupling\">coupling</a> 
+to implement a drive consisting if two permanent magnet DC machines. 
+Note that <code>dcpm1</code> is turning in positive direction, whereas <code>dcpm2</code> is turning in the opposite direction. 
+Therefore the armature of <code>dcpm2</code> is connected reversed to the source.
+</p>
+<p>
+Machine <code>dcpm1</code> starts the drive with a voltage ramp up to half of the no-load speed, the armature of <code>dcpm2</code> is not connected. 
+Since the induced voltage of <code>dcpm2</code> is the same as that of <code>dcdcInverter2</code>, the <code>switch</code> is closed without any transient. 
+After that, the armature voltage of <code>dcpm2</code> is slightly increased, causing <code>dcpm2</code> to drive as motor and <code>dcpm1</code> to brake as generator. 
+Therefore the common speed increases. 
+</p>
+<p>
+Note that in stationary operation the <code>battery</code> only delivers the losses of both machines, since power is exchanged directly between both machines. 
+Only during short time spans with transient operation power is delivered back to the <code>battery</code>, 
+which is the case after accelerating the whole drive when angular velocity settles. 
+An additional energy storage between the battery and the inverters (like a large capacitor or a super capacitor) would help to avoid such situations 
+as well as smoothing current spikes.
+</p>
+</html>"));
+end DCPM_Drive;

--- a/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Drive.mo
+++ b/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Drive.mo
@@ -135,7 +135,7 @@ Note that in stationary operation the <code>battery</code> only delivers the los
 Only during short time spans with transient operation power is delivered back to the <code>battery</code>, 
 which is the case after accelerating the whole drive when angular velocity settles. 
 An additional energy storage between the battery and the inverters (like a large capacitor or a super capacitor) would help to avoid such situations 
-as well as smoothing current spikes.
+and to smooth possible current spikes.
 </p>
 </html>"));
 end DCPM_Drive;

--- a/Modelica/Electrical/Machines/Examples/DCMachines/package.order
+++ b/Modelica/Electrical/Machines/Examples/DCMachines/package.order
@@ -8,3 +8,4 @@ DCPM_Cooling
 DCPM_QuasiStatic
 DCPM_withLosses
 DC_CompareCharacteristics
+DCPM_Drive

--- a/Modelica/Mechanics/Rotational/Components/Coupling.mo
+++ b/Modelica/Mechanics/Rotational/Components/Coupling.mo
@@ -1,0 +1,75 @@
+within Modelica.Mechanics.Rotational.Components;
+model Coupling "Ideal rotational coupling"
+  extends Modelica.Mechanics.Rotational.Interfaces.PartialTwoFlanges;
+  Modelica.Units.SI.AngularVelocity w(displayUnit="rpm") = der(flange_a.phi) "Angular velocity of bith flanges";
+  Modelica.Units.SI.Torque tau = flange_a.tau "Torque driving b from a";
+equation
+  flange_a.phi + flange_b.phi = 0;
+  flange_a.tau - flange_b.tau = 0;
+  annotation (Icon(graphics={
+        Rectangle(
+          lineColor={64,64,64},
+          fillColor={192,192,192},
+          fillPattern=FillPattern.HorizontalCylinder,
+          extent={{-100,-10},{100,10}}),
+        Text(textColor={0,0,255},
+          extent={{-150,80},{150,120}},
+          textString="%name"),
+        Rectangle(
+          lineColor={64,64,64},
+          fillColor={192,192,192},
+          fillPattern=FillPattern.HorizontalCylinder,
+          extent={{-30,-60},{30,60}}),
+        Rectangle(
+          extent={{-10,42},{10,38}},
+          lineColor={0,0,0},
+          fillColor={0,0,0},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-10,22},{10,18}},
+          lineColor={0,0,0},
+          fillColor={0,0,0},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-10,2},{10,-2}},
+          lineColor={0,0,0},
+          fillColor={0,0,0},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-10,-18},{10,-22}},
+          lineColor={0,0,0},
+          fillColor={0,0,0},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-10,-38},{10,-42}},
+          lineColor={0,0,0},
+          fillColor={0,0,0},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-10,60},{10,58}},
+          lineColor={0,0,0},
+          fillColor={0,0,0},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-10,-58},{10,-60}},
+          lineColor={0,0,0},
+          fillColor={0,0,0},
+          fillPattern=FillPattern.Solid),
+        Line(points={{10,58},{10,40},{-10,40},{-10,20},{10,20},{10,-2},{-10,0},{
+              -10,-22},{10,-20},{10,-42},{-10,-40},{-10,-60}}, color={0,0,0})}),
+      Documentation(info="<html>
+<p>
+This is a model of an ideal stiff coupling (face to face), 
+i.e. the angular velocity if flange_b is exactly in opposite direction of flange_a, 
+and the torque of both flanges is identical.
+</p>
+<p>
+The usage is demonstrated in an <a href=\"modelica://Modelica.Electrical.Machines.Examples.DCMachines.DCPM_Drive\">example in Modelica.Electrical.Machines</a>.
+</p>
+<p>
+Variable <code>w</code> shows angular velocity of the connected flanges, 
+whereas <code>tau</code> shows the torque transferred from flange_a to flange_b, 
+i.e. a positive torque means flange_a is driving flange_b. 
+</p>
+</html>"));
+end Coupling;

--- a/Modelica/Mechanics/Rotational/Components/Coupling.mo
+++ b/Modelica/Mechanics/Rotational/Components/Coupling.mo
@@ -68,8 +68,7 @@ The usage is demonstrated in an <a href=\"modelica://Modelica.Electrical.Machine
 </p>
 <p>
 Variable <code>w</code> shows angular velocity of the connected flanges, 
-whereas <code>tau</code> shows the torque transferred from flange_a to flange_b, 
-i.e. a positive torque means flange_a is driving flange_b. 
+whereas <code>tau</code> shows the torque transferred between flange_a and flange_b.
 </p>
 </html>"));
 end Coupling;

--- a/Modelica/Mechanics/Rotational/Components/Coupling.mo
+++ b/Modelica/Mechanics/Rotational/Components/Coupling.mo
@@ -60,7 +60,7 @@ equation
       Documentation(info="<html>
 <p>
 This is a model of an ideal stiff coupling (face to face), 
-i.e. the angular velocity if flange_b is exactly in opposite direction of flange_a, 
+i.e., the angular velocity if <code>flange_b</code> is exactly in opposite direction of <code>flange_a</code>, 
 and the torque of both flanges is identical.
 </p>
 <p>
@@ -68,7 +68,7 @@ The usage is demonstrated in an <a href=\"modelica://Modelica.Electrical.Machine
 </p>
 <p>
 Variable <code>w</code> shows angular velocity of the connected flanges, 
-whereas <code>tau</code> shows the torque transferred between flange_a and flange_b.
+whereas <code>tau</code> shows the torque transferred between <code>flange_a</code> and <code>flange_b</code>.
 </p>
 </html>"));
 end Coupling;

--- a/Modelica/Mechanics/Rotational/Components/Coupling.mo
+++ b/Modelica/Mechanics/Rotational/Components/Coupling.mo
@@ -67,8 +67,8 @@ and the torque of both flanges is identical.
 The usage is demonstrated in an <a href=\"modelica://Modelica.Electrical.Machines.Examples.DCMachines.DCPM_Drive\">example in Modelica.Electrical.Machines</a>.
 </p>
 <p>
-Variable <code>w</code> shows angular velocity of the connected flanges, 
-whereas <code>tau</code> shows the torque transferred between <code>flange_a</code> and <code>flange_b</code>.
+Variable <code>w</code> represents the angular velocity of <code>flange_a</code>
+and <code>tau</code> represents the torque transferred between <code>flange_a</code> and <code>flange_b</code>.
 </p>
 </html>"));
 end Coupling;

--- a/Modelica/Mechanics/Rotational/Components/Coupling.mo
+++ b/Modelica/Mechanics/Rotational/Components/Coupling.mo
@@ -1,8 +1,8 @@
 within Modelica.Mechanics.Rotational.Components;
 model Coupling "Ideal rotational coupling"
   extends Modelica.Mechanics.Rotational.Interfaces.PartialTwoFlanges;
-  Modelica.Units.SI.AngularVelocity w(displayUnit="rpm") = der(flange_a.phi) "Angular velocity of bith flanges";
-  Modelica.Units.SI.Torque tau = flange_a.tau "Torque driving b from a";
+  Modelica.Units.SI.AngularVelocity w(displayUnit="rpm") = der(flange_a.phi) "Angular velocity of flange_a";
+  Modelica.Units.SI.Torque tau = flange_a.tau "Torque of flange_a and flange_b";
 equation
   flange_a.phi + flange_b.phi = 0;
   flange_a.tau - flange_b.tau = 0;

--- a/Modelica/Mechanics/Rotational/Components/package.order
+++ b/Modelica/Mechanics/Rotational/Components/package.order
@@ -1,6 +1,7 @@
 Fixed
 Inertia
 Disc
+Coupling
 Spring
 Damper
 SpringDamper

--- a/Modelica/Resources/Reference/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Drive/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Drive/comparisonSignals.txt
@@ -1,0 +1,5 @@
+time
+coupling.w
+coupling.tau
+multiSensor.v
+multiSensor.i

--- a/ModelicaTest/Resources/Reference/ModelicaTest/Rotational/AllComponents/comparisonSignals.txt
+++ b/ModelicaTest/Resources/Reference/ModelicaTest/Rotational/AllComponents/comparisonSignals.txt
@@ -37,3 +37,5 @@ clutch.startBackward
 clutch.startForward
 gear2_1.lossyGear.mode
 lossyGear.mode
+coupling.w
+coupling.tau

--- a/ModelicaTest/Rotational.mo
+++ b/ModelicaTest/Rotational.mo
@@ -1139,9 +1139,7 @@ they were not deleted yet.")}));
       annotation (Line(points={{-119,-220},{-112,-220}}, color={0,0,127}));
     connect(step.y, torque2.tau)
       annotation (Line(points={{39,-220},{32,-220}}, color={0,0,127}));
-    annotation (experiment(StopTime=0.9), Diagram(coordinateSystem(
-            preserveAspectRatio=true, extent={{-180,-240},{180,160}})),
-      Icon(coordinateSystem(extent={{-100,-100},{100,100}})));
+    annotation (experiment(StopTime=0.9), Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-180,-240},{180,160}})));
   end AllComponents;
 
   model TestBearingConversion

--- a/ModelicaTest/Rotational.mo
+++ b/ModelicaTest/Rotational.mo
@@ -936,7 +936,7 @@ they were not deleted yet.")}));
                                                               J=2,
       phi(fixed=true, start=0),
       w(fixed=true, start=0))                                      annotation (
-        Placement(transformation(extent={{-70,-200},{-50,-180}})));
+        Placement(transformation(extent={{-70,-190},{-50,-170}})));
     Modelica.Mechanics.Rotational.Components.ElastoBacklash2 elastoBacklash2(
       c=1e4,
       d=20,
@@ -944,15 +944,40 @@ they were not deleted yet.")}));
       w_rel(fixed=true),
       b=1.7453292519943e-07,
       stateSelect=StateSelect.always)
-                         annotation (Placement(transformation(extent={{-30,-200},
-              {-10,-180}})));
+                         annotation (Placement(transformation(extent={{-30,-190},{
+              -10,-170}})));
     Modelica.Mechanics.Rotational.Components.Inertia inertia18(
                                                               J=2) annotation (
-        Placement(transformation(extent={{0,-200},{20,-180}})));
+        Placement(transformation(extent={{0,-190},{20,-170}})));
     Modelica.Mechanics.Rotational.Sources.Torque torque1
-      annotation (Placement(transformation(extent={{-96,-200},{-76,-180}})));
+      annotation (Placement(transformation(extent={{-96,-190},{-76,-170}})));
     Modelica.Blocks.Sources.ExpSine expSine(f=2, damping=0.5)
-      annotation (Placement(transformation(extent={{-140,-200},{-120,-180}})));
+      annotation (Placement(transformation(extent={{-140,-190},{-120,-170}})));
+    Modelica.Mechanics.Rotational.Components.Inertia inertia19(
+      J=2,
+      phi(start=0),
+      w(start=0))                                                  annotation (
+        Placement(transformation(extent={{-80,-230},{-60,-210}})));
+    Modelica.Mechanics.Rotational.Components.Inertia inertia20(J=2)
+                                                                   annotation (
+        Placement(transformation(extent={{-20,-230},{0,-210}})));
+    Modelica.Mechanics.Rotational.Sources.Torque torque2
+      annotation (Placement(transformation(extent={{30,-230},{10,-210}})));
+    Modelica.Mechanics.Rotational.Components.Coupling coupling
+      annotation (Placement(transformation(extent={{-50,-230},{-30,-210}})));
+    Modelica.Mechanics.Rotational.Sources.Speed speed2(useSupport=false, exact=true)
+      annotation (Placement(transformation(extent={{-110,-230},{-90,-210}})));
+    Modelica.Blocks.Sources.Ramp ramp(
+      height=100,
+      duration=0.5,
+      offset=0,
+      startTime=0)
+      annotation (Placement(transformation(extent={{-140,-230},{-120,-210}})));
+    Modelica.Blocks.Sources.Step step(
+      height=400,
+      offset=0,
+      startTime=0.75)
+      annotation (Placement(transformation(extent={{60,-230},{40,-210}})));
   equation
     connect(inertia.flange_b, idealGear.flange_a) annotation (Line(
         points={{-60,90},{-50,90}}));
@@ -1095,15 +1120,28 @@ they were not deleted yet.")}));
     connect(inertia16.flange_b, powerSensor.flange_a) annotation (Line(
         points={{-100,-140},{-90,-140}}));
     connect(inertia17.flange_b, elastoBacklash2.flange_a) annotation (Line(
-          points={{-50,-190},{-40,-190},{-30,-190}}));
+          points={{-50,-180},{-30,-180}}));
     connect(elastoBacklash2.flange_b, inertia18.flange_a)
-      annotation (Line(points={{-10,-190},{-5,-190},{0,-190}}));
-    connect(inertia17.flange_a, torque1.flange) annotation (Line(points={{-70,
-            -190},{-74,-190},{-76,-190}}));
-    connect(torque1.tau, expSine.y) annotation (Line(points={{-98,-190},{-108,
-            -190},{-119,-190}}, color={0,0,127}));
+      annotation (Line(points={{-10,-180},{0,-180}}));
+    connect(inertia17.flange_a, torque1.flange) annotation (Line(points={{-70,-180},
+            {-76,-180}}));
+    connect(torque1.tau, expSine.y) annotation (Line(points={{-98,-180},{-119,-180}},
+                                color={0,0,127}));
+    connect(torque2.flange, inertia20.flange_b)
+      annotation (Line(points={{10,-220},{0,-220}}, color={0,0,0}));
+    connect(inertia19.flange_b, coupling.flange_a)
+      annotation (Line(points={{-60,-220},{-50,-220}}, color={0,0,0}));
+    connect(coupling.flange_b, inertia20.flange_a)
+      annotation (Line(points={{-30,-220},{-20,-220}}, color={0,0,0}));
+    connect(speed2.flange, inertia19.flange_a)
+      annotation (Line(points={{-90,-220},{-80,-220}}, color={0,0,0}));
+    connect(ramp.y, speed2.w_ref)
+      annotation (Line(points={{-119,-220},{-112,-220}}, color={0,0,127}));
+    connect(step.y, torque2.tau)
+      annotation (Line(points={{39,-220},{32,-220}}, color={0,0,127}));
     annotation (experiment(StopTime=0.9), Diagram(coordinateSystem(
-            preserveAspectRatio=true, extent={{-160,-200},{160,160}})));
+            preserveAspectRatio=true, extent={{-180,-240},{180,160}})),
+      Icon(coordinateSystem(extent={{-100,-100},{100,100}})));
   end AllComponents;
 
   model TestBearingConversion


### PR DESCRIPTION
I just realized that we have no component like an ideal rotational coupling to couple two electrical machines in a realistic way, i.e. when one machine (the devide under test) turns in positive direction and the other one (the dynamometer) has to turn in the opposite direction. To test and demonstrate the usage, I've implemented a nice example (in Electrical.Machines) that shows some other facts about test beds and their power supply that could be usefull for education.