### PR TITLE
Removes commented Modelica URI link in documentation with list

### DIFF
--- a/Modelica/Electrical/Machines/Thermal/package.mo
+++ b/Modelica/Electrical/Machines/Thermal/package.mo
@@ -137,16 +137,6 @@ In sub-package <a href=\"modelica://Modelica.Electrical.Machines.Thermal.Constan
 <li><code>heatPortStrayLoad</code>: stray load losses</li>
 <li><code>heatPortFriction</code>: friction losses</li>
 </ul>
-<h5><!--<a href=\"modelica://Modelica.Electrical.Machines.BasicMachines.DCMachines.DC_Compound\">-->DC machine with compound excitation (not yet implemented)<!--</a>--></h5>
-<ul>
-<li><code>heatPortArmature</code>: armature losses</li>
-<li><code>heatPortShuntExcitation</code>: electrical (shunt) excitation</li>
-<li><code>heatPortSeriesExcitation</code>: electrical series excitation</li>
-<li><code>heatPortBrush</code>: brush losses</li>
-<li><code>heatPortCore</code>: armature core losses</li>
-<li><code>heatPortStrayLoad</code>: stray load losses</li>
-<li><code>heatPortFriction</code>: friction losses</li>
-</ul>
 <h5><a href=\"modelica://Modelica.Electrical.Machines.BasicMachines.Transformers\">Transformers</a></h5>
 <ul>
 <li><code>heatPort1[m]</code>: m=3 heatPorts for the m=3 primary phases</li>


### PR DESCRIPTION
Fixes #3937
Documentation should state what **is** implemented and not point to something that *might* get implemented. Here this resulted also in a list without heading. 
