### PR TITLE
Avoid unneeded integration errors for angles

### DIFF
--- a/Modelica/Electrical/QuasiStatic/Machines/Examples/TransformerTestbench.mo
+++ b/Modelica/Electrical/QuasiStatic/Machines/Examples/TransformerTestbench.mo
@@ -11,8 +11,7 @@ model TransformerTestbench "Transformer test bench"
   QuasiStatic.Polyphase.Sources.VoltageSource source(
     f=50,
     V=fill(100/sqrt(3), 3),
-    m=m,
-    gamma(fixed=true, start=0)) annotation (Placement(transformation(
+    m=m) annotation (Placement(transformation(
         origin={-90,0},
         extent={{-10,10},{10,-10}},
         rotation=270)));

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Examples/BalancingDelta.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Examples/BalancingDelta.mo
@@ -15,8 +15,7 @@ model BalancingDelta "Balancing an unsymmetrical delta-connected load"
     m=m,
     f=f,
     V=fill(V_LL, m),
-    phi=-Modelica.Electrical.Polyphase.Functions.symmetricOrientation(m),
-    gamma(fixed=true, start=0)) annotation (Placement(transformation(
+    phi=-Modelica.Electrical.Polyphase.Functions.symmetricOrientation(m)) annotation (Placement(transformation(
         origin={-80,-20},
         extent={{-10,-10},{10,10}},
         rotation=270)));

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Examples/BalancingStar.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Examples/BalancingStar.mo
@@ -15,8 +15,7 @@ model BalancingStar "Balancing an unsymmetrical star-connected load"
     m=m,
     f=f,
     V=fill(V, m),
-    phi=-Modelica.Electrical.Polyphase.Functions.symmetricOrientation(m),
-    gamma(fixed=true, start=0)) annotation (Placement(transformation(
+    phi=-Modelica.Electrical.Polyphase.Functions.symmetricOrientation(m)) annotation (Placement(transformation(
         origin={-80,-20},
         extent={{-10,-10},{10,10}},
         rotation=270)));

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Examples/TestSensors.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Examples/TestSensors.mo
@@ -16,9 +16,7 @@ model TestSensors
   Modelica.Electrical.QuasiStatic.Polyphase.Sources.VoltageSource sineVoltage(
     final m=m,
     f=f,
-    V=fill(VRMS, m),
-    gamma(fixed=true, start=0))
-                       annotation (Placement(transformation(
+    V=fill(VRMS, m))   annotation (Placement(transformation(
         origin={-20,-30},
         extent={{10,-10},{-10,10}},
         rotation=90)));

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sources/CurrentSource.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sources/CurrentSource.mo
@@ -10,7 +10,7 @@ model CurrentSource "Constant polyphase AC current"
       Modelica.Electrical.Polyphase.Functions.symmetricOrientation(m)
     "Phase shift of the source";
 equation
-  omega = 2*Modelica.Constants.pi*f;
+  plug_p.reference.gamma = 2*Modelica.Constants.pi*f*time "Avoid integration error in loops";
   i = {I[k]*exp(j*phi[k]) for k in 1:m};
   annotation (
     Icon(graphics={Line(points={{0,50},{0,-50}}, color={85,170,255}),

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Sources/VoltageSource.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Sources/VoltageSource.mo
@@ -10,7 +10,7 @@ model VoltageSource "Constant polyphase AC voltage"
       Modelica.Electrical.Polyphase.Functions.symmetricOrientation(m)
     "Phase shift of the source";
 equation
-  omega = 2*Modelica.Constants.pi*f;
+  plug_p.reference.gamma = 2*Modelica.Constants.pi*f*time "Avoid integration error in loops";
   v = {V[k]*exp(j*phi[k]) for k in 1:m};
   annotation (
     Icon(graphics={

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/Rectifier.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/Rectifier.mo
@@ -10,8 +10,7 @@ model Rectifier "Rectifier example"
     f=50,
     V=VAC,
     phi=0,
-    i(re(start=0), im(start=0)),
-    gamma(fixed=true, start=0)) annotation (Placement(transformation(
+    i(re(start=0), im(start=0))) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-80,50})));

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/Transformer.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/Transformer.mo
@@ -4,8 +4,7 @@ model Transformer "Example of transformer with short circuit impedance, transmis
   Sources.VoltageSource voltageSource(
     f=50,
     V=1000,
-    phi=0,
-    gamma(fixed=true, start=0)) annotation (Placement(transformation(
+    phi=0) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-90,-30})));
@@ -61,7 +60,8 @@ equation
   connect(load.f, constFrequency.y) annotation (Line(points={{92,-36},{100,-36},{100,-80},{81,-80}}, color={0,0,127}));
   connect(sensorL.currentP, v2.pin_p) annotation (Line(points={{50,-10},{40,-10},{40,-22}}, color={85,170,255}));
   connect(i2.pin_n, sensorL.currentP) annotation (Line(points={{40,-10},{40,-10},{50,-10}}, color={85,170,255}));
-  connect(sensor0.currentN, i1.pin_p) annotation (Line(points={{-60,-10},{-60,-10}}, color={85,170,255}));
+  connect(sensor0.currentN, i1.pin_p) annotation (Line(points={{-60,-10},{-60,
+          -10}},                                                                     color={85,170,255}));
   connect(i1.pin_n, zk.pin_p) annotation (Line(points={{-40,-10},{-35,-10},{-30,-10}}, color={85,170,255}));
   connect(idealTransformer.pin_p2, i2.pin_p) annotation (Line(points={{10,-20},{12,-20},{12,-10},{20,-10}}, color={85,170,255}));
   annotation (experiment(StopTime=1),Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics={Rectangle(

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Sources/CurrentSource.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Sources/CurrentSource.mo
@@ -5,7 +5,7 @@ model CurrentSource "Constant AC current"
   parameter SI.Current I(start=1) "RMS current of the source";
   parameter SI.Angle phi(start=0) "Phase shift of the source";
 equation
-  omega = 2*Modelica.Constants.pi*f;
+  pin_p.reference.gamma = 2*Modelica.Constants.pi*f*time "Avoid integration error in loops";
   i = Complex(I*cos(phi), I*sin(phi));
   annotation (
     Icon(graphics={

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Sources/VoltageSource.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Sources/VoltageSource.mo
@@ -5,7 +5,7 @@ model VoltageSource "Constant AC voltage"
   parameter SI.Voltage V(start=1) "RMS voltage of the source";
   parameter SI.Angle phi(start=0) "Phase shift of the source";
 equation
-  omega = 2*Modelica.Constants.pi*f;
+  pin_p.reference.gamma = 2*Modelica.Constants.pi*f*time "Avoid integration error in loops";
   v = Complex(V*cos(phi), V*sin(phi));
   annotation (Icon(graphics={
         Line(points={{-50,0},{50,0}}, color={85,170,255}),


### PR DESCRIPTION
See https://github.com/modelica/ModelicaSpecification/issues/3249

There are two known remaining related issues:
* The start-value for gamma should be removed when using this source - possibly including a conversion (which will mean it is delayed).
*  A possibility would be to change other sources to not require gamma(fixed=true), as it seems needlessly cumbersome. The simplest idea is to add that to the sources to not repeat it. 

I haven't checked if all cases are handled for the first item.