### PR TITLE
Fix for #3971.

### DIFF
--- a/Modelica/Clocked/RealSignals/Interfaces/PartialNoise.mo
+++ b/Modelica/Clocked/RealSignals/Interfaces/PartialNoise.mo
@@ -2,4 +2,10 @@ within Modelica.Clocked.RealSignals.Interfaces;
 partial block PartialNoise
   "Interface for SISO blocks with Real signals that add noise to the signal"
   extends Clocked.RealSignals.Interfaces.PartialClockedSISO;
+
+  parameter Real noiseMax=0.1 "Upper limit of noise band";
+  parameter Real noiseMin=-noiseMax "Lower limit of noise band";
+  annotation (Documentation(info="<html>
+<p><span style=\"font-family: Arial;\">Interface block for uniformly distributed noise in some range noiseMin&nbsp;&hellip;&nbsp;noiseMax applied to a clocked Real input signal; the resulting noisy signal is provided as clocked Real output signal.</span></p>
+</html>"));
 end PartialNoise;

--- a/Modelica/Clocked/RealSignals/Interfaces/PartialNoise.mo
+++ b/Modelica/Clocked/RealSignals/Interfaces/PartialNoise.mo
@@ -6,6 +6,6 @@ partial block PartialNoise
   parameter Real noiseMax=0.1 "Upper limit of noise band";
   parameter Real noiseMin=-noiseMax "Lower limit of noise band";
   annotation (Documentation(info="<html>
-<p><span style=\"font-family: Arial;\">Interface block for uniformly distributed noise in some range noiseMin&nbsp;&hellip;&nbsp;noiseMax applied to a clocked Real input signal; the resulting noisy signal is provided as clocked Real output signal.</span></p>
+<p>Interface block for uniformly distributed noise in some range noiseMin&nbsp;&hellip;&nbsp;noiseMax applied to a clocked Real input signal; the resulting noisy signal is provided as clocked Real output signal.</p>
 </html>"));
 end PartialNoise;

--- a/Modelica/Clocked/RealSignals/Sampler/Utilities/Internal/UniformNoise.mo
+++ b/Modelica/Clocked/RealSignals/Sampler/Utilities/Internal/UniformNoise.mo
@@ -1,8 +1,6 @@
 within Modelica.Clocked.RealSignals.Sampler.Utilities.Internal;
 block UniformNoise "Add band-limited uniform noise using a variant of the Wichmann-Hill algorithm"
   extends Clocked.RealSignals.Interfaces.PartialNoise;
-  parameter Real noiseMax=0.1 "Upper limit of noise band";
-  parameter Real noiseMin=-noiseMax "Lower limit of noise band";
   parameter Integer firstSeed[3](each min=0, each max=255) = {23,87,187}
     "Integer[3] defining random sequence; required element range: 0..255";
 protected

--- a/Modelica/Clocked/RealSignals/Sampler/Utilities/Internal/UniformNoiseXorshift64star.mo
+++ b/Modelica/Clocked/RealSignals/Sampler/Utilities/Internal/UniformNoiseXorshift64star.mo
@@ -2,8 +2,6 @@ within Modelica.Clocked.RealSignals.Sampler.Utilities.Internal;
 block UniformNoiseXorshift64star
   "Add band-limited uniform noise based on a xorshift64* number generator"
   extends Clocked.RealSignals.Interfaces.PartialNoise;
-  parameter Real noiseMax=0.1 "Upper limit of noise band";
-  parameter Real noiseMin=-noiseMax "Lower limit of noise band";
 
   parameter Integer globalSeed = 30020 "Global seed to initialize random number generator";
   // Random number generators with exposed state


### PR DESCRIPTION
Fix for #3971: Moved the parameters into the interface. I double checked that all interface implementations (subclasses) in fact introduce both parameters; their defaults have been the same.