### PR TITLE
Revert major part of #227, and remove unit from gain parameter of Modelica.Blocks.Continuous.* blocks and Modelica.Blocks.Math.Gain

### DIFF
--- a/Modelica/Blocks/Continuous.mo
+++ b/Modelica/Blocks/Continuous.mo
@@ -7,7 +7,7 @@ package Continuous "Library of continuous control blocks with internal states"
 
   block Integrator "Output the integral of the input signal with optional reset"
     import Modelica.Blocks.Types.Init;
-    parameter Real k(unit="1")=1 "Integrator gain";
+    parameter Real k=1 "Integrator gain";
     parameter Boolean use_reset = false "= true, if reset port enabled"
       annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
     parameter Boolean use_set = false "= true, if set port enabled and used as reinitialization value when reset"

--- a/Modelica/Blocks/Continuous.mo
+++ b/Modelica/Blocks/Continuous.mo
@@ -126,7 +126,7 @@ port has a rising edge.
 
   block LimIntegrator "Integrator with limited value of the output and optional reset"
     import Modelica.Blocks.Types.Init;
-    parameter Real k(unit="1")=1 "Integrator gain";
+    parameter Real k=1 "Integrator gain";
     parameter Real outMax(start=1) "Upper limit of output";
     parameter Real outMin=-outMax "Lower limit of output";
     parameter Boolean use_reset = false "= true, if reset port enabled"
@@ -265,7 +265,7 @@ port has a rising edge.
 
   block Derivative "Approximated derivative block"
     import Modelica.Blocks.Types.Init;
-    parameter Real k(unit="1")=1 "Gains";
+    parameter Real k=1 "Gains";
     parameter SI.Time T(min=Modelica.Constants.small) = 0.01
       "Time constants (T>0 required; T=0 is ideal derivative block)";
     parameter Init initType=Init.NoInit
@@ -350,7 +350,7 @@ If k=0, the block reduces to y=0.
 
   block FirstOrder "First order transfer function block (= 1 pole)"
     import Modelica.Blocks.Types.Init;
