### PR TITLE
Missing initialization of Blocks.Math.Mean and derived blocks

### DIFF
--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2218,6 +2218,7 @@ y_im = u_abs * sin( u_arg )
     extends Modelica.Blocks.Interfaces.SISO;
     parameter SI.Frequency f(start=50) "Base frequency";
     parameter Real x0=0 "Start value of integrator state";
+    parameter Real y0=0 "Start value of output";
     parameter Boolean yGreaterOrEqualZero=false
       "= true, if output y is guaranteed to be >= 0 for the exact solution"
       annotation (Evaluate=true, Dialog(tab="Advanced"));
@@ -2228,7 +2229,7 @@ y_im = u_abs * sin( u_arg )
   initial equation
     t0 = time;
     x = x0;
-    y_last = 0;
+    y_last = y0;
   equation
     der(x) = u;
     when sample(t0 + 1/f, 1/f) then
@@ -2267,7 +2268,9 @@ explicitly set to 0.0, if the mean value results in a negative value.
     extends Modelica.Blocks.Interfaces.SISO;
     parameter SI.Frequency f(start=50) "Base frequency";
     parameter Real x0=0 "Start value of integrator state";
-    Mean mean(final f=f, final x0=x0)
+    parameter Real y0(final min=0)=0 "Start value of output";
+    Mean mean(final f=f, final x0=x0,
+      final y0=y0)
       annotation (Placement(transformation(extent={{0,-10},{20,10}})));
     Blocks.Math.Abs abs1
       annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
@@ -2380,10 +2383,12 @@ This block is demonstrated in the examples
     extends Modelica.Blocks.Interfaces.SISO;
     parameter SI.Frequency f(start=50) "Base frequency";
     parameter Real x0=0 "Start value of integrator state";
+    parameter Real y0(final min=0)=0 "Start value of output";
     MultiProduct product(nu=2)
       annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
     Mean mean(
       final f=f,
+      final y0=y0^2,
       final yGreaterOrEqualZero=true,
       final x0=x0)
       annotation (Placement(transformation(extent={{0,-10},{20,10}})));
@@ -2714,6 +2719,9 @@ This block is demonstrated in the examples
       annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
     parameter Real x0Cos=0 "Start value of cos integrator state";
     parameter Real x0Sin=0 "Start value of sin integrator state";
