### PR TITLE
Remove `align=bottom` from guidelines and code

### DIFF
--- a/Modelica/Electrical/Analog/Basic/SaturatingInductor.mo
+++ b/Modelica/Electrical/Analog/Basic/SaturatingInductor.mo
@@ -76,7 +76,7 @@ This approximation is with good performance and easy to adjust to a given charac
 </p>
 
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Tab.&nbsp;1:</strong> Characteristic parameters of the saturating inductor model</caption>
+  <caption><strong>Tab.&nbsp;1:</strong> Characteristic parameters of the saturating inductor model</caption>
   <tr>
     <th>Variable</th>
     <th>Description</th>
@@ -106,7 +106,7 @@ Lnom = Linf + (Lzer - Linf)*atan(Inom/Ipar)/(Inom/Ipar)
 </pre></blockquote>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig.&nbsp;1:</strong> Actual inductance <code>Lact</code> versus current <code>i</code></caption>
+  <caption><strong>Fig.&nbsp;1:</strong> Actual inductance <code>Lact</code> versus current <code>i</code></caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Electrical/Analog/Basic/SaturatingInductor_Lact_i.png\" alt=\"Lact vs. i\">
@@ -115,7 +115,7 @@ Lnom = Linf + (Lzer - Linf)*atan(Inom/Ipar)/(Inom/Ipar)
 </table>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig.&nbsp;2:</strong> Actual flux linkage <code>Psi</code> versus current <code>i</code></caption>
+  <caption><strong>Fig.&nbsp;2:</strong> Actual flux linkage <code>Psi</code> versus current <code>i</code></caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Electrical/Analog/Basic/SaturatingInductor_Psi_i.png\" alt=\"Psi vs. i\">

--- a/Modelica/Electrical/Analog/Sources/LightningImpulse.mo
+++ b/Modelica/Electrical/Analog/Sources/LightningImpulse.mo
@@ -89,7 +89,7 @@ The decay time to half value <code>T2</code> is defined as the time span between
 </p>
 <p>Note: Due to numerical reasons, for the double-exponential function <code>T1 &lt; 0.2*T2</code> is required.</p>
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 1:</strong> Parameters of the lightning current</caption>
+  <caption><strong>Fig. 1:</strong> Parameters of the lightning current</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Electrical/Analog/Sources/Lightning.png\">

--- a/Modelica/Electrical/Machines/SpacePhasors/Blocks/Rotator.mo
+++ b/Modelica/Electrical/Machines/SpacePhasors/Blocks/Rotator.mo
@@ -37,7 +37,7 @@ Rotates a space phasor (voltage or current) input <code>u</code> by the <code>an
       <img src=\"modelica://Modelica/Resources/Images/Electrical/Machines/Rotator.png\">
     </td>
   </tr>
-  <caption align=\"bottom\"><strong>Fig. 1:</strong> Original and rotated reference frame of a space phasor </caption>
+  <caption><strong>Fig. 1:</strong> Original and rotated reference frame of a space phasor </caption>
 </table>
 
 </html>"));

--- a/Modelica/Electrical/Machines/SpacePhasors/Functions/Rotator.mo
+++ b/Modelica/Electrical/Machines/SpacePhasors/Functions/Rotator.mo
@@ -18,7 +18,7 @@ Rotates a space phasor (voltage or current) input <code>u</code> by the <code>an
       <img src=\"modelica://Modelica/Resources/Images/Electrical/Machines/Rotator.png\">
     </td>
   </tr>
-  <caption align=\"bottom\"><strong>Fig. 1:</strong> Original and rotated reference frame of a space phasor </caption>
+  <caption><strong>Fig. 1:</strong> Original and rotated reference frame of a space phasor </caption>
 </table>
 </html>"));
 end Rotator;

--- a/Modelica/Electrical/Polyphase/UsersGuide/PhaseOrientation.mo
+++ b/Modelica/Electrical/Polyphase/UsersGuide/PhaseOrientation.mo
@@ -21,7 +21,7 @@ In symmetrical polyphase systems odd and even phase numbers have to be distingui
 For a symmetrical polyphase system with m phases the displacement of the sine waves is 2 &pi; / m.
 </p>
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 1: </strong>Symmetrical (a) three-phase and (b) five-phase current system</caption>
+  <caption><strong>Fig. 1: </strong>Symmetrical (a) three-phase and (b) five-phase current system</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/UsersGuide/Polyphase/phase35.png\"
@@ -41,7 +41,7 @@ The number of base systems n<sub>Base</sub> is defined by the number of division
 For a base system with m<sub>Base</sub> phases the displacement of the sine waves belonging to that base system is 2 &pi; / m<sub>Base</sub>.
 </p>
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 2: </strong>Symmetrical (a) six and (b) ten phase current system</caption>
+  <caption><strong>Fig. 2: </strong>Symmetrical (a) six and (b) ten phase current system</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/UsersGuide/Polyphase/phase610.png\"
@@ -75,7 +75,7 @@ For polyphase systems, star connection of the m phases is unambiguous, i.e., eac
 whereas for polygon connection (m<sub>Base</sub> - 1)/2 alternatives exist (refer to Fig. 3).
 </p>
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 3: </strong>Line-to-neutral voltages and line-to-line voltages for different systems</caption>
+  <caption><strong>Fig. 3: </strong>Line-to-neutral voltages and line-to-line voltages for different systems</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Electrical/Polyphase/Polygon2phase.png\" alt=\"Polygon2phase.png\">

