### PR TITLE
Unify spelling of controllers

### DIFF
--- a/Modelica/Blocks/Continuous.mo
+++ b/Modelica/Blocks/Continuous.mo
@@ -1022,7 +1022,7 @@ together) and using the following strategy:
      occur in the previous step, start with Ti=0.01 s.</li>
 <li> If you want to make the reaction of the control loop faster
      (but probably less robust against disturbances and measurement noise)
-     select a <strong>PID</strong> Controller and manually adjust parameters
+     select a <strong>PID</strong> controller and manually adjust parameters
      <strong>k</strong>, <strong>Ti</strong>, <strong>Td</strong> (time constant of derivative block).</li>
 <li> Set the limits yMax and yMin according to your specification.</li>
 <li> Perform simulations such that the output of the PID controller

--- a/Modelica/Blocks/Continuous.mo
+++ b/Modelica/Blocks/Continuous.mo
@@ -598,7 +598,7 @@ This is discussed in the description of package
             textString="T=%T")}));
   end PI;
 
-  block PID "PID-controller in additive description form"
+  block PID "PID controller in additive description form"
     import Modelica.Blocks.Types.Init;
     extends Interfaces.SISO;
 
@@ -689,8 +689,8 @@ This is discussed in the description of package
             textString="Ti=%Ti")}),
       Documentation(info="<html>
 <p>
-This is the text-book version of a PID-controller.
-For a more practically useful PID-controller, use
+This is the text-book version of a PID controller.
+For a more practically useful PID controller, use
 block LimPID.
 </p>
 
@@ -1011,18 +1011,18 @@ together) and using the following strategy:
 
 <ol>
 <li> Set very large limits, e.g., yMax = Modelica.Constants.inf</li>
-<li> Select a <strong>P</strong>-controller and manually enlarge parameter <strong>k</strong>
+<li> Select a <strong>P</strong> controller and manually enlarge parameter <strong>k</strong>
      (the total gain of the controller) until the closed-loop response
      cannot be improved any more.</li>
-<li> Select a <strong>PI</strong>-controller and manually adjust parameters
+<li> Select a <strong>PI</strong> controller and manually adjust parameters
      <strong>k</strong> and <strong>Ti</strong> (the time constant of the integrator).
      The first value of Ti can be selected, such that it is in the
      order of the time constant of the oscillations occurring with
-     the P-controller. If, e.g., vibrations in the order of T=10 ms
+     the P controller. If, e.g., vibrations in the order of T=10 ms
      occur in the previous step, start with Ti=0.01 s.</li>
 <li> If you want to make the reaction of the control loop faster
      (but probably less robust against disturbances and measurement noise)
-     select a <strong>PID</strong>-Controller and manually adjust parameters
+     select a <strong>PID</strong> Controller and manually adjust parameters
      <strong>k</strong>, <strong>Ti</strong>, <strong>Td</strong> (time constant of derivative block).</li>
 <li> Set the limits yMax and yMin according to your specification.</li>
 <li> Perform simulations such that the output of the PID controller

--- a/Modelica/Clocked/Examples/Systems/ControlledMixingUnit.mo
+++ b/Modelica/Clocked/Examples/Systems/ControlledMixingUnit.mo
@@ -249,7 +249,7 @@ as desired cooling temperature at the output of the controller)
 and the desired temperature T (which is used as desired value for
 the feedback controller). This part of the control system is the
 \"feed-forward\" part that computes the desired actuator signal.
-As feedback controller a simple P Controller with one gain is used.
+As feedback controller a simple P controller with one gain is used.
 </p>
 
 <p>

--- a/Modelica/Clocked/Examples/Systems/ControlledMixingUnit.mo
+++ b/Modelica/Clocked/Examples/Systems/ControlledMixingUnit.mo
@@ -249,7 +249,7 @@ as desired cooling temperature at the output of the controller)
 and the desired temperature T (which is used as desired value for
 the feedback controller). This part of the control system is the
 \"feed-forward\" part that computes the desired actuator signal.
-As feedback controller a simple P-Controller with one gain is used.
+As feedback controller a simple P Controller with one gain is used.
 </p>
 
 <p>

--- a/Modelica/Electrical/Machines/Examples/ControlledDCDrives/Utilities/LimitedPI.mo
+++ b/Modelica/Electrical/Machines/Examples/ControlledDCDrives/Utilities/LimitedPI.mo
@@ -1,6 +1,6 @@
 within Modelica.Electrical.Machines.Examples.ControlledDCDrives.Utilities;
 block LimitedPI
-  "Limited PI-controller with anti-windup and feed-forward"
+  "Limited PI controller with anti-windup and feed-forward"
   extends Modelica.Blocks.Interfaces.SISO;
   import Modelica.Blocks.Types.Init;
   import Modelica.Constants.inf;
@@ -196,7 +196,7 @@ equation
 Proportional - Integral - controller with optional feed-forward and limitation at the output.
 </p>
 <p>
-The integral part can be switched off to obtain a limited P-controller.
+The integral part can be switched off to obtain a limited P controller.
 </p>
 <p>
 The feed-forward gain can either be constant or given by the optional input kFF.