+    parameter Real y0Cos=0 "Start value of cos result";
+    parameter Real y0Sin=0 "Start value of sin result";
+
     Sources.Cosine      sin1(
       final amplitude=sqrt(2),
       final f=k*f,
@@ -2732,9 +2740,11 @@ This block is demonstrated in the examples
       annotation (Placement(transformation(extent={{-60,30},{-40,50}})));
     MultiProduct product2(nu=2)
       annotation (Placement(transformation(extent={{-60,-50},{-40,-30}})));
-    Mean mean1(final f=f, final x0=x0Cos)
+    Mean mean1(final f=f, final x0=x0Cos,
+      final y0=y0Cos)
       annotation (Placement(transformation(extent={{-20,30},{0,50}})));
-    Mean mean2(final f=f, final x0=x0Sin)
+    Mean mean2(final f=f, final x0=x0Sin,
+      final y0=y0Sin)
       annotation (Placement(transformation(extent={{-20,-50},{0,-30}})));
     Blocks.Interfaces.RealInput u
       annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2794,7 +2794,7 @@ Note: The output is updated after each period defined by 1/f.
 <h4>Note:</h4>
 <ul>
 <li>The harmonic is defined by <code>&radic;2 rms cos(k 2 &pi; f t - arg)</code> if useConjugateComplex=false (default)</li>
-<li>The harmonic is defined by <code>&radic;2 rms cos(k 2 &pi; f t + arg)</code> if useConjugateComplex=true<(li>
+<li>The harmonic is defined by <code>&radic;2 rms cos(k 2 &pi; f t + arg)</code> if useConjugateComplex=true</li>
 </ul>
 </html>"), Icon(graphics={
           Text(

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2791,11 +2791,11 @@ This block calculates the root mean square and the phase angle of a single harmo
 <p>
 Note: The output is updated after each period defined by 1/f.
 </p>
-<p>
-Note:<br>
-The harmonic is defined by <code>&radic;2 rms cos(k 2 &pi; f t - arg)</code> if useConjugateComplex=false (default)<br>
-The harmonic is defined by <code>&radic;2 rms cos(k 2 &pi; f t + arg)</code> if useConjugateComplex=true
-</p>
+<h4>Note:</h4>
+<ul>
+<li>The harmonic is defined by <code>&radic;2 rms cos(k 2 &pi; f t - arg)</code> if useConjugateComplex=false (default)</li>
+<li>The harmonic is defined by <code>&radic;2 rms cos(k 2 &pi; f t + arg)</code> if useConjugateComplex=true<(li>
+</ul>
 </html>"), Icon(graphics={
           Text(
             extent={{-80,60},{80,20}},

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2820,8 +2820,10 @@ Note: The output is updated after each period defined by 1/f.
       final f=f,
       final k=1,
       final x0Cos=0,
-      final x0Sin=0) annotation (Placement(transformation(extent={{-70,-62},{-50,-42}})));
-    RootMeanSquare rootMeanSquare(final f=f, final x0=0) annotation (Placement(transformation(extent={{-70,20},{-50,40}})));
+      final x0Sin=0,
+      final y0Cos=0,
+      final y0Sin=0) annotation (Placement(transformation(extent={{-70,-62},{-50,-42}})));
+    RootMeanSquare rootMeanSquare(final f=f, final x0=0, final y0=0) annotation (Placement(transformation(extent={{-70,20},{-50,40}})));
     Logical.GreaterThreshold greaterThreshold annotation (Placement(transformation(extent={{10,-70},{30,-50}})));
     Interfaces.BooleanOutput valid "True, if output y is valid" annotation (Placement(transformation(extent={{100,-70},{120,-50}})));
     Division division annotation (Placement(transformation(extent={{60,-10},{80,10}})));

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1545,18 +1545,18 @@ whereas signalExtrema2 catches the extrema rather good due to the fact that samp
 </tr>
 <tr>
 <td><p>Mean</code></td>
-<td><code>mean.y</span></code></td>
-<td><code>y_mean</span></code></td>
+<td><code>mean.y</code></td>
+<td><code>y_mean</code></td>
 </tr>
 <tr>
 <td><p>Rectfied mean</code></td>
-<td><code>rectifiedMean.y</span></code></td>
-<td><code>y_rect</span></code></td>
+<td><code>rectifiedMean.y</code></td>
+<td><code>y_rect</code></td>
 </tr>
 <tr>
 <td><p>Root mean square</code></td>
-<td><code>rootMeanSquare.y</span></code></td>
-<td><code>y_rms</span></code></td>
+<td><code>rootMeanSquare.y</code></td>
+<td><code>y_rms</code></td>
 </tr>
 <tr>
 <td><p>First harmonic</code></td>

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1,4 +1,4 @@
-within Modelica;
+﻿within Modelica;
 package Blocks "Library of basic input/output control blocks (continuous, discrete, logical, table blocks)"
 
   extends Modelica.Icons.Package;
@@ -1489,6 +1489,66 @@ whereas signalExtrema2 catches the extrema rather good due to the fact that samp
 </p>
 </html>"));
   end DemonstrateSignalExtrema;
+
+  model DemoSignalCharacteristic
+    "Demonstrate characteristic values of a signal"
+    extends Modelica.Icons.Example;
+    import Modelica.Constants.pi;
+    parameter Real app(final min=0)=1 "Peak-to-peak";
+    parameter Real dutyCycle(final min=0, final max=1)=0.5 "Duty cycle";
+    parameter Real offset=0 "Offset";
+    parameter Modelica.Units.SI.Frequency f=50 "Base frequency";
+    //Analytical prediction of results
+    parameter Real y_mean=offset + app*dutyCycle "Mean value";
+    parameter Real y_rect=abs(offset + app)*dutyCycle + abs(offset)*(1 - dutyCycle) "Rectified mean";
+    parameter Real y_rms=sqrt((offset + app)^2*dutyCycle + offset^2*(1 - dutyCycle)) "Root mean square";
+    parameter Real y_cos=((offset + app)*( sin(dutyCycle*2*pi) - sin(0)) + offset*( sin(2*pi) - sin(dutyCycle*2*pi)))/pi/sqrt(2) "1st harmonic - cos";
+    parameter Real y_sin=((offset + app)*(-cos(dutyCycle*2*pi) + cos(0)) + offset*(-cos(2*pi) + cos(dutyCycle*2*pi)))/pi/sqrt(2) "1st harmonic - sin";
+    Sources.Pulse pulse(
+      amplitude=app,
+      width=dutyCycle*100,
+      period=1/f,
+      offset=offset)
+      annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
+    Math.Mean mean(f=f, y0=y_mean)
+      annotation (Placement(transformation(extent={{-10,50},{10,70}})));
+    Math.RectifiedMean rectifiedMean(f=f, y0=y_rect)
+      annotation (Placement(transformation(extent={{-10,10},{10,30}})));
+    Math.RootMeanSquare rootMeanSquare(f=f, y0=y_rms)
+      annotation (Placement(transformation(extent={{-10,-30},{10,-10}})));
+    Math.Harmonic harmonic(f=f, k=1,
+      y0Cos=y_cos,
+      y0Sin=y_sin)
+      annotation (Placement(transformation(extent={{-10,-70},{10,-50}})));
+  equation
+    connect(pulse.y, mean.u) annotation (Line(points={{-39,0},{-20,0},{-20,60},{-12,
+            60}}, color={0,0,127}));
+    connect(pulse.y, rectifiedMean.u) annotation (Line(points={{-39,0},{-20,0},{-20,
+            20},{-12,20}}, color={0,0,127}));
+    connect(pulse.y, rootMeanSquare.u) annotation (Line(points={{-39,0},{-20,0},{-20,
+            -20},{-12,-20}}, color={0,0,127}));
+    connect(pulse.y, harmonic.u) annotation (Line(points={{-39,0},{-20,0},{-20,-60},
+            {-12,-60}}, color={0,0,127}));
+    annotation (experiment(
+        StopTime=0.5,
+        Interval=0.0005,
+        Tolerance=1e-06), Documentation(info="<html>
+<p>This example demonstrate hiw to calculate characteristic values of a signal:</p>
+<ul>
+<li>Mean</li>
+<li>RectfiedMean</li>
+<li>RootMeanSquare<li>
+<li>1stHarmonic</li>
+</ul>
+<p>The output of these blocks is updated after each period of the signal.</p>
+<p>
+Using a simple pulse series, these values can be calculated analytically. 
+Propagating these values as intitial values for the output, 
+we can compare the numerical solution with the analytical solution: 
+The output is constant from the beginning.
+</p>
+</html>"));
+  end DemoSignalCharacteristic;
 
   package Noise "Library of examples to demonstrate the usage of package Blocks.Noise"
     extends Modelica.Icons.ExamplesPackage;

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1,4 +1,4 @@
-﻿within Modelica;
+within Modelica;
 package Blocks "Library of basic input/output control blocks (continuous, discrete, logical, table blocks)"
 
   extends Modelica.Icons.Package;
@@ -1537,7 +1537,7 @@ whereas signalExtrema2 catches the extrema rather good due to the fact that samp
 <ul>
 <li>Mean</li>
 <li>RectfiedMean</li>
-<li>RootMeanSquare<li>
+<li>RootMeanSquare</li>
 <li>1stHarmonic</li>
 </ul>
 <p>The output of these blocks is updated after each period of the signal.</p>

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1561,7 +1561,7 @@ whereas signalExtrema2 catches the extrema rather good due to the fact that samp
 <tr>
 <td><p>First harmonic</code></td>
 <td><code>harmonic.y_rms</code><br><code>harmonic.y_arg</code></td>
-<td><code>y1_abs</code><br><code>y1_arg</code></td>
+<td><code>y1_rms</code><br><code>y1_arg</code></td>
 </tr>
 </table>
 

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1533,7 +1533,7 @@ whereas signalExtrema2 catches the extrema rather good due to the fact that samp
         StopTime=0.5,
         Interval=0.0005,
         Tolerance=1e-06), Documentation(info="<html>
-<p>This example demonstrate hiw to calculate characteristic values of a signal:</p>
+<p>This example demonstrate how to calculate characteristic values of a signal:</p>
 <ul>
 <li>Mean</li>
 <li>RectfiedMean</li>

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1499,6 +1499,7 @@ whereas signalExtrema2 catches the extrema rather good due to the fact that samp
     parameter Real offset=0 "Offset";
     parameter Modelica.Units.SI.Frequency f=50 "Base frequency";
     //Analytical prediction of results
+    Real y = pulse.y "Investigated pulse signal";
     parameter Real y_mean=offset + app*dutyCycle "Mean value";
     parameter Real y_rect=abs(offset + app)*dutyCycle + abs(offset)*(1 - dutyCycle) "Rectified mean";
     parameter Real y_rms=sqrt((offset + app)^2*dutyCycle + offset^2*(1 - dutyCycle)) "Root mean square";

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1494,17 +1494,19 @@ whereas signalExtrema2 catches the extrema rather good due to the fact that samp
     "Demonstrate characteristic values of a signal"
     extends Modelica.Icons.Example;
     import Modelica.Constants.pi;
-    parameter Real app(final min=0)=1 "Peak-to-peak";
-    parameter Real dutyCycle(final min=0, final max=1)=0.5 "Duty cycle";
-    parameter Real offset=0 "Offset";
-    parameter Modelica.Units.SI.Frequency f=50 "Base frequency";
-    //Analytical prediction of results
+    parameter Real app(final min=0)=1 "Peak-to-peak value of pulse signal";
+    parameter Real dutyCycle(final min=0, final max=1)=0.5 "Duty cycle of pulse signal";
+    parameter Real offset=0 "Offset of pulse signal";
+    parameter Modelica.Units.SI.Frequency f=50 "Base frequency of pulse signal";
     Real y = pulse.y "Investigated pulse signal";
+    //Analytical prediction of results
     parameter Real y_mean=offset + app*dutyCycle "Mean value";
     parameter Real y_rect=abs(offset + app)*dutyCycle + abs(offset)*(1 - dutyCycle) "Rectified mean";
     parameter Real y_rms=sqrt((offset + app)^2*dutyCycle + offset^2*(1 - dutyCycle)) "Root mean square";
-    parameter Real y_cos=((offset + app)*( sin(dutyCycle*2*pi) - sin(0)) + offset*( sin(2*pi) - sin(dutyCycle*2*pi)))/pi/sqrt(2) "1st harmonic - cos";
-    parameter Real y_sin=((offset + app)*(-cos(dutyCycle*2*pi) + cos(0)) + offset*(-cos(2*pi) + cos(dutyCycle*2*pi)))/pi/sqrt(2) "1st harmonic - sin";
+    parameter Real y1_cos=((offset + app)*( sin(dutyCycle*2*pi) - sin(0)) + offset*( sin(2*pi) - sin(dutyCycle*2*pi)))/pi/sqrt(2) "First harmonic cosine rms component";
+    parameter Real y1_sin=((offset + app)*(-cos(dutyCycle*2*pi) + cos(0)) + offset*(-cos(2*pi) + cos(dutyCycle*2*pi)))/pi/sqrt(2) "First harmonic sine rms component";
+    parameter Real y1_rms=sqrt(y1_cos^2+y1_sin^2) "RMS value of first harmonic";
+    parameter Real y1_arg=atan2(y1_sin,y1_cos) "Argument of first harmonic";
     Sources.Pulse pulse(
       amplitude=app,
       width=dutyCycle*100,
@@ -1518,8 +1520,8 @@ whereas signalExtrema2 catches the extrema rather good due to the fact that samp
     Math.RootMeanSquare rootMeanSquare(f=f, y0=y_rms)
       annotation (Placement(transformation(extent={{-10,-30},{10,-10}})));
     Math.Harmonic harmonic(f=f, k=1,
-      y0Cos=y_cos,
-      y0Sin=y_sin)
+      y0Cos=y1_cos,
+      y0Sin=y1_sin)
       annotation (Placement(transformation(extent={{-10,-70},{10,-50}})));
   equation
     connect(pulse.y, mean.u) annotation (Line(points={{-39,0},{-20,0},{-20,60},{-12,
@@ -1534,13 +1536,35 @@ whereas signalExtrema2 catches the extrema rather good due to the fact that samp
         StopTime=0.5,
         Interval=0.0005,
         Tolerance=1e-06), Documentation(info="<html>
-<p>This example demonstrate how to calculate characteristic values of a signal:</p>
-<ul>
-<li>Mean</li>
-<li>RectfiedMean</li>
-<li>RootMeanSquare</li>
-<li>1stHarmonic</li>
-</ul>
+<p>This example demonstrates how to calculate characteristic values of the pulse signal <code>y</code></p>
+
+<table cellspacing=\"0\" cellpadding=\"2\" border=\"1\"><tr>
+<td><p>Characteristic quantity</code></td>
+<td><p>Numerically calculated</code></td>
+<td><p>Analytically calculated</code></td>
+</tr>
+<tr>
+<td><p>Mean</code></td>
+<td><code>mean.y</span></code></td>
+<td><code>y_mean</span></code></td>
+</tr>
+<tr>
+<td><p>Rectfied mean</code></td>
+<td><code>rectifiedMean.y</span></code></td>
+<td><code>y_rect</span></code></td>
+</tr>
+<tr>
+<td><p>Root mean square</code></td>
+<td><code>rootMeanSquare.y</span></code></td>
+<td><code>y_rms</span></code></td>
+</tr>
+<tr>
+<td><p>First harmonic</code></td>
+<td><code>harmonic.y_rms</code><br><code>harmonic.y_arg</code></td>
+<td><code>y1_abs</code><br><code>y1_arg</code></td>
+</tr>
+</table>
+
 <p>The output of these blocks is updated after each period of the signal.</p>
 <p>
 Using a simple pulse series, these values can be calculated analytically. 

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1,4 +1,4 @@
-within Modelica;
+﻿within Modelica;
 package Blocks "Library of basic input/output control blocks (continuous, discrete, logical, table blocks)"
 
   extends Modelica.Icons.Package;
@@ -1538,28 +1538,29 @@ whereas signalExtrema2 catches the extrema rather good due to the fact that samp
         Tolerance=1e-06), Documentation(info="<html>
 <p>This example demonstrates how to calculate characteristic values of the pulse signal <code>y</code></p>
 
-<table cellspacing=\"0\" cellpadding=\"2\" border=\"1\"><tr>
-<td><p>Characteristic quantity</code></td>
-<td><p>Numerically calculated</code></td>
-<td><p>Analytically calculated</code></td>
+<table cellspacing=\"0\" cellpadding=\"2\" border=\"1\">
+<tr>
+<td>Characteristic quantity</td>
+<td>Numerically calculated</td>
+<td>Analytically calculated</td>
 </tr>
 <tr>
-<td><p>Mean</code></td>
+<td><code>Mean</code></td>
 <td><code>mean.y</code></td>
 <td><code>y_mean</code></td>
 </tr>
 <tr>
-<td><p>Rectfied mean</code></td>
+<td><code>Rectfied mean</code></td>
 <td><code>rectifiedMean.y</code></td>
 <td><code>y_rect</code></td>
 </tr>
 <tr>
-<td><p>Root mean square</code></td>
+<td><code>Root mean square</code></td>
 <td><code>rootMeanSquare.y</code></td>
 <td><code>y_rms</code></td>
 </tr>
 <tr>
-<td><p>First harmonic</code></td>
+<td><code>First harmonic</code></td>
 <td><code>harmonic.y_rms</code><br><code>harmonic.y_arg</code></td>
 <td><code>y1_rms</code><br><code>y1_arg</code></td>
 </tr>

--- a/Modelica/Resources/Reference/Modelica/Blocks/Examples/DemonstrateSignalCharaceristic/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Blocks/Examples/DemonstrateSignalCharaceristic/comparisonSignals.txt
@@ -1,0 +1,6 @@
+time
+mean.y
+rectifiedMean.y
+rootMeanSquare.y
+harmonic.mean1.y
+harmonic.mean2.y


### PR DESCRIPTION
I just realized that the possibility to initialize the output of Blocks.Math.Mean and derived blocks (RectifiedMean, RootMeanSquare and Harmonic) is missing - so I implemented that in a backwards compatible way and added a demo example.
Consider that Mean is an idealized model of an integrating ADC. Using this block in a control algorithm, it is necessary to intialize the output of this block.