### PR TITLE
Add QuasiRMS voltage and current single-phase sensors

### DIFF
--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/CurrentRMSSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/CurrentRMSSensor.mo
@@ -1,25 +1,24 @@
 within Modelica.Electrical.QuasiStatic.SinglePhase.Sensors;
-model CurrentSensor "Current sensor"
+model CurrentRMSSensor "Continuous current RMS sensor for single-phase system"
   extends Modelica.Electrical.QuasiStatic.SinglePhase.Interfaces.RelativeSensorElementary;
-  Modelica.ComplexBlocks.Interfaces.ComplexOutput i(re(unit = "A"), im(unit = "A")) "Complex current" annotation (Placement(
-        transformation(
-        origin={0,-110},
-        extent={{-10,-10},{10,10}},
-        rotation=270), iconTransformation(
-        extent={{-10,-10},{10,10}},
-        rotation=270,
-        origin={0,-110})));
-  SI.Current abs_i=Modelica.ComplexMath.abs(i) "Magnitude of complex current";
-  SI.Angle arg_i=Modelica.ComplexMath.arg(i) "Argument of complex current";
+  Modelica.Blocks.Interfaces.RealOutput I(unit="A")
+    "Continuous average RMS of current" annotation(
+    Placement(transformation(origin = {0, -110}, extent = {{-10, -10}, {10, 10}}, rotation = -90), iconTransformation(origin = {0, -110}, extent = {{-10, -10}, {10, 10}}, rotation = -90)));
+  SI.ComplexCurrent i "Complex current";
   SI.ComplexVoltage v "Complex voltage";
 equation
