### PR TITLE
Introduce zero absolute temperature offset for relative/absolute conversions

### DIFF
--- a/Modelica/Constants.mo
+++ b/Modelica/Constants.mo
@@ -53,7 +53,7 @@ package Constants
   final constant SI.Permeability mu_0 = 4*pi*1.00000000055e-7 "Magnetic constant";
   final constant Real epsilon_0(final unit="F/m") = 1/(mu_0*c*c)
     "Electric constant";
-  final constant SI.Temperature T_zero_K = -273.15
+  final constant SI.Temperature T_zero_K = 0
     "Absolute zero temperature in kelvin";
   final constant NonSI.Temperature_degC T_zero = -273.15
     "Absolute zero temperature in degree Celsius";

--- a/Modelica/Constants.mo
+++ b/Modelica/Constants.mo
@@ -57,7 +57,6 @@ package Constants
     "Absolute zero temperature in kelvin";
   final constant NonSI.Temperature_degC T_zero = -273.15
     "Absolute zero temperature in degree Celsius";
-
   annotation (
     Documentation(info="<html>
 <p>

--- a/Modelica/Constants.mo
+++ b/Modelica/Constants.mo
@@ -53,8 +53,11 @@ package Constants
   final constant SI.Permeability mu_0 = 4*pi*1.00000000055e-7 "Magnetic constant";
   final constant Real epsilon_0(final unit="F/m") = 1/(mu_0*c*c)
     "Electric constant";
-  final constant NonSI.Temperature_degC T_zero=-273.15
-    "Absolute zero temperature";
+  final constant SI.Temperature T_zero_K = -273.15
+    "Absolute zero temperature in kelvin";
+  final constant NonSI.Temperature_degC T_zero = -273.15
+    "Absolute zero temperature in degree Celsius";
+
   annotation (
     Documentation(info="<html>
 <p>

--- a/Modelica/Media/package.mo
+++ b/Modelica/Media/package.mo
@@ -3611,7 +3611,7 @@ no mass or energy is stored in the pipe.
           V=0.1) annotation (Placement(transformation(extent={{-40,0},{-20,20}})));
         FixedMassFlowRate fixedMassFlowRate(
           redeclare package Medium = Medium,
-          T_ambient=1.2*T_start,
+          T_ambient=Modelica.Constants.T_zero_K + 1.2*T_start,
           h_ambient=1.2*h_start,
           m_flow=1,
           X_ambient=0.5*X_start) annotation (Placement(transformation(extent={{
@@ -3659,7 +3659,7 @@ no mass or energy is stored in the pipe.
           V=0.1) annotation (Placement(transformation(extent={{-60,0},{-40,20}})));
         FixedMassFlowRate fixedMassFlowRate(
           redeclare package Medium = Medium,
-          T_ambient=1.2*T_start,
+          T_ambient=Modelica.Constants.T_zero_K + 1.2*T_start,
           h_ambient=1.2*h_start,
           m_flow=1,
           X_ambient=0.5*X_start) annotation (Placement(transformation(extent={{

--- a/Modelica/Thermal/FluidHeatFlow/BaseClasses/SinglePortBottom.mo
+++ b/Modelica/Thermal/FluidHeatFlow/BaseClasses/SinglePortBottom.mo
@@ -16,8 +16,8 @@ protected
     annotation(HideResult=true);
   SI.SpecificEnthalpy h "Specific enthalpy in the volume";
 equation
-  T_port=flowPort.h/medium.cp;
-  T=h/medium.cp;
+  T_port=Modelica.Constants.T_zero_K + flowPort.h/medium.cp;
+  T=Modelica.Constants.T_zero_K + h/medium.cp;
   // mass flow -> ambient: mixing rule
   // mass flow <- ambient: energy flow defined by ambient's temperature
   if Exchange then

--- a/Modelica/Thermal/FluidHeatFlow/BaseClasses/SinglePortLeft.mo
+++ b/Modelica/Thermal/FluidHeatFlow/BaseClasses/SinglePortLeft.mo
@@ -16,8 +16,8 @@ protected
     annotation(HideResult=true);
   SI.SpecificEnthalpy h "Specific enthalpy in the volume";
 equation
-  T_port=flowPort.h/medium.cp;
-  T=h/medium.cp;
+  T_port=Modelica.Constants.T_zero_K + flowPort.h/medium.cp;
+  T=Modelica.Constants.T_zero_K + h/medium.cp;
   // mass flow -> ambient: mixing rule
   // mass flow <- ambient: energy flow defined by ambient's temperature
   if Exchange then

--- a/Modelica/Thermal/FluidHeatFlow/BaseClasses/TwoPort.mo
+++ b/Modelica/Thermal/FluidHeatFlow/BaseClasses/TwoPort.mo
@@ -32,8 +32,8 @@ public
 equation
   dp=flowPort_a.p - flowPort_b.p;
   V_flow=flowPort_a.m_flow/medium.rho;
-  T_a=flowPort_a.h/medium.cp;
-  T_b=flowPort_b.h/medium.cp;
+  T_a=Modelica.Constants.T_zero_K + flowPort_a.h/medium.cp;
+  T_b=Modelica.Constants.T_zero_K + flowPort_b.h/medium.cp;
   dT=if noEvent(V_flow>=0) then T-T_a else T_b-T;
   h = medium.cp*T;
   T_q = T  - noEvent(sign(V_flow))*(1 - tapT)*dT;

--- a/Modelica/Thermal/HeatTransfer/Examples/TwoMasses.mo
+++ b/Modelica/Thermal/HeatTransfer/Examples/TwoMasses.mo
@@ -23,7 +23,7 @@ equation
   connect(mass2.port, Tsensor2.port) annotation (Line(points={{70,20},{70,
           -60},{60,-60}}, color={191,0,0}));
 initial equation
-  T_final_K = Modelica.Constants.T_zero_K + (mass1.T*mass1.C + mass2.T*mass2.C)/(mass1.C + mass2.C);
+  T_final_K - Modelica.Constants.T_zero_K =  ((mass1.T-Modelica.Constants.T_zero_K)*mass1.C + (mass2.T-Modelica.Constants.T_zero_K)*mass2.C)/(mass1.C + mass2.C);
   annotation (Documentation(info="<html>
 <p>
 This example demonstrates the thermal response of two masses connected by

--- a/Modelica/Thermal/HeatTransfer/Examples/TwoMasses.mo
+++ b/Modelica/Thermal/HeatTransfer/Examples/TwoMasses.mo
@@ -23,7 +23,7 @@ equation
   connect(mass2.port, Tsensor2.port) annotation (Line(points={{70,20},{70,
           -60},{60,-60}}, color={191,0,0}));
 initial equation
-  T_final_K = (mass1.T*mass1.C + mass2.T*mass2.C)/(mass1.C + mass2.C);
+  T_final_K = Modelica.Constants.T_zero_K + (mass1.T*mass1.C + mass2.T*mass2.C)/(mass1.C + mass2.C);
   annotation (Documentation(info="<html>
 <p>
 This example demonstrates the thermal response of two masses connected by


### PR DESCRIPTION
I think the community is aware that we at Wolfram are currently making a push in the handling and checking of units.  This PR is on the advanced topic of `absoluteValue`-correctness, and I know it will take some discussion to get everyone onboard this time.

## Background

Before getting to any technical detail of the proposed changes, let me divide unit errors into the following three categories:
1. Mismatched powers of base unit symbols, such as assigning an expression in `"m"` to a variable with unit `"s"`.
2. Mismatched prefix scaling, such as assigning an expression in `"ms"` to a variable with unit `"s"`.
3. Mismatched delta-character, such as assigning a `TemperatureDifference` expression to a `Temperature` variable.

Here, (1) is probably the category that first comes to mind.  It is harmless in the sense that it won't affect the numerical values used to set parameters or `start`-attributes, or the axis reading of a plotted result.  The only problem is that the values are presented with a bad unit.

I am aware that many consider it poor modeling style to even risk ending up in (2), but if one does, these unit errors are dangerous compared to (1).  The reason is that it will impact values used to set parameters or `start`-values, or axis readings in a plot.  For example, if the user prefers to edit values and plot results in the unit `"s"`, but a variable has been incorrectly given the unit `"ms"` instead of `"s"`, parameter values given in `"s"` will be multiplied by 1000 when turned into the value of a parameter modification, and simulation results will be divided by 1000 when shown in a plot with `"s"` on the axis.  Fortunately, detecting errors of this kind comes naturally with a system able to detect (1).

If (2) is considered a sign of bad modeling style (existence of `unit` with prefix), the same can't be said about the more subtle (3) as both `Temperature` and `TemperatureDifference` have roles to play in correct modeling with temperatures.  Further, ability to detect (3) is not a problem with an of-the-shelf solution that most people have an intuitive understanding of.  Even worse, the consequences of (3) are worse than (2) due to the subtle difference between applying and not applying a unit's offset when performing unit conversions.  From here on, an error in category (3) is called just a _delta error_.

Inspired by other unit handling systems' ability to model and check the delta-aspect of a quantity, we have developed a solution around `absoluteValue` in System Modeler.  Similar to any other aspect of unit correctness, we have done this without any support in the specification, driven by the necessity to avoid ending up with the subtle delta errors – especially in a context where variables are automatically inferred to have temperature units.

## Rationale

Similar to how we have recently fixed many other unit errors in the MSL without any support in the specification, I suggest that this PR is also considered in view of the same lack of formal specification.  Instead, I'll give a couple of examples to motivate the pattern behind the proposed changes.

### Absolute plus difference is absolute

Suppose that the delta error is not detected here:
```
model DeltaError1
  parameter Modelica.SIunits.TemperatureDifference p = 1000;
  Modelica.SIunits.Temperature x = p; /* Delta error */
end DeltaError1;
```
When plotting the result of `x` in the default display unit `"degC"`, the offset will be taken into consideration, causing `x` to appear as having value 726.85 °C.  Had the error in the model been fixed by changing the type of `x`,
```
  Modelica.SIunits.TemperatureDifference x = p; /* OK */
```
the value would display correctly as a temperature difference of 1000 °C.

Another way of fixing the model would be to turn the temperature difference into an absolute temperature, by adding it to an absolute temperature:
```
  constant Modelica.SIunits.Temperature T_zero_K = 0;
  Modelica.SIunits.Temperature x = T_zero_K + p; /* OK */
```
In this case, it would be correct to display the value of `x` as an absolute temperature of 726.85 °C.

### Multiplicative operations give relative results

In short, what this PR does, is to convert relative temperature expressions into absolute temperature by adding an absolute temperature offset of 0 K.  Adding 0 will not affect computed numerical values, but only addresses the delta errors.

The long story needs to explain why the converted expressions are considered relative temperatures, and here the central insight is that multiplicative operations are problematic for absolute temperatures.  For example, consider this erroneous model:
```
model DeltaError2
  parameter Modelica.SIunits.Temperature tYesterday = 293.15;
  Modelica.SIunits.Temperature tToday = 1.2 * tYesterday; /* "20% warmer today than yesterday." */
end DeltaError2;
```
The user has entered that the temperature yesterday was 20 °C, and has tried to express that today's temperature of 24 °C is 20% warmer.  As this model shows, this way of calculating with absolute temperatures doesn't make sense, as the resulting `tToday` would have been 58.63 °C.  A sound system for unit checking needs to detect that `1.2 * tYesterday` is not compatible with `tToday`, and the user can fix the problem by performing the multiplication on a temperature difference instead:
```
model DeltaError2_correct
  parameter Modelica.SIunits.Temperature tYesterday = 293.15;
  constant Modelica.SIunits.Temperature t0 = 273.15 "Reference temperature";
  Modelica.SIunits.TemperatureDifference dT = tYesterday - t0; /* Intermediate variable just for extra clarity. */
  Modelica.SIunits.Temperature tToday = t0 + 1.2 * dT; /* 20% warmer today than yesterday, relative to reference temperature. */
end DeltaError2_correct;
```

Allowing `1.2 * tYesterday` even though `tYesterday` is an absolute temperature is a problem in itself, but outside the scope of this PR.  If reviewers find the PR incomplete with this limitation of scope, they are encouraged to speak up.

Another example of a multiplicative relation that does not make sense for absolute temperatures is the heat capacity relation.  As temperature is the only quantity where we have units with offset, we can treat all other quantities as being differences by default without risk of incorrect unit conversions, here applied to thermal energy and heat capacity.  A correct model could thus look like this:
```
partial model HeatCapacityEquation
  parameter Modelica.SIunits.Temperature t0 = 293.15;
  parameter Modelica.SIunits.HeatCapacity C = 100 "Heat capacity at temperature t0";
  Modelica.SIunits.Energy delta_Q;
  Modelica.SIunits.TemperatureDifference delta_T = delta_Q / C;
end HeatCapacityEquation;
```

Similar to `DeltaError2` above, it would have been problematic to assign `delta_Q / C` to an absolute temperature variable, but such a problem can be addressed by adding a zero absolute temperature offset:
```
  Modelica.SIunits.Temperature t = T_zero_K + delta_Q / C;
```

Of course, there could also be other ways of addressing the "delta error" that make more sense from a modeling perspective – this is just a minimal fix without any effect on calculated values.
