### PR TITLE
State temperatures in PartialHeatTransfer declared as Medium-specific type

### DIFF
--- a/Modelica/Fluid/Interfaces.mo
+++ b/Modelica/Fluid/Interfaces.mo
@@ -473,7 +473,7 @@ end PartialTwoPortTransport;
       annotation (Placement(transformation(extent={{-10,60},{10,80}}), iconTransformation(extent={{-20,60},{20,80}})));
 
     // Variables
-    SI.Temperature[n] Ts = Medium.temperature(states)
+    Medium.Temperature[n] Ts = Medium.temperature(states)
       "Temperatures defined by fluid states";
 
   equation


### PR DESCRIPTION
State temperatures in the Modelica.Fluid.Interfaces.PartialHeatTransfer model are not Medium-specific, causing some tools (notably OpenModelica) to throw warnings concerning nominal and/or initial conditions