-    parameter Real k(unit="1")=1 "Gain";
+    parameter Real k=1 "Gain";
     parameter SI.Time T(start=1) "Time Constant";
     parameter Init initType=Init.NoInit
       "Type of initialization (1: no init, 2: steady state, 3/4: initial output)" annotation(Evaluate=true,
@@ -424,7 +424,7 @@ Example:
 
   block SecondOrder "Second order transfer function block (= 2 poles)"
     import Modelica.Blocks.Types.Init;
-    parameter Real k(unit="1")=1 "Gain";
+    parameter Real k=1 "Gain";
     parameter Real w(start=1) "Angular frequency";
     parameter Real D(start=1) "Damping";
     parameter Init initType=Init.NoInit
@@ -507,7 +507,7 @@ Example:
 
   block PI "Proportional-Integral controller"
     import Modelica.Blocks.Types.Init;
-    parameter Real k(unit="1")=1 "Gain";
+    parameter Real k=1 "Gain";
     parameter SI.Time T(start=1,min=Modelica.Constants.small)
       "Time Constant (T>0 required)";
     parameter Init initType=Init.NoInit
@@ -602,7 +602,7 @@ This is discussed in the description of package
     import Modelica.Blocks.Types.Init;
     extends Interfaces.SISO;
 
-    parameter Real k(unit="1")=1 "Gain";
+    parameter Real k=1 "Gain";
     parameter SI.Time Ti(min=Modelica.Constants.small, start=0.5)
       "Time Constant of Integrator";
     parameter SI.Time Td(min=0, start=0.1)
@@ -765,7 +765,7 @@ to compute u by an algebraic equation.
       "Control error (set point - measurement)";
     parameter .Modelica.Blocks.Types.SimpleController controllerType=
            .Modelica.Blocks.Types.SimpleController.PID "Type of controller";
-    parameter Real k(min=0, unit="1") = 1 "Gain of controller";
+    parameter Real k(min=0) = 1 "Gain of controller";
     parameter SI.Time Ti(min=Modelica.Constants.small)=0.5
       "Time constant of Integrator block" annotation (Dialog(enable=
             controllerType == .Modelica.Blocks.Types.SimpleController.PI or

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -540,7 +540,7 @@ InverseBlockConstraint invert[3];  // Block to be inverted has 3 input signals
 
   block Gain "Output the product of a gain value with the input signal"
 
-    parameter Real k(start=1, unit="1")
+    parameter Real k(start=1)
       "Gain value multiplied with input signal";
   public
     Interfaces.RealInput u "Input signal connector" annotation (Placement(

--- a/Modelica/Electrical/Machines/Examples/ControlledDCDrives/Utilities/LimitedPI.mo
+++ b/Modelica/Electrical/Machines/Examples/ControlledDCDrives/Utilities/LimitedPI.mo
@@ -37,7 +37,7 @@ block LimitedPI
         extent={{20,-20},{-20,20}})));
   output Real controlError = u - u_m
     "Control error (set point - measurement)";
-  parameter Real k(unit="1")=1 "Gain";
+  parameter Real k=1 "Gain";
   parameter Boolean useI=true "PI else P" annotation(Evaluate=true);
   parameter SI.Time Ti(min=Modelica.Constants.small)=1
     "Integral time constant (T>0 required)" annotation(Dialog(enable=useI));
@@ -45,7 +45,7 @@ block LimitedPI
     annotation(Dialog(group="Feed-forward"));
   parameter Boolean useConstantKFF=true "Use constant feed-forward factor?"
     annotation(Dialog(group="Feed-forward", enable=useFF));
-  parameter Real KFF(unit="1")=1 "Feed-forward gain"
+  parameter Real KFF=1 "Feed-forward gain"
     annotation(Dialog(group="Feed-forward", enable=useFF and useConstantKFF));
   parameter Boolean constantLimits=true "Use constant limits?"
     annotation(Dialog(group="Limitation"));

--- a/ModelicaTest/Blocks.mo
+++ b/ModelicaTest/Blocks.mo
@@ -780,6 +780,7 @@ if homotopy is active, the solution accepted by the assert statement (x = 100) i
 
   model UnitDeduction "Test unit deduction"
     extends Modelica.Icons.Example;
+    parameter Real k(unit="1")=1 "Propagated to relevant blocks";
     Modelica.Blocks.Continuous.Integrator integrator
       annotation (Placement(transformation(extent={{0,30},{20,50}})));
     Modelica.Mechanics.Rotational.Components.Inertia inertia(
@@ -789,27 +790,30 @@ if homotopy is active, the solution accepted by the assert statement (x = 100) i
       annotation (Placement(transformation(extent={{-80,60},{-60,80}})));
     Modelica.Mechanics.Rotational.Sensors.SpeedSensor speedSensor
       annotation (Placement(transformation(extent={{-50,60},{-30,80}})));
-    Modelica.Blocks.Math.Gain gain(k=2)
+    Modelica.Blocks.Math.Gain gain(k=2*k)
       annotation (Placement(transformation(extent={{0,80},{20,100}})));
-    Modelica.Blocks.Continuous.LimIntegrator limIntegrator(outMax=3)
+    Modelica.Blocks.Continuous.LimIntegrator limIntegrator(outMax=3, k=k)
       annotation (Placement(transformation(extent={{0,0},{20,20}})));
-    Modelica.Blocks.Continuous.Derivative derivative(initType=Modelica.Blocks.Types.Init.InitialState)
+    Modelica.Blocks.Continuous.Derivative derivative(k=k, initType=Modelica.Blocks.Types.Init.InitialState)
       annotation (Placement(transformation(extent={{0,-30},{20,-10}})));
-    Modelica.Blocks.Continuous.FirstOrder firstOrder(T=2, initType=Modelica.Blocks.Types.Init.InitialState)
+    Modelica.Blocks.Continuous.FirstOrder firstOrder(k=k, T=2, initType=Modelica.Blocks.Types.Init.InitialState)
       annotation (Placement(transformation(extent={{0,-60},{20,-40}})));
     Modelica.Blocks.Continuous.SecondOrder secondOrder(
+      k=k,
       w=2,
       D=3,
       initType=Modelica.Blocks.Types.Init.InitialState)
       annotation (Placement(transformation(extent={{0,-90},{20,-70}})));
-    Modelica.Blocks.Continuous.PI PI(T=2, initType=Modelica.Blocks.Types.Init.InitialState)
+    Modelica.Blocks.Continuous.PI PI(T=2, k=k, initType=Modelica.Blocks.Types.Init.InitialState)
       annotation (Placement(transformation(extent={{60,60},{80,80}})));
     Modelica.Blocks.Continuous.PID PID(
+      k=k,
       Ti=2,
       Td=3,
       initType=Modelica.Blocks.Types.Init.InitialState)
       annotation (Placement(transformation(extent={{60,30},{80,50}})));
     Modelica.Blocks.Continuous.LimPID PID1(
+      k=k,
       Ti=2,
       Td=3,
       yMax=4,


### PR DESCRIPTION
Ccompare with af01213debfd82ab3e16d76346673466b4c6925b
If you want unit="1" for a gain-block, add parameter with unit="1" as in the updated test-case.
Closes #3878