### PR TITLE
Fix initialization of Lines as discussed in #3826

### DIFF
--- a/Modelica/Electrical/Analog/Lines/OLine.mo
+++ b/Modelica/Electrical/Analog/Lines/OLine.mo
@@ -46,17 +46,12 @@ model OLine "Lossy Transmission Line"
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort
     annotation (Placement(transformation(extent={{-110,-110},{-90,-90}}),
         iconTransformation(extent={{-110,-110},{-90,-90}})));
-protected
-  parameter SI.Resistance rm[N + 1]=
-  {if i==1 or i==N + 1 then r*length/(N*2) else r*length/N for i in 1:N+1};
   Modelica.Electrical.Analog.Basic.Resistor R[N + 1](
     R=rm,
     T_ref=fill(T_ref, N + 1),
     alpha=fill(alpha_R, N + 1),
     useHeatPort=fill(useHeatPort, N + 1),
     T=fill(T, N + 1));
-  parameter SI.Inductance lm[N + 1]=
-  {if i==1 or i==N + 1 then l*length/(N*2) else l*length/N for i in 1:N+1};
   Modelica.Electrical.Analog.Basic.Inductor L[N + 1](L=lm);
   Modelica.Electrical.Analog.Basic.Capacitor C[N](C=fill(c*length/(N), N));
   Modelica.Electrical.Analog.Basic.Conductor G[N](
@@ -65,6 +60,11 @@ protected
     alpha=fill(alpha_G, N),
     useHeatPort=fill(useHeatPort, N),
     T=fill(T, N));
+protected
+  parameter SI.Resistance rm[N + 1]=
+  {if i==1 or i==N + 1 then r*length/(N*2) else r*length/N for i in 1:N+1};
+  parameter SI.Inductance lm[N + 1]=
+  {if i==1 or i==N + 1 then l*length/(N*2) else l*length/N for i in 1:N+1};
 equation
   v13 = p1.v - p3.v;
   v23 = p2.v - p3.v;

--- a/Modelica/Electrical/Analog/Lines/TLine1.mo
+++ b/Modelica/Electrical/Analog/Lines/TLine1.mo
@@ -6,9 +6,8 @@ model TLine1
   parameter SI.Resistance Z0(start=1)
     "Characteristic impedance";
   parameter SI.Time TD(start=1) "Transmission delay";
-protected
-  SI.Voltage er;
-  SI.Voltage es;
+  SI.Voltage er(start=0);
+  SI.Voltage es(start=0);
 equation
   assert(Z0 > 0, "Z0 has to be positive");
   assert(TD > 0, "TD has to be positive");

--- a/Modelica/Electrical/Analog/Lines/TLine1.mo
+++ b/Modelica/Electrical/Analog/Lines/TLine1.mo
@@ -6,8 +6,8 @@ model TLine1
   parameter SI.Resistance Z0(start=1)
     "Characteristic impedance";
   parameter SI.Time TD(start=1) "Transmission delay";
-  SI.Voltage er(start=0);
-  SI.Voltage es(start=0);
+  SI.Voltage er(start=0) "Reflected voltage wave";
+  SI.Voltage es(start=0) "Incident voltage wave";
 equation
   assert(Z0 > 0, "Z0 has to be positive");
   assert(TD > 0, "TD has to be positive");

--- a/Modelica/Electrical/Analog/Lines/TLine1.mo
+++ b/Modelica/Electrical/Analog/Lines/TLine1.mo
@@ -6,8 +6,8 @@ model TLine1
   parameter SI.Resistance Z0(start=1)
     "Characteristic impedance";
   parameter SI.Time TD(start=1) "Transmission delay";
-  SI.Voltage er(start=0) "Reflected voltage wave";
-  SI.Voltage es(start=0) "Incident voltage wave";
+  SI.Voltage es(start=0) "Voltage source of forward travelling wave";
+  SI.Voltage er(start=0) "Voltage source of reflected wave";
 equation
   assert(Z0 > 0, "Z0 has to be positive");
   assert(TD > 0, "TD has to be positive");

--- a/Modelica/Electrical/Analog/Lines/TLine2.mo
+++ b/Modelica/Electrical/Analog/Lines/TLine2.mo
@@ -7,8 +7,8 @@ model TLine2
     "Characteristic impedance";
   parameter SI.Frequency F(start=1) "Frequency";
   parameter Real NL(start=1) "Normalized length";
-  SI.Voltage er(start=0);
-  SI.Voltage es(start=0);
+  SI.Voltage er(start=0) "Reflected voltage wave";
+  SI.Voltage es(start=0) "Incident voltage wave";
 protected
   parameter SI.Time TD=NL/F;
 equation

--- a/Modelica/Electrical/Analog/Lines/TLine2.mo
+++ b/Modelica/Electrical/Analog/Lines/TLine2.mo
@@ -7,9 +7,9 @@ model TLine2
     "Characteristic impedance";
   parameter SI.Frequency F(start=1) "Frequency";
   parameter Real NL(start=1) "Normalized length";
