### PR TITLE
maint/4.0.x: Fix derivatives in 2D-table for one-sided extrapolation by constant continuation

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -1,6 +1,6 @@
 /* ModelicaStandardTables.c - External table functions
 
-   Copyright (C) 2013-2020, Modelica Association and contributors
+   Copyright (C) 2013-2021, Modelica Association and contributors
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,10 @@
       Modelica.Blocks.Tables.CombiTable2Dv
 
    Changelog:
+      Nov. 12, 2021: by Thomas Beutlich
+                     Fixed derivatives in CombiTable2D for one-sided extrapolation
+                     by constant continuation (ticket #3894)
+
       May 27, 2020:  by Thomas Beutlich
                      Fixed invalid memory access in error messages of
                      isValidCombiTimeTable and isValidCombiTable1D (ticket #3562)
@@ -4283,6 +4287,9 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                             break;
 
                         case HOLD_LAST_POINT:
+                            der_y = (TABLE(1, last2 + 2) - TABLE(1, last2 + 1))/
+                                (TABLE_ROW0(last2 + 2) - TABLE_ROW0(last2 + 1));
+                            der_y *= der_u2;
                             break;
 
                         case NO_EXTRAPOLATION:
@@ -4425,6 +4432,9 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                             break;
 
                         case HOLD_LAST_POINT:
+                            der_y = (TABLE(last1 + 2, 1) - TABLE(last1 + 1, 1))/
+                                (TABLE_COL0(last1 + 2) - TABLE_COL0(last1 + 1));
+                            der_y *= der_u1;
                             break;
 
                         case NO_EXTRAPOLATION:
@@ -4572,6 +4582,9 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                                  break;
 
                             case HOLD_LAST_POINT:
+                                der_y = (TABLE(last1 + 2, last2 + 1) - TABLE(last1 + 1, last2 + 1))/
+                                    (TABLE_COL0(last1 + 2) - TABLE_COL0(last1 + 1));
+                                der_y *= der_u1;
                                 break;
 
                             case NO_EXTRAPOLATION:
@@ -4640,6 +4653,9 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                                  break;
 
                             case HOLD_LAST_POINT:
+                                der_y = (TABLE(last1 + 2, last2 + 2) - TABLE(last1 + 1, last2 + 2))/
+                                    (TABLE_COL0(last1 + 2) - TABLE_COL0(last1 + 1));
+                                der_y *= der_u1;
                                 break;
 
                             case NO_EXTRAPOLATION:
@@ -4700,6 +4716,9 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                                  break;
 
                             case HOLD_LAST_POINT:
+                                der_y = (TABLE(last1 + 1, last2 + 2) - TABLE(last1 + 1, last2 + 1))/
+                                    (TABLE_ROW0(last2 + 2) - TABLE_ROW0(last2 + 1));
+                                der_y *= der_u2;
                                 break;
 
                             case NO_EXTRAPOLATION:
@@ -4891,6 +4910,9 @@ double ModelicaStandardTables_CombiTable2D_getDerValue(void* _tableID, double u1
                                  break;
 
                             case HOLD_LAST_POINT:
+                                der_y = (TABLE(last1 + 2, last2 + 2) - TABLE(last1 + 2, last2 + 1))/
+                                    (TABLE_ROW0(last2 + 2) - TABLE_ROW0(last2 + 1));
+                                der_y *= der_u2;
                                 break;
 
                             case NO_EXTRAPOLATION:
@@ -5187,6 +5209,9 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                             break;
 
                         case HOLD_LAST_POINT:
+                            der2_y = (TABLE(1, last2 + 2) - TABLE(1, last2 + 1))/
+                                (TABLE_ROW0(last2 + 2) - TABLE_ROW0(last2 + 1));
+                            der2_y *= der2_u2;
                             break;
 
                         case NO_EXTRAPOLATION:
@@ -5330,6 +5355,9 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                             break;
 
                         case HOLD_LAST_POINT:
+                            der2_y = (TABLE(last1 + 2, 1) - TABLE(last1 + 1, 1))/
+                                (TABLE_COL0(last1 + 2) - TABLE_COL0(last1 + 1));
+                            der2_y *= der2_u1;
                             break;
 
                         case NO_EXTRAPOLATION:
@@ -5489,6 +5517,9 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                                  break;
 
                             case HOLD_LAST_POINT:
+                                der2_y = (TABLE(last1 + 2, last2 + 1) - TABLE(last1 + 1, last2 + 1))/
+                                    (TABLE_COL0(last1 + 2) - TABLE_COL0(last1 + 1));
+                                der2_y *= der2_u1;
                                 break;
 
                             case NO_EXTRAPOLATION:
@@ -5559,6 +5590,9 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                                  break;
 
                             case HOLD_LAST_POINT:
+                                der2_y = (TABLE(last1 + 2, last2 + 2) - TABLE(last1 + 1, last2 + 2))/
+                                    (TABLE_COL0(last1 + 2) - TABLE_COL0(last1 + 1));
+                                der2_y *= der2_u1;
                                 break;
 
                             case NO_EXTRAPOLATION:
@@ -5621,6 +5655,9 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                                  break;
 
                             case HOLD_LAST_POINT:
+                                der2_y = (TABLE(last1 + 1, last2 + 2) - TABLE(last1 + 1, last2 + 1))/
+                                    (TABLE_ROW0(last2 + 2) - TABLE_ROW0(last2 + 1));
+                                der2_y *= der2_u2;
                                 break;
 
                             case NO_EXTRAPOLATION:
@@ -5821,6 +5858,9 @@ double ModelicaStandardTables_CombiTable2D_getDer2Value(void* _tableID, double u
                                  break;
 
                             case HOLD_LAST_POINT:
+                                der2_y = (TABLE(last1 + 2, last2 + 2) - TABLE(last1 + 2, last2 + 1))/
+                                    (TABLE_ROW0(last2 + 2) - TABLE_ROW0(last2 + 1));
+                                der2_y *= der2_u2;
                                 break;
 
                             case NO_EXTRAPOLATION:

--- a/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt
+++ b/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2013-2020, Modelica Association and contributors
+Copyright (C) 2013-2021, Modelica Association and contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -2350,6 +2350,36 @@ more of the following changes.
 </html>"));
 end VersionManagement;
 
+class Version_4_0_1 "Version 4.0.1 (Month D, 20YY)"
+  extends Modelica.Icons.ReleaseNotes;
+
+  annotation (Documentation(info="<html>
+<p>
+Version 4.0.1 is the new bug-fix version.
+Short Overview:
+</p>
+
+<p>
+The following <font color=\"blue\"><strong>Modelica packages</strong></font> have been tested that they work together with this release of package Modelica (alphabetical list).
+</p>
+
+<table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
+</table>
+
+
+<p><br>
+The following <font color=\"red\"><strong>critical errors</strong></font> have been fixed (i.e., errors
+that can lead to wrong simulation results):
+</p>
+
+<table border=\"1\" cellspacing=\"0\" cellpadding=\"2\" style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><strong>Modelica.Blocks.Tables</strong></td></tr>
+<tr><td>CombiTable2Ds<br>CombiTable2Dv</td>
+    <td>The derivatives for one-sided extrapolation by constant continuation (i.e., extrapolation=Modelica.Blocks.Types.Extrapolation.HoldLastPoint) returned a constant zero value. This has been corrected.</td></tr>
+</table>
+</html>"));
+end Version_4_0_1;
+
 class Version_4_0_0 "Version 4.0.0 (June 4, 2020)"
   extends Modelica.Icons.ReleaseNotes;
 

--- a/ModelicaTest/Resources/Reference/ModelicaTest/Tables/CombiTable2Ds/Test33/comparisonSignals.txt
+++ b/ModelicaTest/Resources/Reference/ModelicaTest/Tables/CombiTable2Ds/Test33/comparisonSignals.txt
@@ -1,0 +1,5 @@
+time
+t_new.y
+d_t_new.y
+trapezoid1.y
+trapezoid2.y

--- a/ModelicaTest/Resources/Reference/ModelicaTest/Tables/CombiTable2Dv/Test33/comparisonSignals.txt
+++ b/ModelicaTest/Resources/Reference/ModelicaTest/Tables/CombiTable2Dv/Test33/comparisonSignals.txt
@@ -1,0 +1,5 @@
+time
+t_new.y
+d_t_new.y
+trapezoid1.y
+trapezoid2.y

--- a/ModelicaTest/Tables/CombiTable2Ds.mo
+++ b/ModelicaTest/Tables/CombiTable2Ds.mo
@@ -1076,4 +1076,34 @@ double mydummyfunc(double dummy_in) {
         points={{-59,-10},{-50,-10},{-50,4},{-42,4}}, color={0,0,127}));
     annotation (experiment(StartTime=0, StopTime=60));
   end Test31;
+
+  model Test33 "Extrapolation by constant continuation (Ticket #3894)"
+    extends Modelica.Icons.Example;
+    extends TestDer(t_new(table=[0, 1, 2; 1, 1, 7; 2, 2, 4],
+            smoothness=Modelica.Blocks.Types.Smoothness.LinearSegments,
+            extrapolation=Modelica.Blocks.Types.Extrapolation.HoldLastPoint));
+    Modelica.Blocks.Sources.Trapezoid trapezoid1(
+      amplitude=3,
+      rising=3,
+      width=3,
+      falling=3,
+      period=12,
+      nperiod=1,
+      offset=0) annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
+    Modelica.Blocks.Sources.Trapezoid trapezoid2(
+      amplitude=3,
+      rising=3,
+      width=3,
+      falling=3,
+      period=12,
+      nperiod=1,
+      offset=0,
+      startTime=3) annotation (Placement(transformation(extent={{-80,-20},{-60,0}})));
+  equation
+    connect(trapezoid1.y, t_new.u1) annotation (Line(
+        points={{-59,30},{-52,30},{-52,16},{-42,16}}, color={0,0,127}));
+    connect(trapezoid2.y, t_new.u2) annotation (Line(
+        points={{-59,-10},{-52,-10},{-52,4},{-42,4}}, color={0,0,127}));
+    annotation (experiment(StartTime=0, StopTime=14));
+  end Test33;
 end CombiTable2Ds;

--- a/ModelicaTest/Tables/CombiTable2Dv.mo
+++ b/ModelicaTest/Tables/CombiTable2Dv.mo
@@ -901,4 +901,34 @@ double mydummyfunc(double dummy_in) {
         points={{-59,-10},{-50,-10},{-50,4},{-42,4}}, color={0,0,127}));
     annotation (experiment(StartTime=0, StopTime=60));
   end Test31;
+
+  model Test33 "Extrapolation by constant continuation (Ticket #3894)"
+    extends Modelica.Icons.Example;
+    extends TestDer(t_new(table=[0, 1, 2; 1, 1, 7; 2, 2, 4],
+            smoothness=Modelica.Blocks.Types.Smoothness.LinearSegments,
+            extrapolation=Modelica.Blocks.Types.Extrapolation.HoldLastPoint));
+    Modelica.Blocks.Sources.Trapezoid trapezoid1(
+      amplitude=3,
+      rising=3,
+      width=3,
+      falling=3,
+      period=12,
+      nperiod=1,
+      offset=0) annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
+    Modelica.Blocks.Sources.Trapezoid trapezoid2(
+      amplitude=3,
+      rising=3,
+      width=3,
+      falling=3,
+      period=12,
+      nperiod=1,
+      offset=0,
+      startTime=3) annotation (Placement(transformation(extent={{-80,-20},{-60,0}})));
+  equation
+    connect(trapezoid1.y, t_new.u1[1]) annotation (Line(
+        points={{-59,30},{-52,30},{-52,16},{-42,16}}, color={0,0,127}));
+    connect(trapezoid2.y, t_new.u2[1]) annotation (Line(
+        points={{-59,-10},{-52,-10},{-52,4},{-42,4}}, color={0,0,127}));
+    annotation (experiment(StartTime=0, StopTime=14));
+  end Test33;
 end CombiTable2Dv;


### PR DESCRIPTION
Backport #3896 from master to maint/4.0.x.