### PR TITLE
Fix SI units by introducing reference phase impedance ZsRef

### DIFF
--- a/Modelica/Electrical/Machines/BasicMachines/InductionMachines/IM_SlipRing.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/InductionMachines/IM_SlipRing.mo
@@ -24,17 +24,17 @@ model IM_SlipRing "Induction machine with slipring rotor"
     final Lm=Lm,
     final m=m) annotation (Placement(transformation(extent={{-10,-10},{10,10}},
           rotation=270)));
-  parameter SI.Inductance Lm(start=3*sqrt(1 - 0.0667)/(2*pi
+  parameter SI.Inductance Lm(start=3*ZsRef*sqrt(1 - 0.0667)/(2*pi
         *fsNominal)) "Stator main field inductance per phase"
     annotation (Dialog(tab="Nominal resistances and inductances"));
-  parameter SI.Inductance Lrsigma(start=3*(1 - sqrt(1 -
+  parameter SI.Inductance Lrsigma(start=3*ZsRef*(1 - sqrt(1 -
         0.0667))/(2*pi*fsNominal))
     "Rotor stray inductance per phase w.r.t. rotor side"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter SI.Inductance Lrzero=Lrsigma
     "Rotor zero sequence inductance w.r.t. rotor side"
     annotation (Dialog(tab="Nominal resistances and inductances"));
-  parameter SI.Resistance Rr(start=0.04)
+  parameter SI.Resistance Rr(start=0.04*ZsRef)
     "Rotor resistance per phase at TRef w.r.t. rotor side"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter SI.Temperature TrRef(start=293.15)

--- a/Modelica/Electrical/Machines/BasicMachines/InductionMachines/IM_SquirrelCage.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/InductionMachines/IM_SquirrelCage.mo
@@ -23,14 +23,14 @@ model IM_SquirrelCage
     final Lm=Lm,
     final m=m) annotation (Placement(transformation(extent={{-10,-10},{10,10}},
           rotation=270)));
-  parameter SI.Inductance Lm(start=3*sqrt(1 - 0.0667)/(2*pi
+  parameter SI.Inductance Lm(start=3*ZsRef*sqrt(1 - 0.0667)/(2*pi
         *fsNominal)) "Stator main field inductance per phase"
     annotation (Dialog(tab="Nominal resistances and inductances"));
-  parameter SI.Inductance Lrsigma(start=3*(1 - sqrt(1 -
+  parameter SI.Inductance Lrsigma(start=3*ZsRef*(1 - sqrt(1 -
         0.0667))/(2*pi*fsNominal))
     "Rotor stray inductance per phase (equivalent three-phase winding)"
     annotation (Dialog(tab="Nominal resistances and inductances"));
-  parameter SI.Resistance Rr(start=0.04)
+  parameter SI.Resistance Rr(start=0.04*ZsRef)
     "Rotor resistance per phase (equivalent three-phase winding) at TRef"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter SI.Temperature TrRef(start=293.15)

--- a/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_ElectricalExcited.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_ElectricalExcited.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.Machines.BasicMachines.SynchronousMachines;
 model SM_ElectricalExcited
   "Electrical excited synchronous machine with damper cage"
   extends Machines.Interfaces.PartialBasicInductionMachine(
-    Lssigma(start=0.1*unitR/(2*pi*fsNominal)),
+    Lssigma(start=0.1*ZsRef/(2*pi*fsNominal)),
     final idq_ss=airGap.i_ss,
     final idq_sr=airGap.i_sr,
     final idq_rs=airGap.i_rs,
@@ -45,16 +45,16 @@ model SM_ElectricalExcited
     "Operational temperature of (optional) damper cage" annotation (
       Dialog(group="Operational temperatures", enable=not useThermalPort
            and useDamperCage));
-  parameter SI.Inductance Lmd(start=1.5*unitR/(2*pi*fsNominal))
+  parameter SI.Inductance Lmd(start=1.5*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance per phase in d-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
-  parameter SI.Inductance Lmq(start=1.5*unitR/(2*pi*fsNominal))
+  parameter SI.Inductance Lmq(start=1.5*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance per phase in q-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter Boolean useDamperCage(start=true)
     "Enable / disable damper cage" annotation (Evaluate=true, Dialog(tab=
           "Nominal resistances and inductances", group="Damper cage"));
-  parameter SI.Inductance Lrsigmad(start=0.05*unitR/(2*pi*
+  parameter SI.Inductance Lrsigmad(start=0.05*ZsRef/(2*pi*
         fsNominal)) "Damper stray inductance in d-axis" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
@@ -156,7 +156,7 @@ model SM_ElectricalExcited
         rotation=90,
         origin={-80,40})));
 protected
-  final constant SI.Resistance unitR=1;
+  final parameter SI.Impedance ZsRef = 1 "Reference phase impedance based on nominal voltage 100 V and nominal current 100 A; per phase";
   final parameter Real turnsRatio=sqrt(2)*VsNominal/(2*pi*fsNominal*Lmd*
       IeOpenCircuit) "Stator current / excitation current";
   final parameter SI.Inductance Lesigma=Lmd*turnsRatio^2*3/

--- a/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_ElectricalExcited.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_ElectricalExcited.mo
@@ -65,7 +65,7 @@ model SM_ElectricalExcited
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
-  parameter SI.Resistance Rrd(start=0.04)
+  parameter SI.Resistance Rrd(start=0.04*ZsRef)
     "Damper resistance in d-axis at TRef" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
@@ -156,7 +156,6 @@ model SM_ElectricalExcited
         rotation=90,
         origin={-80,40})));
 protected
-  final parameter SI.Impedance ZsRef = 1 "Reference phase impedance based on nominal voltage 100 V and nominal current 100 A; per phase";
   final parameter Real turnsRatio=sqrt(2)*VsNominal/(2*pi*fsNominal*Lmd*
       IeOpenCircuit) "Stator current / excitation current";
   final parameter SI.Inductance Lesigma=Lmd*turnsRatio^2*3/

--- a/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_ElectricalExcited.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_ElectricalExcited.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.Machines.BasicMachines.SynchronousMachines;
 model SM_ElectricalExcited
   "Electrical excited synchronous machine with damper cage"
   extends Machines.Interfaces.PartialBasicInductionMachine(
-    Lssigma(start=0.1/(2*pi*fsNominal)),
+    Lssigma(start=0.1*unitR/(2*pi*fsNominal)),
     final idq_ss=airGap.i_ss,
     final idq_sr=airGap.i_sr,
     final idq_rs=airGap.i_rs,
@@ -45,16 +45,16 @@ model SM_ElectricalExcited
     "Operational temperature of (optional) damper cage" annotation (
       Dialog(group="Operational temperatures", enable=not useThermalPort
            and useDamperCage));
-  parameter SI.Inductance Lmd(start=1.5/(2*pi*fsNominal))
+  parameter SI.Inductance Lmd(start=1.5*unitR/(2*pi*fsNominal))
     "Stator main field inductance per phase in d-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
-  parameter SI.Inductance Lmq(start=1.5/(2*pi*fsNominal))
+  parameter SI.Inductance Lmq(start=1.5*unitR/(2*pi*fsNominal))
     "Stator main field inductance per phase in q-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter Boolean useDamperCage(start=true)
     "Enable / disable damper cage" annotation (Evaluate=true, Dialog(tab=
           "Nominal resistances and inductances", group="Damper cage"));
-  parameter SI.Inductance Lrsigmad(start=0.05/(2*pi*
+  parameter SI.Inductance Lrsigmad(start=0.05*unitR/(2*pi*
         fsNominal)) "Damper stray inductance in d-axis" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
@@ -156,6 +156,7 @@ model SM_ElectricalExcited
         rotation=90,
         origin={-80,40})));
 protected
+  final constant SI.Resistance unitR=1;
   final parameter Real turnsRatio=sqrt(2)*VsNominal/(2*pi*fsNominal*Lmd*
       IeOpenCircuit) "Stator current / excitation current";
   final parameter SI.Inductance Lesigma=Lmd*turnsRatio^2*3/

--- a/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_PermanentMagnet.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_PermanentMagnet.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Machines.BasicMachines.SynchronousMachines;
 model SM_PermanentMagnet "Permanent magnet synchronous machine"
   extends Machines.Interfaces.PartialBasicInductionMachine(
-    Lssigma(start=0.1/(2*pi*fsNominal)),
+    Lssigma(start=0.1*unitR/(2*pi*fsNominal)),
     final idq_ss=airGap.i_ss,
     final idq_sr=airGap.i_sr,
     final idq_rs=airGap.i_rs,
@@ -47,16 +47,16 @@ model SM_PermanentMagnet "Permanent magnet synchronous machine"
            and useDamperCage));
   parameter SI.Voltage VsOpenCircuit(start=112.3)
     "Open circuit RMS voltage per phase @ fsNominal";
-  parameter SI.Inductance Lmd(start=0.3/(2*pi*fsNominal))
+  parameter SI.Inductance Lmd(start=0.3*unitR/(2*pi*fsNominal))
     "Stator main field inductance per phase in d-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
-  parameter SI.Inductance Lmq(start=0.3/(2*pi*fsNominal))
+  parameter SI.Inductance Lmq(start=0.3*unitR/(2*pi*fsNominal))
     "Stator main field inductance per phase in q-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter Boolean useDamperCage(start=true)
     "Enable / disable damper cage" annotation (Evaluate=true, Dialog(tab=
           "Nominal resistances and inductances", group="Damper cage"));
-  parameter SI.Inductance Lrsigmad(start=0.05/(2*pi*
+  parameter SI.Inductance Lrsigmad(start=0.05*unitR/(2*pi*
         fsNominal)) "Damper stray inductance in d-axis" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
@@ -114,6 +114,7 @@ model SM_PermanentMagnet "Permanent magnet synchronous machine"
         extent={{-10,-10},{10,10}},
         rotation=270)));
 protected
+  final constant SI.Resistance unitR=1;
   final parameter SI.Current Ie=sqrt(2)*VsOpenCircuit/(Lmd*
       2*pi*fsNominal) "Equivalent excitation current";
   Modelica.Blocks.Interfaces.RealOutput damperCageLossPower(final

--- a/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_PermanentMagnet.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_PermanentMagnet.mo
@@ -1,7 +1,7 @@
 within Modelica.Electrical.Machines.BasicMachines.SynchronousMachines;
 model SM_PermanentMagnet "Permanent magnet synchronous machine"
   extends Machines.Interfaces.PartialBasicInductionMachine(
-    Lssigma(start=0.1*unitR/(2*pi*fsNominal)),
+    Lssigma(start=0.1*ZsRef/(2*pi*fsNominal)),
     final idq_ss=airGap.i_ss,
     final idq_sr=airGap.i_sr,
     final idq_rs=airGap.i_rs,
@@ -47,16 +47,16 @@ model SM_PermanentMagnet "Permanent magnet synchronous machine"
            and useDamperCage));
   parameter SI.Voltage VsOpenCircuit(start=112.3)
     "Open circuit RMS voltage per phase @ fsNominal";
-  parameter SI.Inductance Lmd(start=0.3*unitR/(2*pi*fsNominal))
+  parameter SI.Inductance Lmd(start=0.3*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance per phase in d-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
-  parameter SI.Inductance Lmq(start=0.3*unitR/(2*pi*fsNominal))
+  parameter SI.Inductance Lmq(start=0.3*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance per phase in q-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter Boolean useDamperCage(start=true)
     "Enable / disable damper cage" annotation (Evaluate=true, Dialog(tab=
           "Nominal resistances and inductances", group="Damper cage"));
-  parameter SI.Inductance Lrsigmad(start=0.05*unitR/(2*pi*
+  parameter SI.Inductance Lrsigmad(start=0.05*ZsRef/(2*pi*
         fsNominal)) "Damper stray inductance in d-axis" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
@@ -114,7 +114,7 @@ model SM_PermanentMagnet "Permanent magnet synchronous machine"
         extent={{-10,-10},{10,10}},
         rotation=270)));
 protected
-  final constant SI.Resistance unitR=1;
+  final parameter SI.Impedance ZsRef = 1 "Reference phase impedance based on nominal voltage 100 V and nominal current 100 A; per phase";
   final parameter SI.Current Ie=sqrt(2)*VsOpenCircuit/(Lmd*
       2*pi*fsNominal) "Equivalent excitation current";
   Modelica.Blocks.Interfaces.RealOutput damperCageLossPower(final

--- a/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_PermanentMagnet.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_PermanentMagnet.mo
@@ -67,7 +67,7 @@ model SM_PermanentMagnet "Permanent magnet synchronous machine"
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
-  parameter SI.Resistance Rrd(start=0.04)
+  parameter SI.Resistance Rrd(start=0.04*ZsRef)
     "Damper resistance in d-axis at TRef" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
@@ -114,7 +114,6 @@ model SM_PermanentMagnet "Permanent magnet synchronous machine"
         extent={{-10,-10},{10,10}},
         rotation=270)));
 protected
-  final parameter SI.Impedance ZsRef = 1 "Reference phase impedance based on nominal voltage 100 V and nominal current 100 A; per phase";
   final parameter SI.Current Ie=sqrt(2)*VsOpenCircuit/(Lmd*
       2*pi*fsNominal) "Equivalent excitation current";
   Modelica.Blocks.Interfaces.RealOutput damperCageLossPower(final

--- a/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_ReluctanceRotor.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_ReluctanceRotor.mo
@@ -2,14 +2,13 @@ within Modelica.Electrical.Machines.BasicMachines.SynchronousMachines;
 model SM_ReluctanceRotor
   "Synchronous machine with reluctance rotor and damper cage"
   extends Machines.Interfaces.PartialBasicInductionMachine(
-    Lssigma(start=0.1/(2*pi*fsNominal)),
+    Lssigma(start=0.1*unitR/(2*pi*fsNominal)),
     final idq_ss=airGap.i_ss,
     final idq_sr=airGap.i_sr,
     final idq_rs=airGap.i_rs,
     final idq_rr=airGap.i_rr,
     redeclare final Machines.Thermal.SynchronousMachines.ThermalAmbientSMR
       thermalAmbient(final useDamperCage=useDamperCage, final Tr=TrOperational),
-
     redeclare final Machines.Interfaces.InductionMachines.ThermalPortSMR
       thermalPort(final useDamperCage=useDamperCage),
     redeclare final Machines.Interfaces.InductionMachines.ThermalPortSMR
@@ -40,16 +39,16 @@ model SM_ReluctanceRotor
     "Operational temperature of (optional) damper cage" annotation (
       Dialog(group="Operational temperatures", enable=not useThermalPort
            and useDamperCage));
-  parameter SI.Inductance Lmd(start=2.9/(2*pi*fsNominal))
+  parameter SI.Inductance Lmd(start=2.9*unitR/(2*pi*fsNominal))
     "Stator main field inductance per phase in d-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
-  parameter SI.Inductance Lmq(start=0.9/(2*pi*fsNominal))
+  parameter SI.Inductance Lmq(start=0.9*unitR/(2*pi*fsNominal))
     "Stator main field inductance per phase in q-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter Boolean useDamperCage(start=true)
     "Enable / disable damper cage" annotation (Evaluate=true, Dialog(tab=
           "Nominal resistances and inductances", group="Damper cage"));
-  parameter SI.Inductance Lrsigmad(start=0.05/(2*pi*
+  parameter SI.Inductance Lrsigmad(start=0.05*unitR/(2*pi*
         fsNominal)) "Damper stray inductance in d-axis" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
@@ -95,6 +94,7 @@ model SM_ReluctanceRotor
         extent={{-10,-10},{10,10}},
         rotation=270)));
 protected
+  final constant SI.Resistance unitR=1;
   Modelica.Blocks.Interfaces.RealOutput damperCageLossPower(final
       quantity="Power", final unit="W") "Damper losses";
 equation

--- a/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_ReluctanceRotor.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_ReluctanceRotor.mo
@@ -59,7 +59,7 @@ model SM_ReluctanceRotor
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
-  parameter SI.Resistance Rrd(start=0.04)
+  parameter SI.Resistance Rrd(start=0.04*ZsRef)
     "Damper resistance in d-axis at TRef" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
@@ -94,7 +94,6 @@ model SM_ReluctanceRotor
         extent={{-10,-10},{10,10}},
         rotation=270)));
 protected
-  final SI.Impedance ZsRef = 1 "Reference phase impedance based on nominal voltage 100 V and nominal current 100 A; per phase";
   Modelica.Blocks.Interfaces.RealOutput damperCageLossPower(final
       quantity="Power", final unit="W") "Damper losses";
 equation

--- a/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_ReluctanceRotor.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/SynchronousMachines/SM_ReluctanceRotor.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.Machines.BasicMachines.SynchronousMachines;
 model SM_ReluctanceRotor
   "Synchronous machine with reluctance rotor and damper cage"
   extends Machines.Interfaces.PartialBasicInductionMachine(
-    Lssigma(start=0.1*unitR/(2*pi*fsNominal)),
+    Lssigma(start=0.1*ZsRef/(2*pi*fsNominal)),
     final idq_ss=airGap.i_ss,
     final idq_sr=airGap.i_sr,
     final idq_rs=airGap.i_rs,
@@ -39,16 +39,16 @@ model SM_ReluctanceRotor
     "Operational temperature of (optional) damper cage" annotation (
       Dialog(group="Operational temperatures", enable=not useThermalPort
            and useDamperCage));
-  parameter SI.Inductance Lmd(start=2.9*unitR/(2*pi*fsNominal))
+  parameter SI.Inductance Lmd(start=2.9*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance per phase in d-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
-  parameter SI.Inductance Lmq(start=0.9*unitR/(2*pi*fsNominal))
+  parameter SI.Inductance Lmq(start=0.9*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance per phase in q-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter Boolean useDamperCage(start=true)
     "Enable / disable damper cage" annotation (Evaluate=true, Dialog(tab=
           "Nominal resistances and inductances", group="Damper cage"));
-  parameter SI.Inductance Lrsigmad(start=0.05*unitR/(2*pi*
+  parameter SI.Inductance Lrsigmad(start=0.05*ZsRef/(2*pi*
         fsNominal)) "Damper stray inductance in d-axis" annotation (
       Dialog(
       tab="Nominal resistances and inductances",
@@ -94,7 +94,7 @@ model SM_ReluctanceRotor
         extent={{-10,-10},{10,10}},
         rotation=270)));
 protected
-  final constant SI.Resistance unitR=1;
+  final SI.Impedance ZsRef = 1 "Reference phase impedance based on nominal voltage 100 V and nominal current 100 A; per phase";
   Modelica.Blocks.Interfaces.RealOutput damperCageLossPower(final
       quantity="Power", final unit="W") "Damper losses";
 equation

--- a/Modelica/Electrical/Machines/Interfaces/PartialBasicInductionMachine.mo
+++ b/Modelica/Electrical/Machines/Interfaces/PartialBasicInductionMachine.mo
@@ -8,7 +8,7 @@ partial model PartialBasicInductionMachine
   parameter SI.Temperature TsOperational(start=293.15)
     "Operational temperature of stator resistance" annotation (Dialog(group=
          "Operational temperatures", enable=not useThermalPort));
-  parameter SI.Resistance Rs(start=0.03)
+  parameter SI.Resistance Rs(start=0.03*ZsRef)
     "Stator resistance per phase at TRef"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter SI.Temperature TsRef(start=293.15)
@@ -20,7 +20,7 @@ partial model PartialBasicInductionMachine
   parameter SI.Inductance Lszero=Lssigma
     "Stator zero sequence inductance"
     annotation (Dialog(tab="Nominal resistances and inductances"));
-  parameter SI.Inductance Lssigma(start=3*(1 - sqrt(1 -
+  parameter SI.Inductance Lssigma(start=3*ZsRef*(1 - sqrt(1 -
         0.0667))/(2*pi*fsNominal)) "Stator stray inductance per phase"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   extends PartialBasicMachine(
@@ -100,8 +100,8 @@ partial model PartialBasicInductionMachine
     final useHeatPort=true,
     final m=m) annotation (Placement(transformation(extent={{90,70},{70,90}})));
   replaceable
-    Machines.Interfaces.InductionMachines.PartialThermalPortInductionMachines thermalPort(final m=m) if
-       useThermalPort
+    Machines.Interfaces.InductionMachines.PartialThermalPortInductionMachines thermalPort(final m=m)
+    if useThermalPort
     annotation (Placement(transformation(extent={{-10,-110},{10,-90}})));
   replaceable
     Machines.Interfaces.InductionMachines.PartialThermalAmbientInductionMachines
@@ -113,6 +113,7 @@ partial model PartialBasicInductionMachine
         rotation=270,
         origin={-30,-80})));
 protected
+  final parameter SI.Impedance ZsRef = 1 "Reference phase impedance based on nominal voltage 100 V and nominal current 100 A; per phase";
   constant Real pi = Modelica.Constants.pi;
   replaceable
     Machines.Interfaces.InductionMachines.PartialThermalPortInductionMachines internalThermalPort(final m=m)

--- a/Modelica/Magnetic/FundamentalWave/BaseClasses/Machine.mo
+++ b/Modelica/Magnetic/FundamentalWave/BaseClasses/Machine.mo
@@ -18,7 +18,7 @@ partial model Machine "Base model of machines"
   parameter SI.Temperature TsOperational(start=293.15)
     "Operational temperature of stator resistance" annotation (Dialog(group=
          "Operational temperatures", enable=not useThermalPort));
-  parameter SI.Resistance Rs(start=0.03)
+  parameter SI.Resistance Rs(start=ZsRef*0.03)
     "Stator resistance per phase at TRef"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter SI.Temperature TsRef(start=293.15)
@@ -30,7 +30,7 @@ partial model Machine "Base model of machines"
     "Temperature coefficient of stator resistance at 20 degC"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter Real effectiveStatorTurns=1 "Effective number of stator turns";
-  parameter SI.Inductance Lssigma(start=3*(1 - sqrt(1 -
+  parameter SI.Inductance Lssigma(start=3*ZsRef*(1 - sqrt(1 -
         0.0667))/(2*pi*fsNominal)) "Stator stray inductance"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter Real ratioCommonStatorLeakage(final min=0, final max=1)=1
@@ -170,6 +170,8 @@ partial model Machine "Base model of machines"
     annotation (Placement(transformation(extent={{-44,-94},{-36,-86}})));
   Modelica.Mechanics.Rotational.Interfaces.Support internalSupport
     annotation (Placement(transformation(extent={{56,-104},{64,-96}})));
+protected
+  final parameter SI.Impedance ZsRef = 1 "Reference phase impedance based on nominal voltage 100 V and nominal current 100 A; per phase";
 initial algorithm
   assert(not Modelica.Math.isPowerOf2(m), String(m) +
     " phases are currently not supported in this version of FundametalWave");

--- a/Modelica/Magnetic/FundamentalWave/BasicMachines/InductionMachines/IM_SlipRing.mo
+++ b/Modelica/Magnetic/FundamentalWave/BasicMachines/InductionMachines/IM_SlipRing.mo
@@ -3,8 +3,8 @@ model IM_SlipRing "Induction machine with slip ring rotor"
   parameter Integer mr(min=3) = m "Number of rotor phases" annotation(Evaluate=true);
   extends Magnetic.FundamentalWave.BaseClasses.Machine(
     is(start=zeros(m)),
-    Rs(start=0.03),
-    Lssigma(start=3*(1 - sqrt(1 - 0.0667))/(2*pi*fsNominal)),
+    Rs(start=0.03*ZsRef),
+    Lssigma(start=3*ZsRef*(1 - sqrt(1 - 0.0667))/(2*pi*fsNominal)),
     final L0(d=2.0*Lm/m/effectiveStatorTurns^2, q=2.0*Lm/m/effectiveStatorTurns
           ^2),
     redeclare final
@@ -31,11 +31,11 @@ model IM_SlipRing "Induction machine with slip ring rotor"
   Modelica.Electrical.Polyphase.Interfaces.PositivePlug plug_rp(final m=
         mr) "Positive plug of rotor" annotation (Placement(transformation(
           extent={{-110,70},{-90,50}})));
-  parameter SI.Inductance Lm(start=3*sqrt(1 - 0.0667)/(2*pi
+  parameter SI.Inductance Lm(start=3*ZsRef*sqrt(1 - 0.0667)/(2*pi
         *fsNominal)) "Stator main field inductance" annotation (Dialog(
         tab="Nominal resistances and inductances", groupImage=
           "modelica://Modelica/Resources/Images/Electrical/Machines/IMS.png"));
-  parameter SI.Inductance Lrsigma(start=3*(1 - sqrt(1 -
+  parameter SI.Inductance Lrsigma(start=3*ZsRef*(1 - sqrt(1 -
         0.0667))/(2*pi*fsNominal))
     "Rotor leakage inductance w.r.t. rotor side"
     annotation (Dialog(tab="Nominal resistances and inductances"));
@@ -45,7 +45,7 @@ model IM_SlipRing "Induction machine with slip ring rotor"
   parameter SI.Inductance Lrzero=Lrsigma
     "Rotor zero inductance w.r.t. rotor side"
     annotation (Dialog(tab="Nominal resistances and inductances"));
-  parameter SI.Resistance Rr(start=0.04)
+  parameter SI.Resistance Rr(start=0.04*ZsRef)
     "Rotor resistance per phase w.r.t. rotor side"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter SI.Temperature TrRef(start=293.15)

--- a/Modelica/Magnetic/FundamentalWave/BasicMachines/InductionMachines/IM_SquirrelCage.mo
+++ b/Modelica/Magnetic/FundamentalWave/BasicMachines/InductionMachines/IM_SquirrelCage.mo
@@ -3,8 +3,8 @@ model IM_SquirrelCage
   "Induction machine with squirrel cage"
   extends Magnetic.FundamentalWave.BaseClasses.Machine(
     is(start=zeros(m)),
-    Rs(start=0.03),
-    Lssigma(start=3*(1 - sqrt(1 - 0.0667))/(2*pi*fsNominal)),
+    Rs(start=0.03*ZsRef),
+    Lssigma(start=3*ZsRef*(1 - sqrt(1 - 0.0667))/(2*pi*fsNominal)),
     final L0(d=2.0*Lm/m/effectiveStatorTurns^2, q=2.0*Lm/m/effectiveStatorTurns
           ^2),
     redeclare final
@@ -20,15 +20,15 @@ model IM_SquirrelCage
       Modelica.Electrical.Machines.Interfaces.InductionMachines.PowerBalanceIMC
       powerBalance(final lossPowerRotorWinding=sum(rotorCage.resistor.resistor.LossPower),
         final lossPowerRotorCore=0));
-  parameter SI.Inductance Lm(start=3*sqrt(1 - 0.0667)/(2*pi
+  parameter SI.Inductance Lm(start=3*ZsRef*sqrt(1 - 0.0667)/(2*pi
         *fsNominal)) "Stator main field inductance" annotation (Dialog(
         tab="Nominal resistances and inductances", groupImage=
           "modelica://Modelica/Resources/Images/Electrical/Machines/IMC.png"));
-  parameter SI.Inductance Lrsigma(start=3*(1 - sqrt(1 -
+  parameter SI.Inductance Lrsigma(start=3*ZsRef*(1 - sqrt(1 -
         0.0667))/(2*pi*fsNominal))
     "Rotor leakage inductance of equivalent m phase winding w.r.t. stator side"
     annotation (Dialog(tab="Nominal resistances and inductances"));
-  parameter SI.Resistance Rr(start=0.04)
+  parameter SI.Resistance Rr(start=0.04*ZsRef)
     "Rotor resistance of equivalent m phase winding w.r.t. stator side"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter SI.Temperature TrRef(start=293.15)

--- a/Modelica/Magnetic/FundamentalWave/BasicMachines/SynchronousMachines/SM_ElectricalExcited.mo
+++ b/Modelica/Magnetic/FundamentalWave/BasicMachines/SynchronousMachines/SM_ElectricalExcited.mo
@@ -3,8 +3,8 @@ model SM_ElectricalExcited
   "Electrical excited synchronous machine with optional damper cage"
   extends Magnetic.FundamentalWave.BaseClasses.Machine(
     is(start=zeros(m)),
-    Rs(start=0.03),
-    Lssigma(start=0.1/(2*pi*fsNominal)),
+    Rs(start=0.03*ZsRef),
+    Lssigma(start=0.1*ZsRef/(2*pi*fsNominal)),
     final L0(d=2.0*Lmd/m/effectiveStatorTurns^2, q=2.0*Lmq/m/
           effectiveStatorTurns^2),
     redeclare final
@@ -28,18 +28,18 @@ model SM_ElectricalExcited
       final lossPowerBrush=brush.lossPower,
       final lossPowerRotorCore=0));
   // Main field parameters
-  parameter SI.Inductance Lmd(start=1.5/(2*pi*fsNominal))
+  parameter SI.Inductance Lmd(start=1.5*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance, d-axis" annotation (Dialog(tab=
           "Nominal resistances and inductances", groupImage=
           "modelica://Modelica/Resources/Images/Electrical/Machines/SMEE.png"));
-  parameter SI.Inductance Lmq(start=1.5/(2*pi*fsNominal))
+  parameter SI.Inductance Lmq(start=1.5*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance, q-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   // Rotor cage parameters
   parameter Boolean useDamperCage(start=true)
     "Enable/disable damper cage" annotation (Dialog(tab=
           "Nominal resistances and inductances", group="Damper cage"));
-  parameter SI.Inductance Lrsigmad(start=0.05/(2*pi*
+  parameter SI.Inductance Lrsigmad(start=0.05*ZsRef/(2*pi*
         fsNominal))
     "Rotor damper cage leakage inductance, d-axis, w.r.t. stator side" annotation (
       Dialog(
@@ -52,7 +52,7 @@ model SM_ElectricalExcited
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
-  parameter SI.Resistance Rrd(start=0.04)
+  parameter SI.Resistance Rrd(start=0.04*ZsRef)
     "Rotor damper cage resistance, d-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",

--- a/Modelica/Magnetic/FundamentalWave/BasicMachines/SynchronousMachines/SM_PermanentMagnet.mo
+++ b/Modelica/Magnetic/FundamentalWave/BasicMachines/SynchronousMachines/SM_PermanentMagnet.mo
@@ -3,8 +3,8 @@ model SM_PermanentMagnet
   "Permanent magnet synchronous machine with optional damper cage"
   extends Magnetic.FundamentalWave.BaseClasses.Machine(
     is(start=zeros(m)),
-    Rs(start=0.03),
-    Lssigma(start=0.1/(2*pi*fsNominal)),
+    Rs(start=0.03*ZsRef),
+    Lssigma(start=0.1*ZsRef/(2*pi*fsNominal)),
     final L0(d=2.0*Lmd/m/effectiveStatorTurns^2, q=2.0*Lmq/m/
           effectiveStatorTurns^2),
     redeclare final
@@ -26,18 +26,18 @@ model SM_PermanentMagnet
       final lossPowerRotorCore=0,
       final lossPowerPermanentMagnet=permanentMagnet.lossPower));
   // Main field parameters
-  parameter SI.Inductance Lmd(start=0.3/(2*pi*fsNominal))
+  parameter SI.Inductance Lmd(start=0.3*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance, d-axis" annotation (Dialog(tab=
           "Nominal resistances and inductances", groupImage=
           "modelica://Modelica/Resources/Images/Electrical/Machines/SMPM.png"));
-  parameter SI.Inductance Lmq(start=0.3/(2*pi*fsNominal))
+  parameter SI.Inductance Lmq(start=0.3*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance, q-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   // Rotor cage parameters
   parameter Boolean useDamperCage(start=true)
     "Enable/disable damper cage" annotation (Dialog(tab=
           "Nominal resistances and inductances", group="Damper cage"));
-  parameter SI.Inductance Lrsigmad(start=0.05/(2*pi*
+  parameter SI.Inductance Lrsigmad(start=0.05*ZsRef/(2*pi*
         fsNominal))
     "Rotor damper cage leakage inductance, d-axis, w.r.t. stator side" annotation (
       Dialog(
@@ -50,7 +50,7 @@ model SM_PermanentMagnet
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
-  parameter SI.Resistance Rrd(start=0.04)
+  parameter SI.Resistance Rrd(start=0.04*ZsRef)
     "Rotor damper cage resistance, d-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",

--- a/Modelica/Magnetic/FundamentalWave/BasicMachines/SynchronousMachines/SM_ReluctanceRotor.mo
+++ b/Modelica/Magnetic/FundamentalWave/BasicMachines/SynchronousMachines/SM_ReluctanceRotor.mo
@@ -2,8 +2,8 @@ within Modelica.Magnetic.FundamentalWave.BasicMachines.SynchronousMachines;
 model SM_ReluctanceRotor "Reluctance machine with optional damper cage"
   extends Magnetic.FundamentalWave.BaseClasses.Machine(
     is(start=zeros(m)),
-    Rs(start=0.03),
-    Lssigma(start=0.1/(2*pi*fsNominal)),
+    Rs(start=0.03*ZsRef),
+    Lssigma(start=0.1*ZsRef/(2*pi*fsNominal)),
     final L0(d=2.0*Lmd/m/effectiveStatorTurns^2, q=2.0*Lmq/m/
           effectiveStatorTurns^2),
     redeclare final
@@ -25,18 +25,18 @@ model SM_ReluctanceRotor "Reluctance machine with optional damper cage"
     "Operational temperature of (optional) damper cage" annotation (
       Dialog(group="Operational temperatures", enable=not useThermalPort
            and useDamperCage));
-  parameter SI.Inductance Lmd(start=2.9/(2*pi*fsNominal))
+  parameter SI.Inductance Lmd(start=2.9*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance, d-axis" annotation (Dialog(tab=
           "Nominal resistances and inductances", groupImage=
           "modelica://Modelica/Resources/Images/Electrical/Machines/SMR.png"));
-  parameter SI.Inductance Lmq(start=0.9/(2*pi*fsNominal))
+  parameter SI.Inductance Lmq(start=0.9*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance, q-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   // Rotor cage parameters
   parameter Boolean useDamperCage(start=true)
     "Enable/disable damper cage" annotation (Dialog(tab=
           "Nominal resistances and inductances", group="Damper cage"));
-  parameter SI.Inductance Lrsigmad(start=0.05/(2*pi*
+  parameter SI.Inductance Lrsigmad(start=0.05*ZsRef/(2*pi*
         fsNominal))
     "Rotor damper cage leakage inductance, d-axis, w.r.t. stator side" annotation (
       Dialog(
@@ -49,7 +49,7 @@ model SM_ReluctanceRotor "Reluctance machine with optional damper cage"
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
-  parameter SI.Resistance Rrd(start=0.04)
+  parameter SI.Resistance Rrd(start=0.04*ZsRef)
     "Rotor damper cage resistance, d-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/BaseClasses/Machine.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/BaseClasses/Machine.mo
@@ -196,6 +196,8 @@ partial model Machine "Base model of machines"
     annotation (Placement(transformation(extent={{-44,-94},{-36,-86}})));
   Modelica.Mechanics.Rotational.Interfaces.Support internalSupport
     annotation (Placement(transformation(extent={{56,-104},{64,-96}})));
+protected
+  final parameter SI.Impedance ZsRef = 1 "Reference phase impedance based on nominal voltage 100 V and nominal current 100 A; per phase";
 initial algorithm
   assert(not Modelica.Math.isPowerOf2(m), String(m) +
     " phases are currently not supported in this version of FundametalWave");

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/InductionMachines/IM_SlipRing.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/InductionMachines/IM_SlipRing.mo
@@ -2,8 +2,8 @@ within Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.InductionMach
 model IM_SlipRing "Induction machine with slip ring rotor"
   parameter Integer mr(min=3) = m "Number of rotor phases" annotation(Evaluate=true);
   extends BaseClasses.Machine(
-    Rs(start=0.03),
-    Lssigma(start=3*(1 - sqrt(1 - 0.0667))/(2*pi*fsNominal)),
+    Rs(start=0.03*ZsRef),
+    Lssigma(start=3*ZsRef*(1 - sqrt(1 - 0.0667))/(2*pi*fsNominal)),
     final L0(d=2.0*Lm/m/effectiveStatorTurns^2, q=2.0*Lm/m/
           effectiveStatorTurns^2),
     redeclare final
@@ -22,9 +22,7 @@ model IM_SlipRing "Induction machine with slip ring rotor"
       final lossPowerRotorCore=rotor.core.lossPower,
       final lossPowerBrush=0,
       final powerRotor=
-          Modelica.Electrical.QuasiStatic.Polyphase.Functions.activePower(
-                                                                 vr,
-          ir)));
+          Modelica.Electrical.QuasiStatic.Polyphase.Functions.activePower(vr, ir)));
 
   Modelica.Electrical.QuasiStatic.Polyphase.Interfaces.NegativePlug
     plug_rn(final m=mr) "Negative plug of rotor" annotation (Placement(
@@ -32,15 +30,15 @@ model IM_SlipRing "Induction machine with slip ring rotor"
   Modelica.Electrical.QuasiStatic.Polyphase.Interfaces.PositivePlug
     plug_rp(final m=mr) "Positive plug of rotor" annotation (Placement(
         transformation(extent={{-110,70},{-90,50}})));
-  parameter SI.Inductance Lm(start=3*sqrt(1 - 0.0667)/(2*pi
+  parameter SI.Inductance Lm(start=3*ZsRef*sqrt(1 - 0.0667)/(2*pi
         *fsNominal)) "Stator main field inductance per phase" annotation (
      Dialog(tab="Nominal resistances and inductances", groupImage=
           "modelica://Modelica/Resources/Images/Electrical/Machines/IMS.png"));
-  parameter SI.Inductance Lrsigma(start=3*(1 - sqrt(1 -
+  parameter SI.Inductance Lrsigma(start=3*ZsRef*(1 - sqrt(1 -
         0.0667))/(2*pi*fsNominal))
     "Rotor leakage inductance per phase w.r.t. rotor side"
     annotation (Dialog(tab="Nominal resistances and inductances"));
-  parameter SI.Resistance Rr(start=0.04)
+  parameter SI.Resistance Rr(start=0.04*ZsRef)
     "Rotor resistance per phase w.r.t. rotor side"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter SI.Temperature TrRef(start=293.15)

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/InductionMachines/IM_SquirrelCage.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/InductionMachines/IM_SquirrelCage.mo
@@ -2,8 +2,8 @@ within Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.InductionMach
 model IM_SquirrelCage "Induction machine with squirrel cage"
   // Removed from extension of FUNDAMENTAL WAVE model: is(start=zeros(m)) ##
   extends BaseClasses.Machine(
-    Rs(start=0.03),
-    Lssigma(start=3*(1 - sqrt(1 - 0.0667))/(2*pi*fsNominal)),
+    Rs(start=0.03*ZsRef),
+    Lssigma(start=3*ZsRef*(1 - sqrt(1 - 0.0667))/(2*pi*fsNominal)),
     final L0(d=2.0*Lm/m/effectiveStatorTurns^2, q=2.0*Lm/m/
           effectiveStatorTurns^2),
     redeclare final
@@ -19,15 +19,15 @@ model IM_SquirrelCage "Induction machine with squirrel cage"
       Modelica.Electrical.Machines.Interfaces.InductionMachines.PowerBalanceIMC
       powerBalance(final lossPowerRotorWinding=sum(rotorCage.resistor.resistor.LossPower),
         final lossPowerRotorCore=0));
-  parameter SI.Inductance Lm(start=3*sqrt(1 - 0.0667)/(2*pi
+  parameter SI.Inductance Lm(start=3*ZsRef*sqrt(1 - 0.0667)/(2*pi
         *fsNominal)) "Stator main field inductance per phase" annotation (
      Dialog(tab="Nominal resistances and inductances", groupImage=
           "modelica://Modelica/Resources/Images/Electrical/Machines/IMC.png"));
-  parameter SI.Inductance Lrsigma(start=3*(1 - sqrt(1 -
+  parameter SI.Inductance Lrsigma(start=3*ZsRef*(1 - sqrt(1 -
         0.0667))/(2*pi*fsNominal))
     "Rotor leakage inductance of equivalent m phase winding w.r.t. stator side"
     annotation (Dialog(tab="Nominal resistances and inductances"));
-  parameter SI.Resistance Rr(start=0.04)
+  parameter SI.Resistance Rr(start=0.04*ZsRef)
     "Rotor resistance of equivalent m phase winding w.r.t. stator side"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   parameter SI.Temperature TrRef(start=293.15)

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/SynchronousMachines/SM_ElectricalExcited.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/SynchronousMachines/SM_ElectricalExcited.mo
@@ -2,8 +2,8 @@ within Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.SynchronousMa
 model SM_ElectricalExcited
   "Electrical excited synchronous machine with optional damper cage"
   extends BaseClasses.Machine(
-    Rs(start=0.03),
-    Lssigma(start=0.1/(2*pi*fsNominal)),
+    Rs(start=0.03*ZsRef),
+    Lssigma(start=0.1*ZsRef/(2*pi*fsNominal)),
     final L0(d=2.0*Lmd/m/effectiveStatorTurns^2, q=2.0*Lmq/m/
           effectiveStatorTurns^2),
     redeclare final
@@ -27,18 +27,18 @@ model SM_ElectricalExcited
       final lossPowerBrush=brush.lossPower,
       final lossPowerRotorCore=0));
   // Main field parameters
-  parameter SI.Inductance Lmd(start=1.5/(2*pi*fsNominal))
+  parameter SI.Inductance Lmd(start=1.5*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance per phase, d-axis" annotation (Dialog(
         tab="Nominal resistances and inductances", groupImage=
           "modelica://Modelica/Resources/Images/Electrical/Machines/SMEE.png"));
-  parameter SI.Inductance Lmq(start=1.5/(2*pi*fsNominal))
+  parameter SI.Inductance Lmq(start=1.5*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance per phase, q-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   // Rotor cage parameters
   parameter Boolean useDamperCage(start=true)
     "Enable/disable damper cage" annotation (Dialog(tab=
           "Nominal resistances and inductances", group="Damper cage"));
-  parameter SI.Inductance Lrsigmad(start=0.05/(2*pi*
+  parameter SI.Inductance Lrsigmad(start=0.05*ZsRef/(2*pi*
         fsNominal))
     "Rotor damper cage leakage inductance, d-axis, w.r.t. stator side" annotation (
       Dialog(
@@ -51,7 +51,7 @@ model SM_ElectricalExcited
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
-  parameter SI.Resistance Rrd(start=0.04)
+  parameter SI.Resistance Rrd(start=0.04*ZsRef)
     "Rotor damper cage resistance, d-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
@@ -122,8 +122,8 @@ model SM_ElectricalExcited
     final TOperational=TrOperational,
     final RRef(d=Rrd, q=Rrq),
     final alpha20=alpha20r,
-    final effectiveTurns=sqrt(m/2.0)*effectiveStatorTurns) if
-    useDamperCage
+    final effectiveTurns=sqrt(m/2.0)*effectiveStatorTurns)
+ if useDamperCage
     "Symmetric rotor cage winding including resistances and stray inductances"
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/SynchronousMachines/SM_PermanentMagnet.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/SynchronousMachines/SM_PermanentMagnet.mo
@@ -2,8 +2,8 @@ within Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.SynchronousMa
 model SM_PermanentMagnet
   "Permanent magnet synchronous machine with optional damper cage"
   extends BaseClasses.Machine(
-    Rs(start=0.03),
-    Lssigma(start=0.1/(2*pi*fsNominal)),
+    Rs(start=0.03*ZsRef),
+    Lssigma(start=0.1*ZsRef/(2*pi*fsNominal)),
     final L0(d=2.0*Lmd/m/effectiveStatorTurns^2, q=2.0*Lmq/m/
           effectiveStatorTurns^2),
     redeclare final
@@ -25,18 +25,18 @@ model SM_PermanentMagnet
       final lossPowerRotorCore=0,
       final lossPowerPermanentMagnet=permanentMagnet.lossPower));
   // Main field parameters
-  parameter SI.Inductance Lmd(start=0.3/(2*pi*fsNominal))
+  parameter SI.Inductance Lmd(start=0.3*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance per phase, d-axis" annotation (Dialog(
         tab="Nominal resistances and inductances", groupImage=
           "modelica://Modelica/Resources/Images/Electrical/Machines/SMPM.png"));
-  parameter SI.Inductance Lmq(start=0.3/(2*pi*fsNominal))
+  parameter SI.Inductance Lmq(start=0.3*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance per phase, q-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   // Rotor cage parameters
   parameter Boolean useDamperCage(start=true)
     "Enable/disable damper cage" annotation (Dialog(tab=
           "Nominal resistances and inductances", group="Damper cage"));
-  parameter SI.Inductance Lrsigmad(start=0.05/(2*pi*
+  parameter SI.Inductance Lrsigmad(start=0.05*ZsRef/(2*pi*
         fsNominal))
     "Rotor damper cage leakage inductance, d-axis, w.r.t. stator side" annotation (
       Dialog(
@@ -49,7 +49,7 @@ model SM_PermanentMagnet
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
-  parameter SI.Resistance Rrd(start=0.04)
+  parameter SI.Resistance Rrd(start=0.04*ZsRef)
     "Rotor damper cage resistance, d-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
@@ -106,8 +106,8 @@ model SM_PermanentMagnet
     final TRef=TrRef,
     final TOperational=TrOperational,
     final alpha20=alpha20r,
-    final effectiveTurns=sqrt(m/2.0)*effectiveStatorTurns) if
-    useDamperCage
+    final effectiveTurns=sqrt(m/2.0)*effectiveStatorTurns)
+ if useDamperCage
     "Symmetric rotor cage winding including resistances and stray inductances"
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/SynchronousMachines/SM_ReluctanceRotor.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/BasicMachines/SynchronousMachines/SM_ReluctanceRotor.mo
@@ -2,8 +2,8 @@ within Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.SynchronousMa
 model SM_ReluctanceRotor
   "Synchronous reluctance machine with optional damper cage"
   extends BaseClasses.Machine(
-    Rs(start=0.03),
-    Lssigma(start=0.1/(2*pi*fsNominal)),
+    Rs(start=0.03*ZsRef),
+    Lssigma(start=0.1*ZsRef/(2*pi*fsNominal)),
     final L0(d=2.0*Lmd/m/effectiveStatorTurns^2, q=2.0*Lmq/m/
           effectiveStatorTurns^2),
     redeclare final
@@ -21,18 +21,18 @@ model SM_ReluctanceRotor
       powerBalance(final lossPowerRotorWinding=damperCageLossPower,
         final lossPowerRotorCore=0));
 
-  parameter SI.Inductance Lmd(start=2.9/(2*pi*fsNominal))
+  parameter SI.Inductance Lmd(start=2.9*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance per phase, d-axis" annotation (Dialog(
         tab="Nominal resistances and inductances", groupImage=
           "modelica://Modelica/Resources/Images/Electrical/Machines/SMR.png"));
-  parameter SI.Inductance Lmq(start=0.9/(2*pi*fsNominal))
+  parameter SI.Inductance Lmq(start=0.9*ZsRef/(2*pi*fsNominal))
     "Stator main field inductance per phase, q-axis"
     annotation (Dialog(tab="Nominal resistances and inductances"));
   // Rotor cage parameters
   parameter Boolean useDamperCage(start=true)
     "Enable/disable damper cage" annotation (Dialog(tab=
           "Nominal resistances and inductances", group="Damper cage"));
-  parameter SI.Inductance Lrsigmad(start=0.05/(2*pi*
+  parameter SI.Inductance Lrsigmad(start=0.05*ZsRef/(2*pi*
         fsNominal))
     "Rotor damper cage leakage inductance, d-axis, w.r.t. stator side" annotation (
       Dialog(
@@ -45,7 +45,7 @@ model SM_ReluctanceRotor
       tab="Nominal resistances and inductances",
       group="Damper cage",
       enable=useDamperCage));
-  parameter SI.Resistance Rrd(start=0.04)
+  parameter SI.Resistance Rrd(start=0.04*ZsRef)
     "Rotor damper cage resistance, d-axis, w.r.t. stator side" annotation (Dialog(
       tab="Nominal resistances and inductances",
       group="Damper cage",
@@ -91,8 +91,8 @@ model SM_ReluctanceRotor
     final TRef=TrRef,
     final TOperational=TrOperational,
     final alpha20=alpha20r,
-    final effectiveTurns=sqrt(m/2.0)*effectiveStatorTurns) if
-    useDamperCage
+    final effectiveTurns=sqrt(m/2.0)*effectiveStatorTurns)
+ if useDamperCage
     "Symmetric rotor cage winding including resistances and stray inductances"
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},


### PR DESCRIPTION
Fix the unit for the inductances. 
Eliminates non-local unit errors based on https://github.com/modelica/ModelicaSpecification/pull/3266 (combined with other unit-changes.)