### PR TITLE
Remove incorrect unit-casting

### DIFF
--- a/Modelica/Magnetic/FluxTubes/Shapes/HysteresisAndMagnets/GenericHystTellinenHard.mo
+++ b/Modelica/Magnetic/FluxTubes/Shapes/HysteresisAndMagnets/GenericHystTellinenHard.mo
@@ -7,7 +7,7 @@ model GenericHystTellinenHard
   //Hysteresis parameter
   parameter SI.MagneticFluxDensity Br=1.2 "Remanence" annotation (Dialog(group="Hysteresis", groupImage="modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Shapes/HysteresisAndMagnets/GenericHystTellinenHard/HardMagneticHysteresis.png"));
   parameter SI.MagneticFieldStrength Hc=5e5 "Coercitivity" annotation (Dialog(group="Hysteresis"));
-  parameter Real M = 10/Hc "Slope of tanh()-function" annotation (Dialog(group="Hysteresis"));
+  parameter Real M(final unit="m/A") = 10/Hc "Slope of tanh()-function" annotation (Dialog(group="Hysteresis"));
   parameter Real K=1 "Slope of hysteresis in the saturation region (K*mu_0)" annotation (Dialog(group="Hysteresis"));
 
 protected

--- a/Modelica/Magnetic/FluxTubes/Shapes/HysteresisAndMagnets/GenericHystTellinenHard.mo
+++ b/Modelica/Magnetic/FluxTubes/Shapes/HysteresisAndMagnets/GenericHystTellinenHard.mo
@@ -13,15 +13,15 @@ model GenericHystTellinenHard
 protected
   final parameter SI.MagneticFluxDensity eps = Br/1000;
   //final parameter Real mu0(final unit="N/A2") = K*mu_0;
-  final parameter SI.MagneticFieldStrength H0= 0.5*log((1+mu0*Hc/Br)/(1-mu0*Hc/Br)) + M*Hc;
+  final parameter Real H0= 0.5*log((1+mu0*Hc/Br)/(1-mu0*Hc/Br)) + M*Hc;
   constant SI.MagneticFieldStrength unitH = 1;
 
   Real tanhR;
   Real tanhF;
 
 equation
-  tanhR = tanh((M*H - H0)/unitH);
-  tanhF = tanh((M*H + H0)/unitH);
+  tanhR = tanh(M*H - H0);
+  tanhF = tanh(M*H + H0);
   hystR = Br*tanhR + mu0*H - eps/2;
   hystF = Br*tanhF + mu0*H + eps/2;
 

--- a/Modelica/Magnetic/FluxTubes/Shapes/HysteresisAndMagnets/GenericHystTellinenSoft.mo
+++ b/Modelica/Magnetic/FluxTubes/Shapes/HysteresisAndMagnets/GenericHystTellinenSoft.mo
@@ -17,8 +17,8 @@ protected
   constant SI.MagneticFieldStrength unitH = 1;
 
 equation
-  hystR = Js*tanh((M*Hstat - H0)/unitH) + mu0*Hstat - eps/2;
-  hystF = Js*tanh((M*Hstat + H0)/unitH) + mu0*Hstat + eps/2;
+  hystR = Js*tanh(M*Hstat - H0) + mu0*Hstat - eps/2;
+  hystF = Js*tanh(M*Hstat + H0) + mu0*Hstat + eps/2;
 
   annotation (defaultComponentName="core", Documentation(info="<html>
 <p>Flux tube element for modeling soft magnetic materials with ferromagnetic and dynamic hysteresis (eddy currents). The ferromagnetic hysteresis behavior is defined by the <a href=\"modelica://Modelica.Magnetic.FluxTubes.UsersGuide.Hysteresis.StaticHysteresis.Tellinen\">Tellinen hysteresis model</a>. The shape of the limiting hysteresis loop (see Fig. 1) is described by simple hyperbolic tangent functions with 4 parameters. Therefore, the hysteresis shape variety is limited but the parameterization of the model is very simple and the model is relatively fast and robust. The rising (hyst<sub>R</sub>) and falling (hyst<sub>F</sub>) branches of the limiting hysteresis loop are defined by the following equations.</p>


### PR DESCRIPTION
The basic issue is that `H0` shouldn't be seen as a magnetic field strength, but as a dimensionless value (which makes sense given that it is the result of a logarithm). That implies that the argument to tanh is already dimensionless - when M has the unit of inverse magnetic field strength.

The commit also makes the two models more similar.
As far as I can tell this issue was already present in the original commit of these models.