### PR TITLE
Fix release notes generation

### DIFF
--- a/.github/workflows/generateReleaseNotes.yml
+++ b/.github/workflows/generateReleaseNotes.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install python packages
-        run: pip install --disable-pip-version-check --user docraptor==3.0.0 Jinja2==3.1.2 Markdown==3.4.4 requests PyYAML==6.0.1
+        run: pip install --disable-pip-version-check --user docraptor==3.1.0 Jinja2==3.1.3 Markdown==3.5.2 requests PyYAML==6.0.1
       - name: Generate MSL release notes from closed GitHub issues
         timeout-minutes: 3
         env:

--- a/.github/workflows/generateReleaseNotes.yml
+++ b/.github/workflows/generateReleaseNotes.yml
@@ -11,6 +11,11 @@ on:
         description: 'Version of the release'
         default: '4.1.0'
         required: true
+      watermark:
+        description: 'PDF contains watermark for test'
+        default: true
+        required: true
+        type: boolean
 
 jobs:
   generate_release_notes:
@@ -25,9 +30,12 @@ jobs:
         with:
           python-version: 3.8
       - name: Install python packages
-        run: pip install --user requests
+        run: pip install --user docraptor==2.0.0 Jinja2==3.1.2 Markdown==3.3.7 requests PyYAML==6.0
       - name: Generate MSL release notes from closed GitHub issues
         timeout-minutes: 3
+        env:
+          DOCRAPTOR_API_KEY: ${{ secrets.DOCRAPTOR_API_KEY }}
+          DOCRAPTOR_TEST: ${{ github.event.inputs.watermark }}
         run: python ./Modelica/Resources/Documentation/Generate-ReleaseNotes.py ${{ github.event.inputs.milestone }} ${{ github.event.inputs.version }}
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/generateReleaseNotes.yml
+++ b/.github/workflows/generateReleaseNotes.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install python packages
-        run: pip install --user docraptor==2.0.0 Jinja2==3.1.2 Markdown==3.3.7 requests PyYAML==6.0
+        run: pip install --disable-pip-version-check --user docraptor==3.0.0 Jinja2==3.1.2 Markdown==3.4.4 requests PyYAML==6.0.1
       - name: Generate MSL release notes from closed GitHub issues
         timeout-minutes: 3
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ buildlog.txt
 config.*
 configure
 depcomp
-docverter.css
 dsfinal.txt
 dsin.txt
 dslog.txt

--- a/Modelica/Resources/Documentation/Modelica-ReleaseNotes-Template.html
+++ b/Modelica/Resources/Documentation/Modelica-ReleaseNotes-Template.html
@@ -1,71 +1,19 @@
-<!-- See https://github.com/jgm/pandoc-templates -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"$if(lang)$ lang="$lang$" xml:lang="$lang$"$endif$$if(dir)$ dir="$dir$"$endif$>
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
-$for(author-meta)$
-  <meta name="author" content="$author-meta$" />
-$endfor$
-$if(date-meta)$
-  <meta name="date" content="$date-meta$" />
-$endif$
-$if(keywords)$
-  <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$" />
-$endif$
-  <title>$if(title-prefix)$$title-prefix$$endif$</title>
+  <title>{{ title }}</title>
   <style type="text/css">
       h1, h2, h3, li, p{font-family: sans-serif;}
       code{white-space: pre-wrap;}
       span.smallcaps{font-variant: small-caps;}
       span.underline{text-decoration: underline;}
       div.column{display: inline-block; vertical-align: top; width: 50%;}
-$if(quotes)$
-      q { quotes: "“" "”" "‘" "’"; }
-$endif$
+      @page {size: A4 portrait;}
   </style>
-$if(highlighting-css)$
-  <style type="text/css">
-$highlighting-css$
-  </style>
-$endif$
-$for(css)$
-  <link rel="stylesheet" href="$css$" type="text/css" />
-$endfor$
-$if(math)$
-  $math$
-$endif$
-$for(header-includes)$
-  $header-includes$
-$endfor$
 </head>
 <body>
-$for(include-before)$
-$include-before$
-$endfor$
-$if(title)$
-<div id="$idprefix$header">
-<h1 class="title">$title$</h1>
-$if(subtitle)$
-<h1 class="subtitle">$subtitle$</h1>
-$endif$
-$for(author)$
-<h2 class="author">$author$</h2>
-$endfor$
-$if(date)$
-<h3 class="date">$date$</h3>
-$endif$
-</div>
-$endif$
-$if(toc)$
-<div id="$idprefix$TOC">
-$table-of-contents$
-</div>
-$endif$
-$body$
-$for(include-after)$
-$include-after$
-$endfor$
+{{ content }}
 </body>
 </html>


### PR DESCRIPTION
The previously used docverter service for MD to HTML/PDF conversion was shut down and will not come back. This is an alternative implementation with local MD to HTML conversion and utilizing the docraptor service for HTML to PDF conversion.

It also fixes the GitHub Action introduced by #3886.