+  I = sqrt(i.re^2 + i.im^2);
   i = pin_p.i;
   v = pin_p.v - pin_n.v;
   v = Complex(0,0);
   annotation (Documentation(info="<html>
 <p>
-This sensor can be used to measure the complex current.
+This sensor determines the continuous root mean square (<a href=\"modelica://Modelica.Electrical.QuasiStatic.UsersGuide.Overview.Introduction\">RMS</a>)
+value of a single-phase current system.
 </p>
+<blockquote><pre>
+I = abs(i)
+</pre></blockquote>
 
 <h4>See also</h4>
 
@@ -29,16 +28,13 @@ This sensor can be used to measure the complex current.
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.PotentialSensor\">PotentialSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageSensor\">VoltageSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageRMSSensor\">VoltageRMSSensor</a>,
-<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentRMSSensor\">CurrentRMSSensor</a>,
+<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentSensor\">CurrentSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.PowerSensor\">PowerSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.MultiSensor\">MultiSensor</a>
 </p>
 
 </html>"),
        Icon(graphics={
-        Text(
-          extent={{-30,-10},{30,-70}},
-          textColor={64,64,64},
-          textString="A"),
+        Text(textColor = {64, 64, 64}, extent = {{-30, -10}, {30, -70}}, textString = "A"),
         Line(points={{-70,0},{70,0}},   color={85,170,255})}));
-end CurrentSensor;
+end CurrentRMSSensor;

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/FrequencySensor.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/FrequencySensor.mo
@@ -18,7 +18,9 @@ This sensor can be used to measure the frequency of the reference system.
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.ReferenceSensor\">ReferenceSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.PotentialSensor\">PotentialSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageSensor\">VoltageSensor</a>,
+<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageRMSSensor\">VoltageRMSSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentSensor\">CurrentSensor</a>,
+<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentRMSSensor\">CurrentRMSSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.PowerSensor\">PowerSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.MultiSensor\">MultiSensor</a>
 </p>

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/MultiSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/MultiSensor.mo
@@ -103,8 +103,10 @@ The internal resistance of the current path is zero, the internal resistance of 
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.FrequencySensor\">FrequencySensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.PotentialSensor\">PotentialSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageSensor\">VoltageSensor</a>,
+<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageRMSSensor\">VoltageRMSSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentSensor\">CurrentSensor</a>,
-<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.PowerSensor\">PowerSensor</a>,
+<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentRMSSensor\">CurrentRMSSensor</a>,
+<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.PowerSensor\">PowerSensor</a>
 </p>
 </html>", revisions="<html>
 <ul>

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/PotentialSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/PotentialSensor.mo
@@ -19,9 +19,10 @@ This sensor can be used to measure the complex potential.
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.ReferenceSensor\">ReferenceSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.FrequencySensor\">FrequencySensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageSensor\">VoltageSensor</a>,
+<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageRMSSensor\">VoltageRMSSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentSensor\">CurrentSensor</a>,
+<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentRMSSensor\">CurrentRMSSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.PowerSensor\">PowerSensor</a>,
-<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.MultiSensor\">MultiSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.MultiSensor\">MultiSensor</a>
 </p>
 

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/PowerSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/PowerSensor.mo
@@ -64,7 +64,9 @@ This sensor can be used to measure the complex apparent power.
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.FrequencySensor\">FrequencySensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.PotentialSensor\">PotentialSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageSensor\">VoltageSensor</a>,
+<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageRMSSensor\">VoltageRMSSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentSensor\">CurrentSensor</a>,
+<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentRMSSensor\">CurrentRMSSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.MultiSensor\">MultiSensor</a>
 </p>
 

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/ReferenceSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/ReferenceSensor.mo
@@ -16,7 +16,9 @@ This sensor can be used to measure the reference angle.
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.FrequencySensor\">FrequencySensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.PotentialSensor\">PotentialSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageSensor\">VoltageSensor</a>,
+<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageRMSSensor\">VoltageRMSSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentSensor\">CurrentSensor</a>,
+<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentRMSSensor\">CurrentRMSSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.PowerSensor\">PowerSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.MultiSensor\">MultiSensor</a>
 </p>

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/VoltageRMSSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/VoltageRMSSensor.mo
@@ -1,25 +1,24 @@
 within Modelica.Electrical.QuasiStatic.SinglePhase.Sensors;
-model CurrentSensor "Current sensor"
+model VoltageRMSSensor "Continuous voltage RMS sensor for single-phase system"
   extends Modelica.Electrical.QuasiStatic.SinglePhase.Interfaces.RelativeSensorElementary;
-  Modelica.ComplexBlocks.Interfaces.ComplexOutput i(re(unit = "A"), im(unit = "A")) "Complex current" annotation (Placement(
-        transformation(
-        origin={0,-110},
-        extent={{-10,-10},{10,10}},
-        rotation=270), iconTransformation(
-        extent={{-10,-10},{10,10}},
-        rotation=270,
-        origin={0,-110})));
-  SI.Current abs_i=Modelica.ComplexMath.abs(i) "Magnitude of complex current";
-  SI.Angle arg_i=Modelica.ComplexMath.arg(i) "Argument of complex current";
+  Modelica.Blocks.Interfaces.RealOutput V(unit="V")
+    "Continuous average RMS of voltage" annotation(
+    Placement(transformation(origin = {0, -110}, extent = {{-10, -10}, {10, 10}}, rotation = -90), iconTransformation(origin = {0, -110}, extent = {{-10, -10}, {10, 10}}, rotation = -90)));
   SI.ComplexVoltage v "Complex voltage";
+  SI.ComplexCurrent i "Complex current";
 equation
-  i = pin_p.i;
+  V = sqrt(v.re^2 + v.im^2);
   v = pin_p.v - pin_n.v;
-  v = Complex(0,0);
+  i = pin_p.i;
+  i = Complex(0,0);
   annotation (Documentation(info="<html>
 <p>
-This sensor can be used to measure the complex current.
+This sensor determines the continuous root mean square (<a href=\"modelica://Modelica.Electrical.QuasiStatic.UsersGuide.Overview.Introduction\">RMS</a>)
+value of a single-phase voltage system.
 </p>
+<blockquote><pre>
+V = abs(v)
+</pre></blockquote>
 
 <h4>See also</h4>
 
@@ -28,7 +27,7 @@ This sensor can be used to measure the complex current.
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.FrequencySensor\">FrequencySensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.PotentialSensor\">PotentialSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageSensor\">VoltageSensor</a>,
-<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageRMSSensor\">VoltageRMSSensor</a>,
+<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentSensor\">CurrentSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentRMSSensor\">CurrentRMSSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.PowerSensor\">PowerSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.MultiSensor\">MultiSensor</a>
@@ -36,9 +35,7 @@ This sensor can be used to measure the complex current.
 
 </html>"),
        Icon(graphics={
-        Text(
-          extent={{-30,-10},{30,-70}},
-          textColor={64,64,64},
-          textString="A"),
-        Line(points={{-70,0},{70,0}},   color={85,170,255})}));
-end CurrentSensor;
+        Text(textColor = {64, 64, 64}, extent = {{-30, -10}, {30, -70}}, textString = "V"),
+        Line(points={{-100,0},{-70,0}}, color={85,170,255}),
+        Line(points={{70,0},{100,0}},   color={85,170,255})}));
+end VoltageRMSSensor;

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/VoltageSensor.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/VoltageSensor.mo
@@ -27,7 +27,9 @@ This sensor can be used to measure the complex voltage.
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.ReferenceSensor\">ReferenceSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.FrequencySensor\">FrequencySensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.PotentialSensor\">PotentialSensor</a>,
+<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageRMSSensor\">VoltageRMSSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentSensor\">CurrentSensor</a>,
+<a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentRMSSensor\">CurrentRMSSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.PowerSensor\">PowerSensor</a>,
 <a href=\"modelica://Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.MultiSensor\">MultiSensor</a>
 </p>

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/package.order
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Sensors/package.order
@@ -2,6 +2,8 @@ ReferenceSensor
 FrequencySensor
 PotentialSensor
 VoltageSensor
+VoltageRMSSensor
 CurrentSensor
+CurrentRMSSensor
 PowerSensor
 MultiSensor

--- a/ModelicaTest/Electrical/QuasiStatic/SinglePhase.mo
+++ b/ModelicaTest/Electrical/QuasiStatic/SinglePhase.mo
@@ -43,6 +43,16 @@ package SinglePhase "Single-phase quasi-static package"
       duration=1,
       offset=10,
       startTime=0) annotation (Placement(transformation(extent={{-100,-30},{-80,-10}})));
