### PR TITLE
Compound exitation DC machines and examples

### DIFF
--- a/Modelica/Electrical/Machines/BasicMachines/Components/AirGapDC.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/Components/AirGapDC.mo
@@ -1,15 +1,58 @@
 within Modelica.Electrical.Machines.BasicMachines.Components;
-model AirGapDC "Linear airgap model of a DC machine"
+model AirGapDC "Airgap model of a DC machine"
   extends PartialAirGapDC;
-  parameter SI.Inductance Le "Excitation inductance";
+
+  import Modelica.Constants.pi;
+  import Modelica.Constants.eps;
+  import Modelica.Constants.small;
+  import Modelica.Math.atan;
+  import Modelica.Units.SI;
+
+  parameter Boolean considerSaturation=false "Consider saturation of excitation inductance"
+    annotation (Dialog(tab="Inductance"), choices(checkBox=true));
+  parameter SI.Inductance Le "Excitation inductance" annotation (Dialog(tab="Inductance", group="Linear",
+      enable=not considerSaturation));
+  parameter SI.Current Inom(start=1) "Nominal current" annotation(Dialog(tab="Inductance",
+      groupImage="modelica://Modelica/Resources/Images/Electrical/Analog/Basic/SaturatingInductor_Lact_i_tight.png",
+      group="Saturating",
+      enable=considerSaturation));
+  parameter SI.Inductance Lnom(start=1) "Nominal inductance at Nominal current" annotation (Dialog(tab="Inductance",
+      group="Saturating",
+      enable=considerSaturation));
+  parameter SI.Inductance Lzer(start=2*Lnom) "Inductance near current=0" annotation (Dialog(tab="Inductance",
+      group="Saturating",
+      enable=considerSaturation));
+  parameter SI.Inductance Linf(start=Lnom/2) "Inductance at large currents" annotation (Dialog(tab="Inductance",
+      group="Saturating",
+      enable=considerSaturation));
+
+  SI.Inductance Lact(start=Lzer) "Present inductance";
+
+protected
+  parameter SI.Current Ipar(start=Inom/10, fixed=false);
+initial equation
+  (Lnom - Linf)/(Lzer - Linf)=Ipar/Inom*(pi/2 - atan(Ipar/Inom));
 equation
