### PR TITLE
Fix (all but one) conversion issues reported by Dymola

### DIFF
--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -1761,6 +1761,15 @@ convertElement({"Modelica.Electrical.Machines.BasicMachines.SynchronousInduction
                 "Modelica.Electrical.Machines.BasicMachines.SynchronousInductionMachines.SM_ElectricalExcited",
                 "Modelica.Electrical.Machines.BasicMachines.SynchronousInductionMachines.SM_ReluctanceRotor"},
                 "airGapR", "airGap")
+convertModifiers({"Modelica.Electrical.Spice3.Internal.MOS2"},
+                  {"vp"}, fill("", 0))
+convertModifiers({"Modelica.Fluid.Machines.BaseClasses.PartialPump"},
+                  {"show_NPSHa"}, fill("", 0))
+convertModifiers({"Modelica.Mechanics.MultiBody.Parts.Body"},
+                  {"z_a_start"}, fill("", 0))
+convertModifiers({"Modelica.Magnetic.QuasiStatic.FundamentalWave.Utilities.SwitchYD",
+                  "Modelica.Electrical.Machines.Utilities.SwitchYD"},
+                  {"idealCommutingSwitch"}, fill("", 0))
 
 // New element Modelica.Mechanics.MultiBody.Visualizers.Advanced.Vector
 convertModifiers({"Modelica.Mechanics.MultiBody.Sensors.AbsoluteSensor",


### PR DESCRIPTION
```
Inconsistent conversion script modelica://Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos, for version 3.2.3:
Modelica.Blocks.Types.Init.DoNotUse_InitialIntegratorState Old class missing
Modelica.Electrical.Machines.Utilities.SwitchYD:idealCommutingSwitch Old component is missing, without conversion
Modelica.Electrical.Spice3.Internal.MOS2:vp Old component is missing, without conversion
Modelica.Magnetic.QuasiStatic.FundamentalWave.Utilities.SwitchYD:idealCommutingSwitch Old component is missing, without conversion
Modelica.Mechanics.MultiBody.Parts.Body:z_a_start Old component is missing, without conversion
Modelica.Fluid.Machines.BaseClasses.PartialPump:show_NPSHa Old component is missing, without conversion
```