### PR TITLE
Remove Evaluate=true for fixed=false parameter 'n_b'

### DIFF
--- a/Modelica/Mechanics/MultiBody/Joints/Assemblies/JointRRR.mo
+++ b/Modelica/Mechanics/MultiBody/Joints/Assemblies/JointRRR.mo
@@ -37,8 +37,7 @@ model JointRRR
     "Axes of revolute joints resolved in frame_a (all axes are parallel to each other)"
     annotation (Evaluate=true);
   final parameter Real n_b[3](each final unit="1",each fixed=false, start = {0,0,1})
-    "Axis of revolute joint fixed and resolved in frame_b"
-    annotation (Evaluate=true);
+    "Axis of revolute joint fixed and resolved in frame_b";
   parameter SI.Position rRod1_ia[3]={1,0,0}
     "Vector from origin of frame_a to revolute joint in the middle, resolved in frame_ia"
     annotation (Evaluate=true);


### PR DESCRIPTION
From the brief discussion in https://github.com/modelica/ModelicaSpecification/issues/2951, it seems that `Evaluate = true` on a parameter with `fixed = false` is not expected to have any effect.  Thus I'd like to propose that the `Evaluate = true` is removed in order to get better correspondence between presence of `Evaluate = true` and parameters actually becoming evaluated.