-  // excitation flux: linearly dependent on excitation current
-  psi_e = Le*ie;
+  if considerSaturation then
+    assert(Lzer > Lnom*(1 + eps), "Lzer (= " + String(Lzer) +
+      ") has to be > Lnom (= " + String(Lnom) + ")");
+    assert(Linf < Lnom*(1 - eps), "Linf (= " + String(Linf) +
+      ") has to be < Lnom (= " + String(Lnom) + ")");
+    Lact = Linf + (Lzer - Linf)*(if noEvent(abs(ie)/Ipar<small) then 1 else atan(ie/Ipar)/(ie/Ipar));
+    // excitation flux: saturating with excitation current by atan function
+    psi_e = Linf*ie + (Lzer - Linf)*Ipar*atan(ie/Ipar);
+  else
+    // excitation flux: linearly dependent on excitation current
+    Lact = Le;
+    psi_e = Le*ie;
+  end if;
   annotation (
     defaultComponentName="airGap",
     Documentation(info="<html>
-Linear model of the airgap (without saturation effects) of a DC machine, using only equations.<br>
-Induced excitation voltage is calculated from der(flux), where flux is defined by excitation inductance times excitation current.<br>
-Induced armature voltage is calculated from flux times angular velocity.
+<h4>Linear correlation (considerSaturation=false)</h4>
+<p>Linear model of the airgap (without saturation effects) of a DC machine, using only equations.</p><p>Induced excitation voltage is calculated from der(flux), where flux is defined by excitation inductance times excitation current.</p><p>Induced armature voltage is calculated from flux times angular velocity. </p>
+<h4>With saturation (considerSaturation=true)</h4>
+<p>The magnetic flux cannot rise infinitely with the excitation current.</p>
+<p>For values above nominal current, the saturation mechanism from <a href=\"modelica://Modelica.Electrical.Analog.Basic.SaturatingInductor\">SaturatingInductor</a> is implemented.</p>
 </html>"));
 end AirGapDC;

--- a/Modelica/Electrical/Machines/BasicMachines/DCMachines/DC_CompoundExcited.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/DCMachines/DC_CompoundExcited.mo
@@ -1,0 +1,277 @@
+within Modelica.Electrical.Machines.BasicMachines.DCMachines;
+model DC_CompoundExcited "Compound excited linear DC machine"
+  extends Machines.Interfaces.PartialBasicDCMachine(
+    wNominal(start=1410*2*pi/60),
+    final ViNominal=VaNominal - (Machines.Thermal.convertResistance(
+        Ra,
+        TaRef,
+        alpha20a,
+        TaNominal) + Machines.Thermal.convertResistance(
+        Res,
+        TeRef,
+        alpha20e,
+        TeNominal))*IaNominal - Machines.Losses.DCMachines.brushVoltageDrop(brushParameters, IaNominal),
+    final psi_eNominal=Lme*IeNominal + excitationTurnsRatio*Lme*abs(IaNominal),
+    redeclare final Machines.Thermal.DCMachines.ThermalAmbientDCCE thermalAmbient(Te=TeOperational,
+        final Tse=TeOperational),
+    redeclare final Machines.Interfaces.DCMachines.ThermalPortDCCE thermalPort,
+    redeclare final Machines.Interfaces.DCMachines.ThermalPortDCCE internalThermalPort,
+    redeclare final Machines.Interfaces.DCMachines.PowerBalanceDCCE powerBalance(
+      final powerShuntExcitation=vee*iee,
+      final lossPowerShuntExcitation=ree.LossPower,
+      final powerSeriesExcitation=ves*ies,
+      final lossPowerSeriesExcitation=res.LossPower),
+    core(final w=airGapDC.w));
+
+  parameter SI.Current IeNominal(start=1)
+    "Nominal shunt excitation current" annotation (Dialog(tab="Excitation"));
+  parameter SI.Resistance Res(start=0.01) "Series excitation resistance at TeRef"
+    annotation (Dialog(tab="Excitation"));
+  parameter SI.Resistance Ree(start=100) "Shunt excitation resistance at TeRef"
+    annotation (Dialog(tab="Excitation"));
+  parameter SI.Temperature TeRef(start=293.15) "Reference temperature of excitation resistance"
+    annotation (Dialog(tab="Excitation"));
+  parameter Machines.Thermal.LinearTemperatureCoefficient20 alpha20e(start=0)
+    "Temperature coefficient of excitation resistance" annotation (Dialog(tab="Excitation"));
+  parameter SI.Inductance Le(start=1) "Total field excitation inductance"
+    annotation (Dialog(tab="Excitation"));
+  parameter Real sigmae(
+    min=0,
+    max=0.99,
+    start=0) "Stray fraction of total excitation inductance"
+    annotation (Dialog(tab="Excitation"));
+  parameter SI.Temperature TeNominal(start=293.15) "Nominal series excitation temperature"
+    annotation (Dialog(tab="Nominal parameters"));
+  parameter SI.Temperature TeOperational(start=293.15) "Operational series excitation temperature"
+    annotation (Dialog(group="Operational temperatures", enable=not useThermalPort));
+  parameter Real excitationTurnsRatio(start=-0.005) "Ratio of series excitation turns over shunt excitation turns"
+    annotation (Dialog(tab="Excitation"));
+  parameter Boolean considerSaturation=true "Consider saturation of excitation inductance"
+    annotation (Dialog(tab="Excitation", group="Saturation"), choices(checkBox=true));
+  parameter SI.Inductance Lzer=Le*10 "Inductance near current=0"
+    annotation (Dialog(
+      tab="Excitation",
+      group="Saturation",
+      enable=considerSaturation));
+  parameter SI.Inductance Linf=Le/10 "Inductance at large currents"
+    annotation (Dialog(
+      tab="Excitation",
+      group="Saturation",
+      enable=considerSaturation));
+  output SI.Voltage vee=pin_eep.v - pin_en.v "Field shunt excitation voltage";
+  output SI.Voltage ves=pin_esp.v - pin_en.v "Field series excitation voltage";
+  output SI.Current iee=pin_eep.i "Field shunt excitation current";
+  output SI.Current ies=pin_esp.i "Field series excitation current";
+  Machines.BasicMachines.Components.AirGapDC airGapDC(
+    final turnsRatio=turnsRatio,
+    considerSaturation=considerSaturation,
+    final Le=Lme,
+    final quasiStatic=quasiStatic,
+    Inom=IeNominal,
+    Lnom=Lme,
+    Lzer=Lzer*(1 - sigmae),
+    Linf=Linf*(1 - sigmae))        annotation (Placement(transformation(extent={{-10,-10},{10,10}}, rotation=270)));
+  Machines.BasicMachines.Components.CompoundDCExcitation compoundDCExcitation(final excitationTurnsRatio=
+        excitationTurnsRatio) annotation (Placement(transformation(extent={{-10,-30},{10,-10}})));
+  Modelica.Electrical.Analog.Basic.Ground ground
+    annotation (Placement(transformation(extent={{-30,-30},{-10,-10}})));
+  Modelica.Electrical.Analog.Basic.Resistor res(
+    final R=Res,
+    final T_ref=TeRef,
+    final alpha=Machines.Thermal.convertAlpha(alpha20e, TeRef),
+    final useHeatPort=true)
+    annotation (Placement(transformation(
+        origin={-80,50},
+        extent={{-10,10},{10,-10}},
+        rotation=270)));
+  Machines.BasicMachines.Components.InductorDC lesigmas(final L=Lesigma*excitationTurnsRatio,
+      final quasiStatic=quasiStatic)
+    annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-80,20})));
+  Modelica.Electrical.Analog.Interfaces.PositivePin pin_esp "Positive series excitation pin"
+    annotation (Placement(transformation(extent={{-110,70},{-90,50}})));
+  Modelica.Electrical.Analog.Interfaces.NegativePin pin_en
+    "Negative series excitation pin" annotation (Placement(transformation(
+          extent={{-90,10},{-110,-10}})));
+  Modelica.Electrical.Analog.Interfaces.PositivePin pin_eep "Positive series excitation pin"
+    annotation (Placement(transformation(extent={{-110,-50},{-90,-70}})));
+  Modelica.Electrical.Analog.Basic.Resistor ree(
+    final R=Ree,
+    final T_ref=TeRef,
+    final alpha=Machines.Thermal.convertAlpha(alpha20e, TeRef),
+    final useHeatPort=true)
+    annotation (Placement(transformation(
+        origin={-80,-60},
+        extent={{-10,10},{10,-10}},
+        rotation=0)));
+  Machines.BasicMachines.Components.InductorDC lesigmae(final L=Lesigma, final quasiStatic=quasiStatic)
+    annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=0,
+        origin={-56,-60})));
+protected
+  final parameter SI.Inductance Lme=Le*(1 - sigmae) "Main part of excitation inductance";
+  final parameter SI.Inductance Lesigma=Le*sigmae "Stray part of excitation inductance" annotation (Evaluate=true);
+equation
+  connect(airGapDC.pin_ap, la.n) annotation (Line(
+      points={{10,10},{10,60}}, color={0,0,255}));
+  connect(airGapDC.support, internalSupport) annotation (Line(
+      points={{-10,0},{-40,0},{-40,-90},{60,-90},{60,-100}}));
+  connect(airGapDC.flange, inertiaRotor.flange_a) annotation (Line(
+      points={{10,0},{70,0},{70,0}}));
+  connect(pin_esp, res.p) annotation (Line(points={{-100,60},{-80,60}}, color={0,0,255}));
+  connect(res.n, lesigmas.p) annotation (Line(points={{-80,40},{-80,30}}, color={0,0,255}));
+  connect(airGapDC.pin_en, compoundDCExcitation.pin_n) annotation (Line(
+      points={{-10,-10},{-10,-10}}, color={0,0,255}));
+  connect(compoundDCExcitation.pin_p, airGapDC.pin_ep) annotation (Line(
+      points={{10,-10},{10,-10}}, color={0,0,255}));
+  connect(airGapDC.pin_en, ground.p) annotation (Line(
+      points={{-10,-10},{-20,-10}}, color={0,0,255}));
+  connect(compoundDCExcitation.pin_sen, pin_en) annotation (Line(
+      points={{-10,-30},{-60,-30},{-60,0},{-100,0}},
+                                               color={0,0,255}));
+  connect(compoundDCExcitation.pin_sep, lesigmas.n)
+    annotation (Line(points={{-2,-30},{-2,-40},{-80,-40},{-80,10}}, color={0,0,255}));
+  connect(airGapDC.pin_an, brush.p) annotation (Line(
+      points={{-10,10},{-10,60}}, color={0,0,255}));
+  connect(res.heatPort, internalThermalPort.heatPortSeriesExcitation)
+    annotation (Line(points={{-70,50},{-60,50},{-60,40},{50,40},{50,-80},{0,-80}}, color={191,0,0}));
+  connect(compoundDCExcitation.pin_sen, compoundDCExcitation.pin_en)
+    annotation (Line(points={{-10,-30},{-10,-36},{2,-36},{2,-30}}, color={0,0,255}));
+  connect(pin_eep, ree.p) annotation (Line(points={{-100,-60},{-90,-60}}, color={0,0,255}));
+  connect(ree.n, lesigmae.p) annotation (Line(points={{-70,-60},{-66,-60}}, color={0,0,255}));
+  connect(lesigmae.n, compoundDCExcitation.pin_ep) annotation (Line(points={{-46,-60},{10,-60},{10,-29.8}}, color={0,0,255}));
+  connect(ree.heatPort, internalThermalPort.heatPortShuntExcitation)
+    annotation (Line(points={{-80,-50},{-80,-44},{50,-44},{50,-80},{0,-80}}, color={191,0,0}));
+  annotation (
+    defaultComponentName="dcse",
+    Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{
+            100,100}}), graphics={
+        Line(points={{-100,10},{-105,11},{-109,15},{-110,20},{-109,25},{-105,29},{-100,30}},
+                             color={0,0,255}),
+        Line(points={{-100,30},{-105,31},{-109,35},{-110,40},{-109,45},{-105,49},{-100,50}},
+                              color={0,0,255}),
+        Line(points={{-130,-34},{-129,-29},{-125,-25},{-120,-24},{-115,-25},{-111,-29},{-110,-34}},
+                             color={0,0,255}),
+        Line(points={{-110,-34},{-109,-29},{-105,-25},{-100,-24},{-95,-25},{-91,-29},{-90,-34}},
+                         color={0,0,255}),
+        Line(points={{-90,-34},{-89,-29},{-85,-25},{-80,-24},{-75,-25},{-71,-29},{-70,-34}},
+                    color={0,0,255}),
+        Line(points={{-100,-50},{-100,-40},{-70,-40},{-70,-32}},color={0,0,255}),
+        Line(points={{-100,-10},{-100,-20},{-130,-20},{-130,-34}},
+                                                               color={0,0,
+              255})}),
+    Documentation(info="<html>
+<p><strong>Model of a DC Machine with compound excitation.</strong><br>
+Armature resistance and inductance are modeled directly after the armature pins, then using a <em>AirGapDC</em> model.<br>
+The machine models take the following loss effects into account:
+</p>
+
+<ul>
+<li>heat losses in the temperature dependent armature winding resistance</li>
+<li>heat losses in the temperature dependent excitation winding resistance</li>
+<li>brush losses in the armature circuit</li>
+<li>friction losses</li>
+<li>core losses (only eddy current losses, no hysteresis losses)</li>
+<li>stray load losses</li>
+</ul>
+
+<p>Saturation is modelled <em>AirGapDC</em> model.<br>
+Compound excitation has to be connected by the user's external circuit.
+<br><strong>Default values for machine's parameters (a realistic example) are:</strong><br></p>
+<table>
+<tr>
+<td>stator's moment of inertia</td>
+<td>0.29</td><td>kg.m2</td>
+</tr>
+<tr>
+<td>rotor's moment of inertia</td>
+<td>0.15</td><td>kg.m2</td>
+</tr>
+<tr>
+<td>nominal armature voltage</td>
+<td>100</td><td>V</td>
+</tr>
+<tr>
+<td>nominal armature current</td>
+<td>100</td><td>A</td>
+</tr>
+<tr>
+<td>nominal torque</td>
+<td>63.66</td><td>Nm</td>
+</tr>
+<tr>
+<td>nominal speed</td>
+<td>1410</td><td>rpm</td>
+</tr>
+<tr>
+<td>nominal mechanical output</td>
+<td>9.4</td><td>kW</td>
+</tr>
+<tr>
+<td>efficiency</td>
+<td>94.0</td><td>% only armature</td>
+</tr>
+<tr>
+<td>armature resistance</td>
+<td>0.05</td><td>Ohm at reference temperature</td>
+</tr>
+<tr>
+<td>reference temperature TaRef</td>
+<td>20</td><td>&deg;C</td>
+</tr>
+<tr>
+<td>temperature coefficient alpha20a </td>
+<td>0</td><td>1/K</td>
+</tr>
+<tr>
+<td>armature inductance</td>
+<td>0.0015</td><td>H</td>
+</tr>
+<tr>
+<td>excitation resistance</td>
+<td>0.01</td><td>Ohm at reference temperature</td>
+</tr>
+<tr>
+<td>reference temperature TeRef</td>
+<td>20</td><td>&deg;C</td>
+</tr>
+<tr>
+<td>temperature coefficient alpha20e</td>
+<td>0</td><td>1/K</td>
+</tr>
+<tr>
+<td>excitation inductance</td>
+<td>0.0005</td><td>H</td>
+</tr>
+<tr>
+<td>stray part of excitation inductance</td>
+<td>0</td><td> </td>
+</tr>
+<tr>
+<td>armature nominal temperature TaNominal</td>
+<td>20</td><td>&deg;C</td>
+</tr>
+<tr>
+<td>series excitation nominal temperature TeNominal</td>
+<td>20</td><td>&deg;C</td>
+</tr>
+<tr>
+<td>armature operational temperature TaOperational</td>
+<td>20</td><td>&deg;C</td>
+</tr>
+<tr>
+<td>series excitation operational temperature TeOperational</td>
+<td>20</td><td>&deg;C</td>
+</tr>
+</table>
+Armature resistance resp. inductance include resistance resp. inductance of commutating pole winding and
+compensation winding, if present.<br>
+Parameter nominal armature voltage includes voltage drop of series excitation;<br>
+but for output the voltage is split into:<br>
+va = armature voltage without voltage drop of series excitation<br>
+ve = voltage drop of series excitation
+</html>"));
+end DC_CompoundExcited;

--- a/Modelica/Electrical/Machines/BasicMachines/DCMachines/package.order
+++ b/Modelica/Electrical/Machines/BasicMachines/DCMachines/package.order
@@ -1,3 +1,4 @@
 DC_PermanentMagnet
 DC_ElectricalExcited
 DC_SeriesExcited
+DC_CompoundExcited

--- a/Modelica/Electrical/Machines/BasicMachines/QuasiStaticDCMachines/DC_CompoundExcited.mo
+++ b/Modelica/Electrical/Machines/BasicMachines/QuasiStaticDCMachines/DC_CompoundExcited.mo
@@ -1,0 +1,12 @@
+within Modelica.Electrical.Machines.BasicMachines.QuasiStaticDCMachines;
+model DC_CompoundExcited "Quasi-static compound excited linear DC machine"
+  extends Machines.BasicMachines.DCMachines.DC_CompoundExcited(final quasiStatic=
+        true);
+  extends Machines.Icons.QuasiStaticMachine;
+  annotation (defaultComponentName="dcse", Documentation(info="<html>
+<strong>Quasi-static model of a DC Machine with Compound excitation.</strong><br>
+This model is fully compatible with the
+<a href=\"modelica://Modelica.Electrical.Machines.BasicMachines.DCMachines.DC_CompoundExcited\">transient machine model of a DC machine with compound excitation</a>;
+the only difference is that electrical transients are neglected.
+</html>"));
+end DC_CompoundExcited;

--- a/Modelica/Electrical/Machines/BasicMachines/QuasiStaticDCMachines/package.order
+++ b/Modelica/Electrical/Machines/BasicMachines/QuasiStaticDCMachines/package.order
@@ -1,3 +1,4 @@
 DC_PermanentMagnet
 DC_ElectricalExcited
 DC_SeriesExcited
+DC_CompoundExcited

--- a/Modelica/Electrical/Machines/Examples/DCMachines/DCCE_Generator.mo
+++ b/Modelica/Electrical/Machines/Examples/DCMachines/DCCE_Generator.mo
@@ -1,0 +1,91 @@
+within Modelica.Electrical.Machines.Examples.DCMachines;
+model DCCE_Generator "Test example: DC with compound excitation generating power"
+  extends Modelica.Icons.Example;
+  parameter Modelica.Units.SI.Voltage Va=100 "Actual armature voltage";
+  parameter Modelica.Units.SI.Time tStart=0.1 "Start of resistance ramp";
+  parameter Modelica.Units.SI.Time tRamp=0.9 "Resistance ramp";
+  parameter SI.Voltage Ve=100 "Actual excitation voltage";
+  parameter Modelica.Units.SI.Torque TLoad=63.66 "Nominal load torque";
+  parameter Modelica.Units.SI.AngularVelocity wLoad(displayUnit="rev/min")=1410*2*Modelica.Constants.pi/60 "Nominal load speed";
+  parameter Modelica.Units.SI.Inertia JLoad=0.15 "Load's moment of inertia";
+  BasicMachines.DCMachines.DC_CompoundExcited dcce(
+    VaNominal=dcceData.VaNominal,
+    IaNominal=dcceData.IaNominal,
+    wNominal=dcceData.wNominal,
+    TaNominal=dcceData.TaNominal,
+    ia(fixed=true, start=-1),
+    IeNominal=dcceData.IeNominal,
+    Ree=dcceData.Ree,
+    TeNominal=dcceData.TeNominal,
+    Ra=dcceData.Ra,
+    TaRef=dcceData.TaRef,
+    La=dcceData.La,
+    Jr=dcceData.Jr,
+    Js=dcceData.Js,
+    frictionParameters=dcceData.frictionParameters,
+    coreParameters=dcceData.coreParameters,
+    strayLoadParameters=dcceData.strayLoadParameters,
+    brushParameters=dcceData.brushParameters,
+    Res=dcceData.Res,
+    TeRef=dcceData.TeRef,
+    Le=dcceData.Le,
+    sigmae=dcceData.sigmae,
+    TaOperational=293.15,
+    alpha20a=dcceData.alpha20a,
+    alpha20e=dcceData.alpha20e,
+    TeOperational=293.15,
+    excitationTurnsRatio=dcceData.excitationTurnsRatio,
+    considerSaturation=dcceData.considerSaturation,
+    Lzer=dcceData.Lzer,
+    Linf=dcceData.Linf)
+                     annotation (Placement(transformation(extent={{-20,-50},{0,-30}})));
+  Modelica.Blocks.Sources.Ramp ramp(
+    duration=tRamp,
+    startTime=tStart,
+    height=-100,
+    offset=101)
+              annotation (Placement(transformation(extent={{60,0},{40,20}})));
+  Modelica.Electrical.Analog.Basic.Ground ground annotation (Placement(
+        transformation(
+        origin={-70,40},
+        extent={{-10,-10},{10,10}},
+        rotation=270)));
+  Modelica.Blocks.Sources.Constant const(k=160)
+    annotation (Placement(transformation(extent={{94,-50},{74,-30}})));
+  Modelica.Mechanics.Rotational.Sources.Speed speed(useSupport=false)
+    annotation (Placement(transformation(extent={{60,-50},{40,-30}})));
+  Modelica.Electrical.Analog.Basic.VariableResistor variableResistor
+    annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={0,10})));
+  parameter Utilities.ParameterRecords.DcCompoundExcitedData dcceData(excitationTurnsRatio=-7e-4)
+    "DC machine data"
+    annotation (Placement(transformation(extent={{-20,-80},{0,-60}})));
+equation
+  connect(dcce.pin_esp,dcce. pin_an) annotation (Line(points={{-20,-34},{-20,-30},{-16,-30}}, color={0,0,255}));
+  connect(speed.flange,dcce. flange) annotation (Line(points={{40,-40},{0,-40}}, color={0,0,0}));
+  connect(const.y, speed.w_ref) annotation (Line(points={{73,-40},{62,-40}}, color={0,0,127}));
+  connect(dcce.pin_ap, variableResistor.n) annotation (Line(points={{-4,-30},{0,-30},{0,0},{-1.77636e-15,0}}, color={0,0,255}));
+  connect(ground.p, dcce.pin_en) annotation (Line(points={{-60,40},{-24,40},{-24,-40},{-20,-40}}, color={0,0,255}));
+  connect(ramp.y, variableResistor.R) annotation (Line(points={{39,10},{12,10}}, color={0,0,127}));
+  connect(variableResistor.p, dcce.pin_en)
+    annotation (Line(points={{0,20},{0,40},{-24,40},{-24,-40},{-20,-40}}, color={0,0,255}));
+  connect(dcce.pin_eep, dcce.pin_ap)
+    annotation (Line(points={{-20,-46},{-30,-46},{-30,-14},{0,-14},{0,-30},{-4,-30}}, color={0,0,255}));
+  annotation (experiment(StopTime=2.0, Interval=1E-4, Tolerance=1E-6), Documentation(
+        info="<html>
+<h4>Test example: Compound excited DC machine with a variable resistor as load</h4>
+<p>Compound excitation is a combination of series and shunt excitation. The shunt part maintains a constant idle voltage utilizing saturation effects.</p>
+<p>When a load is applied, the series part increases the excitation flux to keep the voltage constant.</p>
+<p>This behaviour can be adapted by the <span style=\"font-family: Courier New;\">dcce.excitationTurnsRatio</span> parameter. If the voltage should rise or fall with load applied. </p>
+<p>Simulate for 2 seconds and plot (versus time): </p>
+<ul>
+<li>dcce.va: armature voltage</li>
+<li>dcce.ia: armature current</li>
+<li>dcce.tauElectrical: motor&apos;s torque</li>
+</ul>
+<p>Default machine parameters of model <i>DC_CompoundExcited</i> are used.</p>
+<p>It is very imported to set a start value with <span style=\"font-family: Courier New;\">fixed=true</span> to <span style=\"font-family: Courier New;\">dcce.ia</span> as the excitation needs an initial stimulus to build up.</p>
+</html>"));
+end DCCE_Generator;

--- a/Modelica/Electrical/Machines/Examples/DCMachines/package.order
+++ b/Modelica/Electrical/Machines/Examples/DCMachines/package.order
@@ -9,3 +9,4 @@ DCPM_QuasiStatic
 DCPM_withLosses
 DC_CompareCharacteristics
 DCPM_Drive
+DCCE_Generator

--- a/Modelica/Electrical/Machines/Utilities/ParameterRecords/DcCompoundExcitedData.mo
+++ b/Modelica/Electrical/Machines/Utilities/ParameterRecords/DcCompoundExcitedData.mo
@@ -1,0 +1,49 @@
+within Modelica.Electrical.Machines.Utilities.ParameterRecords;
+record DcCompoundExcitedData "Common parameters for DC machines"
+  extends DcPermanentMagnetData(wNominal=1410*2*pi/60);
+  import Modelica.Constants.pi;
+  parameter SI.Current IeNominal=1
+    "Nominal excitation current" annotation (Dialog(tab="Excitation"));
+  parameter SI.Resistance Ree=100
+    "Shunt excitation resistance at TeRef"
+    annotation (Dialog(tab="Excitation"));
+  parameter SI.Resistance Res=0.01
+    "Series excitation resistance at TeRef"
+    annotation (Dialog(tab="Excitation"));
+  parameter SI.Temperature TeRef=293.15
+    "Reference temperature of excitation resistance"
+    annotation (Dialog(tab="Excitation"));
+  parameter Machines.Thermal.LinearTemperatureCoefficient20 alpha20e=0
+    "Temperature coefficient of excitation resistance"
+    annotation (Dialog(tab="Excitation"));
+  parameter SI.Inductance Le=1
+    "Total field excitation inductance"
+    annotation (Dialog(tab="Excitation"));
+  parameter Real sigmae(
+    min=0,
+    max=0.99) = 0 "Stray fraction of total excitation inductance"
+    annotation (Dialog(tab="Excitation"));
+  parameter Real excitationTurnsRatio=-0.005 "Ratio of series excitation turns over shunt excitation turns"
+    annotation (Dialog(tab="Excitation"));
+  parameter SI.Temperature TeNominal=293.15
+    "Nominal series excitation temperature"
+    annotation (Dialog(tab="Nominal parameters"));
+  parameter Boolean considerSaturation=true "Consider saturation of excitation inductance"
+    annotation (Dialog(tab="Excitation", group="Saturation"), choices(checkBox=true));
+  parameter SI.Inductance Lzer=Le*10 "Inductance near current=0"
+    annotation (Dialog(
+      tab="Excitation",
+      group="Saturation",
+      enable=considerSaturation));
+  parameter SI.Inductance Linf=Le/10 "Inductance at large currents"
+    annotation (Dialog(
+      tab="Excitation",
+      group="Saturation",
+      enable=considerSaturation));
+  annotation (
+    defaultComponentName="dcseData",
+    defaultComponentPrefixes="parameter",
+    Documentation(info="<html>
+<p>Basic parameters of DC machines are predefined with default values.</p>
+</html>"));
+end DcCompoundExcitedData;

--- a/Modelica/Electrical/Machines/Utilities/ParameterRecords/package.order
+++ b/Modelica/Electrical/Machines/Utilities/ParameterRecords/package.order
@@ -7,4 +7,5 @@ SM_ReluctanceRotorData
 DcPermanentMagnetData
 DcElectricalExcitedData
 DcSeriesExcitedData
+DcCompoundExcitedData
 TransformerData


### PR DESCRIPTION
Component models to implement compound excitation already existed and just had to be combined in the right way.

To allow modeling of a self-exciting DC generator, additionally I introduced saturation in the `AirGapDC `model.

It has to be discussed if the stray induction also needs a saturation model.
