### PR TITLE
Fixed Wb_flows discretization terms for DynamicPipe

### DIFF
--- a/ModelicaTest/Fluid/TestComponents/Pipes/DynamicPipeEnergyConservationCheck.mo
+++ b/ModelicaTest/Fluid/TestComponents/Pipes/DynamicPipeEnergyConservationCheck.mo
@@ -305,18 +305,18 @@ model DynamicPipeEnergyConservationCheck
     redeclare package Medium = Modelica.Media.Water.StandardWater,
     p=100000) annotation (Placement(transformation(extent={{40,-80},{20,-60}})));
 equation
-  assert(Modelica.Math.isEqual(pipeAV_B2.state_a.h, pipeAV_B2.state_b.h), "Energy not conserved!");
-  assert(Modelica.Math.isEqual(pipeAV_B3.state_a.h, pipeAV_B3.state_b.h), "Energy not conserved!");
-  assert(Modelica.Math.isEqual(pipeAV_B4.state_a.h, pipeAV_B4.state_b.h), "Energy not conserved!");
-  assert(Modelica.Math.isEqual(pipeA_VB2.state_a.h, pipeA_VB2.state_b.h), "Energy not conserved!");
-  assert(Modelica.Math.isEqual(pipeA_VB3.state_a.h, pipeA_VB3.state_b.h), "Energy not conserved!");
-  assert(Modelica.Math.isEqual(pipeA_VB4.state_a.h, pipeA_VB4.state_b.h), "Energy not conserved!");
-  assert(Modelica.Math.isEqual(pipeAV_VB2.state_a.h, pipeAV_VB2.state_b.h), "Energy not conserved!");
-  assert(Modelica.Math.isEqual(pipeAV_VB3.state_a.h, pipeAV_VB3.state_b.h), "Energy not conserved!");
-  assert(Modelica.Math.isEqual(pipeAV_VB4.state_a.h, pipeAV_VB4.state_b.h), "Energy not conserved!");
-  assert(Modelica.Math.isEqual(pipeA_V_B2.state_a.h, pipeA_V_B2.state_b.h), "Energy not conserved!");
-  assert(Modelica.Math.isEqual(pipeA_V_B3.state_a.h, pipeA_V_B3.state_b.h), "Energy not conserved!");
-  assert(Modelica.Math.isEqual(pipeA_V_B4.state_a.h, pipeA_V_B4.state_b.h), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeAV_B2.state_a.h, pipeAV_B2.state_b.h, 1e-12), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeAV_B3.state_a.h, pipeAV_B3.state_b.h, 1e-12), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeAV_B4.state_a.h, pipeAV_B4.state_b.h, 1e-12), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeA_VB2.state_a.h, pipeA_VB2.state_b.h, 1e-12), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeA_VB3.state_a.h, pipeA_VB3.state_b.h, 1e-12), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeA_VB4.state_a.h, pipeA_VB4.state_b.h, 1e-12), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeAV_VB2.state_a.h, pipeAV_VB2.state_b.h, 1e-12), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeAV_VB3.state_a.h, pipeAV_VB3.state_b.h, 1e-12), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeAV_VB4.state_a.h, pipeAV_VB4.state_b.h, 1e-12), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeA_V_B2.state_a.h, pipeA_V_B2.state_b.h, 1e-12), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeA_V_B3.state_a.h, pipeA_V_B3.state_b.h, 1e-12), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeA_V_B4.state_a.h, pipeA_V_B4.state_b.h, 1e-12), "Energy not conserved!");
   connect(boundary.ports[1], pipeAV_B4.port_a)
     annotation (Line(points={{80,50},{90,50}}, color={0,127,255}));
   connect(pipeAV_B4.port_b, boundary1.ports[1])

