### PR TITLE
Remove plural 's' in 'height of ramps'

### DIFF
--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -242,7 +242,7 @@ The Real output y is a step signal:
   end Step;
 
   block Ramp "Generate ramp signal"
-    parameter Real height=1 "Height of ramps"
+    parameter Real height=1 "Height of ramp"
       annotation(Dialog(groupImage="modelica://Modelica/Resources/Images/Blocks/Sources/Ramp.png"));
     parameter SI.Time duration(min=0.0, start=2)
       "Duration of ramp (= 0.0 gives a Step)";

--- a/Modelica/Clocked/RealSignals/TickBasedSources/Ramp.mo
+++ b/Modelica/Clocked/RealSignals/TickBasedSources/Ramp.mo
@@ -1,7 +1,7 @@
 within Modelica.Clocked.RealSignals.TickBasedSources;
 block Ramp "Generate ramp signal based on counted clock ticks"
   extends Interfaces.PartialClockedSO;
-  parameter Real height=1 "Height of ramps";
+  parameter Real height=1 "Height of ramp";
   parameter Integer durationTicks(min=1) = 1
 "Durations of ramp in number of clock ticks";
   parameter Real offset=0 "Offset of output signal";

--- a/Modelica/Clocked/RealSignals/TimeBasedSources/Ramp.mo
+++ b/Modelica/Clocked/RealSignals/TimeBasedSources/Ramp.mo
@@ -1,7 +1,7 @@
 within Modelica.Clocked.RealSignals.TimeBasedSources;
 block Ramp "Generate ramp signal"
   extends Interfaces.PartialClockedSO;
-  parameter Real height=1 "Height of ramps";
+  parameter Real height=1 "Height of ramp";
   parameter SI.Time duration(min=Modelica.Constants.small, start = 2)
 "Durations of ramp";
   parameter Real offset=0 "Offset of output signal";


### PR DESCRIPTION
As far as I can tell, there is only one ramp.
