### PR TITLE
startBackward and startForward should not be reference results (#3866)

### DIFF
--- a/Modelica/Resources/Reference/Modelica/Mechanics/MultiBody/Examples/Systems/RobotR3/OneAxis/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Mechanics/MultiBody/Examples/Systems/RobotR3/OneAxis/comparisonSignals.txt
@@ -7,5 +7,3 @@ axis.initializeFlange.w_flange
 axis.motor.C.v
 axis.motor.La.i
 axis.gear.bearingFriction.mode
-axis.gear.bearingFriction.startBackward
-axis.gear.bearingFriction.startForward

--- a/Modelica/Resources/Reference/Modelica/Mechanics/Rotational/Examples/CoupledClutches/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Mechanics/Rotational/Examples/CoupledClutches/comparisonSignals.txt
@@ -8,11 +8,5 @@ clutch2.w_rel
 clutch3.phi_rel
 clutch3.w_rel
 clutch1.mode
-clutch1.startBackward
-clutch1.startForward
 clutch2.mode
-clutch2.startBackward
-clutch2.startForward
 clutch3.mode
-clutch3.startBackward
-clutch3.startForward

--- a/Modelica/Resources/Reference/Modelica/Mechanics/Rotational/Examples/Friction/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Mechanics/Rotational/Examples/Friction/comparisonSignals.txt
@@ -6,8 +6,4 @@ inertia3.w
 spring.phi_rel
 spring.w_rel
 brake.mode
-brake.startBackward
-brake.startForward
 clutch.mode
-clutch.startBackward
-clutch.startForward

--- a/Modelica/Resources/Reference/Modelica/Mechanics/Rotational/Examples/HeatLosses/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Mechanics/Rotational/Examples/HeatLosses/comparisonSignals.txt
@@ -12,14 +12,7 @@ oneWayClutch.w_rel
 springDamper.phi_rel
 springDamper.w_rel
 bearingFriction.mode
-bearingFriction.startBackward
-bearingFriction.startForward
 brake.mode
-brake.startBackward
-brake.startForward
 clutch.mode
-clutch.startBackward
-clutch.startForward
 lossyGear.mode
-oneWayClutch.startForward
 oneWayClutch.stuck

--- a/Modelica/Resources/Reference/Modelica/Mechanics/Rotational/Examples/LossyGearDemo2/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Mechanics/Rotational/Examples/LossyGearDemo2/comparisonSignals.txt
@@ -2,6 +2,4 @@ time
 Inertia2.phi
 Inertia2.w
 bearingFriction.mode
-bearingFriction.startBackward
-bearingFriction.startForward
 gear.mode

--- a/Modelica/Resources/Reference/Modelica/Mechanics/Rotational/Examples/SimpleGearShift/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Mechanics/Rotational/Examples/SimpleGearShift/comparisonSignals.txt
@@ -6,8 +6,4 @@ engine.w
 load.phi
 load.w
 brake.mode
-brake.startBackward
-brake.startForward
 clutch.mode
-clutch.startBackward
-clutch.startForward

--- a/Modelica/Resources/Reference/Modelica/Mechanics/Translational/Examples/Brake/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Mechanics/Translational/Examples/Brake/comparisonSignals.txt
@@ -4,8 +4,4 @@ mass1.v
 mass2.s
 mass2.v
 brake.mode
-brake.startBackward
-brake.startForward
 brake1.mode
-brake1.startBackward
-brake1.startForward

--- a/Modelica/Resources/Reference/Modelica/Mechanics/Translational/Examples/Friction/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Mechanics/Translational/Examples/Friction/comparisonSignals.txt
@@ -6,11 +6,5 @@ stop1.v
 stop2.s
 stop2.v
 stop1.mode
-stop1.startBackward
-stop1.startForward
 stop2.mode
-stop2.startBackward
-stop2.startForward
 supportFriction.mode
-supportFriction.startBackward
-supportFriction.startForward

--- a/Modelica/Resources/Reference/Modelica/Mechanics/Translational/Examples/HeatLosses/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Mechanics/Translational/Examples/HeatLosses/comparisonSignals.txt
@@ -8,11 +8,5 @@ springDamper.v_rel
 springDamper1.s_rel
 springDamper1.v_rel
 brake.mode
-brake.startBackward
-brake.startForward
 massWithStopAndFriction.mode
-massWithStopAndFriction.startBackward
-massWithStopAndFriction.startForward
 supportFriction.mode
-supportFriction.startBackward
-supportFriction.startForward

--- a/ModelicaTest/Resources/Reference/ModelicaTest/Rotational/AllComponents/comparisonSignals.txt
+++ b/ModelicaTest/Resources/Reference/ModelicaTest/Rotational/AllComponents/comparisonSignals.txt
@@ -27,14 +27,8 @@ speed.w
 springDamper.phi_rel
 springDamper.w_rel
 bearingFriction.mode
-bearingFriction.startBackward
-bearingFriction.startForward
 brake.mode
-brake.startBackward
-brake.startForward
 clutch.mode
-clutch.startBackward
-clutch.startForward
 gear2_1.lossyGear.mode
 lossyGear.mode
 coupling.w

--- a/ModelicaTest/Resources/Reference/ModelicaTest/Rotational/ForUsersGuide/SupportTorque1/comparisonSignals.txt
+++ b/ModelicaTest/Resources/Reference/ModelicaTest/Rotational/ForUsersGuide/SupportTorque1/comparisonSignals.txt
@@ -2,5 +2,3 @@ time
 inertia4.phi
 inertia4.w
 bearingFriction1.mode
-bearingFriction1.startBackward
-bearingFriction1.startForward

--- a/ModelicaTest/Resources/Reference/ModelicaTest/Rotational/TestBearingConversion/comparisonSignals.txt
+++ b/ModelicaTest/Resources/Reference/ModelicaTest/Rotational/TestBearingConversion/comparisonSignals.txt
@@ -40,17 +40,9 @@ slidingMass.v
 slidingMass1.s
 slidingMass1.v
 bearingFriction.mode
-bearingFriction.startBackward
-bearingFriction.startForward
 bearingFriction1.mode
-bearingFriction1.startBackward
-bearingFriction1.startForward
 brake.mode
-brake.startBackward
-brake.startForward
 brake1.mode
-brake1.startBackward
-brake1.startForward
 gear2_1.lossyGear.mode
 gear2_2.lossyGear.mode
 lossyGear.mode

--- a/ModelicaTest/Resources/Reference/ModelicaTest/Rotational/TestFriction/comparisonSignals.txt
+++ b/ModelicaTest/Resources/Reference/ModelicaTest/Rotational/TestFriction/comparisonSignals.txt
@@ -12,13 +12,6 @@ inertia5.w
 oneWayClutch.phi_rel
 oneWayClutch.w_rel
 bearingFriction.mode
-bearingFriction.startBackward
-bearingFriction.startForward
 brake.mode
-brake.startBackward
-brake.startForward
 clutch.mode
-clutch.startBackward
-clutch.startForward
-oneWayClutch.startForward
 oneWayClutch.stuck


### PR DESCRIPTION
remove startBackward and startForward from the reference results, because the transition from these states to mode = Backward or Forward depends on the random value of the velocity difference in the state Stuck