### PR TITLE
The dT is a temperature difference

### DIFF
--- a/Modelica/Fluid/Examples/HeatExchanger.mo
+++ b/Modelica/Fluid/Examples/HeatExchanger.mo
@@ -419,7 +419,7 @@ The design flow direction with positive m_flow variables is counterflow.</p>
         "Formulation of energy balance"
         annotation(Evaluate=true, Dialog(tab = "Assumptions", group="Dynamics"));
       parameter SI.Temperature T_start "Wall temperature start value";
-      parameter SI.Temperature dT "Start value for port_b.T - port_a.T";
+      parameter SI.TemperatureDifference dT "Start value for port_b.T - port_a.T";
     //Temperatures
       SI.Temperature[n] Tb(each start=T_start+0.5*dT);
       SI.Temperature[n] Ta(each start=T_start-0.5*dT);


### PR DESCRIPTION
So declare it as such.
This ensure that plotting dT in Celsius doesn't give non-sensical answers.
I could not find any similar errors at a quick glance.