### PR TITLE
Remove unit error safe

### DIFF
--- a/Modelica/Electrical/Machines/Examples/ControlledDCDrives/Utilities/IdealDcDc.mo
+++ b/Modelica/Electrical/Machines/Examples/ControlledDCDrives/Utilities/IdealDcDc.mo
@@ -28,7 +28,7 @@ model IdealDcDc "Ideal DC-DC inverter"
   Modelica.Blocks.Continuous.Integrator powerController(
     initType=Modelica.Blocks.Types.Init.InitialOutput,
     y_start=0,
-    k=1/Ti) annotation (Placement(transformation(extent={{30,10},{10,30}})));
+    k=1/Ti/unitVoltage) annotation (Placement(transformation(extent={{30,10},{10,30}})));
   Modelica.Electrical.Analog.Basic.Ground groundMotor annotation (Placement(
         transformation(
         extent={{-10,10},{10,-10}},
@@ -45,6 +45,8 @@ model IdealDcDc "Ideal DC-DC inverter"
     annotation (Placement(transformation(extent={{90,-112},{110,-92}})));
   Modelica.Blocks.Interfaces.RealInput vRef
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
+protected
+  constant SI.Voltage unitVoltage=1 annotation(HideResult=true);
 equation
   connect(signalCurrent.p, powerBat.nc)
     annotation (Line(points={{10,70},{20,70}},         color={0,0,255}));

--- a/Modelica/Electrical/Machines/Examples/SynchronousMachines/SMEE_LoadDump.mo
+++ b/Modelica/Electrical/Machines/Examples/SynchronousMachines/SMEE_LoadDump.mo
@@ -99,8 +99,7 @@ model SMEE_LoadDump
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={30,-50})));
-  Modelica.Blocks.Math.Gain setPointGain(k=(smeeData.VsNominal/wNominal)/
-        unitMagneticFlux)
+  Modelica.Blocks.Math.Gain setPointGain(k=(smeeData.VsNominal/wNominal))
     annotation (Placement(transformation(extent={{-50,-90},{-70,-70}})));
   Machines.Sensors.VoltageQuasiRMSSensor voltageQuasiRMSSensor(ToSpacePhasor1(y(
           each start=1E-3, each fixed=true))) annotation (Placement(

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMEE_LoadDump.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMEE_LoadDump.mo
@@ -104,8 +104,7 @@ model SMEE_LoadDump
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={30,-50})));
-  Modelica.Blocks.Math.Gain setPointGain(k=(smeeData.VsNominal/wNominal)/
-        unitMagneticFlux)
+  Modelica.Blocks.Math.Gain setPointGain(k=(smeeData.VsNominal/wNominal))
     annotation (Placement(transformation(extent={{-50,-90},{-70,-70}})));
   Modelica.Electrical.Machines.Sensors.VoltageQuasiRMSSensor voltageQuasiRMSSensor(
       ToSpacePhasor1(y(each start=1E-3, each fixed=true))) annotation (


### PR DESCRIPTION
This is related to https://github.com/modelica/ModelicaStandardLibrary/pull/3881
I strongly believe that both this and and #3881 should be back-ported to maintenance-branch.

These changes don't impact the simulation results and the first is 100% safe, the second is safe as long as people don't extend from an utility-model in an Example-package and add the same declaration.