### PR TITLE
Propagate useSolver to these variants as well.

### DIFF
--- a/Modelica/Clocked/ClockSignals/Clocks/Logical/PartialLogicalClock.mo
+++ b/Modelica/Clocked/ClockSignals/Clocks/Logical/PartialLogicalClock.mo
@@ -18,7 +18,7 @@ partial block PartialLogicalClock
      infinite many ticks for an infinitesimal short time period."
     annotation (Placement(transformation(extent = {{20,-10},{40,10}})));
 
-  EventClock clock
+  EventClock clock(useSolver=useSolver, solverMethod=solverMethod)
     annotation (Placement(transformation(extent = {{60,-10},{80,10}})));
 
   // Array of input trackers:

--- a/Modelica/Clocked/ClockSignals/Clocks/Rotational/FixedRotationalClock.mo
+++ b/Modelica/Clocked/ClockSignals/Clocks/Rotational/FixedRotationalClock.mo
@@ -6,7 +6,7 @@ model FixedRotationalClock
   parameter SI.Angle trigger_interval = 2*Modelica.Constants.pi
     "Rotational-interval the input angle must be changed to trigger the next clock tick";
 
-  RotationalClock rotationalClock
+  RotationalClock rotationalClock(useSolver=useSolver, solverMethod=solverMethod)
     annotation (Placement(transformation(extent = {{-10,-10},{10,10}})));
   Modelica.Blocks.Sources.Constant threshold(k = trigger_interval)
     annotation (Placement(transformation(extent = {{-80,20},{-60,40}})));


### PR DESCRIPTION
I'm unsure if we should have an example for this, as I couldn't find any for useSolver in general.
Obviously I made a small test-case (it also checks the normal RotationalClock that was working):
[TestUseSolver.zip](https://github.com/modelica/ModelicaStandardLibrary/files/10409479/TestUseSolver.zip)

Closes #4070