### PR TITLE
Propagate parameter T in Polyphase Resistors and Conductors (#3964)

### DIFF
--- a/Modelica/Electrical/Polyphase/Basic/Conductor.mo
+++ b/Modelica/Electrical/Polyphase/Basic/Conductor.mo
@@ -12,7 +12,8 @@ model Conductor "Ideal linear electrical conductors"
     final G=G,
     final T_ref=T_ref,
     final alpha=alpha,
-    each final useHeatPort=useHeatPort) annotation (Placement(
+    each final useHeatPort=useHeatPort,
+    final T=T) annotation (Placement(
         transformation(extent={{-10,-10},{10,10}})));
 equation
   connect(plug_p.pin, conductor.p)

--- a/Modelica/Electrical/Polyphase/Basic/Resistor.mo
+++ b/Modelica/Electrical/Polyphase/Basic/Resistor.mo
@@ -12,7 +12,8 @@ model Resistor "Ideal linear electrical resistors"
     final R=R,
     final T_ref=T_ref,
     final alpha=alpha,
-    each final useHeatPort=useHeatPort) annotation (Placement(
+    each final useHeatPort=useHeatPort,
+    final T=T) annotation (Placement(
         transformation(extent={{-10,-10},{10,10}})));
 equation
   connect(resistor.p, plug_p.pin)

--- a/Modelica/Electrical/Polyphase/Basic/VariableConductor.mo
+++ b/Modelica/Electrical/Polyphase/Basic/VariableConductor.mo
@@ -18,7 +18,8 @@ model VariableConductor
   Modelica.Electrical.Analog.Basic.VariableConductor variableConductor[m](
     final T_ref=T_ref,
     final alpha=alpha,
-    each final useHeatPort=useHeatPort) annotation (Placement(
+    each final useHeatPort=useHeatPort,
+    final T=T) annotation (Placement(
         transformation(extent={{-10,-10},{10,10}})));
 equation
   connect(variableConductor.p, plug_p.pin)

--- a/Modelica/Electrical/Polyphase/Basic/VariableResistor.mo
+++ b/Modelica/Electrical/Polyphase/Basic/VariableResistor.mo
@@ -18,7 +18,8 @@ model VariableResistor
   Modelica.Electrical.Analog.Basic.VariableResistor variableResistor[m](
     final T_ref=T_ref,
     final alpha=alpha,
-    each final useHeatPort=useHeatPort) annotation (Placement(
+    each final useHeatPort=useHeatPort,
+    final T=T) annotation (Placement(
         transformation(extent={{-10,-10},{10,10}})));
 equation
   connect(variableResistor.p, plug_p.pin)


### PR DESCRIPTION
* fix #3963 

* Clean up whitespaces.

Co-authored-by: Dietmar Winkler <dietmar.winkler@dwe.no>
