### PR TITLE
Removing duplicate "and" in doc string

### DIFF
--- a/Modelica/Clocked/BooleanSignals/Sampler/ShiftSample.mo
+++ b/Modelica/Clocked/BooleanSignals/Sampler/ShiftSample.mo
@@ -1,6 +1,6 @@
 within Modelica.Clocked.BooleanSignals.Sampler;
 block ShiftSample
-  "Shift the clocked Boolean input signal by a fraction of the last interval and and provide it as clocked output signal"
+  "Shift the clocked Boolean input signal by a fraction of the last interval and provide it as clocked output signal"
   parameter Integer shiftCounter(min=0)=0 "Numerator of shifting formula"
         annotation(Evaluate=true, Dialog(group="Shift first clock activation for 'shiftCounter/resolution*interval(u)' seconds"));
   parameter Integer resolution(min=1)=1 "Denominator of shifting formula"

--- a/Modelica/Clocked/IntegerSignals/Sampler/ShiftSample.mo
+++ b/Modelica/Clocked/IntegerSignals/Sampler/ShiftSample.mo
@@ -1,6 +1,6 @@
 within Modelica.Clocked.IntegerSignals.Sampler;
 block ShiftSample
-  "Shift the clocked Integer input signal by a fraction of the last interval and and provide it as clocked output signal"
+  "Shift the clocked Integer input signal by a fraction of the last interval and provide it as clocked output signal"
   parameter Integer shiftCounter(min=0)=0 "Numerator of shifting formula"
     annotation(Evaluate=true, Dialog(group="Shift first clock activation for 'shiftCounter/resolution*interval(u)' seconds"));
   parameter Integer resolution(min=1)=1 "Denominator of shifting formula"

--- a/Modelica/Clocked/RealSignals/Sampler/ShiftSample.mo
+++ b/Modelica/Clocked/RealSignals/Sampler/ShiftSample.mo
@@ -1,6 +1,6 @@
 within Modelica.Clocked.RealSignals.Sampler;
 block ShiftSample
-  "Shift the clocked Real input signal by a fraction of the last interval and and provide it as clocked output signal"
+  "Shift the clocked Real input signal by a fraction of the last interval and provide it as clocked output signal"
 
   parameter Integer shiftCounter(min=0)=0 "Numerator of shifting formula"
         annotation(Evaluate=true, Dialog(group="Shift first clock activation for 'shiftCounter/resolution*interval(u)' seconds"));


### PR DESCRIPTION
Correcting typo in description of shiftSample:

- Modelica/Clocked/RealSignals/Sampler/ShiftSample.mo
- Modelica/Clocked/IntegerSignals/Sampler/ShiftSample.mo
- Modelica/Clocked/BooleanSignals/Sampler/ShiftSample.mo