### PR TITLE
Fix unit error in SimpleAir

### DIFF
--- a/Modelica/Media/Air/SimpleAir.mo
+++ b/Modelica/Media/Air/SimpleAir.mo
@@ -5,7 +5,7 @@ package SimpleAir "Air: Simple dry air model (0..100 degC)"
     mediumName="SimpleAir",
     cp_const=1005.45,
     MM_const=0.0289651159,
-    R_gas=Constants.R/0.0289651159,
+    R_gas=Constants.R/MM_const,
     eta_const=1.82e-5,
     lambda_const=0.026,
     T_min=Cv.from_degC(0),


### PR DESCRIPTION
The language design group has been trying to standardize the handling of units, so that literal values do not contribute to the unit of an expression in a way that would prevent further unit checking. We expect fixes similar to the one present in this PR to be necessary in the future.