+  SI.Voltage er(start=0);
+  SI.Voltage es(start=0);
 protected
-  SI.Voltage er;
-  SI.Voltage es;
   parameter SI.Time TD=NL/F;
 equation
   assert(Z0 > 0, "Z0 has to be positive");

--- a/Modelica/Electrical/Analog/Lines/TLine2.mo
+++ b/Modelica/Electrical/Analog/Lines/TLine2.mo
@@ -7,8 +7,8 @@ model TLine2
     "Characteristic impedance";
   parameter SI.Frequency F(start=1) "Frequency";
   parameter Real NL(start=1) "Normalized length";
-  SI.Voltage er(start=0) "Reflected voltage wave";
-  SI.Voltage es(start=0) "Incident voltage wave";
+  SI.Voltage es(start=0) "Voltage source of forward travelling wave";
+  SI.Voltage er(start=0) "Voltage source of reflected wave";
 protected
   parameter SI.Time TD=NL/F;
 equation

--- a/Modelica/Electrical/Analog/Lines/TLine3.mo
+++ b/Modelica/Electrical/Analog/Lines/TLine3.mo
@@ -4,8 +4,8 @@ model TLine3
   extends Modelica.Electrical.Analog.Interfaces.TwoPort;
   parameter SI.Resistance Z0(start=1) "Natural impedance";
   parameter SI.Frequency F(start=1) "Frequency";
-  SI.Voltage er(start=0);
-  SI.Voltage es(start=0);
+  SI.Voltage er(start=0) "Reflected voltage wave";
+  SI.Voltage es(start=0) "Incident voltage wave";
 protected
   parameter SI.Time TD=1/F/4;
 equation

--- a/Modelica/Electrical/Analog/Lines/TLine3.mo
+++ b/Modelica/Electrical/Analog/Lines/TLine3.mo
@@ -4,8 +4,8 @@ model TLine3
   extends Modelica.Electrical.Analog.Interfaces.TwoPort;
   parameter SI.Resistance Z0(start=1) "Natural impedance";
   parameter SI.Frequency F(start=1) "Frequency";
-  SI.Voltage er(start=0) "Reflected voltage wave";
-  SI.Voltage es(start=0) "Incident voltage wave";
+  SI.Voltage es(start=0) "Voltage source of forward travelling wave";
+  SI.Voltage er(start=0) "Voltage source of reflected wave";
 protected
   parameter SI.Time TD=1/F/4;
 equation

--- a/Modelica/Electrical/Analog/Lines/TLine3.mo
+++ b/Modelica/Electrical/Analog/Lines/TLine3.mo
@@ -4,9 +4,9 @@ model TLine3
   extends Modelica.Electrical.Analog.Interfaces.TwoPort;
   parameter SI.Resistance Z0(start=1) "Natural impedance";
   parameter SI.Frequency F(start=1) "Frequency";
+  SI.Voltage er(start=0);
+  SI.Voltage es(start=0);
 protected
-  SI.Voltage er;
-  SI.Voltage es;
   parameter SI.Time TD=1/F/4;
 equation
   assert(Z0 > 0, "Z0 has to be positive");

--- a/Modelica/Electrical/Analog/Lines/ULine.mo
+++ b/Modelica/Electrical/Analog/Lines/ULine.mo
@@ -37,9 +37,6 @@ model ULine "Lossy RC Line"
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort
     annotation (Placement(transformation(extent={{-110,-110},{-90,-90}}),
         iconTransformation(extent={{-110,-110},{-90,-90}})));
-protected
-   parameter SI.Resistance rm[N + 1]=
-  {if i==1 or i==N + 1 then r*length/(N*2) else r*length/N for i in 1:N+1};
   Modelica.Electrical.Analog.Basic.Resistor R[N + 1](
     R=rm,
     T_ref=fill(T_ref, N + 1),
@@ -47,6 +44,9 @@ protected
     useHeatPort=fill(useHeatPort, N + 1),
     T=fill(T, N + 1));
   Modelica.Electrical.Analog.Basic.Capacitor C[N](C=fill(c*length/(N), N));
+protected
+   parameter SI.Resistance rm[N + 1]=
+  {if i==1 or i==N + 1 then r*length/(N*2) else r*length/N for i in 1:N+1};
 equation
   v13 = p1.v - p3.v;
   v23 = p2.v - p3.v;


### PR DESCRIPTION
The models `Analog.Lines.{OLine, ULine, TLine1, TLine2, TLine3}` lack the possibility for proper initialization, since the components that have to be accessed for initialization are protected. I've made them public.
`Analog.Lines.M_OLine` is bugfixed in #3827.
@dietmarw can you back-port this to maint/4.0.x?
I suppose after merging this PR and #3827 we should rebase #3819 or create a new PR.