### PR TITLE
Remove unit error changing

### DIFF
--- a/Modelica/Electrical/Machines/Examples/ControlledDCDrives/Utilities/DcdcInverter.mo
+++ b/Modelica/Electrical/Machines/Examples/ControlledDCDrives/Utilities/DcdcInverter.mo
@@ -113,7 +113,7 @@ model DcdcInverter "DC-DC inverter"
     k=1,
     T=Tmf,
     initType=Modelica.Blocks.Types.Init.InitialOutput,
-    y_start=VMax)
+    y_start=0)
     annotation (Placement(transformation(extent={{60,50},{80,70}})));
 equation
   connect(iMotSensor.p, pin_nMot) annotation (Line(points={{-50,-80},{

--- a/Modelica/Electrical/Machines/Examples/ControlledDCDrives/Utilities/IdealDcDc.mo
+++ b/Modelica/Electrical/Machines/Examples/ControlledDCDrives/Utilities/IdealDcDc.mo
@@ -28,7 +28,7 @@ model IdealDcDc "Ideal DC-DC inverter"
   Modelica.Blocks.Continuous.Integrator powerController(
     initType=Modelica.Blocks.Types.Init.InitialOutput,
     y_start=0,
-    k=1/Ti) annotation (Placement(transformation(extent={{30,10},{10,30}})));
+    k=1/Ti/unitVoltage) annotation (Placement(transformation(extent={{30,10},{10,30}})));
   Modelica.Electrical.Analog.Basic.Ground groundMotor annotation (Placement(
         transformation(
         extent={{-10,10},{10,-10}},
@@ -45,6 +45,8 @@ model IdealDcDc "Ideal DC-DC inverter"
     annotation (Placement(transformation(extent={{90,-112},{110,-92}})));
   Modelica.Blocks.Interfaces.RealInput vRef
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
+protected
+  constant SI.Voltage unitVoltage=1 annotation(HideResult=true);
 equation
   connect(signalCurrent.p, powerBat.nc)
     annotation (Line(points={{10,70},{20,70}},         color={0,0,255}));

--- a/Modelica/Electrical/Machines/Examples/SynchronousMachines/SMEE_LoadDump.mo
+++ b/Modelica/Electrical/Machines/Examples/SynchronousMachines/SMEE_LoadDump.mo
@@ -99,8 +99,7 @@ model SMEE_LoadDump
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={30,-50})));
-  Modelica.Blocks.Math.Gain setPointGain(k=(smeeData.VsNominal/wNominal)/
-        unitMagneticFlux)
+  Modelica.Blocks.Math.Gain setPointGain(k=(smeeData.VsNominal/wNominal))
     annotation (Placement(transformation(extent={{-50,-90},{-70,-70}})));
   Machines.Sensors.VoltageQuasiRMSSensor voltageQuasiRMSSensor(ToSpacePhasor1(y(
           each start=1E-3, each fixed=true))) annotation (Placement(

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMEE_LoadDump.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMEE_LoadDump.mo
@@ -104,8 +104,7 @@ model SMEE_LoadDump
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={30,-50})));
-  Modelica.Blocks.Math.Gain setPointGain(k=(smeeData.VsNominal/wNominal)/
-        unitMagneticFlux)
+  Modelica.Blocks.Math.Gain setPointGain(k=(smeeData.VsNominal/wNominal))
     annotation (Placement(transformation(extent={{-50,-90},{-70,-70}})));
   Modelica.Electrical.Machines.Sensors.VoltageQuasiRMSSensor voltageQuasiRMSSensor(
       ToSpacePhasor1(y(each start=1E-3, each fixed=true))) annotation (


### PR DESCRIPTION
It builds on #4040
There is only one new commit here (the latest one); it might be better to cherry-pick - but this combined PR ensures that there are no unit-errors in the library.

This commit changes a start-value and actually changes the simulation results for the example as follows.
Simulating Modelica.Electrical.Machines.Examples.ControlledDCDrives.SpeedControlledDCPM we get:

![SpeedControlledDCPM](https://user-images.githubusercontent.com/13217430/193268190-c9d3cdc7-3e17-4892-b108-86798b51a933.png)

The blue line indicates that previously the inverter started with a current of 120A and then quickly settled at 0A, now it starts at 0A. The start-value was VMax - which doesn't make sense for a current; I believe it was copied from the voltage-controller-component.

I believe we should consider also back-porting this to the maintenance-branch.