### PR TITLE
Added new power block for raising an input to a user parameterized exponent

### DIFF
--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -1759,6 +1759,42 @@ y = base <strong>^</strong> u;
 </html>"));
   end Power;
 
+  block Exponentiation "Output the input raised to an exponent"
+    extends Interfaces.SISO;
+    parameter Real exponent=2 "Exponent of power" annotation (Evaluate=true);
+  equation
+    y = u^exponent;
+    annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
+              {100,100}}), graphics={
+          Line(points={{0,-80},{0,68}}, color={192,192,192}),
+          Polygon(
+            points={{0,90},{-8,68},{8,68},{0,90}},
+            lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Text(
+            extent={{-86,50},{-14,2}},
+            textColor={192,192,192},
+            textString="^"),
+          Line(points={{-80,60},{-70,27.2},{-60,-1.3},{-50,-25.3},{-40,-45},{-30,-60.3},
+                {-20,-71.3},{-10,-77.8},{0,-80},{10,-77.8},{20,-71.3},{30,-60.3},{
+                40,-45},{50,-25.3},{60,-1.3},{70,27.2},{80,60}}, smooth=Smooth.Bezier),
+          Line(
+            points={{-90,-80.3976},{68,-80.3976}},
+            color={192,192,192},
+            smooth=Smooth.Bezier),
+          Polygon(
+            points={{90,-80.3976},{68,-72.3976},{68,-88.3976},{90,-80.3976}},
+            lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid)}), Documentation(info="<html>
+<p>This blocks computes the output <strong>y</strong> as the input <strong>u</strong> raised to <em>exponent</em>:</p>
+<blockquote><pre>
+y = u <strong>^</strong> exponent;
+</pre></blockquote>
+</html>"));
+  end Exponentiation;
+
   block Log
     "Output the logarithm (default base e) of the input (input > 0 required)"
 

--- a/ModelicaTest/Blocks.mo
+++ b/ModelicaTest/Blocks.mo
@@ -2042,4 +2042,59 @@ the whole homotopy transformation.</p>
 </html>"));
   end LimPID;
 
+  model Exponentiation
+    extends Modelica.Icons.Example;
+
+    Modelica.Blocks.Sources.Ramp negativeToPositiveRamp(
+      height=4,
+      duration=1,
+      offset=-2,
+      startTime=0)
+      annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
+    Modelica.Blocks.Math.Exponentiation evenExponent(exponent=2)
+      annotation (Placement(transformation(extent={{0,80},{20,100}})));
+    Modelica.Blocks.Math.Exponentiation oddExponent(exponent=3)
+      annotation (Placement(transformation(extent={{0,50},{20,70}})));
+    Modelica.Blocks.Math.Exponentiation oneExponent(exponent=1)
+      annotation (Placement(transformation(extent={{0,20},{20,40}})));
+    Modelica.Blocks.Math.Exponentiation zeroExponent(exponent=0)
+      annotation (Placement(transformation(extent={{0,-10},{20,10}})));
+    Modelica.Blocks.Math.Abs abs1
+      annotation (Placement(transformation(extent={{-40,-40},{-20,-20}})));
+    Modelica.Blocks.Math.Exponentiation nonInteger(exponent=2.1)
+      annotation (Placement(transformation(extent={{0,-40},{20,-20}})));
+    Modelica.Blocks.Math.Exponentiation sqrtExponent(exponent=0.5)
+      annotation (Placement(transformation(extent={{0,-70},{20,-50}})));
+    Modelica.Blocks.Math.Max max1
+      annotation (Placement(transformation(extent={{-40,-100},{-20,-80}})));
+    Modelica.Blocks.Sources.Constant oneTenth(k=0.1)
+      annotation (Placement(transformation(extent={{-80,-100},{-60,-80}})));
+    Modelica.Blocks.Math.Exponentiation inverse(exponent=-1)
+      annotation (Placement(transformation(extent={{0,-100},{20,-80}})));
+  equation
+    connect(negativeToPositiveRamp.y, evenExponent.u)
+      annotation (Line(points={{-79,90},{-2,90}}, color={0,0,127}));
+    connect(abs1.u, evenExponent.u) annotation (Line(points={{-42,-30},{-50,-30},
+            {-50,90},{-2,90}},
+                           color={0,0,127}));
+    connect(abs1.y, nonInteger.u)
+      annotation (Line(points={{-19,-30},{-2,-30}},color={0,0,127}));
+    connect(oddExponent.u, evenExponent.u) annotation (Line(points={{-2,60},{
+            -20,60},{-20,90},{-2,90}},
+                                    color={0,0,127}));
+    connect(oneExponent.u, evenExponent.u) annotation (Line(points={{-2,30},{
+            -20,30},{-20,90},{-2,90}},
+                                color={0,0,127}));
+    connect(sqrtExponent.u, nonInteger.u) annotation (Line(points={{-2,-60},{
+            -10,-60},{-10,-30},{-2,-30}}, color={0,0,127}));
+    connect(max1.y, inverse.u)
+      annotation (Line(points={{-19,-90},{-2,-90}}, color={0,0,127}));
+    connect(zeroExponent.u, evenExponent.u) annotation (Line(points={{-2,0},{
+            -20,0},{-20,90},{-2,90}}, color={0,0,127}));
+    connect(max1.u1, evenExponent.u) annotation (Line(points={{-42,-84},{-50,
+            -84},{-50,90},{-2,90}}, color={0,0,127}));
+    connect(oneTenth.y, max1.u2) annotation (Line(points={{-59,-90},{-50,-90},{
+            -50,-96},{-42,-96}}, color={0,0,127}));
+    annotation (experiment(StopTime=1.0));
+  end Exponentiation;
 end Blocks;

--- a/ModelicaTest/Resources/Reference/ModelicaTest/Blocks/Exponentiation/comparisonSignals.txt
+++ b/ModelicaTest/Resources/Reference/ModelicaTest/Blocks/Exponentiation/comparisonSignals.txt
@@ -1,0 +1,8 @@
+time
+evenExponent.y
+oddExponent.y
+oneExponent.y
+zeroExponent.y
+nonInteger.y
+sqrtExponent.y
+inverse.y


### PR DESCRIPTION
This block adds a key missing mathematical function that is not available in Modelica.Blocks.Math. It was previously discussed here: https://github.com/modelica/ModelicaStandardLibrary/discussions/3967

Note that ideally this block should be called "Power" while the existing block called "Power" should be called "Exponentiation". Potentially in the future a conversion script could be used to swap the naming.