### PR TITLE
Fix startTime of (SignalPWM) -> ZeroOrderHold 

### DIFF
--- a/Modelica/Blocks/Discrete.mo
+++ b/Modelica/Blocks/Discrete.mo
@@ -5,11 +5,11 @@ package Discrete
   extends Modelica.Icons.Package;
 
   block Sampler "Ideal sampling of continuous signals"
-    extends Interfaces.DiscreteSISO;
+    extends Interfaces.DiscreteSISO(y(start=0, fixed=true));
 
   equation
     when {sampleTrigger, initial()} then
-      y = u;
+      y = if time>=startTime then u else pre(y);
     end when;
     annotation (
       Icon(
@@ -44,7 +44,7 @@ via parameter <strong>samplePeriod</strong>.
 
   equation
     when {sampleTrigger, initial()} then
-      ySample = u;
+      ySample = if time>=startTime then u else pre(ySample);
     end when;
     /* Define y=ySample with an infinitesimal delay to break potential
        algebraic loops if both the continuous and the discrete part have


### PR DESCRIPTION
This is a copy of  #4037 which was accidentally merged. It should not be merged before the discussion in #4035 is resolved. Hence it is still a **DRAFT**.

### description
parameter startTime is implemented but ignored.
It seems that Sampler and ZeroOrderHold have the same functionality and should extend one from the other?