### PR TITLE
First figure

### DIFF
--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -155,7 +155,10 @@ works reasonably, since the input to the limiter (PI.limiter.u)
 is forced back to its limit after a transient phase.
 </p>
 
-</html>"));
+</html>", figures = {Figure(title = "Anti-windup compensation", identifier = "anti-windup", preferred = true, plots = {Plot(title = "Reference tracking", identifier = "tracking", curves = {Curve(y = integrator.y, legend = "Reference speed"), Curve(y = inertia1.w, legend = "Actual speed")}), Plot(title = "Anti-windup limiter", identifier = "limiter", curves = {Curve(y = PI.limiter.u, legend = "Input to the anti-windup limiter "), Curve(y = PI.y, legend = "Controller output")})}, caption = "%(plot:tracking) Reference speed (%(variable:integrator.y)) and the actual speed (%(variable:inertia1.w)). The system initializes in steady state, since no transients are present. The inertia follows the reference speed quite good until the end of the constant speed phase. Then there is a deviation.
+
+%(plot:limiter) Here the reason for the deviation can be seen: The output of the controller (%(variable:PI.y)) is in its limits. The anti-windup compensation works reasonably, since the input to the limiter (%(variable:PI.limiter.u)) is forced back to its limit after a transient phase.
+")}));
   end PID_Controller;
 
   model Filter "Demonstrates the Continuous.Filter block with various options"

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -2444,7 +2444,7 @@ Short Overview:
 </p>
 <ul>
 <li>About <a href=\"modelica://Modelica/Resources/Documentation/Version-4.0.0/ResolvedGitHubIssues.html\">649 issues (including 432 pull requests)</a> have been addressed for this release.</li>
-<li>This version is based on the recent Modelica language standard version 3.4.</li>
+<li>This version is based on the recent Modelica language standard version 3.5.</li>
 <li>The library version (i.e., \"4.0.0\") follows semantic versioning using the convention <code>MAJOR.MINOR.BUGFIX</code>
 (see <a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.VersionManagement\">Version Management</a> for details)
  and was decoupled from the version of the utilized version of the Modelica language standard.</li>
@@ -9071,7 +9071,7 @@ This version of the Modelica Standard Library consists of
 </ul>
 <p>
 that are directly usable (= number of public, non-partial, non-internal and non-obsolete classes). It is fully compliant
-to <a href=\"https://modelica.org/documents/ModelicaSpec34.pdf\">Modelica Specification version 3.4</a>
+to <a href=\"https://specification.modelica.org/maint/3.5/MLS.html\">Modelica Specification version 3.5</a>
 and it has been tested with Modelica tools from different vendors.
 </p>
 


### PR DESCRIPTION
With love from the Modelica design meeting held this week:

This PR adds the first case of an example making use of the Modelica `Figure` annotation introduced in Modelica 3.5.  Note that this means there are actually two important changes in this PR:
- Switching language version to Modelica 3.5.
- Adding a figure to the `PID_Controller` example.

This is what the added figure looks like in System Modeler:
![image](https://user-images.githubusercontent.com/25294143/225350421-e70c8863-d816-4012-ae64-7fa81b8786cc.png)
