### PR TITLE
Remove obsoleted BMBF link

### DIFF
--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -3918,8 +3918,7 @@ the following new language elements (compared to Modelica Specification 3.1):
 <p>
 A large part of the new classes have been developed with
 partial financial support by
-<a href=\"http://www.bmbf.de/en/index.php\">BMBF</a>
-(BMBF F&ouml;rderkennzeichen: 01IS07022F)
+BMBF (BMBF F&ouml;rderkennzeichen: 01IS07022F)
 within the <a href=\"http://www.itea2.org\">ITEA2</a> project
 EUROSYSLIB.
 We highly appreciate this funding.


### PR DESCRIPTION
The link got obsoleted, but it is good enough to mention BMBF with FKZ as in other locations, e.g., https://github.com/modelica/ModelicaStandardLibrary/blob/4577c01e1f71fc684c256837250b5adcbf58fd5a/Modelica/Fluid/package.mo#L1685