+    Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.VoltageRMSSensor
+      voltageRMSSensor annotation (Placement(transformation(
+          extent={{-10,10},{10,-10}},
+          rotation=270,
+          origin={10,-20})));
+    Modelica.Electrical.QuasiStatic.SinglePhase.Sensors.CurrentRMSSensor
+      currentRMSSensor annotation (Placement(transformation(
+          extent={{-10,-10},{10,10}},
+          rotation=270,
+          origin={90,0})));
   equation
 
     connect(const.y, variableResistor.R_ref) annotation (Line(points={{-29,60},{-20,60},{-20,42}}, color={0,0,127}));
@@ -57,7 +67,6 @@ package SinglePhase "Single-phase quasi-static package"
     connect(variableResistor.pin_n, variableConductor.pin_p) annotation (Line(points={{-10,30},{-5,30},{0,30}}, color={85,170,255}));
     connect(variableConductor.pin_n, variableCapacitor.pin_p) annotation (Line(points={{20,30},{25,30},{30,30}}, color={85,170,255}));
     connect(variableCapacitor.pin_n, variableInductor.pin_p) annotation (Line(points={{50,30},{55,30},{60,30}}, color={85,170,255}));
-    connect(variableInductor.pin_n, variableImpedance.pin_p) annotation (Line(points={{80,30},{90,30},{90,-40},{80,-40}}, color={85,170,255}));
     connect(variableImpedance.pin_n, variableAdmittance.pin_p) annotation (Line(points={{60,-40},{55,-40},{50,-40}}, color={85,170,255}));
     connect(const4.y, variableAdmittance.Y_ref) annotation (Line(points={{21,-60},{30,-60},{40,-60},{40,-52}}, color={85,170,255}));
     connect(const5.y, variableImpedance.Z_ref) annotation (Line(points={{-9,-80},{28,-80},{70,-80},{70,-52}}, color={85,170,255}));
@@ -66,6 +75,10 @@ package SinglePhase "Single-phase quasi-static package"
     connect(voltageSensor.pin_n, ground.pin) annotation (Line(points={{-20,-30},{-20,-40},{-50,-40}}, color={85,170,255}));
     connect(const6.y, currentSource.I) annotation (Line(points={{-79,-50},{-70,-50},{-70,-26},{-62,-26}}, color={85,170,255}));
     connect(ramp.y, currentSource.f) annotation (Line(points={{-79,-20},{-74,-20},{-70,-20},{-70,-14},{-62,-14}}, color={0,0,127}));
+    connect(voltageRMSSensor.pin_p, conductor.pin_p) annotation (Line(points={{10,-10},{10,0},{-90,0}}, color={85,170,255}));
+    connect(voltageRMSSensor.pin_n, ground.pin) annotation (Line(points={{10,-30},{10,-40},{-50,-40}}, color={85,170,255}));
+    connect(variableInductor.pin_n, currentRMSSensor.pin_p) annotation (Line(points={{80,30},{90,30},{90,10}}, color={85,170,255}));
+    connect(currentRMSSensor.pin_n, variableImpedance.pin_p) annotation (Line(points={{90,-10},{90,-40},{80,-40}}, color={85,170,255}));
     annotation (experiment(StopTime=1),
       Documentation(info="<html>
 <p>Serial connection of different single-phase basic components</p>
@@ -208,8 +221,7 @@ package SinglePhase "Single-phase quasi-static package"
           extent={{-10,-10},{10,10}},
           rotation=270,
           origin={50,40})));
-    Modelica.Electrical.QuasiStatic.SinglePhase.Basic.Ground groundV1
-                                                                         annotation (Placement(transformation(extent={{-10,0},{10,20}})));
+    Modelica.Electrical.QuasiStatic.SinglePhase.Basic.Ground groundV1    annotation (Placement(transformation(extent={{-10,0},{10,20}})));
     Modelica.ComplexBlocks.Sources.ComplexRampPhasor complexRampL(
       magnitude1=100,
       magnitude2=0.01,
@@ -230,8 +242,7 @@ package SinglePhase "Single-phase quasi-static package"
           extent={{-10,-10},{10,10}},
           rotation=270,
           origin={50,-40})));
-    Modelica.Electrical.QuasiStatic.SinglePhase.Basic.Ground groundI1
-                                                                         annotation (Placement(transformation(extent={{-10,-80},{10,-60}})));
+    Modelica.Electrical.QuasiStatic.SinglePhase.Basic.Ground groundI1    annotation (Placement(transformation(extent={{-10,-80},{10,-60}})));
     Modelica.ComplexBlocks.Sources.ComplexRampPhasor complexRampC(
       useLogRamp=true,
       startTime=0,


### PR DESCRIPTION
- Added CurrentQuasiRMSSensor and VoltageQuasiRMSSensor for single-phase systems
- Mirrored the style, formatting, and documentation of the polyphase equivalent sensors
- Updated the documentation for the other quasi single-phase sensors to refer to these sensors