### PR TITLE
Generate MSL Release Notes by GitHub Actions

### DIFF
--- a/.github/workflows/generateReleaseNotes.yml
+++ b/.github/workflows/generateReleaseNotes.yml
@@ -1,0 +1,35 @@
+name: GenerateReleaseNotes
+
+on:
+  workflow_dispatch:
+    inputs:
+      milestone:
+        description: 'Milestone number of the release'
+        default: '61'
+        required: true
+      version:
+        description: 'Version of the release'
+        default: '4.1.0'
+        required: true
+
+jobs:
+  generate_release_notes:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 5
+      - name: Setup python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install python packages
+        run: pip install --user requests
+      - name: Generate MSL release notes from closed GitHub issues
+        timeout-minutes: 3
+        run: python ./Modelica/Resources/Documentation/Generate-ReleaseNotes.py ${{ github.event.inputs.milestone }} ${{ github.event.inputs.version }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ResolvedGitHubIssues-Version-${{ github.event.inputs.version }}
+          path: ./Modelica/Resources/Documentation/Version-${{ github.event.inputs.version }}/

--- a/Modelica/Resources/Documentation/Generate-ReleaseNotes.py
+++ b/Modelica/Resources/Documentation/Generate-ReleaseNotes.py
@@ -129,7 +129,7 @@ def main(dir, milestone, version, auth):
     with open(os.path.join(path, 'ResolvedGitHubIssues.pdf'), 'wb') as f:
         url = 'http://c.docverter.com/convert'
         css = 'docverter.css'
-        with open(css, 'w') as c:
+        with open(os.path.join(dir, css), 'w') as c:
             pageInfo = '@page {size: A4 portrait;}'
             c.write(pageInfo)
         data = {'to': 'pdf', 'from': 'markdown', 'css': css, 'template': template}


### PR DESCRIPTION
See https://github.com/beutlich/ModelicaStandardLibrary/actions/runs/1391688197 for an example.