### PR TITLE
Fix C89 compliance

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaInternal.c
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.c
@@ -132,6 +132,10 @@
                      ModelicaInternal_getFullPath
 */
 
+#if defined(__gnu_linux__) && !defined(NO_FILE_SYSTEM)
+#define _GNU_SOURCE 1
+#endif
+
 #include "ModelicaInternal.h"
 #include "ModelicaUtilities.h"
 

--- a/Modelica/Resources/C-Sources/snprintf.c
+++ b/Modelica/Resources/C-Sources/snprintf.c
@@ -522,7 +522,7 @@ static UINTMAX_T cast(LDOUBLE);
 static UINTMAX_T myround(LDOUBLE);
 static LDOUBLE mypow10(int);
 
-//extern int errno;
+/*extern int errno;*/
 
 int
 rpl_vsnprintf(char *str, size_t size, const char *format, va_list args)

--- a/Modelica/Resources/C-Sources/zlib/gzguts.h
+++ b/Modelica/Resources/C-Sources/zlib/gzguts.h
@@ -101,6 +101,9 @@
 #  ifdef __MVS__
 #    define NO_vsnprintf
 #  endif
+#  ifndef STDC99
+#    define NO_vsnprintf
+#  endif
 #endif
 
 /* unlike snprintf (which is required in C99), _snprintf does not guarantee


### PR DESCRIPTION
POSIX is not availabe if C-Sources are compiled with `-ansi` (or `-std=c89`).