### PR TITLE
Do not preserveAspectRatio for terminate-block.

### DIFF
--- a/Modelica/Blocks/Logical.mo
+++ b/Modelica/Blocks/Logical.mo
@@ -942,7 +942,7 @@ The output <code>Q</code> is set by the input <code>S</code>, is reset by the in
       terminate(terminationText);
     end when;
     annotation (Icon(
-        coordinateSystem(preserveAspectRatio=true,
+        coordinateSystem(preserveAspectRatio=false,
           extent={{-200,-20},{200,20}},
           initialScale=0.2),
           graphics={


### PR DESCRIPTION
The reason is that you want to write an expression and it is natural to adapt
the length of the block to the expression, which will give different aspect ratios.
This is consistent with the source-block BooleanExpression.
Related to #3985 