### PR TITLE
New block for raising an input to an Integer exponent

### DIFF
--- a/Modelica/Blocks/Math.mo
+++ b/Modelica/Blocks/Math.mo
@@ -1759,7 +1759,7 @@ y = base <strong>^</strong> u;
 </html>"));
   end Power;
 
-  block Exponentiation "Output the input raised to an exponent"
+  block Exponentiation "Output the input raised to a Real exponent"
     extends Interfaces.SISO;
     parameter Real exponent=2 "Exponent of power" annotation (Evaluate=true);
   equation
@@ -1788,12 +1788,49 @@ y = base <strong>^</strong> u;
             lineColor={192,192,192},
             fillColor={192,192,192},
             fillPattern=FillPattern.Solid)}), Documentation(info="<html>
-<p>This blocks computes the output <strong>y</strong> as the input <strong>u</strong> raised to <em>exponent</em>:</p>
+<p>This blocks computes the output <strong>y</strong> as the input <strong>u</strong> raised to <em>exponent</em>, where <em>exponent</em> is an evaluated <strong>Real</strong> parameter::</p>
 <blockquote><pre>
 y = u <strong>^</strong> exponent;
 </pre></blockquote>
 </html>"));
   end Exponentiation;
+
+  block IntegerExponentiation "Output the input raised to an Integer exponent"
+    extends Interfaces.SISO;
+    parameter Integer exponent = 2 "Exponent of power" annotation (Evaluate=true);
+  equation
+    y = u^exponent;
+    annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
+              {100,100}}), graphics={
+          Line(points={{0,-80},{0,68}}, color={192,192,192}),
+          Polygon(
+            points={{0,90},{-8,68},{8,68},{0,90}},
+            lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Text(
+            origin = {-0, 35.587},
+            textColor = {192, 192, 192},
+            extent = {{-82.494, -20}, {82.494, 20}},
+            textString = "^Integer"),
+          Line(points={{-80,60},{-70,27.2},{-60,-1.3},{-50,-25.3},{-40,-45},{-30,-60.3},
+                {-20,-71.3},{-10,-77.8},{0,-80},{10,-77.8},{20,-71.3},{30,-60.3},{
+                40,-45},{50,-25.3},{60,-1.3},{70,27.2},{80,60}}, smooth=Smooth.Bezier),
+          Line(
+            points={{-90,-80.3976},{68,-80.3976}},
+            color={192,192,192},
+            smooth=Smooth.Bezier),
+          Polygon(
+            points={{90,-80.3976},{68,-72.3976},{68,-88.3976},{90,-80.3976}},
+            lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid)}), Documentation(info="<html>
+<p>This blocks computes the output <strong>y</strong> as the input <strong>u</strong> raised to <em>exponent</em>, where <em>exponent</em> is an evaluated <strong>Integer</strong> parameter:</p>
+<blockquote><pre>
+y = u <strong>^</strong> exponent;
+</pre></blockquote>
+</html>"));
+  end IntegerExponentiation;
 
   block Log
     "Output the logarithm (default base e) of the input (input > 0 required)"


### PR DESCRIPTION
It is good that the MSL now has the `Exponentiation` block.  In the future, when the MSL uses Modelica 3.6, however, there will be a difference between raising an expression to a `Real` or to an `Integer` exponent, see:
- https://specification.modelica.org/maint/3.6/arrays.html#element-wise-exponentiation

This PR introduces an `IntegerExponentiation` block similar to `Exponentiation`, but with an `Integer` exponent.

The fact that there is no separation in semantics in the Modelica version used by the MSL today doesn't mean one cannot have two different blocks already today.  Offering both blocks makes it possible to make a future-proof selection of which block to use, and users may also be able to take advantage of the `IntegerExponent` even before the MSL changes to Modelica 3.6, as it is often possible for users to enable more modern language features in tools while still using an MSL pointing to a language version from the past.
