### PR TITLE
Implement continuous version of SignalExtrema

### DIFF
--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2530,6 +2530,101 @@ This means that:</p>
 </html>"));
   end SignalExtrema;
 
+  block ContinuousSignalExtrema "Peak of input signal"
+    extends Modelica.Blocks.Icons.Block;
+    parameter Modelica.Units.SI.Time T(min=Modelica.Constants.small)=1e-6 "Derivative time constant";
+    Modelica.Blocks.Interfaces.RealInput u
+      annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
+    Modelica.Blocks.Interfaces.RealOutput y_min
+      annotation (Placement(transformation(extent={{100,-70},{120,-50}})));
+    Modelica.Blocks.Interfaces.RealOutput y_max
+      annotation (Placement(transformation(extent={{100,50},{120,70}})));
+    output Modelica.Units.SI.Time t_min "Time instant of last found minimum";
+    output Modelica.Units.SI.Time t_max "Time instant of last found maximum";
+  protected
+    Real x "Aux.state";
+  initial equation
+    x = u;
+    y_min = u;
+    y_max = u;
+    t_min = time;
+    t_max = time;
+  equation
+    //first order approximation of input
+    der(x) = (u - x)/T;
+    //first order approximation of derivative of input
+    when {u<=x, u>=x, terminal()} then
+    //detect local extrema at zero derivative, just before and after a step, and at the end of the simulation
+      y_min = min({pre(y_min), u, pre(u)});
+      y_max = max({pre(y_max), u, pre(u)});
+      if y_min<pre(y_min) then
+        t_min=time;
+        t_max=pre(t_max);
+      elseif y_max>pre(y_max) then
+        t_min=pre(t_min);
+        t_max=time;
+      else
+        t_min=pre(t_min);
+        t_max=pre(t_max);
+      end if;
+    end when;
+    annotation (defaultComponentName="signalExtrema",
+    Documentation(info="<html>
+<p>
+This block detects positive and negative peaks of differentiable and non-differentiable input signals without sampling.
+</p>
+<p>
+For differentiable input singals, an extremum is detected if the derivative of the input signal is zero.
+</p>
+<p>
+To handle non-differentiable input signals, the input signal <code>u</code> is conditioned by a first order wth time constant <code>T</code>. 
+Like in the <a href=\"modelica://Modelica.Blocks.Continuous.Derivative\">derivative block</a>, 
+the derivative of the input signal is approximated by <code>(u - x)/T</code>. 
+This way even steps with local extrema just before and after the step are taken into account.
+</p>
+<p>
+Additionally, when the simulation terminates, <code>y_max</code>y_min and <code>y_max</code> are updated.
+</p>
+</html>"),
+      Icon(graphics={
+          Polygon(
+            points={{-80,90},{-88,68},{-72,68},{-80,90}},
+            lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Line(
+            points={{-80,0},{-75.2,32.3},{-72,50.3},{-68.7,64.5},{-65.5,74.2},{
+                -62.3,79.3},{-59.1,79.6},{-55.9,75.3},{-52.7,67.1},{-48.6,52.2},
+                {-43,25.8},{-35,-13.9},{-30.2,-33.7},{-26.1,-45.9},{-22.1,-53.2},
+                {-18,-56},{-14.1,-52.5},{-10.1,-45.3},{-5.23,-32.1},{8.44,13.7},
+                {13.3,26.4},{18.1,34.8},{22.1,38},{26.9,37.2},{31.8,31.8},{38.2,
+                19.4},{51.1,-10.5},{57.5,-21.2},{63.1,-25.9},{68.7,-25.9},{75.2,
+                -20.5},{80,-13.8}},
+            smooth=Smooth.Bezier,
+            color={192,192,192}),
+          Line(points={{-90,0},{68,0}}, color={192,192,192}),
+          Line(points={{-80,68},{-80,-80}}, color={192,192,192}),
+          Polygon(
+            points={{90,0},{68,8},{68,-8},{90,0}},
+            lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Line(
+            points={{-60,80},{52,80}},
+            color={0,0,0},
+            pattern=LinePattern.Dash),
+          Line(
+            points={{-18,-56},{50,-56}},
+            color={0,0,0},
+            pattern=LinePattern.Dash),
+          Text(extent={{60,-50},{92,-70}},
+                                 textColor={0,0,0},
+            textString="min"),
+          Text(extent={{60,70},{92,50}},
+                                 textColor={0,0,0},
+            textString="max")}));
+  end ContinuousSignalExtrema;
+
   block Variance "Calculates the empirical variance of its input signal"
     extends Modelica.Blocks.Icons.Block;
     parameter SI.Time t_eps(min=100*Modelica.Constants.eps)=1e-7

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2566,7 +2566,7 @@ This means that:</p>
 This block detects positive and negative peaks of differentiable and non-differentiable input signals without sampling.
 </p>
 <p>
-For differentiable input singals, an extremum is detected if the derivative of the input signal is zero.
+For differentiable input signals, an extremum is detected if the derivative of the input signal is zero.
 </p>
 <p>
 To handle non-differentiable input signals, the input signal <code>u</code> is conditioned by a first order with time constant <code>T</code>. 

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2569,7 +2569,7 @@ This block detects positive and negative peaks of differentiable and non-differe
 For differentiable input singals, an extremum is detected if the derivative of the input signal is zero.
 </p>
 <p>
-To handle non-differentiable input signals, the input signal <code>u</code> is conditioned by a first order wth time constant <code>T</code>. 
+To handle non-differentiable input signals, the input signal <code>u</code> is conditioned by a first order with time constant <code>T</code>. 
 Like in the <a href=\"modelica://Modelica.Blocks.Continuous.Derivative\">derivative block</a>, 
 the derivative of the input signal is approximated by <code>(u - x)/T</code>. 
 This way even steps with local extrema just before and after the step are taken into account.

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2530,7 +2530,7 @@ This means that:</p>
 </html>"));
   end SignalExtrema;
 
-  block ContinuousSignalExtrema "Peak of input signal"
+  block ContinuousSignalExtrema "Store the minimum and maximum values of the input signal"
     extends Modelica.Blocks.Icons.Block;
     parameter Modelica.Units.SI.Time T(min=Modelica.Constants.small)=1e-6 "Derivative time constant";
     Modelica.Blocks.Interfaces.RealInput u

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2557,16 +2557,8 @@ This means that:</p>
     //detect local extrema at zero derivative, just before and after a step, and at the end of the simulation
       y_min = min({pre(y_min), u, pre(u)});
       y_max = max({pre(y_max), u, pre(u)});
-      if y_min<pre(y_min) then
-        t_min=time;
-        t_max=pre(t_max);
-      elseif y_max>pre(y_max) then
-        t_min=pre(t_min);
-        t_max=time;
-      else
-        t_min=pre(t_min);
-        t_max=pre(t_max);
-      end if;
+      t_min = if y_min<pre(y_min) then time else pre(t_min);
+      t_max = if y_max>pre(y_max) then time else pre(t_max);
     end when;
     annotation (defaultComponentName="signalExtrema",
     Documentation(info="<html>

--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -2575,7 +2575,7 @@ the derivative of the input signal is approximated by <code>(u - x)/T</code>.
 This way even steps with local extrema just before and after the step are taken into account.
 </p>
 <p>
-Additionally, when the simulation terminates, <code>y_max</code>y_min and <code>y_max</code> are updated.
+Additionally, when the simulation terminates, <code>y_min</code> and <code>y_max</code> are updated.
 </p>
 </html>"),
       Icon(graphics={

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1490,6 +1490,58 @@ whereas signalExtrema2 catches the extrema rather good due to the fact that samp
 </html>"));
   end DemonstrateSignalExtrema;
 
+  model DemonstrateContinuousSignalExtrema
+    "Test the ContinuousSignalExtrema block"
+    extends Modelica.Icons.Example;
+    Modelica.Blocks.Sources.Sine sine(
+      amplitude=1,
+      f=9,
+      offset=-2)
+      annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
+    Modelica.Blocks.Sources.SawTooth sawTooth(
+      amplitude=2,
+      period=1/9,
+      offset=1)
+      annotation (Placement(transformation(extent={{-80,-40},{-60,-20}})));
+    Modelica.Blocks.Sources.Sine amplitude(
+      amplitude=1,
+      f=0.75,
+      offset=0)
+      annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
+    Modelica.Blocks.Math.Product product1
+      annotation (Placement(transformation(extent={{-20,20},{0,40}})));
+    Modelica.Blocks.Math.Product product2
+      annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
+    Modelica.Blocks.Math.ContinuousSignalExtrema signalExtrema1
+      annotation (Placement(transformation(extent={{20,20},{40,40}})));
+    Modelica.Blocks.Math.ContinuousSignalExtrema signalExtrema2
+      annotation (Placement(transformation(extent={{20,-40},{40,-20}})));
+  equation
+    connect(amplitude.y, product1.u2) annotation (Line(points={{-39,0},{-30,0},{
+            -30,24},{-22,24}}, color={0,0,127}));
+    connect(amplitude.y, product2.u1) annotation (Line(points={{-39,0},{-30,0},{
+            -30,-24},{-22,-24}}, color={0,0,127}));
+    connect(sine.y, product1.u1) annotation (Line(points={{-59,30},{-40,30},{-40,
+            36},{-22,36}}, color={0,0,127}));
+    connect(sawTooth.y, product2.u2) annotation (Line(points={{-59,-30},{-40,-30},
+            {-40,-36},{-22,-36}}, color={0,0,127}));
+    connect(product1.y, signalExtrema1.u)
+      annotation (Line(points={{1,30},{18,30}}, color={0,0,127}));
+    connect(product2.y, signalExtrema2.u)
+      annotation (Line(points={{1,-30},{18,-30}}, color={0,0,127}));
+    annotation (experiment(
+        StopTime=1,
+        Interval=0.0001,
+        Tolerance=1e-06), Documentation(info="<html>
+<p>
+The amplitude of both a differentiable sinudoidal signal (frequency 9 Hz) and a non-differentiable sawtooth signal (period 1/9 s) is modulated sinusoidally /frequency 0.75 Hz).
+</p>
+<p>
+Note that the ContinuousSignalExtremaBlock detects extrema of both signals without sampling.
+</p>
+</html>"));
+  end DemonstrateContinuousSignalExtrema;
+
   model DemoSignalCharacteristic
     "Demonstrate characteristic values of a signal"
     extends Modelica.Icons.Example;

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1505,7 +1505,7 @@ whereas signalExtrema2 catches the extrema rather good due to the fact that samp
       annotation (Placement(transformation(extent={{-80,-40},{-60,-20}})));
     Modelica.Blocks.Sources.Sine amplitude(
       amplitude=1,
-      f=0.75,
+      f=1.75,
       offset=0)
       annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
     Modelica.Blocks.Math.Product product1

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1497,38 +1497,69 @@ whereas signalExtrema2 catches the extrema rather good due to the fact that samp
       amplitude=1,
       f=9,
       offset=-2)
-      annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
+      annotation (Placement(transformation(extent={{-60,70},{-40,90}})));
     Modelica.Blocks.Sources.SawTooth sawTooth(
       amplitude=2,
       period=1/9,
       offset=1)
-      annotation (Placement(transformation(extent={{-80,-40},{-60,-20}})));
+      annotation (Placement(transformation(extent={{-60,10},{-40,30}})));
     Modelica.Blocks.Sources.Sine amplitude(
       amplitude=1,
       f=1.75,
       offset=0)
-      annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
+      annotation (Placement(transformation(extent={{-40,40},{-20,60}})));
     Modelica.Blocks.Math.Product product1
-      annotation (Placement(transformation(extent={{-20,20},{0,40}})));
+      annotation (Placement(transformation(extent={{0,70},{20,90}})));
     Modelica.Blocks.Math.Product product2
-      annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
+      annotation (Placement(transformation(extent={{0,10},{20,30}})));
     Modelica.Blocks.Math.ContinuousSignalExtrema signalExtrema1
-      annotation (Placement(transformation(extent={{20,20},{40,40}})));
+      annotation (Placement(transformation(extent={{60,70},{80,90}})));
     Modelica.Blocks.Math.ContinuousSignalExtrema signalExtrema2
-      annotation (Placement(transformation(extent={{20,-40},{40,-20}})));
+      annotation (Placement(transformation(extent={{60,10},{80,30}})));
+    Sources.Sine                 sine1(
+      amplitude=1,
+      f=7,
+      offset=-2)
+      annotation (Placement(transformation(extent={{-60,-50},{-40,-30}})));
+    Sources.Pulse                    pulse(
+      amplitude=2,
+      period=1/9,
+      offset=1)
+      annotation (Placement(transformation(extent={{-60,-90},{-40,-70}})));
+    Math.Add add
+      annotation (Placement(transformation(extent={{-20,-70},{0,-50}})));
+    Math.Product                 product3
+      annotation (Placement(transformation(extent={{20,-50},{40,-30}})));
+    Sources.SawTooth                 sawTooth1(
+      amplitude=2,
+      period=1/13,
+      offset=-1)
+      annotation (Placement(transformation(extent={{-20,-30},{0,-10}})));
+    Math.ContinuousSignalExtrema                 signalExtrema3
+      annotation (Placement(transformation(extent={{60,-50},{80,-30}})));
   equation
-    connect(amplitude.y, product1.u2) annotation (Line(points={{-39,0},{-30,0},{
-            -30,24},{-22,24}}, color={0,0,127}));
-    connect(amplitude.y, product2.u1) annotation (Line(points={{-39,0},{-30,0},{
-            -30,-24},{-22,-24}}, color={0,0,127}));
-    connect(sine.y, product1.u1) annotation (Line(points={{-59,30},{-40,30},{-40,
-            36},{-22,36}}, color={0,0,127}));
-    connect(sawTooth.y, product2.u2) annotation (Line(points={{-59,-30},{-40,-30},
-            {-40,-36},{-22,-36}}, color={0,0,127}));
+    connect(amplitude.y, product1.u2) annotation (Line(points={{-19,50},{-10,50},
+            {-10,74},{-2,74}}, color={0,0,127}));
+    connect(amplitude.y, product2.u1) annotation (Line(points={{-19,50},{-10,50},
+            {-10,26},{-2,26}},   color={0,0,127}));
+    connect(sine.y, product1.u1) annotation (Line(points={{-39,80},{-20,80},{-20,
+            86},{-2,86}},  color={0,0,127}));
+    connect(sawTooth.y, product2.u2) annotation (Line(points={{-39,20},{-20,20},
+            {-20,14},{-2,14}},    color={0,0,127}));
     connect(product1.y, signalExtrema1.u)
-      annotation (Line(points={{1,30},{18,30}}, color={0,0,127}));
+      annotation (Line(points={{21,80},{58,80}},color={0,0,127}));
     connect(product2.y, signalExtrema2.u)
-      annotation (Line(points={{1,-30},{18,-30}}, color={0,0,127}));
+      annotation (Line(points={{21,20},{58,20}},  color={0,0,127}));
+    connect(sine1.y, add.u1) annotation (Line(points={{-39,-40},{-32,-40},{-32,
+            -54},{-22,-54}}, color={0,0,127}));
+    connect(pulse.y, add.u2) annotation (Line(points={{-39,-80},{-32,-80},{-32,
+            -66},{-22,-66}}, color={0,0,127}));
+    connect(add.y, product3.u2) annotation (Line(points={{1,-60},{10,-60},{10,
+            -46},{18,-46}}, color={0,0,127}));
+    connect(sawTooth1.y, product3.u1) annotation (Line(points={{1,-20},{10,-20},
+            {10,-34},{18,-34}}, color={0,0,127}));
+    connect(product3.y, signalExtrema3.u)
+      annotation (Line(points={{41,-40},{58,-40}}, color={0,0,127}));
     annotation (experiment(
         StopTime=1,
         Interval=0.0001,

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -1565,7 +1565,7 @@ whereas signalExtrema2 catches the extrema rather good due to the fact that samp
         Interval=0.0001,
         Tolerance=1e-06), Documentation(info="<html>
 <p>
-The amplitude of both a differentiable sinudoidal signal (frequency 9 Hz) and a non-differentiable sawtooth signal (period 1/9 s) is modulated sinusoidally /frequency 0.75 Hz).
+The amplitude of both a differentiable sinusoidal signal (frequency 9 Hz) and a non-differentiable sawtooth signal (period 1/9 s) is modulated sinusoidally /frequency 0.75 Hz).
 </p>
 <p>
 Note that the ContinuousSignalExtremaBlock detects extrema of both signals without sampling.

--- a/Modelica/Resources/Reference/Modelica/Blocks/Examples/DemonstrateContinuousSignalExtrema/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Blocks/Examples/DemonstrateContinuousSignalExtrema/comparisonSignals.txt
@@ -1,0 +1,10 @@
+time
+signalExtrema1.y_min
+signalExtrema1.y_max
+signalExtrema1.t_min
+signalExtrema1.t_max
+signalExtrema2.y_min
+signalExtrema2.y_max
+signalExtrema2.t_min
+signalExtrema2.t_max
+

--- a/Modelica/Resources/Reference/Modelica/Blocks/Examples/DemonstrateContinuousSignalExtrema/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Blocks/Examples/DemonstrateContinuousSignalExtrema/comparisonSignals.txt
@@ -7,4 +7,8 @@ signalExtrema2.y_min
 signalExtrema2.y_max
 signalExtrema2.t_min
 signalExtrema2.t_max
+signalExtrema3.y_min
+signalExtrema3.y_max
+signalExtrema3.t_min
+signalExtrema3.t_max
 


### PR DESCRIPTION
Triggered by a discussion with @GallLeo and looking into #3762, I developed a continuous block to detect signal extrema, based on derivative. It works for non-differentiable inputs, too. 