--- a/Modelica/Electrical/PowerConverters/DCDC/Control/SignalPWM.mo
+++ b/Modelica/Electrical/PowerConverters/DCDC/Control/SignalPWM.mo
@@ -107,7 +107,7 @@ to the switching period. The output firing signal is strictly determined by the 
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 1:</strong> Firing (<code>fire</code>) and inverse firing (<code>notFire</code>) signal of PWM control; <code>d</code> = duty cycle; <code>f</code> = switching frequency </caption>
+  <caption><strong>Fig. 1:</strong> Firing (<code>fire</code>) and inverse firing (<code>notFire</code>) signal of PWM control; <code>d</code> = duty cycle; <code>f</code> = switching frequency </caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Electrical/PowerConverters/dutyCycle.png\">

--- a/Modelica/Electrical/PowerConverters/DCDC/HBridge.mo
+++ b/Modelica/Electrical/PowerConverters/DCDC/HBridge.mo
@@ -122,7 +122,7 @@ equation
 The H bridge is a four quadrant DC/DC converter. It consists of two single-phase DC/AC converters which are controlled differently; see Fig.&nbsp;1.</p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 1:</strong> H bridge</caption>
+  <caption><strong>Fig. 1:</strong> H bridge</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Electrical/PowerConverters/Hbridge.png\">

--- a/Modelica/Electrical/QuasiStatic/UsersGuide/Overview/ACCircuit.mo
+++ b/Modelica/Electrical/QuasiStatic/UsersGuide/Overview/ACCircuit.mo
@@ -18,7 +18,7 @@ the voltage drops across the resistor, the inductor and the capacitor should be 
            alt=\"resonance_circuit.png\">
     </td>
   </tr>
-  <caption align=\"bottom\">Fig. 1: Series AC circuit of a resistor and an inductor at variable frequency</caption>
+  <caption>Fig. 1: Series AC circuit of a resistor and an inductor at variable frequency</caption>
 </table>
 
 <p>
@@ -80,7 +80,7 @@ as illustrated in the phasor diagram of Fig. 2.
            alt=\"phasor_diagram.png\">
     </td>
   </tr>
-  <caption align=\"bottom\">Fig. 2: Phasor diagram of a resistor and inductance series connection</caption>
+  <caption>Fig. 2: Phasor diagram of a resistor and inductance series connection</caption>
 </table>
 
 <p>Due to the series connection of the resistor, inductor and capacitor, the three currents are all equal:</p>

--- a/Modelica/Electrical/QuasiStatic/UsersGuide/Overview/Introduction.mo
+++ b/Modelica/Electrical/QuasiStatic/UsersGuide/Overview/Introduction.mo
@@ -49,7 +49,7 @@ This equation is also illustrated in Fig. 1.
            alt=\"phasor_voltage.png\">
     </td>
   </tr>
-  <caption align=\"bottom\">Fig. 1: Relationship between voltage phasor and time domain voltage</caption>
+  <caption>Fig. 1: Relationship between voltage phasor and time domain voltage</caption>
 </table>
 
 <p>

--- a/Modelica/Electrical/QuasiStatic/UsersGuide/Overview/Power.mo
+++ b/Modelica/Electrical/QuasiStatic/UsersGuide/Overview/Power.mo
@@ -46,7 +46,7 @@ Therefore, the instantaneous power is
            alt=\"power_resistor.png\">
     </td>
   </tr>
-  <caption align=\"bottom\">Fig. 1: Instantaneous voltage, current of power of a resistor</caption>
+  <caption>Fig. 1: Instantaneous voltage, current of power of a resistor</caption>
 </table>
 
 <p>Real power of the resistor is the average of instantaneous power:</p>
@@ -84,7 +84,7 @@ Therefore, the instantaneous power is
            alt=\"power_inductor.png\">
     </td>
   </tr>
-  <caption align=\"bottom\">Fig. 2: Instantaneous voltage, current of power of an inductor</caption>
+  <caption>Fig. 2: Instantaneous voltage, current of power of an inductor</caption>
 </table>
 
 <p>Reactive power of the inductor is:</p>
@@ -122,7 +122,7 @@ Therefore, the instantaneous power is
            alt=\"power_capacitor.png\">
     </td>
   </tr>
-  <caption align=\"bottom\">Fig. 3: Instantaneous voltage, current of power of a capacitor</caption>
+  <caption>Fig. 3: Instantaneous voltage, current of power of a capacitor</caption>
 </table>
 
 <p>Reactive power of the capacitor is:</p>

--- a/Modelica/Fluid/Vessels.mo
+++ b/Modelica/Fluid/Vessels.mo
@@ -556,7 +556,7 @@ If a <strong>straight pipe with constant cross section is mounted into a vessel 
 </p>
 
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\">Pressure loss coefficients for outlets, entrance at a distance from wall</caption>
+  <caption>Pressure loss coefficients for outlets, entrance at a distance from wall</caption>
   <tr>
     <td></td> <td>   </td><th colspan=\"5\" align=\"center\"> b / D_hyd  </th>
   </tr>
@@ -585,7 +585,7 @@ If a <strong>straight pipe with a circular bellmouth inlet (collector) without b
 </p>
 
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\">Pressure loss coefficients for outlets, bellmouth flush with wall</caption>
+  <caption>Pressure loss coefficients for outlets, bellmouth flush with wall</caption>
   <tr>
     <td></td> <th colspan=\"6\" align=\"center\"> r / D_hyd  </th>
   </tr>