--- a/ModelicaTest/Fluid/TestComponents/Pipes/DynamicPipeEnergyConservationCheck.mo
+++ b/ModelicaTest/Fluid/TestComponents/Pipes/DynamicPipeEnergyConservationCheck.mo
@@ -1,0 +1,374 @@
+within ModelicaTest.Fluid.TestComponents.Pipes;
+model DynamicPipeEnergyConservationCheck
+  "Test DynamicPipe for energy conservation using each discretization scheme and number of control volumes"
+  extends Modelica.Icons.Example;
+  Modelica.Fluid.Pipes.DynamicPipe pipeAV_B4(
+    length=100,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    use_T_start=false,
+    h_start=3000e3,
+    m_flow_start=1,
+    diameter=0.3,
+    redeclare model FlowModel =
+        Modelica.Fluid.Pipes.BaseClasses.FlowModels.NominalLaminarFlow (
+          dp_nominal=100000, m_flow_nominal=1),
+    nNodes=4,
+    p_a_start=200000,
+    p_b_start=100000,
+    modelStructure=Modelica.Fluid.Types.ModelStructure.av_b,
+    useInnerPortProperties=true)
+    annotation (Placement(transformation(extent={{90,40},{110,60}})));
+  inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState)
+    annotation (Placement(transformation(extent={{-140,80},{-120,100}})));
+  Modelica.Fluid.Sources.MassFlowSource_h boundary(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    m_flow=1,
+    h=3000e3) annotation (Placement(transformation(extent={{60,40},{80,60}})));
+  Modelica.Fluid.Sources.FixedBoundary boundary1(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    p=100000) annotation (Placement(transformation(extent={{140,40},{120,60}})));
+  Modelica.Fluid.Pipes.DynamicPipe pipeAV_B2(
+    length=100,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    use_T_start=false,
+    h_start=3000e3,
+    m_flow_start=1,
+    diameter=0.3,
+    redeclare model FlowModel =
+        Modelica.Fluid.Pipes.BaseClasses.FlowModels.NominalLaminarFlow (
+          dp_nominal=100000, m_flow_nominal=1),
+    nNodes=2,
+    p_a_start=200000,
+    p_b_start=100000,
+    modelStructure=Modelica.Fluid.Types.ModelStructure.av_b,
+    useInnerPortProperties=true)
+    annotation (Placement(transformation(extent={{-110,40},{-90,60}})));
+  Modelica.Fluid.Sources.MassFlowSource_h boundary2(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    m_flow=1,
+    h=3000e3) annotation (Placement(transformation(extent={{-140,40},{-120,60}})));
+  Modelica.Fluid.Sources.FixedBoundary boundary3(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    p=100000) annotation (Placement(transformation(extent={{-60,40},{-80,60}})));
+  Modelica.Fluid.Pipes.DynamicPipe pipeAV_B3(
+    length=100,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    use_T_start=false,
+    h_start=3000e3,
+    m_flow_start=1,
+    diameter=0.3,
+    redeclare model FlowModel =
+        Modelica.Fluid.Pipes.BaseClasses.FlowModels.NominalLaminarFlow (
+          dp_nominal=100000, m_flow_nominal=1),
+    nNodes=3,
+    p_a_start=200000,
+    p_b_start=100000,
+    modelStructure=Modelica.Fluid.Types.ModelStructure.av_b,
+    useInnerPortProperties=true)
+    annotation (Placement(transformation(extent={{-10,40},{10,60}})));
+  Modelica.Fluid.Sources.MassFlowSource_h boundary4(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    m_flow=1,
+    h=3000e3) annotation (Placement(transformation(extent={{-40,40},{-20,60}})));
+  Modelica.Fluid.Sources.FixedBoundary boundary5(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    p=100000) annotation (Placement(transformation(extent={{40,40},{20,60}})));
+  Modelica.Fluid.Pipes.DynamicPipe pipeA_VB4(
+    length=100,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    use_T_start=false,
+    h_start=3000e3,
+    m_flow_start=1,
+    diameter=0.3,
+    redeclare model FlowModel =
+        Modelica.Fluid.Pipes.BaseClasses.FlowModels.NominalLaminarFlow (
+          dp_nominal=100000, m_flow_nominal=1),
+    nNodes=4,
+    p_a_start=200000,
+    p_b_start=100000,
+    modelStructure=Modelica.Fluid.Types.ModelStructure.a_vb,
+    useInnerPortProperties=true)
+    annotation (Placement(transformation(extent={{90,0},{110,20}})));
+  Modelica.Fluid.Sources.MassFlowSource_h boundary6(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    m_flow=1,
+    h=3000e3) annotation (Placement(transformation(extent={{60,0},{80,20}})));
+  Modelica.Fluid.Sources.FixedBoundary boundary7(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    p=100000) annotation (Placement(transformation(extent={{140,0},{120,20}})));
+  Modelica.Fluid.Pipes.DynamicPipe pipeA_VB2(
+    length=100,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    use_T_start=false,
+    h_start=3000e3,
+    m_flow_start=1,
+    diameter=0.3,
+    redeclare model FlowModel =
+        Modelica.Fluid.Pipes.BaseClasses.FlowModels.NominalLaminarFlow (
+          dp_nominal=100000, m_flow_nominal=1),
+    nNodes=2,
+    p_a_start=200000,
+    p_b_start=100000,
+    modelStructure=Modelica.Fluid.Types.ModelStructure.a_vb,
+    useInnerPortProperties=true)
+    annotation (Placement(transformation(extent={{-110,0},{-90,20}})));
+  Modelica.Fluid.Sources.MassFlowSource_h boundary8(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    m_flow=1,
+    h=3000e3) annotation (Placement(transformation(extent={{-140,0},{-120,20}})));
+  Modelica.Fluid.Sources.FixedBoundary boundary9(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    p=100000) annotation (Placement(transformation(extent={{-60,0},{-80,20}})));
+  Modelica.Fluid.Pipes.DynamicPipe pipeA_VB3(
+    length=100,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    use_T_start=false,
+    h_start=3000e3,
+    m_flow_start=1,
+    diameter=0.3,
+    redeclare model FlowModel =
+        Modelica.Fluid.Pipes.BaseClasses.FlowModels.NominalLaminarFlow (
+          dp_nominal=100000, m_flow_nominal=1),
+    nNodes=3,
+    p_a_start=200000,
+    p_b_start=100000,
+    modelStructure=Modelica.Fluid.Types.ModelStructure.a_vb,
+    useInnerPortProperties=true)
+    annotation (Placement(transformation(extent={{-10,0},{10,20}})));
+  Modelica.Fluid.Sources.MassFlowSource_h boundary10(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    m_flow=1,
+    h=3000e3) annotation (Placement(transformation(extent={{-40,0},{-20,20}})));
+  Modelica.Fluid.Sources.FixedBoundary boundary11(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    p=100000) annotation (Placement(transformation(extent={{40,0},{20,20}})));
+  Modelica.Fluid.Pipes.DynamicPipe pipeAV_VB4(
+    length=100,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    use_T_start=false,
+    h_start=3000e3,
+    m_flow_start=1,
+    diameter=0.3,
+    redeclare model FlowModel =
+        Modelica.Fluid.Pipes.BaseClasses.FlowModels.NominalLaminarFlow (
+          dp_nominal=100000, m_flow_nominal=1),
+    nNodes=4,
+    p_a_start=200000,
+    p_b_start=100000,
+    modelStructure=Modelica.Fluid.Types.ModelStructure.av_vb,
+    useInnerPortProperties=true)
+    annotation (Placement(transformation(extent={{90,-40},{110,-20}})));
+  Modelica.Fluid.Sources.MassFlowSource_h boundary12(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    m_flow=1,
+    h=3000e3) annotation (Placement(transformation(extent={{60,-40},{80,-20}})));
+  Modelica.Fluid.Sources.FixedBoundary boundary13(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    p=100000) annotation (Placement(transformation(extent={{140,-40},{120,-20}})));
+  Modelica.Fluid.Pipes.DynamicPipe pipeAV_VB2(
+    length=100,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    use_T_start=false,
+    h_start=3000e3,
+    m_flow_start=1,
+    diameter=0.3,
+    redeclare model FlowModel =
+        Modelica.Fluid.Pipes.BaseClasses.FlowModels.NominalLaminarFlow (
+          dp_nominal=100000, m_flow_nominal=1),
+    nNodes=2,
+    p_a_start=200000,
+    p_b_start=100000,
+    modelStructure=Modelica.Fluid.Types.ModelStructure.av_vb,
+    useInnerPortProperties=true)
+    annotation (Placement(transformation(extent={{-110,-40},{-90,-20}})));
+  Modelica.Fluid.Sources.MassFlowSource_h boundary14(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    m_flow=1,
+    h=3000e3) annotation (Placement(transformation(extent={{-140,-40},{-120,-20}})));
+  Modelica.Fluid.Sources.FixedBoundary boundary15(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    p=100000) annotation (Placement(transformation(extent={{-60,-40},{-80,-20}})));
+  Modelica.Fluid.Pipes.DynamicPipe pipeAV_VB3(
+    length=100,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    use_T_start=false,
+    h_start=3000e3,
+    m_flow_start=1,
+    diameter=0.3,
+    redeclare model FlowModel =
+        Modelica.Fluid.Pipes.BaseClasses.FlowModels.NominalLaminarFlow (
+          dp_nominal=100000, m_flow_nominal=1),
+    nNodes=3,
+    p_a_start=200000,
+    p_b_start=100000,
+    modelStructure=Modelica.Fluid.Types.ModelStructure.av_vb,
+    useInnerPortProperties=true)
+    annotation (Placement(transformation(extent={{-10,-40},{10,-20}})));
+  Modelica.Fluid.Sources.MassFlowSource_h boundary16(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    m_flow=1,
+    h=3000e3) annotation (Placement(transformation(extent={{-40,-40},{-20,-20}})));
+  Modelica.Fluid.Sources.FixedBoundary boundary17(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    p=100000) annotation (Placement(transformation(extent={{40,-40},{20,-20}})));
+  Modelica.Fluid.Pipes.DynamicPipe pipeA_V_B4(
+    length=100,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    use_T_start=false,
+    h_start=3000e3,
+    m_flow_start=1,
+    diameter=0.3,
+    redeclare model FlowModel =
+        Modelica.Fluid.Pipes.BaseClasses.FlowModels.NominalLaminarFlow (
+          dp_nominal=100000, m_flow_nominal=1),
+    nNodes=4,
+    p_a_start=200000,
+    p_b_start=100000,
+    modelStructure=Modelica.Fluid.Types.ModelStructure.a_v_b,
+    useInnerPortProperties=true)
+    annotation (Placement(transformation(extent={{90,-80},{110,-60}})));
+  Modelica.Fluid.Sources.MassFlowSource_h boundary18(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    m_flow=1,
+    h=3000e3) annotation (Placement(transformation(extent={{60,-80},{80,-60}})));
+  Modelica.Fluid.Sources.FixedBoundary boundary19(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    p=100000) annotation (Placement(transformation(extent={{140,-80},{120,-60}})));
+  Modelica.Fluid.Pipes.DynamicPipe pipeA_V_B2(
+    length=100,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    use_T_start=false,
+    h_start=3000e3,
+    m_flow_start=1,
+    diameter=0.3,
+    redeclare model FlowModel =
+        Modelica.Fluid.Pipes.BaseClasses.FlowModels.NominalLaminarFlow (
+          dp_nominal=100000, m_flow_nominal=1),
+    nNodes=2,
+    p_a_start=200000,
+    p_b_start=100000,
+    modelStructure=Modelica.Fluid.Types.ModelStructure.a_v_b,
+    useInnerPortProperties=true)
+    annotation (Placement(transformation(extent={{-110,-80},{-90,-60}})));
+  Modelica.Fluid.Sources.MassFlowSource_h boundary20(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    m_flow=1,
+    h=3000e3) annotation (Placement(transformation(extent={{-140,-80},{-120,-60}})));
+  Modelica.Fluid.Sources.FixedBoundary boundary21(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    p=100000) annotation (Placement(transformation(extent={{-60,-80},{-80,-60}})));
+  Modelica.Fluid.Pipes.DynamicPipe pipeA_V_B3(
+    length=100,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    use_T_start=false,
+    h_start=3000e3,
+    m_flow_start=1,
+    diameter=0.3,
+    redeclare model FlowModel =
+        Modelica.Fluid.Pipes.BaseClasses.FlowModels.NominalLaminarFlow (
+          dp_nominal=100000, m_flow_nominal=1),
+    nNodes=3,
+    p_a_start=200000,
+    p_b_start=100000,
+    modelStructure=Modelica.Fluid.Types.ModelStructure.a_v_b,
+    useInnerPortProperties=true)
+    annotation (Placement(transformation(extent={{-10,-80},{10,-60}})));
+  Modelica.Fluid.Sources.MassFlowSource_h boundary22(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    m_flow=1,
+    h=3000e3) annotation (Placement(transformation(extent={{-40,-80},{-20,-60}})));
+  Modelica.Fluid.Sources.FixedBoundary boundary23(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Water.StandardWater,
+    p=100000) annotation (Placement(transformation(extent={{40,-80},{20,-60}})));
+equation
+  assert(Modelica.Math.isEqual(pipeAV_B2.state_a.h, pipeAV_B2.state_b.h), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeAV_B3.state_a.h, pipeAV_B3.state_b.h), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeAV_B4.state_a.h, pipeAV_B4.state_b.h), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeA_VB2.state_a.h, pipeA_VB2.state_b.h), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeA_VB3.state_a.h, pipeA_VB3.state_b.h), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeA_VB4.state_a.h, pipeA_VB4.state_b.h), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeAV_VB2.state_a.h, pipeAV_VB2.state_b.h), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeAV_VB3.state_a.h, pipeAV_VB3.state_b.h), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeAV_VB4.state_a.h, pipeAV_VB4.state_b.h), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeA_V_B2.state_a.h, pipeA_V_B2.state_b.h), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeA_V_B3.state_a.h, pipeA_V_B3.state_b.h), "Energy not conserved!");
+  assert(Modelica.Math.isEqual(pipeA_V_B4.state_a.h, pipeA_V_B4.state_b.h), "Energy not conserved!");
+  connect(boundary.ports[1], pipeAV_B4.port_a)
+    annotation (Line(points={{80,50},{90,50}}, color={0,127,255}));
+  connect(pipeAV_B4.port_b, boundary1.ports[1])
+    annotation (Line(points={{110,50},{120,50}}, color={0,127,255}));
+  connect(boundary2.ports[1], pipeAV_B2.port_a)
+    annotation (Line(points={{-120,50},{-110,50}}, color={0,127,255}));
+  connect(pipeAV_B2.port_b, boundary3.ports[1])
+    annotation (Line(points={{-90,50},{-80,50}}, color={0,127,255}));
+  connect(boundary4.ports[1], pipeAV_B3.port_a)
+    annotation (Line(points={{-20,50},{-10,50}}, color={0,127,255}));
+  connect(pipeAV_B3.port_b, boundary5.ports[1])
+    annotation (Line(points={{10,50},{20,50}}, color={0,127,255}));
+  connect(boundary6.ports[1], pipeA_VB4.port_a)
+    annotation (Line(points={{80,10},{90,10}}, color={0,127,255}));
+  connect(pipeA_VB4.port_b, boundary7.ports[1])
+    annotation (Line(points={{110,10},{120,10}}, color={0,127,255}));
+  connect(boundary8.ports[1], pipeA_VB2.port_a)
+    annotation (Line(points={{-120,10},{-110,10}}, color={0,127,255}));
+  connect(pipeA_VB2.port_b, boundary9.ports[1])
+    annotation (Line(points={{-90,10},{-80,10}}, color={0,127,255}));
+  connect(boundary10.ports[1], pipeA_VB3.port_a)
+    annotation (Line(points={{-20,10},{-10,10}}, color={0,127,255}));
+  connect(pipeA_VB3.port_b, boundary11.ports[1])
+    annotation (Line(points={{10,10},{20,10}}, color={0,127,255}));
+  connect(boundary12.ports[1], pipeAV_VB4.port_a)
+    annotation (Line(points={{80,-30},{90,-30}}, color={0,127,255}));
+  connect(pipeAV_VB4.port_b, boundary13.ports[1])
+    annotation (Line(points={{110,-30},{120,-30}}, color={0,127,255}));
+  connect(boundary14.ports[1], pipeAV_VB2.port_a)
+    annotation (Line(points={{-120,-30},{-110,-30}}, color={0,127,255}));
+  connect(pipeAV_VB2.port_b, boundary15.ports[1])
+    annotation (Line(points={{-90,-30},{-80,-30}}, color={0,127,255}));
+  connect(boundary16.ports[1], pipeAV_VB3.port_a)
+    annotation (Line(points={{-20,-30},{-10,-30}}, color={0,127,255}));
+  connect(pipeAV_VB3.port_b, boundary17.ports[1])
+    annotation (Line(points={{10,-30},{20,-30}}, color={0,127,255}));
+  connect(boundary18.ports[1], pipeA_V_B4.port_a)
+    annotation (Line(points={{80,-70},{90,-70}}, color={0,127,255}));
+  connect(pipeA_V_B4.port_b, boundary19.ports[1])
+    annotation (Line(points={{110,-70},{120,-70}}, color={0,127,255}));
+  connect(boundary20.ports[1], pipeA_V_B2.port_a)
+    annotation (Line(points={{-120,-70},{-110,-70}}, color={0,127,255}));
+  connect(pipeA_V_B2.port_b, boundary21.ports[1])
+    annotation (Line(points={{-90,-70},{-80,-70}}, color={0,127,255}));
+  connect(boundary22.ports[1], pipeA_V_B3.port_a)
+    annotation (Line(points={{-20,-70},{-10,-70}}, color={0,127,255}));
+  connect(pipeA_V_B3.port_b, boundary23.ports[1])
+    annotation (Line(points={{10,-70},{20,-70}}, color={0,127,255}));
+  annotation (experiment(StopTime=1),
+  Documentation(info="<html>
+  Test of energy conservation in dynamic pipes.
+</html>"),
+    Diagram(coordinateSystem(extent={{-140,-100},{140,100}})),
+    Icon(coordinateSystem(extent={{-100,-100},{100,100}})));
+end DynamicPipeEnergyConservationCheck;

--- a/ModelicaTest/Fluid/TestComponents/Pipes/DynamicPipeEnergyConservationCheck2.mo
+++ b/ModelicaTest/Fluid/TestComponents/Pipes/DynamicPipeEnergyConservationCheck2.mo
@@ -1,0 +1,154 @@
+within ModelicaTest.Fluid.TestComponents.Pipes;
+model DynamicPipeEnergyConservationCheck2
+  "Test DynamicPipe for total energy conservation using each discretization scheme"
+  extends Modelica.Icons.Example;
+  Real total_AV_B_a, total_AV_B_b;
+  Real total_A_VB_a, total_A_VB_b;
+  Real total_AV_VB_a, total_AV_VB_b;
+  Real total_A_V_B_a, total_A_V_B_b;
+  Modelica.Fluid.Pipes.DynamicPipe pipeAV_B(
+    length=100,
+    redeclare package Medium = Modelica.Media.Air.DryAirNasa,
+    use_T_start=false,
+    h_start=3000e3,
+    m_flow_start=1,
+    diameter=0.3,
+    redeclare model FlowModel =
+        Modelica.Fluid.Pipes.BaseClasses.FlowModels.NominalLaminarFlow (
+        useUpstreamScheme=false,
+        use_Ib_flows=true,
+        dp_nominal=100000,
+        m_flow_nominal=1),
+    nNodes=30,
+    p_a_start=200000,
+    p_b_start=100000,
+    modelStructure=Modelica.Fluid.Types.ModelStructure.av_b,
+    useInnerPortProperties=true)
+    annotation (Placement(transformation(extent={{-10,40},{10,60}})));
+  inner Modelica.Fluid.System system
+    annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
+  Modelica.Fluid.Sources.MassFlowSource_h boundary(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Air.DryAirNasa,
+    m_flow=1) annotation (Placement(transformation(extent={{-40,40},{-20,60}})));
+  Modelica.Fluid.Sources.FixedBoundary boundary1(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Air.DryAirNasa,
+    p=100000) annotation (Placement(transformation(extent={{40,40},{20,60}})));
+  Modelica.Fluid.Pipes.DynamicPipe pipeA_VB(
+    length=100,
+    redeclare package Medium = Modelica.Media.Air.DryAirNasa,
+    use_T_start=false,
+    h_start=3000e3,
+    m_flow_start=1,
+    diameter=0.3,
+    redeclare model FlowModel =
+        Modelica.Fluid.Pipes.BaseClasses.FlowModels.NominalLaminarFlow (
+        useUpstreamScheme=false,
+        use_Ib_flows=true,
+        dp_nominal=100000,
+        m_flow_nominal=1),
+    nNodes=30,
+    p_a_start=200000,
+    p_b_start=100000,
+    modelStructure=Modelica.Fluid.Types.ModelStructure.a_vb,
+    useInnerPortProperties=true)
+    annotation (Placement(transformation(extent={{-10,0},{10,20}})));
+  Modelica.Fluid.Sources.MassFlowSource_h boundary6(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Air.DryAirNasa,
+    m_flow=1) annotation (Placement(transformation(extent={{-40,0},{-20,20}})));
+  Modelica.Fluid.Sources.FixedBoundary boundary7(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Air.DryAirNasa,
+    p=100000) annotation (Placement(transformation(extent={{40,0},{20,20}})));
+  Modelica.Fluid.Pipes.DynamicPipe pipeAV_VB(
+    length=100,
+    redeclare package Medium = Modelica.Media.Air.DryAirNasa,
+    use_T_start=false,
+    h_start=3000e3,
+    m_flow_start=1,
+    diameter=0.3,
+    redeclare model FlowModel =
+        Modelica.Fluid.Pipes.BaseClasses.FlowModels.NominalLaminarFlow (
+        useUpstreamScheme=false,
+        use_Ib_flows=true,
+        dp_nominal=100000,
+        m_flow_nominal=1),
+    nNodes=30,
+    p_a_start=200000,
+    p_b_start=100000,
+    modelStructure=Modelica.Fluid.Types.ModelStructure.av_vb,
+    useInnerPortProperties=true)
+    annotation (Placement(transformation(extent={{-10,-40},{10,-20}})));
+  Modelica.Fluid.Sources.MassFlowSource_h boundary12(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Air.DryAirNasa,
+    m_flow=1) annotation (Placement(transformation(extent={{-40,-40},{-20,-20}})));
+  Modelica.Fluid.Sources.FixedBoundary boundary13(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Air.DryAirNasa,
+    p=100000) annotation (Placement(transformation(extent={{40,-40},{20,-20}})));
+  Modelica.Fluid.Pipes.DynamicPipe pipeA_V_B(
+    length=100,
+    redeclare package Medium = Modelica.Media.Air.DryAirNasa,
+    use_T_start=false,
+    h_start=3000e3,
+    m_flow_start=1,
+    diameter=0.3,
+    redeclare model FlowModel =
+        Modelica.Fluid.Pipes.BaseClasses.FlowModels.NominalLaminarFlow (
+        useUpstreamScheme=false,
+        use_Ib_flows=true,
+        dp_nominal=100000,
+        m_flow_nominal=1),
+    nNodes=30,
+    p_a_start=200000,
+    p_b_start=100000,
+    modelStructure=Modelica.Fluid.Types.ModelStructure.a_v_b,
+    useInnerPortProperties=true)
+    annotation (Placement(transformation(extent={{-10,-80},{10,-60}})));
+  Modelica.Fluid.Sources.MassFlowSource_h boundary18(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Air.DryAirNasa,
+    m_flow=1) annotation (Placement(transformation(extent={{-40,-80},{-20,-60}})));
+  Modelica.Fluid.Sources.FixedBoundary boundary19(
+    nPorts=1,
+    redeclare package Medium = Modelica.Media.Air.DryAirNasa,
+    p=100000) annotation (Placement(transformation(extent={{40,-80},{20,-60}})));
+equation
+  total_AV_B_a = pipeAV_B.H_flows[1] + pipeAV_B.m_flows[1]*pipeAV_B.flowModel.vs[1]^2/2;
+  total_AV_B_b = pipeAV_B.H_flows[end] + pipeAV_B.m_flows[end]*pipeAV_B.flowModel.vs[end]^2/2;
+  total_A_VB_a = pipeA_VB.H_flows[1] + pipeA_VB.m_flows[1]*pipeA_VB.flowModel.vs[1]^2/2;
+  total_A_VB_b = pipeA_VB.H_flows[end] + pipeA_VB.m_flows[end]*pipeA_VB.flowModel.vs[end]^2/2;
+  total_AV_VB_a = pipeAV_VB.H_flows[1] + pipeAV_VB.m_flows[1]*pipeAV_VB.flowModel.vs[1]^2/2;
+  total_AV_VB_b = pipeAV_VB.H_flows[end] + pipeAV_VB.m_flows[end]*pipeAV_VB.flowModel.vs[end]^2/2;
+  total_A_V_B_a = pipeA_V_B.H_flows[1] + pipeA_V_B.m_flows[1]*pipeA_V_B.flowModel.vs[1]^2/2;
+  total_A_V_B_b = pipeA_V_B.H_flows[end] + pipeA_V_B.m_flows[end]*pipeA_V_B.flowModel.vs[end]^2/2;
+  assert(time < 500 or Modelica.Math.isEqual(total_AV_B_a, total_AV_B_b, 1), "Energy not conserved!");
+  assert(time < 500 or Modelica.Math.isEqual(total_A_VB_a, total_A_VB_b, 1), "Energy not conserved!");
+  assert(time < 500 or Modelica.Math.isEqual(total_AV_VB_a, total_AV_VB_b, 1), "Energy not conserved!");
+  assert(time < 500 or Modelica.Math.isEqual(total_A_V_B_a, total_A_V_B_b, 1), "Energy not conserved!");
+  connect(boundary.ports[1], pipeAV_B.port_a)
+    annotation (Line(points={{-20,50},{-10,50}}, color={0,127,255}));
+  connect(pipeAV_B.port_b, boundary1.ports[1])
+    annotation (Line(points={{10,50},{20,50}}, color={0,127,255}));
+  connect(boundary6.ports[1], pipeA_VB.port_a)
+    annotation (Line(points={{-20,10},{-10,10}}, color={0,127,255}));
+  connect(pipeA_VB.port_b, boundary7.ports[1])
+    annotation (Line(points={{10,10},{20,10}}, color={0,127,255}));
+  connect(boundary12.ports[1], pipeAV_VB.port_a)
+    annotation (Line(points={{-20,-30},{-10,-30}}, color={0,127,255}));
+  connect(pipeAV_VB.port_b, boundary13.ports[1])
+    annotation (Line(points={{10,-30},{20,-30}}, color={0,127,255}));
+  connect(boundary18.ports[1], pipeA_V_B.port_a)
+    annotation (Line(points={{-20,-70},{-10,-70}}, color={0,127,255}));
+  connect(pipeA_V_B.port_b, boundary19.ports[1])
+    annotation (Line(points={{10,-70},{20,-70}}, color={0,127,255}));
+  annotation (experiment(StopTime=500),
+  Documentation(info="<html>
+  Test of energy conservation in dynamic pipes.
+</html>"),
+    Diagram(coordinateSystem(extent={{-100,-100},{100,100}})),
+    Icon(coordinateSystem(extent={{-100,-100},{100,100}})));
+end DynamicPipeEnergyConservationCheck2;

--- a/ModelicaTest/Fluid/TestComponents/Pipes/package.order
+++ b/ModelicaTest/Fluid/TestComponents/Pipes/package.order
@@ -1,5 +1,7 @@
 DynamicPipesAndFittings
 DynamicPipesWithTraceSubstances
 DynamicPipeWithNominalLaminarFlow
+DynamicPipeEnergyConservationCheck
+DynamicPipeEnergyConservationCheck2
 StaticPipe
 IdealMixing1


### PR DESCRIPTION
- Fixes made for all structure cases: av_b, a_vb, a_v_b, and av_vb
- The updated discretization terms give more accurate derivatives associated with the volumes
- Energy is now properly conserved (previously av_b, a_vb, and a_v_b had conservation errors)