### PR TITLE
Propagate the angle alpha also in the calculation of A in HollowCylinderRadialFlux

### DIFF
--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderRadialFlux.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderRadialFlux.mo
@@ -16,7 +16,7 @@ model HollowCylinderRadialFlux
   parameter SI.Angle alpha=2*Modelica.Constants.pi
   "Central angle";
 equation
-  A = l*pi*(r_o + r_i);
+  A = (r_o + r_i)/2*alpha*l;
   // Area at arithmetic mean radius for calculation of average flux density
   G_m = 2*pi*mu_0*mu_r*l/Modelica.Math.log(r_o/r_i)*alpha/(2*Modelica.Constants.pi);
 

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderRadialFlux.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderRadialFlux.mo
@@ -16,7 +16,7 @@ model HollowCylinderRadialFlux
   parameter SI.Angle alpha=2*Modelica.Constants.pi
   "Central angle";
 equation
-  A = (r_o + r_i)/2*alpha*l;
+  A = l*alpha*(r_o + r_i)/2;
   // Area at arithmetic mean radius for calculation of average flux density
   G_m = 2*pi*mu_0*mu_r*l/Modelica.Math.log(r_o/r_i)*alpha/(2*Modelica.Constants.pi);
 


### PR DESCRIPTION
fix calculation of A in Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderRadialFlux.mo so it can be back-ported. 
After merging this PR, #3993 (here this bugfix is NOT included) can be merged.