@@ -602,7 +602,7 @@ If a <strong>straight pipe with a circular bellmouth inlet (collector) without b
 </p>
 
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\">Pressure loss coefficients for outlets, bellmouth at a distance of wall</caption>
+  <caption>Pressure loss coefficients for outlets, bellmouth at a distance of wall</caption>
   <tr>
     <td></td> <th colspan=\"6\" align=\"center\"> r / D_hyd  </th>
   </tr>
@@ -621,7 +621,7 @@ If a <strong>straight pipe with constant circular cross section is mounted flush
 </p>
 
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\">Pressure loss coefficients for inlets, circular tube flush with wall</caption>
+  <caption>Pressure loss coefficients for inlets, circular tube flush with wall</caption>
   <tr>
     <td></td> <th colspan=\"6\" align=\"center\"> m  </th>
   </tr>
@@ -638,7 +638,7 @@ For larger port diameters, relative to the area of the vessel, the inlet pressur
 </p>
 
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\">Pressure loss coefficients for inlets, circular tube flush with wall</caption>
+  <caption>Pressure loss coefficients for inlets, circular tube flush with wall</caption>
   <tr>
     <td></td> <th colspan=\"6\" align=\"center\"> A_port / A_vessel  </th>
   </tr>

--- a/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/Components/Transformer1PhaseWithHysteresis.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/Components/Transformer1PhaseWithHysteresis.mo
@@ -225,7 +225,7 @@ Simple model of a single-phase transformer with a primary and a secondary windin
 </p>
 
 <table cellspacing=\"0\" cellpadding=\"2\" border=\"0\">
-  <caption align=\"bottom\"><strong>Fig. 1:</strong> Sketch of the modelled transformer with magnetic core, primary and secondary winding</caption>
+  <caption><strong>Fig. 1:</strong> Sketch of the modelled transformer with magnetic core, primary and secondary winding</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Examples/Hysteresis/Components/Transformer1PhaseWithHysteresis/Core_SinglePhase.png\">

--- a/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/Components/Transformer3PhaseYyWithHysteresis.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/Components/Transformer3PhaseYyWithHysteresis.mo
@@ -419,7 +419,7 @@ Simple model of a three-phase transformer with primary and a secondary windings 
 </p>
 
 <table cellspacing=\"0\" cellpadding=\"2\" border=\"0\">
-  <caption align=\"bottom\"><strong>Fig. 1:</strong> Sketch of the modelled transformer with magnetic core, primary and secondary winding</caption>
+  <caption><strong>Fig. 1:</strong> Sketch of the modelled transformer with magnetic core, primary and secondary winding</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Examples/Hysteresis/Components/Transformer3PhaseYyWithHysteresis/Core_ThreePhase1.png\">

--- a/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/HysteresisModelComparison.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/HysteresisModelComparison.mo
@@ -118,7 +118,7 @@ Compared to the complex Preisach hysteresis model the Tellinen model is very sim
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 1: </strong>Simulated magnetic flux densities B of different hysteresis models (b) due to an applied magnetic field strength shown in (a). Corresponding B(H) loops of the hysteresis models GenericHystTellinenSoft (c), GenericHystTellinenTable (d) and GenericHystPreisachEverett (e).</caption>
+  <caption><strong>Fig. 1: </strong>Simulated magnetic flux densities B of different hysteresis models (b) due to an applied magnetic field strength shown in (a). Corresponding B(H) loops of the hysteresis models GenericHystTellinenSoft (c), GenericHystTellinenTable (d) and GenericHystPreisachEverett (e).</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Examples/Hysteresis/HysteresisModelComparison/plot1.png\">

--- a/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/InductorWithHysteresis.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/InductorWithHysteresis.mo
@@ -39,7 +39,7 @@ equation
 This is a simple model of an inductor with a ferromagnetic core. The used GenericHystTellinenEverett model considers the ferromagnetic hysteresis, eddy currents and remanence of the core material. For example you can simulate the model for 0.02s and plot Core.B vs. Core.H to visualize the resulting hysteresis loops.
 </p>
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 1: </strong>Results Core.B(t) and Core.B(H) of the magnetic Core.</caption>
+  <caption><strong>Fig. 1: </strong>Results Core.B(t) and Core.B(H) of the magnetic Core.</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Examples/Hysteresis/InductorWithHysteresis/plot1.png\">

--- a/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/ThreePhaseTransformerWithRectifier.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/ThreePhaseTransformerWithRectifier.mo
@@ -162,7 +162,7 @@ An example simulation shows the transformer inrush currents due to an initially 
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-<caption align=\"bottom\"><strong>Fig. 1:</strong> Transformer inrush currents due to initial magnetization of the magnetic core; (a) transformer primary currents; (b)  transformer secondary currents; (c) flux densities of the transformer legs; (d) B(H) hysteresis loops of transformer leg one.; (e) instantaneous static hysteresis, eddy current and copper losses of the transformer; (f) approximated average static hysteresis, eddy current and copper losses of the transformer</caption>
+<caption><strong>Fig. 1:</strong> Transformer inrush currents due to initial magnetization of the magnetic core; (a) transformer primary currents; (b)  transformer secondary currents; (c) flux densities of the transformer legs; (d) B(H) hysteresis loops of transformer leg one.; (e) instantaneous static hysteresis, eddy current and copper losses of the transformer; (f) approximated average static hysteresis, eddy current and copper losses of the transformer</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Examples/Hysteresis/ThreePhaseTransformerWithRectifier/plot01.png\" hspace=\"10\" vspace=\"10\">