--- a/Modelica/Electrical/Machines/Utilities/DQCurrentController.mo
+++ b/Modelica/Electrical/Machines/Utilities/DQCurrentController.mo
@@ -117,7 +117,7 @@ Simple Current controller
 <p>
 The desired d- and q-component of the space phasor current in rotor fixed coordinate system are given by inputs <code>id</code> and <code>iq</code>.
 Using the given rotor position (input <code>phi</code>), the actual three-phase currents are measured and transformed to the d-q coordinate system.
-Two PI-controllers determine the necessary d- and q- voltages, which are transformed back to three-phase (output <code>y[3]</code>).
+Two PI controllers determine the necessary d- and q- voltages, which are transformed back to three-phase (output <code>y[3]</code>).
 They can be used to feed a voltage source which in turn feeds a permanent magnet synchronous machine.
 </p>
 <p>

--- a/Modelica/Electrical/Machines/Utilities/VfController.mo
+++ b/Modelica/Electrical/Machines/Utilities/VfController.mo
@@ -1,5 +1,5 @@
 within Modelica.Electrical.Machines.Utilities;
-block VfController "Voltage-Frequency-Controller"
+block VfController "Voltage-Frequency controller"
   import Modelica.Constants.pi;
   extends Modelica.Blocks.Interfaces.SIMO(u(unit="Hz"), final nout=m);
   parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
@@ -51,7 +51,7 @@ equation
         Line(visible=EconomyMode, points={{-100,-100},{-90,-98},{-80,-94},{-70,-86},{-60,-74},
               {-50,-60},{-40,-42},{-30,-22},{-20,2},{-10,30},{0,60},{80,60}},
              color={0,0,255})}),   Documentation(info="<html>
-Simple Voltage-Frequency-Controller.<br>
+Simple Voltage-Frequency controller.<br>
 Amplitude of voltage is linear dependent (VNominal/fNominal) on frequency (input signal \"u\"), but limited by VNominal (nominal RMS voltage per phase).<br>
 m sine-waves with amplitudes as described above are provided as output signal \"y\".<br>
 By setting parameter EconomyMode=true, Voltage rises quadratically with frequency which means flux,torque and loss reduction for fan and pump drives.<br>

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Utilities/VfController.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Utilities/VfController.mo
@@ -1,5 +1,5 @@
 within Modelica.Magnetic.QuasiStatic.FundamentalWave.Utilities;
-block VfController "Voltage-Frequency-Controller"
+block VfController "Voltage-Frequency controller"
   import Modelica.Constants.pi;
   parameter Integer m=3 "Number of phases" annotation(Evaluate=true);
   parameter SI.Angle orientation[m]=-
@@ -54,7 +54,7 @@ equation
               textColor={0,0,255})}),
     Documentation(info="<html>
 <p>
-This is a simple voltage-frequency-controller. The amplitude of the voltage is linear dependent (<code>VNominal/fNominal</code>) on the frequency (input signal <code>u</code>), but limited by <code>VNominal</code> (nominal RMS voltage per phase). An
+This is a simple voltage-frequency controller. The amplitude of the voltage is linear dependent (<code>VNominal/fNominal</code>) on the frequency (input signal <code>u</code>), but limited by <code>VNominal</code> (nominal RMS voltage per phase). An
 <code>m</code> quasi-static phasor signal is provided as output signal <code>y</code>, representing complex voltages.
 The output voltages may serve as inputs for complex voltage sources with phase input. Symmetrical voltages are assumed.
 </p>

--- a/Modelica/Mechanics/MultiBody/Examples/Systems/RobotR3/Utilities/Controller.mo
+++ b/Modelica/Mechanics/MultiBody/Examples/Systems/RobotR3/Utilities/Controller.mo
@@ -87,8 +87,8 @@ equation
           lineColor={0,0,127})}),
     Documentation(info="<html>
 <p>
-This controller has an inner PI-controller to control the motor speed,
-and an outer P-controller to control the motor position of one axis.
+This controller has an inner PI controller to control the motor speed,
+and an outer P controller to control the motor position of one axis.
 The reference signals are with respect to the gear-output, and the
 gear ratio is used in the controller to determine the motor
 reference signals. All signals are communicated via the

--- a/Modelica/Thermal/HeatTransfer/Examples/ControlledTemperature.mo
+++ b/Modelica/Thermal/HeatTransfer/Examples/ControlledTemperature.mo
@@ -77,7 +77,7 @@ whose losses v**2/r are dissipated via a
 thermal conductance of 0.1 W/K to ambient temperature 20 degree C.
 The resistor is assumed to have a thermal capacity of 1 J/K,
 having ambient temperature at the beginning of the experiment.
-The temperature of this heating resistor is held by an OnOff-controller
+The temperature of this heating resistor is held by an OnOff controller
 at reference temperature within a given bandwidth +/- 1 K
 by switching on and off the voltage source.
 The reference temperature starts at 25 degree C


### PR DESCRIPTION
Close #3814. unify spelling of controllers by omitting dash in description and documentation