### PR TITLE
Set Evaluate = true for IdealTransformer.considerMagnetization

### DIFF
--- a/Modelica/Electrical/Analog/Ideal/IdealTransformer.mo
+++ b/Modelica/Electrical/Analog/Ideal/IdealTransformer.mo
@@ -3,7 +3,7 @@ model IdealTransformer "Ideal transformer core with or without magnetization"
   extends Modelica.Electrical.Analog.Interfaces.TwoPort;
   parameter Real n(start=1) "Turns ratio primary:secondary voltage";
   parameter Boolean considerMagnetization=false
-    "Choice of considering magnetization";
+    "Choice of considering magnetization" annotation(Evaluate = true);
   parameter SI.Inductance Lm1(start=1)
     "Magnetization inductance w.r.t. primary side"
     annotation (Dialog(enable=considerMagnetization));


### PR DESCRIPTION
Leaving this parameter unevaluated seems like making things overly complicated, and as far as I can see there is nothing that clearly requires the parameter to be treated structurally.  Hence, adding an explicit annotation will increase chances of models being treated equally efficiently across tools.

Of course, I would have preferred to declare considerMagnetization a constant with Dialog annotation instead, but I'm afraid the general preference is to use a parameter with Evaluate = true instead.