### PR TITLE
M_OLine example

### DIFF
--- a/Modelica/Electrical/Analog/Examples/Lines/PowerLineWithFence.mo
+++ b/Modelica/Electrical/Analog/Examples/Lines/PowerLineWithFence.mo
@@ -1,0 +1,129 @@
+within Modelica.Electrical.Analog.Examples.Lines;
+model PowerLineWithFence
+  extends Modelica.Icons.Example;
+  parameter Real freq = 50;
+  Modelica.Electrical.Analog.Lines.M_OLine line(
+    N=2,  c = Ccomp, g = fill(1e-12, div(g.n * (g.n + 1), 2)), l = Lcomp,
+    length=100e3,  lines = g.n, r = g.R1) annotation (
+    Placement(visible = true, transformation(origin={-28,18},     extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Electrical.Analog.Sources.SineVoltage Ub(
+    V=Ua.V,
+    phase=-2.0943951023932,
+    f=Ua.f) annotation (Placement(visible=true, transformation(
+        origin={-62,18},
+        extent={{10,10},{-10,-10}},
+        rotation=180)));
+  Modelica.Electrical.Analog.Basic.Resistor rgUL(R = 1) annotation (
+    Placement(visible = true, transformation(origin={-86,-32},    extent = {{-8, 8}, {8, -8}}, rotation = 270)));
+  Modelica.Electrical.Analog.Basic.Ground ground annotation (
+    Placement(visible = true, transformation(extent={{-96,-64},{-76,-44}},      rotation = 0)));
+  Modelica.Electrical.Analog.Sources.SineVoltage Uc(
+    V=Ua.V,
+    phase=2.0943951023932,
+    f=Ua.f) annotation (Placement(visible=true, transformation(
+        origin={-62,-2},
+        extent={{10,10},{-10,-10}},
+        rotation=180)));
+  Modelica.Electrical.Analog.Basic.Resistor r1(R=500) annotation (Placement(
+        visible=true, transformation(
+        origin={10,34},
+        extent={{-8,-8},{8,8}},
+        rotation=0)));
+  Modelica.Electrical.Analog.Basic.Resistor r2(R=r1.R) annotation (Placement(
+        visible=true, transformation(
+        origin={10,18},
+        extent={{-8,-8},{8,8}},
+        rotation=0)));
+  Modelica.Electrical.Analog.Basic.Resistor r3(R=r1.R) annotation (Placement(
+        visible=true, transformation(
+        origin={10,-2},
+        extent={{-8,-8},{8,8}},
+        rotation=0)));
+  parameter Test_M_Oline.Functions.LineGeometry g(
+    n=4,
+    x={0,-3.048,3.048,-9.144},
+    y={12.192,12.192,12.192,3.048},
+    r=1e-3/2*{12.7,12.7,12.7,4.064},
+    R1=1e-3*{0.348,0.348,0.348,1.802})
+    annotation (Placement(transformation(extent={{42,6},{62,26}})));
+  Modelica.Electrical.Analog.Sources.SineVoltage Ua(V=345e3*sqrt(2/3), f=60)
+    annotation (Placement(visible=true, transformation(
+        origin={-62,36},
+        extent={{10,10},{-10,-10}},
+        rotation=180)));
+  Modelica.Electrical.Analog.Basic.Resistor body(R=1000) annotation (
+      Placement(visible=true, transformation(
+        origin={-18,-22},
+        extent={{-8,8},{8,-8}},
+        rotation=270)));
+
+  parameter Real Rcomp[div(g.n * (g.n + 1), 2)]( fixed=false) "Compact resistance matrix (ohm/m)";
+  parameter Real Xcomp[div(g.n * (g.n + 1), 2)]( fixed=false) "Compact reactance matrix (ohm/m)";
+  parameter Real Lcomp[div(g.n * (g.n + 1), 2)]( fixed=false) "Compact inductance (H/m)";
+
+protected
+  parameter Real Ccomp[div(g.n * (g.n + 1), 2)] = Test_M_Oline.Functions.M_OLineC(
+                                    n = g.n, x = g.x, y = g.y, r = g.r);
+initial algorithm
+  (Rcomp,Xcomp,Lcomp) := Test_M_Oline.Functions.M_OLineZ(
+      n=g.n,
+      x=g.x,
+      y=g.y,
+      r=g.r,
+      R1=g.R1,
+      rho=100,
+      f=freq);
+equation
+
+  connect(ground.p, rgUL.n) annotation (
+    Line(points={{-86,-44},{-86,-40}},      color = {0, 0, 255}));
+  connect(r1.p, line.n[1])
+    annotation (Line(points={{2,34},{-18,34},{-18,18}}, color={0,0,255}));
+  connect(r2.p, line.n[2])
+    annotation (Line(points={{2,18},{-18,18}}, color={0,0,255}));
+  connect(r1.n, r2.n) annotation (Line(points={{18,34},{22,34},{22,18},{18,18}},
+        color={0,0,255}));
+  connect(r2.n, r3.n) annotation (Line(points={{18,18},{22,18},{22,-2},{18,-2}},
+        color={0,0,255}));
+  connect(r3.p, line.n[3])
+    annotation (Line(points={{2,-2},{-14,-2},{-14,14},{-18,14},{-18,18}},
+                                                        color={0,0,255}));
+  connect(Ua.n, line.p[1])
+    annotation (Line(points={{-52,36},{-38,36},{-38,18}}, color={0,0,255}));
+  connect(Ub.n, line.p[2])
+    annotation (Line(points={{-52,18},{-38,18}}, color={0,0,255}));
+  connect(Uc.n, line.p[3])
+    annotation (Line(points={{-52,-2},{-38,-2},{-38,18}}, color={0,0,255}));
+  connect(Ua.p, rgUL.p)
+    annotation (Line(points={{-72,36},{-86,36},{-86,-24}}, color={0,0,255}));
+  connect(Ub.p, rgUL.p)
+    annotation (Line(points={{-72,18},{-86,18},{-86,-24}}, color={0,0,255}));
+  connect(Uc.p, rgUL.p)
+    annotation (Line(points={{-72,-2},{-86,-2},{-86,-24}}, color={0,0,255}));
+  connect(body.p, line.n[4])
+    annotation (Line(points={{-18,-14},{-18,18}}, color={0,0,255}));
+  connect(body.n, ground.p) annotation (Line(points={{-18,-30},{-18,-44},{-86,
+          -44}}, color={0,0,255}));
+  connect(body.n, r3.n) annotation (Line(points={{-18,-30},{-18,-44},{22,-44},
+          {22,-2},{18,-2}}, color={0,0,255}));
+  annotation (
+    Diagram(coordinateSystem(extent = {{-100, -70}, {80, 70}})),
+    Documentation(info="<html>
+<p>This example shows the usage of M_Line in a overhead PowerLine. The line geometry is the one shown in figure 4.1 of [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>].</p>
+<p>A common rule-of-thumb states that for steady-state analysis at industrial frequency each PI model shold be not longer than one tenth of the wave length. For 50 Hz, the wavelength is 6000 km, therefore each pi should not overcome 60 km. This is why for our 100 km line we have chosen just two trunks. </p>
+<p>The results of this example with two trunks are valid only for their steady-state trend. If we want to simulate transients effectively, the number of trunks must be enlarged consistently. See example &quot;CmpLineTrunks&quot;. Moreover, for production-grade results of PowerLine transients, also the frequency-dependance of Z matrix parameters should be taken into consideration, with is out of scope of M_Oline, however.</p>
+<p>The considered line is a three-phase line with a fence all along the line (conductor #4). </p>
+<p>An interesting result is the fence steady-state due to the capacitive coupling with the other wires.</p>
+<p><u>Test 1:</u></p>
+<p>Simulate the model as it is: a person (body) is supposted to be touching the fence, and absorbs the current body.i, around 1A, by large lethal</p>
+<p><u>Test 2:</u></p>
+<p>Simulate the model changing the body resistance to 1e6 or removing body: the steady-state fence voltage line.n[4] has changed from 1390V to 5930 (peak). So there exists a marked difference between the open-circuit voltage and body voltage which, although being much lower, is still very dangerous.</p>
+<p><u>Test 3:</u></p>
+<p>Simulate the original model reducing changing the line length to 3 km. The body current has fallen slightly below 30 mA (RMS), which is considered the maximum safe current a body can resist over 5s.</p>
+<p>Note that the fence voltage before the human contact is roughtly the same for all lengths while the current flowing when contact occurs is very dependent on the line length. </p>
+</html>"),
+    experiment(
+      StopTime=0.04,
+      Interval=0.0001,
+      __Dymola_Algorithm="Dassl"));
+end PowerLineWithFence;

--- a/Modelica/Electrical/Analog/Examples/Lines/package.mo
+++ b/Modelica/Electrical/Analog/Examples/Lines/package.mo
@@ -1,0 +1,5 @@
+within Modelica.Electrical.Analog.Examples;
+package Lines
+   extends Modelica.Icons.ExamplesPackage;
+
+end Lines;

--- a/Modelica/Electrical/Analog/Examples/Lines/package.order
+++ b/Modelica/Electrical/Analog/Examples/Lines/package.order
@@ -1,0 +1,1 @@
+PowerLineWithFence

--- a/Modelica/Electrical/Analog/Lines/Functions/LineGeometry.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/LineGeometry.mo
@@ -1,0 +1,16 @@
+within Modelica.Electrical.Analog.Lines.Functions;
+record LineGeometry "Contains multi-wire line geometry data"
+  extends Modelica.Icons.Record;
+  parameter Integer n=3 "Number of wires" annotation (Evaluate=true);
+  parameter Real x[:]={-1,0,1} "Horizontal abscissas of conductors (m)";
+  parameter Real y[:]={8,10,8} "Vertical abscissas of conductors (m)";
+  parameter Real r[:]=0.5e-3*{12,12,12} "Conductor radii  (m)";
+  parameter Real R1[:]=1e-6*{177,177,177}
+    "Resistance per length of conductors (ohm/m)";
+  parameter Real k_s=0.75 "ratio of equivalent tubular radius to radius for all conductors";
+  parameter Real rho=100 "earth resistivity";
+  annotation (Documentation(info="<html>
+<p>This record will contain the line geometry and resistances of a multi-conductor line.</p>
+<p>This will be used by functions ComputeZ and ComputeY that will compute longitudinal (flow) and transverse (cross)  line matrices.</p>
+</html>"));
+end LineGeometry;

--- a/Modelica/Electrical/Analog/Lines/Functions/M_OLineC.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/M_OLineC.mo
@@ -1,0 +1,64 @@
+within Modelica.Electrical.Analog.Lines.Functions;
+function M_OLineC
+  "Compute matrix of transverse capacitances per metre of a multi-conductor line"
+  // Function created by Massimo Ceraolo from the University of Pisa on May 2021
+  import Modelica.Constants.*;
+  import Modelica.ComplexMath;
+  import Modelica.Utilities.Streams;
+  input Integer n "number of conductors in bundle";
+  output Real Ccompact[div(n*(n + 1), 2)] "Vector of capacitances (F/m)";
+  input Real x[n] "horizontal abscissas of conductors (m)";
+  input Real y[n] "vertical abscissas of conductors (m)";
+  input Real r[n] "conductors radii (m)";
+  output Real Pself, Pmutual "Transposed line self and mutual impedance";
+protected
+  constant Complex j = Complex(0, 1) "Imaginary unit";
+  constant Real K = 1 / (2 * pi * epsilon_0);
+  Real p[n, n] "Maxwell's potential matrix";
+  Real C[n, n] "Computed matrix (F/m)";
+  Real D "generic larger distance";
+  Real d "generic smaller distance";
+  Integer k;
+algorithm
+  //Diagonal elements of the potential matrix:
+  for i in 1:n loop
+    p[i, i] := K * log(2 * y[i] / r[i]);
+  end for;
+  //Out-of Diagonal elements of the potential matrix:
+  for i in 1:n loop
+    for jj in 1:i - 1 loop
+      d := sqrt((x[i] - x[jj]) ^ 2 + (y[i] - y[jj]) ^ 2);
+      D := sqrt((x[i] - x[jj]) ^ 2 + (y[i] + y[jj]) ^ 2);
+      p[i, jj] := K * log(D / d);
+    end for;
+  end for;
+  for i in 1:n loop
+    for jj in i + 1:n loop
+      p[i, jj] := p[jj, i];
+    end for;
+  end for;
+  //The capacitance function is the inverse of the matrix of potentials
+  C := Modelica.Math.Matrices.inv(p);
+  //Select the elements needed by _Oline in a vetor which it can use directly
+  k := 0;
+  for i in 1:n loop
+    for j in i:n loop
+      k := k + 1;
+      Ccompact[k] := C[i, j];
+    end for;
+  end for;
+
+  if n == 3 then
+    Pself := 1 / 3 * (p[1, 1] + p[2, 2] + p[3, 3]);
+    Pmutual := 1 / 3 * (p[1, 2] + p[2, 3] + p[3, 1]);
+  else
+    Pself := 0;
+    Pmutual := 0;
+  end if;
+  annotation (
+    Documentation(info="<html>
+<p>This function computes Capacitances of multi-conductor transmission lines, according to John Carson&apos;s formulas as reported in [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">Ceraolo2018</a>, Appendix].</p>
+<p>The results obtained with this function have been checked with Fig. 4.1 of [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>], with good compliance.</p>
+<p>The output array contains the elements of the C matrix ordered as described in the M_Oline model, and is used in example Examples.Lines.PowerLineWithFence in conjunction ith M_OLine.</p>
+</html>"));
+end M_OLineC;

--- a/Modelica/Electrical/Analog/Lines/Functions/M_OLineZ.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/M_OLineZ.mo
@@ -1,0 +1,72 @@
+within Modelica.Electrical.Analog.Lines.Functions;
+function M_OLineZ
+  "Compute matrix of longitudinal impedance per metre of a multi-conductor line"
+  import Modelica.Constants.*;
+  import Modelica.ComplexMath;
+  import Modelica.Utilities.Streams;
+  input Integer n "number of conductors in line";
+  input Real x[n] "horizontal abscissas of conductors (m)";
+  input Real y[n] "vertical abscissas of conductors (m)";
+  input Real r[n] "conductors radii (m)";
+  input Real R1[n] "conductors lineic resistance (ohm/m)";
+  input Real k_s=0.75 "ratio of equivalent tubular radius to radius for all conductors";
+  //  in case of cylindric conductor this is equal to exp(-mu_r/4)=exp(-0.25)
+  input Real rho=100 "ground resistivity";
+  input Real f=50 "frequency";
+  output Real Rcomp[div(n * (n + 1), 2)] "Compact resistance matrix (ohm/m)";
+  output Real Xcomp[div(n * (n + 1), 2)] "Compact reactance matrix (ohm/m)";
+  output Real Lcomp[div(n * (n + 1), 2)] "Compact inductance (H/m)";
+protected
+  constant Complex j=Complex(0, 1) "Imaginary unit";
+  Real D "generic larger distance";
+  Real d "generic smaller distance";
+  Real Theta "Theta angle for Carson's formulas";
+  Real L "generic inductance";
+  Real P "P coefficient from Carson's original paper";
+  Real Q "Q coefficient from Carson's original paper";
+
+  Complex Z[n, n] "Computed matrix (ohm/m)";
+
+  parameter Real a0=4*pi*sqrt(5)*1e-4*sqrt(f/rho)
+    "multiplies D in a-pameter from EMTPs Theory Book";
+  //  a0*D=a; a is the same as "r" in Carson's paper
+  // where D=2h for self impedanze, D=Dik for mutual impedance
+  Real R_g=pi^2*f*1e-7;
+  Real w=2*pi*f;
+  Integer k;
+algorithm
+  //self impedances with ground return:
+  for i in 1:n loop
+    P := pi / 8 - sqrt(2) / 6 * a0 * 2 * y[i] + (a0 / 2 * y[i]) ^ 2 / 16 * (0.6728 + log(1 / (a0 * y[i])));
+    Q := (-0.0386) + 0.5 * log(1 / (a0 * y[i])) + sqrt(2) / 3 * a0 * y[i];
+    L :=Modelica.Constants.mu_0/(2*pi)*log(2*y[i]/(k_s*r[i]));
+    Z[i, i] := R1[i] + 4 * w * P / 1.e7 + j * w * (L + 4 * Q / 1.e7);
+  end for;
+  //mutual impedances with ground return:
+  for i in 1:n loop
+    for jj in 1:i - 1 loop
+      Theta := atan(abs((x[i] - x[jj]) / (y[i] + y[jj])));
+      d := sqrt((x[i] - x[jj]) ^ 2 + (y[i] - y[jj]) ^ 2);
+      D := sqrt((x[i] - x[jj]) ^ 2 + (y[i] + y[jj]) ^ 2);
+      P := pi / 8 - sqrt(2) / 6 * a0 * 2 * y[i] * cos(Theta) + (a0 / 2 * y[i]) ^ 2 / 16 * (0.6728 + log(1 / (a0 * y[i]))) * cos(2 * Theta);
+      Q := (-0.03860784) + 0.5 * log(1 / (a0 * y[i])) + sqrt(2) / 3 * a0 * y[i] * cos(Theta);
+      L :=Modelica.Constants.mu_0/(2*pi)*log(D/d);
+      Z[i, jj] := 4 * w * P / 1.e7 + j * w * (L + 4 * Q / 1.e7);
+    end for;
+  end for;
+  k := 0;
+  for i in 1:n loop
+    for j in i:n loop
+      k := k + 1;
+      Rcomp[k] := Z[j, i].re;
+      Xcomp[k] := Z[j, i].im;
+      Lcomp[k] := Xcomp[k]/w;
+    end for;
+  end for;
+  annotation (Documentation(info="<html>
+<p>This function computes resistances, reactances, inductances of multi-conductor transmission lines, taking into account ground characteristics according to John Carson&apos;s formulas as reported in [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">Ceraolo2018</a>, Appendix].</p>
+<p>When used in conjunction with M_Oline from its output just inductances are used; resistances could instead be used when ground resistance is to be taken into account.</p>
+<p>The results obtained with this function have been checked with Fig. 4.1 of [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>], in model Examples.TestM_OLineZ, with acceptable compliance. Small differences exist, since Carson&apos;s formulas can be approximated in different ways.</p>
+<p>The output arrays contain the elements of the Z matrix ordered as described in the M_OLine model and is used in example Examples.Lines.PowerLineWithFence in conjunction ith M_OLine.</p>
+</html>"));
+end M_OLineZ;

--- a/Modelica/Electrical/Analog/Lines/Functions/TestM_OLineC.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/TestM_OLineC.mo
@@ -1,0 +1,58 @@
+within Modelica.Electrical.Analog.Lines.Functions;
+model TestM_OLineC
+  extends Modelica.Icons.Example;
+  import Modelica.Utilities.*;
+
+  parameter Test_M_Oline.Functions.LineGeometry g(
+    n=4,
+    x={0,-3.048,3.048,-9.144},
+    y={12.192,12.192,12.192,3.048},
+    r=1e-3/2*{12.7,12.7,12.7,4.064},
+    R1=1e-3*{0.348,0.348,0.348,1.802})
+    annotation (Placement(transformation(extent={{-10,-6},{10,14}})));
+
+  String sC;
+  Real Ccomp[div(g.n*(g.n + 1), 2)] "Compacted matrix";
+protected
+  Integer k;
+algorithm
+  when initial() then
+    Ccomp := Test_M_Oline.Functions.M_OLineC(
+      n=g.n,
+      x=g.x,
+      y=g.y,
+      r=g.r);
+    Streams.print("\n *****               Using M_OLineC, RESULTS in nF/km                 *****");
+    Streams.print(  " *** (one row per matrix row; numbers should be intended right-aligned) ***");
+    k:=0;
+    for i in 1:g.n loop  //matrix row
+      sC := "";
+      for j in 1:g.n-i+1 loop  // matrix column
+        k:=k+1;
+        sC := sC + String(1e12*Ccomp[k]) + "  ";
+      end for;
+      Streams.print(sC);
+    end for;
+/*    
+    Streams.print("\n *** Vector stream ***");
+    for i in 1:div(g.n*(g.n + 1),2) loop 
+      Streams.print(String(1e12*Ccomp[i]));
+    end for;
+*/
+    end when;
+  annotation (Diagram(coordinateSystem(preserveAspectRatio=
+           false, extent={{-60,-40},{60,40}})),
+    Documentation(info="<html>
+<p>This model tests the C matrix as computed with lineX, with the geometry of fig. 4.11 of &quot;Theory Book&quot;. </p>
+<p>The results are given textually in the log, and match very well those from &quot;Theory Book&quot;.</p>
+<p>This simulation runs correctly with Both Dymola and OpenModelica. Computation result using Dymola 2020:<span style=\"font-family: Courier New;\"> </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">*****&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Using M_OLineC, RESULTS in nF/km *****</span> </p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">*** (one row per matrix row; numbers should be intended right-aligned) ***</span> </p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">7.57087&nbsp; -1.62658&nbsp; -1.63038&nbsp; -0.168826&nbsp; </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">7.30876&nbsp; -0.834876&nbsp; -0.275822&nbsp; </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">7.29987&nbsp; -0.118934&nbsp; </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">6.97273&nbsp; </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">... &quot;TestM_OLineC.mat&quot; creating (simulation result file)</span> </p>
+</html>"),
+    experiment(StopTime=0, __Dymola_Algorithm="Dassl"));
+end TestM_OLineC;

--- a/Modelica/Electrical/Analog/Lines/Functions/TestM_OLineZ.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/TestM_OLineZ.mo
@@ -1,0 +1,63 @@
+within Modelica.Electrical.Analog.Lines.Functions;
+model TestM_OLineZ
+  extends Modelica.Icons.Example;
+  import Modelica.Utilities.*;
+  parameter Real f=60;
+
+  parameter Test_M_Oline.Functions.LineGeometry g(
+    n=4,
+    x={0,-3.048,3.048,-9.144},
+    y={12.192,12.192,12.192,3.048},
+    r=1e-3/2*{12.7,12.7,12.7,4.064},
+    R1=1e-3*{0.348,0.348,0.348,1.802},
+    k_s=0.7) annotation (Placement(transformation(extent={{-10,-6},{10,14}})));
+
+  String sC;
+//  Complex Zcomp[div(g.n*(g.n + 1), 2)] "Compacted matrix";
+  Real Rcomp[div(g.n*(g.n + 1), 2)] "Compacted matrix";
+  Real Xcomp[div(g.n*(g.n + 1), 2)] "Compacted matrix";
+
+protected
+  Integer k;
+algorithm
+  when initial() then
+    (Rcomp,Xcomp) := Test_M_Oline.Functions.M_OLineZ(
+      n=g.n,
+      x=g.x,
+      y=g.y,
+      r=g.r,
+      R1=g.R1,
+      k_s=g.k_s,
+      rho=g.rho,
+      f=f);
+
+    Streams.print("\n *****                 Using M_OLineZ, RESULTS in ohm/km              *****");
+    Streams.print(  " *** (one row per matrix row; numbers should be intended right-aligned) ***");
+    k:=0;
+    for i in 1:g.n loop  //matrix row
+      sC := "";
+      for j in 1:g.n-i+1 loop  // matrix column
+        k:=k+1;
+        sC := sC + String(1000*Rcomp[k]) +"+j"+String(1000*Xcomp[k])+ "   ";
+      end for;
+      Streams.print(sC);
+      end for;
+  end when;
+
+  annotation (Diagram(coordinateSystem(preserveAspectRatio=
+           false, extent={{-60,-40},{60,40}})),
+    Documentation(info="<html>
+<p>This model tests the Z matrix as computed with function M_OLineZ, with the geometry of fig. 4.11 of Theory Book. </p>
+<p>The results are given textually in the log. They are not totally conform. Better conformity could be obtained using k_s=0.4 inside LineZ, which should be not correct, since [Ceraolo] says this value to be between 0.70 and 0.778.</p>
+<p>This simulation runs correctly with Dymola, and OpenModelica. Computation result using Dymola 2020:<span style=\"font-family: Courier New;\"> </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">*** Using M_OLineZ, RESULTS in ohm/km ***</span> </p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">*** (one row per matrix row; numbers should be intended right-aligned) ***</span> </p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">0.405338+j0.918874 0.0573527+j0.427059 0.0573527+j0.427059 0.0588135+j0.396721 </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">0.405338+j0.918874 0.0573939+j0.376456 0.0587802+j0.403026 </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">0.405338+j0.918874 0.0588495+j0.391359 </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">1.86075+j1.00337 </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">... &quot;TestM_OLineZ.mat&quot; creating (simulation result file)</span> </p>
+<p>&nbsp; </p>
+</html>"),
+    experiment(StopTime=0, __Dymola_Algorithm="Dassl"));
+end TestM_OLineZ;

--- a/Modelica/Electrical/Analog/Lines/Functions/package.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/package.mo
@@ -1,0 +1,14 @@
+within Modelica.Electrical.Analog.Lines;
+package Functions "Functions and records"
+
+
+
+
+  annotation (Icon(graphics={Rectangle(
+          lineColor={200,200,200},
+          fillColor={255,215,136},
+          fillPattern=FillPattern.HorizontalCylinder,
+          extent={{-100.0,-100.0},{100.0,100.0}},
+          radius=25.0)}));
+
+end Functions;

--- a/Modelica/Electrical/Analog/Lines/Functions/package.order
+++ b/Modelica/Electrical/Analog/Lines/Functions/package.order
@@ -1,0 +1,5 @@
+LineGeometry
+M_OLineC
+M_OLineZ
+TestM_OLineZ
+TestM_OLineC

--- a/Modelica/Electrical/Analog/UsersGuide/References.mo
+++ b/Modelica/Electrical/Analog/UsersGuide/References.mo
@@ -2,43 +2,38 @@ within Modelica.Electrical.Analog.UsersGuide;
 class References "References"
   extends Modelica.Icons.References;
   annotation (preferredView="info",Documentation(info="<html>
-
-<table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-
-  <tr>
-    <td>[<a href=\"https://ieeexplore.ieee.org/document/1447963\">Branin1967</a>]</td>
-    <td>F. H. Branin Jr., &quot;Transient analysis of lossless transmission lines&quot;, <em>Proceedings of the IEEE</em>,
-        vol. 55, pp. 2012-2013, 1967</td>
-  </tr>
-
-  <tr>
-    <td>[Conelly1992]</td>
-    <td>J.A. Conelly, <em>Macromodelling with SPICE</em>, Englewood Cliffs: Prentice-Hall, 1992</td>
-  </tr>
-
-  <tr>
-    <td>[<a href=\"https://www.springer.com/us/book/9783540151609\">Hoefer1985</a>]</td>
-    <td>E. E. E. Hoefer, H. Nielinger, <em>SPICE: Analyseprogramm f&uuml;r elektronische Schaltungen</em>,
-        Springer-Verlag, Berlin, Heidelberg, New York, Tokyo, 1985</td>
-  </tr>
-
-  <tr>
-    <td>[Johnson1991]</td>
-    <td>B. Johnson, T. Quarles, A. R. Newton, D. O. Pederson, A. Sangiovanni-Vincentelli,
-        <em>SPICE3 Version 3e User&#39;s Manual</em>,
-        Department of Electrical Engineering and Computer Sciences,
-        University of California, Berkeley p. 12, p. 106 - 107, April 1, 1991</td>
-  </tr>
-
-  <tr>
-    <td>[Spiro1990]</td>
-    <td>H. Spiro, H, <em>Simulation integrierter Schaltungen</em>, R. Oldenbourg Verlag M&uuml;nchen Wien, 1990</td>
-  </tr>
-
-  <tr>
-    <td>[Vlach1983]</td>
-    <td>J. Vlach, K. Singal, <em>Computer methods for circuit analysis and design</em>, Van Nostrand Reinhold, New York 1983</td>
-  </tr>
+<table cellspacing=\"0\" cellpadding=\"2\" border=\"0\"><tr>
+<td><p>[<a href=\"https://ieeexplore.ieee.org/document/1447963\">Branin1967</a>]</p></td>
+<td><p>F. H. Branin Jr., &quot;Transient analysis of lossless transmission lines&quot;, <i>Proceedings of the IEEE</i>, vol. 55, pp. 2012-2013, 1967</p></td>
+</tr>
+<tr>
+<td><p>[Conelly1992]</p></td>
+<td><p>J.A. Conelly, <i>Macromodelling with SPICE</i>, Englewood Cliffs: Prentice-Hall, 1992</p></td>
+</tr>
+<tr>
+<td><p>[<a href=\"https://www.springer.com/us/book/9783540151609\">Hoefer1985</a>]</p></td>
+<td><p>E. E. E. Hoefer, H. Nielinger, <i>SPICE: Analyseprogramm f&uuml;r elektronische Schaltungen</i>, Springer-Verlag, Berlin, Heidelberg, New York, Tokyo, 1985</p></td>
+</tr>
+<tr>
+<td><p>[<a href=\"https://ieeexplore.ieee.org/document/8076707\">Ceraolo2018</a>]</p></td>
+<td><p>M. Ceraolo, <i>Modeling and Simulation of AC Railway Electric Supply Lines Including Ground Return</i>, IEEE Transactions on Transportation Electrification, March 2018</p></td>
+</tr>
+<tr>
+<td><p>[Johnson1991]</p></td>
+<td><p>B. Johnson, T. Quarles, A. R. Newton, D. O. Pederson, A. Sangiovanni-Vincentelli, <i>SPICE3 Version 3e User&apos;s Manual</i>, Department of Electrical Engineering and Computer Sciences, University of California, Berkeley p. 12, p. 106 - 107, April 1, 1991</p></td>
+</tr>
+<tr>
+<td><p>[Spiro1990]</p></td>
+<td><p>H. Spiro, H, <i>Simulation integrierter Schaltungen</i>, R. Oldenbourg Verlag M&uuml;nchen Wien, 1990</p></td>
+</tr>
+<tr>
+<td><p>[Vlach1983]</p></td>
+<td><p>J. Vlach, K. Singal, <i>Computer methods for circuit analysis and design</i>, Van Nostrand Reinhold, New York 1983</p></td>
+</tr>
+<tr>
+<td><p>[<a href=\"http://www.dee.ufrj.br/ipst/EMTPTB.PDF\">EmtpTheoryBook</a>]</p></td>
+<td><p> <i>Electro-Magnetic Transients Program (EMTP) Theory Book</i></p></td>
+</tr>
 </table>
 </html>"));
 end References;

--- a/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/Lines/PowerLineWithFence/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/Lines/PowerLineWithFence/comparisonSignals.txt
@@ -1,0 +1,3 @@
+time
+body.v
+body.i

--- a/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/Lines/PowerLineWithFence/comparsonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/Lines/PowerLineWithFence/comparsonSignals.txt
@@ -1,0 +1,3 @@
+time
+body.v
+body.i

--- a/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/Lines/PowerLineWithFence/comparsonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/Lines/PowerLineWithFence/comparsonSignals.txt
@@ -1,3 +1,0 @@
-time
-body.v
-body.i

--- a/Modelica/Resources/Reference/Modelica/Electrical/Lines/PowerLineWithFence/comparsonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/Lines/PowerLineWithFence/comparsonSignals.txt
@@ -1,0 +1,3 @@
+time
+body.v
+body.i


### PR DESCRIPTION
I know there is some opinion that M_OLine should be considered obsolete.
However, since I spent some time finding an interesting example of its usage, I created this PR, just in case it may help.
I did it as a Power System Engineer, using M_OLine as a Power Line model.
Unfortunately, M_OLine is not able to consider ground effects correctly, when currents flow into the ground.

Therefore, the example I created is a bit tricky, even though it has some effectiveness.
This is just a "discussion PR": I don't really know whether accepting this is the right thing for MSL. 
Naturally, all limitations of the example proposed are listed and explained in the example documentation.

To create the example I had also to introduce functions that produce Matrices for the lines. These are useful per-se, , i.e. independently on M_OLine, and could be used in the future in case some evolution of M_Line, able to accept resistances also off-diagonal the Z matrix is created (I have a version that does this on my PC already).