### PR TITLE
Propose better unit-handling in equation for LogSweep

### DIFF
--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -941,13 +941,14 @@ The Real output y is a trapezoid signal:
   equation
     y = if time < startTime then wMin else
       if time < (startTime + max(duration,eps)) then
-        10^(log10(wMin) + (log10(wMax) - log10(wMin))*min(1, (time-startTime)/max(duration,eps)))
+        wMin * (wMax/wMin)^min(1, (time-startTime)/max(duration,eps))
       else
         wMax;
      annotation (defaultComponentName="logSweep",
        Documentation(info="<html>
 <p>The output <code>y</code> performs a logarithmic frequency sweep.
 The logarithm of frequency <code>w</code> performs a linear ramp from <code>log10(wMin)</code> to <code>log10(wMax)</code>.
+It uses <code>wMin*(wMax/wMin)^x</code> instead of the equivalent <code>10^(log10(wMin)+log10(wMax)-log10(wMin)*x)</code> to help with unit-checking.
 The output is the decimal power of this logarithmic ramp.
 </p>
 <p>For <code>time &lt; startTime</code> the output is equal to <code>wMin</code>.</p>


### PR DESCRIPTION
As explained in the documentation rewrite to make it easier for unit-checking.

Previously the equation contained `10^(log10(wMin)+(log10(wMax)-log(wMin))*x)` but that is replaced by the equivalent to `wMin*(wMax/wMin)^x`.

Looking at units for the first equation would require some special logic, but the second trivially has the same unit as wMin.