### PR TITLE
Liberate machine parameter m

### DIFF
--- a/Modelica/Electrical/Machines/Utilities/ParameterRecords/InductionMachineData.mo
+++ b/Modelica/Electrical/Machines/Utilities/ParameterRecords/InductionMachineData.mo
@@ -30,7 +30,7 @@ record InductionMachineData "Common parameters for induction machines"
         2*pi*fsNominal/p) "Friction loss parameter record"
     annotation (Dialog(tab="Losses"));
   parameter Machines.Losses.CoreParameters statorCoreParameters(
-    m=m,
+    final m=m,
     PRef=0,
     VRef=100,
     wRef=2*pi*fsNominal)

--- a/Modelica/Electrical/Machines/Utilities/ParameterRecords/InductionMachineData.mo
+++ b/Modelica/Electrical/Machines/Utilities/ParameterRecords/InductionMachineData.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.Machines.Utilities.ParameterRecords;
 record InductionMachineData "Common parameters for induction machines"
   extends Modelica.Icons.Record;
   import Modelica.Constants.pi;
-  final parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
+  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Inertia Jr=0.29 "Rotor's moment of inertia";
   parameter SI.Inertia Js=Jr "Stator's moment of inertia";
   parameter Integer p(min=1) = 2 "Number of pole pairs (Integer)";
@@ -30,7 +30,7 @@ record InductionMachineData "Common parameters for induction machines"
         2*pi*fsNominal/p) "Friction loss parameter record"
     annotation (Dialog(tab="Losses"));
   parameter Machines.Losses.CoreParameters statorCoreParameters(
-    final m=m,
+    m=m,
     PRef=0,
     VRef=100,
     wRef=2*pi*fsNominal)


### PR DESCRIPTION
I recently noticed that setting the parameters 
`Modelica.Electrical.Machines.Utilities.ParameterRecords.InductionMachineData.m` and 
`Modelica.Electrical.Machines.Utilities.ParameterRecords.InductionMachineData.statorCoreParameters.m` 
final is too restrictive. This prevents proper usage for polyphase machine models from `Modelica.Magnetic.FundamentalWave`.
This does'nt change the behaviour or the result of examples and user models, it just enables user to implement parameter records for real machines with arbitrary number of phases. 