### PR TITLE
Removed duplicate definition of m 

### DIFF
--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sources/FrequencySweepCurrentSource.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sources/FrequencySweepCurrentSource.mo
@@ -23,8 +23,7 @@ equation
   connect(logFrequencySweep.y,currentSource. f) annotation (Line(points={{19,-50},{6,-50},{6,-12}},   color={0,0,127}));
   connect(plug_p,currentSource. plug_p) annotation (Line(points={{-100,0},{-10,0}}, color={85,170,255}));
   connect(currentSource.plug_n, plug_n) annotation (Line(points={{10,0},{100,0}}, color={85,170,255}));
-  connect(currentSource.I, const.y) annotation (Line(points={{-6,-12},{-6,-12},{-6,
-          -50},{-39,-50}},                                                                            color={85,170,255}));
+  connect(currentSource.I, const.y) annotation (Line(points={{-6,-12},{-6,-12},{-6,-50},{-39,-50}}, color={85,170,255}));
   annotation (defaultComponentName="currentSource",Icon(graphics={
         Ellipse(
           extent={{-50,50},{50,-50}},

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sources/FrequencySweepCurrentSource.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sources/FrequencySweepCurrentSource.mo
@@ -3,7 +3,6 @@ model FrequencySweepCurrentSource "Current source with integrated frequency swee
   extends Interfaces.TwoPlug;
   import Modelica.Constants.eps;
   SI.Angle gamma(start=0) = plug_p.reference.gamma;
-  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Frequency fStart(final min=eps, start=1) "Start sweep frequency";
   parameter SI.Frequency fStop(final min=eps, start=1) "Stop sweep frequency";
   parameter SI.Time startTime=0 "Start time of frequency sweep";
@@ -24,7 +23,8 @@ equation
   connect(logFrequencySweep.y,currentSource. f) annotation (Line(points={{19,-50},{6,-50},{6,-12}},   color={0,0,127}));
   connect(plug_p,currentSource. plug_p) annotation (Line(points={{-100,0},{-10,0}}, color={85,170,255}));
   connect(currentSource.plug_n, plug_n) annotation (Line(points={{10,0},{100,0}}, color={85,170,255}));
-  connect(currentSource.I, const.y) annotation (Line(points={{-6.2,-12},{-6,-12},{-6,-50},{-39,-50}}, color={85,170,255}));
+  connect(currentSource.I, const.y) annotation (Line(points={{-6,-12},{-6,-12},{-6,
+          -50},{-39,-50}},                                                                            color={85,170,255}));
   annotation (defaultComponentName="currentSource",Icon(graphics={
         Ellipse(
           extent={{-50,50},{50,-50}},

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sources/FrequencySweepVoltageSource.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sources/FrequencySweepVoltageSource.mo
@@ -3,7 +3,6 @@ model FrequencySweepVoltageSource "Voltage source with integrated frequency swee
   extends Interfaces.TwoPlug;
   import Modelica.Constants.eps;
   SI.Angle gamma(start=0) = plug_p.reference.gamma;
-  parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Frequency fStart(final min=eps, start=1) "Start sweep frequency";
   parameter SI.Frequency fStop(final min=eps, start=1) "Stop sweep frequency";
   parameter SI.Time startTime=0 "Start time of frequency sweep";


### PR DESCRIPTION
in Modelica.Electrical.QuasiStatic,Polyphase.Sources.FrequencySweep{Voltage, Current}Source
fixes issue #4021 
Should be back-ported to 3.2.3 (where `QuasiStatic` was named `Quasistationary`, and `Polyphase` was named `MulitPhase`),