### PR TITLE
Fix index-out-of-bounds exception for splines

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -39,6 +39,10 @@
       Modelica.Blocks.Tables.CombiTable2Dv
 
    Changelog:
+      May 03, 2022:  by Hans Olsson, Dassault Systemes
+                     Fixed index-out-of-bounds exception in spline
+                     initialization of 2D tables that actually degrade
+                     to 1D tables (ticket #3983)
 
       Jan. 31, 2022: by Hans Olsson, Dassault Systemes
                      Added better support for one-sided derivatives of CombiTable2D.
@@ -6925,7 +6929,7 @@ static CubicHermite2D* spline2DInit(_In_ const double* table, size_t nRow,
             return NULL;
         }
 
-        spline = (CubicHermite2D*)malloc((nCol - 1)*sizeof(CubicHermite2D));
+        spline = (CubicHermite2D*)malloc((nCol - 2)*sizeof(CubicHermite2D));
         if (NULL == spline) {
             free(tableT);
             return NULL;
@@ -6957,7 +6961,7 @@ static CubicHermite2D* spline2DInit(_In_ const double* table, size_t nRow,
         size_t i;
         int cols = 2;
 
-        spline = (CubicHermite2D*)malloc((nRow - 1)*sizeof(CubicHermite2D));
+        spline = (CubicHermite2D*)malloc((nRow - 2)*sizeof(CubicHermite2D));
         if (NULL == spline) {
             return NULL;
         }

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -6943,7 +6943,7 @@ static CubicHermite2D* spline2DInit(_In_ const double* table, size_t nRow,
             return NULL;
         }
         /* Copy coefficients */
-        for (j = 0; j < nCol - 1; j++) {
+        for (j = 0; j < nCol - 2; j++) {
             const double* c1 = spline1D[j];
             double* c2 = spline[j];
             c2[0] = c1[0];
@@ -6968,7 +6968,7 @@ static CubicHermite2D* spline2DInit(_In_ const double* table, size_t nRow,
             return NULL;
         }
         /* Copy coefficients */
-        for (i = 0; i < nRow - 1; i++) {
+        for (i = 0; i < nRow - 2; i++) {
             const double* c1 = spline1D[i];
             double* c2 = spline[i];
             c2[0] = c1[0];


### PR DESCRIPTION
When compiling with VS 2019 the following models crash:
ModelicaTest.Tables.CombiTable2D[sv].Test2[167]

I believe it is an indexing issue - and have tried to correct the issue; it may be wrong - but there is clearly a major issue. The confusion is that we are sending in nRows-1 as nRows and then constructing nRows-1, i.e. nRows-2.