### PR TITLE
Fix misspelled file name.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,7 +22,7 @@ LICENSE text
 # git archive keyword substitutions for the main package files
 Complex.mo export-subst
 Modelica/package.mo export-subst
-ModelicaReferences/package.mo export-subst
+ModelicaReference/package.mo export-subst
 ModelicaServices/package.mo export-subst
 ModelicaTest/package.mo export-subst
 ModelicaTestOverdetermined.mo export-subst


### PR DESCRIPTION
The package is called `ModelicaReference` without the "s"; the misspelled names means that export-substitutions aren't done in the file. 