### PR TITLE
Pass extrapolation and verbose from init2 to init3 functions

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -2081,7 +2081,7 @@ void* ModelicaStandardTables_CombiTable1D_init2(_In_z_ const char* fileName,
                                                 int extrapolation,
                                                 int verbose) {
     return ModelicaStandardTables_CombiTable1D_init3(fileName, tableName,
-        table, nRow, nColumn, columns, nCols, smoothness, LAST_TWO_POINTS,
+        table, nRow, nColumn, columns, nCols, smoothness, extrapolation,
         1 /* verbose */, ",", 0);
 }
 
@@ -2888,7 +2888,7 @@ void* ModelicaStandardTables_CombiTable2D_init2(_In_z_ const char* fileName,
                                                 int extrapolation,
                                                 int verbose) {
     return ModelicaStandardTables_CombiTable2D_init3(fileName, tableName,
-        table, nRow, nColumn, smoothness, LAST_TWO_POINTS, 1 /* verbose */, ",", 0);
+        table, nRow, nColumn, smoothness, extrapolation, 1 /* verbose */, ",", 0);
 }
 
 void* ModelicaStandardTables_CombiTable2D_init3(_In_z_ const char* fileName,

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -2082,7 +2082,7 @@ void* ModelicaStandardTables_CombiTable1D_init2(_In_z_ const char* fileName,
                                                 int verbose) {
     return ModelicaStandardTables_CombiTable1D_init3(fileName, tableName,
         table, nRow, nColumn, columns, nCols, smoothness, extrapolation,
-        1 /* verbose */, ",", 0);
+        verbose, ",", 0);
 }
 
 void* ModelicaStandardTables_CombiTable1D_init3(_In_z_ const char* fileName,
@@ -2888,7 +2888,7 @@ void* ModelicaStandardTables_CombiTable2D_init2(_In_z_ const char* fileName,
                                                 int extrapolation,
                                                 int verbose) {
     return ModelicaStandardTables_CombiTable2D_init3(fileName, tableName,
-        table, nRow, nColumn, smoothness, extrapolation, 1 /* verbose */, ",", 0);
+        table, nRow, nColumn, smoothness, extrapolation, verbose, ",", 0);
 }
 
 void* ModelicaStandardTables_CombiTable2D_init3(_In_z_ const char* fileName,


### PR DESCRIPTION
The extrapolation funcionality was not passed to the init3 function,
whereas it used to be used by init2. This fixes backwards compatibility.

Initial report: https://github.com/OpenModelica/OpenModelica/issues/8075