--- a/Modelica/Magnetic/FluxTubes/Material/HysteresisTableData/package.mo
+++ b/Modelica/Magnetic/FluxTubes/Material/HysteresisTableData/package.mo
@@ -12,7 +12,7 @@ Fig. 1 and Fig. 2 show library entries based on own measurements of several stee
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-<caption align=\"bottom\"><strong>Fig. 1:</strong> Static hysteresis envelope curves of several steel sheets</caption>
+<caption><strong>Fig. 1:</strong> Static hysteresis envelope curves of several steel sheets</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Material/HysteresisTableData/StaticLoops01.png\">
@@ -21,7 +21,7 @@ Fig. 1 and Fig. 2 show library entries based on own measurements of several stee
 </table>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-<caption align=\"bottom\"><strong>Fig. 2:</strong> Static hysteresis envelope curves of several steel sheets</caption>
+<caption><strong>Fig. 2:</strong> Static hysteresis envelope curves of several steel sheets</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Material/HysteresisTableData/StaticLoops02.png\">
@@ -34,7 +34,7 @@ Fig. 3 shows the static hysteresis loop library entries for soft magnetic cobalt
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-<caption align=\"bottom\"><strong>Fig. 3:</strong> Soft magnetic cobalt iron library entries <a href=\"modelica://Modelica.Magnetic.FluxTubes.UsersGuide.Literature\">[Va01]</a></caption>
+<caption><strong>Fig. 3:</strong> Soft magnetic cobalt iron library entries <a href=\"modelica://Modelica.Magnetic.FluxTubes.UsersGuide.Literature\">[Va01]</a></caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Material/HysteresisTableData/StaticLoops03.png\">

--- a/Modelica/Magnetic/FluxTubes/Shapes/HysteresisAndMagnets/GenericHystTellinenHard.mo
+++ b/Modelica/Magnetic/FluxTubes/Shapes/HysteresisAndMagnets/GenericHystTellinenHard.mo
@@ -62,7 +62,7 @@ equation
 </p>
 
 <table cellspacing=\"0\" cellpadding=\"2\" border=\"0\">
-  <caption align=\"bottom\"><strong>Fig. 1:</strong> Hyperbolic tangent functions define the shape of the ferromagnetic (static) hysteresis</caption>
+  <caption><strong>Fig. 1:</strong> Hyperbolic tangent functions define the shape of the ferromagnetic (static) hysteresis</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Shapes/HysteresisAndMagnets/GenericHystTellinenHard/HardMagneticHysteresis.png\">

--- a/Modelica/Magnetic/FluxTubes/UsersGuide/Hysteresis/DynamicHysteresis.mo
+++ b/Modelica/Magnetic/FluxTubes/UsersGuide/Hysteresis/DynamicHysteresis.mo
@@ -34,7 +34,7 @@ Where <code>&sigma;</code> is the electrical conductivity and <code>d</code> the
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-<caption align=\"bottom\"><strong>Fig. 1:</strong> Static and dynamic portion of the hysteresis B(H)</caption>
+<caption><strong>Fig. 1:</strong> Static and dynamic portion of the hysteresis B(H)</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/DynamicHysteresis/Eddy_BHBHstatBHeddy.png\">
@@ -47,7 +47,7 @@ The following two figures show a comparison between measured and simulated dynam
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-<caption align=\"bottom\"><strong>Fig. 2:</strong> Dynamic hysteresis measurements with an 25 cm Epstein frame according to DIN EN 60404-2 (Material: M330-50A, 4 Sheets)</caption>
+<caption><strong>Fig. 2:</strong> Dynamic hysteresis measurements with an 25 cm Epstein frame according to DIN EN 60404-2 (Material: M330-50A, 4 Sheets)</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/DynamicHysteresis/EddyCurrent_Epstein_Meas.png\">
@@ -56,7 +56,7 @@ The following two figures show a comparison between measured and simulated dynam
 </table>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-<caption align=\"bottom\"><strong>Fig. 3:</strong> Simulation results of a 25 cm Epstein frame model according to the measurement setup of Fig. 1</caption>
+<caption><strong>Fig. 3:</strong> Simulation results of a 25 cm Epstein frame model according to the measurement setup of Fig. 1</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/DynamicHysteresis/EddyCurrent_Epstein_Sim.png\">

