### PR TITLE
Wrap if-condition in noEvent within smooth in OpAmp

### DIFF
--- a/Modelica/Electrical/Analog/Basic/OpAmp.mo
+++ b/Modelica/Electrical/Analog/Basic/OpAmp.mo
@@ -28,7 +28,7 @@ equation
   vin = in_p.v - in_n.v;
   f = 2/(VMax.v - VMin.v);
   absSlope = if (Slope < 0) then -Slope else Slope;
-  out.v = (VMax.v + VMin.v)/2 + absSlope*vin/(1 + absSlope*smooth(0, (if (f*
+  out.v = (VMax.v + VMin.v)/2 + absSlope*vin/(1 + absSlope*smooth(0, (if noEvent(f*
     vin < 0) then -f*vin else f*vin)));
   annotation (
     Documentation(info="<html>


### PR DESCRIPTION
Making it explicit that this condition should not generate events, similar to the smooth expression in `OpAmpDetailed`: https://github.com/modelica/ModelicaStandardLibrary/blob/89d5175dea8b668624c90dbd019cca4bd3f1f5bb/Modelica/Electrical/Analog/Basic/OpAmpDetailed.mo#L200

As far as I can tell, this only improves simulations with this component.
