### PR TITLE
Turn compiler warning of implicit function declaration to error

### DIFF
--- a/Modelica/Resources/BuildProjects/autotools/configure.ac
+++ b/Modelica/Resources/BuildProjects/autotools/configure.ac
@@ -36,6 +36,7 @@ AC_DEFUN([C_FLAG_CHECK_AND_ADD],
 ])
 
 C_FLAG_CHECK_AND_ADD([-fno-delete-null-pointer-checks])
+C_FLAG_CHECK_AND_ADD([-Werror=implicit-function-declaration])
 
 AC_SEARCH_LIBS([floor],[m])
 


### PR DESCRIPTION
As mentioned by @sjoelund in https://github.com/modelica/ModelicaStandardLibrary/pull/3787#issuecomment-815517629. Implicit function declaration usually indicates a servere build env failure.