--- a/Modelica/Magnetic/FluxTubes/UsersGuide/Hysteresis/HysteresisLosses.mo
+++ b/Modelica/Magnetic/FluxTubes/UsersGuide/Hysteresis/HysteresisLosses.mo
@@ -38,7 +38,7 @@ Where <code>&sigma;<sub>cl</sub></code> is the classical eddy current factor (se
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 1:</strong> Diagram of a simple transformer with ferromagnetic core (model available at <a href=\"modelica://Modelica.Magnetic.FluxTubes.Examples.Hysteresis.SinglePhaseTransformerWithHysteresis1\">Examples.Hysteresis.SinglePhaseTransformerWithHysteresis1</a>)</caption>
+  <caption><strong>Fig. 1:</strong> Diagram of a simple transformer with ferromagnetic core (model available at <a href=\"modelica://Modelica.Magnetic.FluxTubes.Examples.Hysteresis.SinglePhaseTransformerWithHysteresis1\">Examples.Hysteresis.SinglePhaseTransformerWithHysteresis1</a>)</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/HysteresisLosses/PowerLoss_Hysteresis01.png\">
@@ -47,7 +47,7 @@ Where <code>&sigma;<sub>cl</sub></code> is the classical eddy current factor (se
 </table>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 2:</strong> Simulated total dynamic hysteresis loop with its static and eddy current fractions</caption>
+  <caption><strong>Fig. 2:</strong> Simulated total dynamic hysteresis loop with its static and eddy current fractions</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/HysteresisLosses/PowerLoss_Hysteresis02.png\">
@@ -56,7 +56,7 @@ Where <code>&sigma;<sub>cl</sub></code> is the classical eddy current factor (se
 </table>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 3:</strong> Simulated outputs of the <code>Core</code> component of Fig. 1</caption>
+  <caption><strong>Fig. 3:</strong> Simulated outputs of the <code>Core</code> component of Fig. 1</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/HysteresisLosses/PowerLoss_Hysteresis03.png\">

--- a/Modelica/Magnetic/FluxTubes/UsersGuide/Hysteresis/StaticHysteresis/Preisach.mo
+++ b/Modelica/Magnetic/FluxTubes/UsersGuide/Hysteresis/StaticHysteresis/Preisach.mo
@@ -10,7 +10,7 @@ This section gives an very brief overview of the Preisach hysteresis model, whic
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 1: </strong>Characteristics of an elementary hysteresis operator.</caption>
+  <caption><strong>Fig. 1: </strong>Characteristics of an elementary hysteresis operator.</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/StaticHysteresis/Preisach/preisach_elementaryOperator.png\">
@@ -23,7 +23,7 @@ Due to &alpha;&ge;&beta;, the switching limits &alpha; and &beta; span a right t
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 2:</strong> Preisach Plane (a) and exemplary plot of the Preisach distribution function P(&alpha;,&beta;) (b)</caption>
+  <caption><strong>Fig. 2:</strong> Preisach Plane (a) and exemplary plot of the Preisach distribution function P(&alpha;,&beta;) (b)</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/StaticHysteresis/Preisach/preisach_PlaneAndDist.png\">
@@ -62,7 +62,7 @@ The Everett function returns the change in magnetization which results when all 
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 3:</strong> Preisach plane and region R over which P(&alpha;,&beta;) is integrated to obtain E(H1,H2)</caption>
+  <caption><strong>Fig. 3:</strong> Preisach plane and region R over which P(&alpha;,&beta;) is integrated to obtain E(H1,H2)</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/StaticHysteresis/Preisach/EverettRegion.png\">

--- a/Modelica/Magnetic/FluxTubes/UsersGuide/Hysteresis/package.mo
+++ b/Modelica/Magnetic/FluxTubes/UsersGuide/Hysteresis/package.mo
@@ -11,7 +11,7 @@ The elements provided in the package Shapes.HysteresisAndMagnets allow for consi
 </p>
 
 <table cellspacing=\"0\" cellpadding=\"2\" border=\"0\">
-  <caption align=\"bottom\"><strong>Fig. 1:</strong> Inductor with ferromagnetic core and hysteresis effects; (a) diagram of the network model; (b) simulated hysteresis characteristics of the core for different excitation frequencies of 0, 10 and 100 Hz (the example model can be found at: <a href=\"modelica://Modelica.Magnetic.FluxTubes.Examples.Hysteresis.InductorWithHysteresis\">Examples.Hysteresis.InductorWithHysteresis</a>)</caption>
+  <caption><strong>Fig. 1:</strong> Inductor with ferromagnetic core and hysteresis effects; (a) diagram of the network model; (b) simulated hysteresis characteristics of the core for different excitation frequencies of 0, 10 and 100 Hz (the example model can be found at: <a href=\"modelica://Modelica.Magnetic.FluxTubes.Examples.Hysteresis.InductorWithHysteresis\">Examples.Hysteresis.InductorWithHysteresis</a>)</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/UsersGuide/Hysteresis/InductorWithHysteresis_DiagramAndSim.png\">

--- a/Modelica/Magnetic/FundamentalWave/BasicMachines/Components/RotorSaliencyAirGap.mo
+++ b/Modelica/Magnetic/FundamentalWave/BasicMachines/Components/RotorSaliencyAirGap.mo
@@ -103,7 +103,7 @@ The air gap model has two magnetic stator and two magnetic rotor
 according to the following figure.
 </p>
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig:</strong> Magnetic equivalent circuit of the air gap model</caption>
+  <caption><strong>Fig:</strong> Magnetic equivalent circuit of the air gap model</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/Machines/Components/airgap_phasors.png\">

--- a/Modelica/Magnetic/FundamentalWave/Components/EddyCurrent.mo
+++ b/Modelica/Magnetic/FundamentalWave/Components/EddyCurrent.mo
@@ -42,7 +42,7 @@ The eddy current loss model with respect to fundamental wave effects is designed
 </blockquote>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\">Fig. 1: equivalent models of eddy current losses</caption>
+  <caption>Fig. 1: equivalent models of eddy current losses</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/Components/eddycurrent_electric.png\"

--- a/Modelica/Magnetic/FundamentalWave/Components/PolyphaseElectroMagneticConverter.mo
+++ b/Modelica/Magnetic/FundamentalWave/Components/PolyphaseElectroMagneticConverter.mo
@@ -122,7 +122,7 @@ The voltages <img src=\"modelica://Modelica/Resources/Images/Magnetic/Fundamenta
 <p>for <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/k_in_1_m.png\"> and is also illustrated by the following figure:</p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig:</strong> Orientation of winding and location of complex magnetic flux</caption>
+  <caption><strong>Fig:</strong> Orientation of winding and location of complex magnetic flux</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/Components/coupling.png\">

--- a/Modelica/Magnetic/FundamentalWave/UsersGuide/Concept.mo
+++ b/Modelica/Magnetic/FundamentalWave/UsersGuide/Concept.mo
@@ -10,7 +10,7 @@ The exact magnetic field in the air gap of an electric machine is usually determ
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 1:</strong> Field lines of a four pole induction machine</caption>
+  <caption><strong>Fig. 1:</strong> Field lines of a four pole induction machine</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/UsersGuide/Concept/aimc_fem.png\">
@@ -22,7 +22,7 @@ The exact magnetic field in the air gap of an electric machine is usually determ
 In the fundamental wave theory only a pure sinusoidal distribution of magnetic quantities is assumed. It is thus assumed that all other harmonic wave effects are not taken into account.</p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 2:</strong> Magnetic potential difference of a four pole machine, where <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/varphi.png\"> is the angle of the spatial domain with respect to one pole pair</caption>
+  <caption><strong>Fig. 2:</strong> Magnetic potential difference of a four pole machine, where <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/varphi.png\"> is the angle of the spatial domain with respect to one pole pair</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/UsersGuide/Concept/four_pole_V_m.png\">
@@ -41,7 +41,7 @@ The waveforms of the magnetic field quantities, e.g., the magnetic potential dif
 <p>It is important to note that the magnetic potential used in this library <strong>always</strong> refers to an equivalent two pole machine.</p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 3:</strong> Spatial distribution of the magnetic potential difference (red shade = positive sine wave, blue shade = negative sine wave) including complex phasor representing this spatial distribution</caption>
+  <caption><strong>Fig. 3:</strong> Spatial distribution of the magnetic potential difference (red shade = positive sine wave, blue shade = negative sine wave) including complex phasor representing this spatial distribution</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/UsersGuide/Concept/electrical_reference_V_m.png\">

--- a/Modelica/Magnetic/FundamentalWave/UsersGuide/Polyphase.mo
+++ b/Modelica/Magnetic/FundamentalWave/UsersGuide/Polyphase.mo
@@ -36,7 +36,7 @@ spatial domain which also applies to polyphase systems.
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 1: </strong>Symmetrical (a) three-phase and (b) five-phase current system</caption>
+  <caption><strong>Fig. 1: </strong>Symmetrical (a) three-phase and (b) five-phase current system</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/UsersGuide/Polyphase/phase35.png\"
@@ -46,7 +46,7 @@ spatial domain which also applies to polyphase systems.
 </table>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 2: </strong>Symmetrical (a) three-phase and (b) five-phase winding</caption>
+  <caption><strong>Fig. 2: </strong>Symmetrical (a) three-phase and (b) five-phase winding</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/UsersGuide/Polyphase/winding35.png\"
@@ -95,7 +95,7 @@ A function for calculating the <a href=\"modelica://Modelica.Electrical.Polyphas
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 3: </strong>Symmetrical (a) six and (b) ten phase current system</caption>
+  <caption><strong>Fig. 3: </strong>Symmetrical (a) six and (b) ten phase current system</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/UsersGuide/Polyphase/phase610.png\"
@@ -105,7 +105,7 @@ A function for calculating the <a href=\"modelica://Modelica.Electrical.Polyphas
 </table>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 4: </strong>Symmetrical (a) six and (b) ten phase winding</caption>
+  <caption><strong>Fig. 4: </strong>Symmetrical (a) six and (b) ten phase winding</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/UsersGuide/Polyphase/winding610.png\"

--- a/Modelica/Magnetic/FundamentalWave/UsersGuide/WindingModel.mo
+++ b/Modelica/Magnetic/FundamentalWave/UsersGuide/WindingModel.mo
@@ -9,7 +9,7 @@ magnetic potential and magnetic flux.
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 1: </strong>Symmetric polyphase winding</caption>
+  <caption><strong>Fig. 1: </strong>Symmetric polyphase winding</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/UsersGuide/WindingModel/SymmetricPolyphaseWinding.png\"

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Components/EddyCurrent.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Components/EddyCurrent.mo
@@ -48,7 +48,7 @@ The eddy current loss model with respect to fundamental wave effects is designed
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\">Fig. 1: equivalent models of eddy current losses</caption>
+  <caption>Fig. 1: equivalent models of eddy current losses</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/FundamentalWave/Components/eddycurrent_electric.png\">

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/UsersGuide/Concept.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/UsersGuide/Concept.mo
@@ -39,7 +39,7 @@ respectively, by means of:
 This is a strict consequence of the electromagnetic coupling between the quasi-static electric and the quasi-static magnetic domain.</p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 1:</strong> Reference frames of the quasi-static fundamental wave library</caption>
+  <caption><strong>Fig. 1:</strong> Reference frames of the quasi-static fundamental wave library</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/QuasiStatic/FundamentalWave/ReferenceFrames.png\"/>

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Utilities/VfController.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Utilities/VfController.mo
@@ -60,7 +60,7 @@ The output voltages may serve as inputs for complex voltage sources with phase i
 </p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 1:</strong> Voltage vs. frequency of voltage frequency controller</caption>
+  <caption><strong>Fig. 1:</strong> Voltage vs. frequency of voltage frequency controller</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/Magnetic/QuasiStatic/FundamentalWave/Utilities/VoltageFrequencyController.png\">

--- a/Modelica/Mechanics/Rotational/UsersGuide/UserDefinedComponents.mo
+++ b/Modelica/Mechanics/Rotational/UsersGuide/UserDefinedComponents.mo
@@ -14,7 +14,7 @@ which are defined in sublibrary Interfaces:
 </p>
 
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\">List of common base classes for 1-dimensional rotational components</caption>
+  <caption>List of common base classes for 1-dimensional rotational components</caption>
   <tr><th>Name</th><th>Description</th></tr>
   <tr>
     <td><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces.PartialCompliant\">PartialCompliant</a>

--- a/Modelica/Mechanics/Translational/UsersGuide/UserDefinedComponents.mo
+++ b/Modelica/Mechanics/Translational/UsersGuide/UserDefinedComponents.mo
@@ -14,7 +14,7 @@ which are defined in sublibrary
 </p>
 
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\">List of common base classes for 1-dimensional translational components</caption>
+  <caption>List of common base classes for 1-dimensional translational components</caption>
   <tr><th>Name</th><th>Description</th></tr>
   <tr>
     <td><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces.PartialCompliant\">PartialCompliant</a>

--- a/Modelica/Media/Water/IF97_Utilities.mo
+++ b/Modelica/Media/Water/IF97_Utilities.mo
@@ -6003,7 +6003,7 @@ region 5 is also covered by a <span class=\"nobr\"><em>g</em>( <em>p</em>,<em>T<
 equations</em>.
 </p>
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\">Figure 1: Regions and equations of IAPWS-IF97</caption>
+  <caption>Figure 1: Regions and equations of IAPWS-IF97</caption>
   <tr>
     <td>
     <img src=\"modelica://Modelica/Resources/Images/Media/Water/if97.png\" alt=\"Regions and equations of IAPWS-IF97\">

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -738,7 +738,7 @@ The <code>PNG</code> files should be placed in a folder which exactly represents
 
 <blockquote><pre>
 &lt;table border=&quot;0&quot; cellspacing=&quot;0&quot; cellpadding=&quot;2&quot;&gt;
-  &lt;caption align=&quot;bottom&quot;&gt;Caption starts with a capital letter&lt;/caption&gt;
+  &lt;caption&gt;Caption starts with a capital letter&lt;/caption&gt;
   &lt;tr&gt;
     &lt;td&gt;
       &lt;img src=&quot;modelica://Modelica/Resources/Images/Blocks/PID_controller.png&quot;
@@ -756,7 +756,7 @@ The <code>PNG</code> files should be placed in a folder which exactly represents
 
 <blockquote><pre>
 &lt;table border=&quot;0&quot; cellspacing=&quot;0&quot; cellpadding=&quot;2&quot;&gt;
-  &lt;caption align=&quot;bottom&quot;&gt;&lt;strong&gt;Fig. 2:&lt;/strong&gt; Caption starts with a capital letter&lt;/caption&gt;
+  &lt;caption&gt;&lt;strong&gt;Fig. 2:&lt;/strong&gt; Caption starts with a capital letter&lt;/caption&gt;
   &lt;tr&gt;
     &lt;td&gt;
       &lt;img src=&quot;modelica://Modelica/Resources/Images/Blocks/PID_controller.png&quot;
@@ -912,7 +912,7 @@ and
 
 <blockquote><pre>
 &lt;table border=&quot;1&quot; cellspacing=&quot;0&quot; cellpadding=&quot;2&quot;&gt;
-  &lt;caption align=&quot;bottom&quot;&gt;Caption starts with a capital letter&lt;/caption&gt;
+  &lt;caption&gt;Caption starts with a capital letter&lt;/caption&gt;
   &lt;tr&gt;
     &lt;th&gt;Head 1&lt;/th&gt;
     &lt;th&gt;Head 2&lt;/th&gt;
@@ -929,7 +929,7 @@ and
 </pre></blockquote>
 <p>appears as</p>
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\">Caption starts with a capital letter</caption>
+  <caption>Caption starts with a capital letter</caption>
   <tr>
     <th><strong>Head 1</strong></th>
     <th><strong>Head 2</strong></th>
@@ -952,7 +952,7 @@ and enumeration should look like this: <strong>Tab. 1:</strong> Tables have to b
 
 <blockquote><pre>
 &lt;table border=&quot;1&quot; cellspacing=&quot;0&quot; cellpadding=&quot;2&quot;&gt;
-  &lt;caption align=&quot;bottom&quot;&gt;&lt;strong&gt;Tab 2:&lt;/strong&gt; Caption starts with a capital letter&lt;/caption&gt;
+  &lt;caption&gt;&lt;strong&gt;Tab 2:&lt;/strong&gt; Caption starts with a capital letter&lt;/caption&gt;
   &lt;tr&gt;
     &lt;th&gt;Head 1&lt;/th&gt;
     &lt;th&gt;Head 2&lt;/th&gt;
@@ -969,7 +969,7 @@ and enumeration should look like this: <strong>Tab. 1:</strong> Tables have to b
 </pre></blockquote>
 <p>appears as</p>
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Tab. 2:</strong> Caption starts with a capital letter</caption>
+  <caption><strong>Tab. 2:</strong> Caption starts with a capital letter</caption>
   <tr>
     <th>Head 1</th>
     <th>Head 2</th>
@@ -1120,7 +1120,7 @@ For parameters, connectors, as well as inputs and outputs of function automatic 
 <p>The terms listed in this package shall be in accordance with <a href=\"http://www.electropedia.org/\">Electropedia</a>.</p>
 
 <table border=\"1\" cellpadding=\"2\" cellspacing=\"0\" >
-  <caption align=\"bottom\">List of electrical term spellings</caption>
+  <caption>List of electrical term spellings</caption>
   <tr>
     <th>To be used</th>
     <th>Not to be used</th>
@@ -1182,7 +1182,7 @@ For parameters, connectors, as well as inputs and outputs of function automatic 
 <p>The terms listed in this package shall be in accordance with <a href=\"http://www.electropedia.org/\">Electropedia</a>.</p>
 
 <table border=\"1\" cellpadding=\"2\" cellspacing=\"0\" >
-  <caption align=\"bottom\">List of magnetic term spellings</caption>
+  <caption>List of magnetic term spellings</caption>
   <tr>
     <th>To be used</th>
     <th>Not to be used</th>
@@ -1268,7 +1268,7 @@ For Boolean parameters, the description string should start with &quot;= true, &
 <p>In the following table typical variable names are listed. This list should be completed.</p>
 
 <table border=\"1\" cellpadding=\"2\" cellspacing=\"0\" >
-   <caption align=\"bottom\">Variables and names</caption>
+   <caption>Variables and names</caption>
    <tr>
       <th>Variable</th>
       <th>Quantity</th>
@@ -1887,7 +1887,7 @@ The authors would like to thank following persons for their support ...
 In the Modelica Standard Library the following color schemes apply:</p>
 
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\">Color schemes applied to particular libraries</caption>
+  <caption>Color schemes applied to particular libraries</caption>
   <tr>
     <th>Package</th>
     <th>Color RGB code</th>
@@ -2036,7 +2036,7 @@ In the Modelica Standard Library the following color schemes apply:</p>
 and the most significant parameter can be displayed within the vertical Diagram range of the icon.</p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 1</strong>: (a) Typical icon, (b) including dimensions</caption>
+  <caption><strong>Fig. 1</strong>: (a) Typical icon, (b) including dimensions</caption>
   <tr>
     <td> (a)
       <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Icon_name.png\"
@@ -2063,7 +2063,7 @@ shall be 10 units below the upper icon boundary, see <strong>Fig.&nbsp;1</strong
 the component name shall be placed above the icon with vertical 10 units of space between icon and lower text box, see <strong>Fig.&nbsp;2</strong>.</p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 2</strong>: Block component name</caption>
+  <caption><strong>Fig. 2</strong>: Block component name</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Block_name.png\"
@@ -2078,7 +2078,7 @@ shall be avoided to keep the design straight, see <strong>Fig.&nbsp;4</strong>. 
 the line shall be interrupted such that this line does not interfere with component name.</p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 3</strong>: Component name between actual icon and connector</caption>
+  <caption><strong>Fig. 3</strong>: Component name between actual icon and connector</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Icon_name_connector_above.png\"
@@ -2090,7 +2090,7 @@ the line shall be interrupted such that this line does not interfere with compon
 <p>In some cases, if there is not alternative, the component name has to be placed below the actual icon, see. <strong>Fig.&nbsp;4</strong>.</p>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 4</strong>: Component name below actual icon</caption>
+  <caption><strong>Fig. 4</strong>: Component name below actual icon</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Icon_name_below.png\"
@@ -2120,7 +2120,7 @@ Preferred connector locations are:</p>
 </ul>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 5</strong>: Connectors located at the four corners of the icon diagram</caption>
+  <caption><strong>Fig. 5</strong>: Connectors located at the four corners of the icon diagram</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Icon_connector_corner.png\"
@@ -2162,7 +2162,7 @@ design of sensors apply:
 </ul>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 6</strong>: Round sensor with (a) short and (b) longer SI unit</caption>
+  <caption><strong>Fig. 6</strong>: Round sensor with (a) short and (b) longer SI unit</caption>
   <tr>
     <td> (a)
       <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Icon_sensor_round.png\"
@@ -2176,7 +2176,7 @@ design of sensors apply:
 </table>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 7</strong>: Rectangular sensor </caption>
+  <caption><strong>Fig. 7</strong>: Rectangular sensor </caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Icon_sensor_rectangular.png\"
@@ -2186,7 +2186,7 @@ design of sensors apply:
 </table>
 
 <table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-  <caption align=\"bottom\"><strong>Fig. 8</strong>: Sensor with multiple signal outputs and SI units located next to the output connectors</caption>
+  <caption><strong>Fig. 8</strong>: Sensor with multiple signal outputs and SI units located next to the output connectors</caption>
   <tr>
     <td>
       <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Icon_sensor_multi.png\"


### PR DESCRIPTION
This fixes #3844 by removing the recommendation and application of `align=\"bottom\"` since tools tend to interpret this differently (e.g., ignore) and the `align` parameter is also deprecated in HTML5. Not using and recommending it  makes it more future proof. 
