### PR TITLE
Update obsolete form of noDerivative in ModelicaReference

### DIFF
--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -726,7 +726,7 @@ function f
   input Real x;
   input Real y;
   output Real z;
-  annotation(derivative(noDerivative(y = g(x))) = f_der);
+  annotation(derivative(noDerivative=y) = f_der);
 algorithm
   ...
 end f;


### PR DESCRIPTION
https://github.com/modelica/ModelicaStandardLibrary/issues/4023
