### PR TITLE
Avoid discontinuities

### DIFF
--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -122,7 +122,7 @@ variable <strong>y</strong> is both a variable and a connector.
     extends Interfaces.SignalSource;
 
   equation
-    y = offset + (if time < startTime then 0 else time - startTime);
+    y = offset + smooth(1, (if time < startTime then 0 else time - startTime));
     annotation (
       Icon(coordinateSystem(
           preserveAspectRatio=true,
@@ -207,7 +207,7 @@ The Real output y is a constant signal:
     extends Interfaces.SignalSource;
 
   equation
-    y = offset + (if time < startTime then 0 else height);
+    y = offset + smooth(1, (if time < startTime then 0 else height));
     annotation (
       Icon(coordinateSystem(
           preserveAspectRatio=true,
@@ -296,8 +296,8 @@ If parameter duration is set to 0.0, the limiting case of a Step signal is achie
     parameter SI.Angle phase=0 "Phase of sine wave";
     extends Interfaces.SignalSource;
   equation
-    y = offset + (if time < startTime then 0 else amplitude*Modelica.Math.sin(2
-      *pi*f*(time - startTime) + phase));
+    y = offset + smooth(1, (if time < startTime then 0 else amplitude*Modelica.Math.sin(2
+      *pi*f*(time - startTime) + phase)));
     annotation (
       Icon(coordinateSystem(
           preserveAspectRatio=true,

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -294,7 +294,8 @@ If parameter duration is set to 0.0, the limiting case of a Step signal is achie
     annotation(Dialog(groupImage="modelica://Modelica/Resources/Images/Blocks/Sources/Sine.png"));
     parameter SI.Frequency f(start=1) "Frequency of sine wave";
     parameter SI.Angle phase=0 "Phase of sine wave";
-    parameter Boolean continuous = false "Make output continuous by starting at offset + amplitude*sin(phase)";
+    parameter Boolean continuous = false "Make output continuous by starting at offset + amplitude*sin(phase)"
+    annotation(Evaluate=true);
     extends Interfaces.SignalSource;
   equation
     if continuous then
@@ -346,7 +347,8 @@ The Real output y is a sine signal:
     annotation(Dialog(groupImage="modelica://Modelica/Resources/Images/Blocks/Sources/Cosine.png"));
     parameter SI.Frequency f(start=1) "Frequency of cosine wave";
     parameter SI.Angle phase=0 "Phase of cosine wave";
-    parameter Boolean continuous = false "Make output continuous by starting at offset + amplitude*cos(phase)";
+    parameter Boolean continuous = false "Make output continuous by starting at offset + amplitude*cos(phase)"
+    annotation(Evaluate=true);
     extends Interfaces.SignalSource;
   equation
     if continuous then
@@ -605,7 +607,8 @@ and that the parameter <code>startTime</code> is omitted since the voltage can b
     parameter Real amplitude=1 "Amplitude of sine wave"
     annotation(Dialog(groupImage="modelica://Modelica/Resources/Images/Blocks/Sources/Sinc.png"));
     parameter SI.Frequency f(start=1) "Frequency of sine wave";
-    parameter Boolean continuous = false "Make output (continuously) differentiable by starting at offset + amplitude rather than just offset";
+    parameter Boolean continuous = false "Make output (continuously) differentiable by starting at offset + amplitude rather than just offset"
+    annotation(Evaluate=true);
     extends Interfaces.SignalSource;
   protected
     SI.Angle x=2*pi*f*(time - startTime);

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -122,7 +122,7 @@ variable <strong>y</strong> is both a variable and a connector.
     extends Interfaces.SignalSource;
 
   equation
-    y = offset + smooth(1, (if time < startTime then 0 else time - startTime));
+    y = offset + smooth(0, (if time < startTime then 0 else time - startTime));
     annotation (
       Icon(coordinateSystem(
           preserveAspectRatio=true,
@@ -207,7 +207,7 @@ The Real output y is a constant signal:
     extends Interfaces.SignalSource;
 
   equation
-    y = offset + smooth(1, (if time < startTime then 0 else height));
+    y = offset + (if time < startTime then 0 else height);
     annotation (
       Icon(coordinateSystem(
           preserveAspectRatio=true,
@@ -298,7 +298,7 @@ If parameter duration is set to 0.0, the limiting case of a Step signal is achie
     extends Interfaces.SignalSource;
   equation
     if continuous then
-      y = offset + amplitude*smooth(1, (if time < startTime then Modelica.Math.sin(phase)
+      y = offset + amplitude*smooth(0, (if time < startTime then Modelica.Math.sin(phase)
         else Modelica.Math.sin(2*pi*f*(time - startTime) + phase)));
     else 
       y = offset + (if time < startTime then 0 else amplitude*Modelica.Math.sin(2
@@ -350,7 +350,7 @@ The Real output y is a sine signal:
     extends Interfaces.SignalSource;
   equation
     if continuous then
-      y = offset + smooth(1, amplitude*(if time < startTime then Modelica.Math.cos(phase)
+      y = offset + smooth(0, amplitude*(if time < startTime then Modelica.Math.cos(phase)
        else Modelica.Math.cos(2*pi*f*(time - startTime) + phase)));
     else
       y = offset + (if time < startTime then 0 else amplitude*Modelica.Math.cos(2

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -605,7 +605,7 @@ and that the parameter <code>startTime</code> is omitted since the voltage can b
     parameter Real amplitude=1 "Amplitude of sine wave"
     annotation(Dialog(groupImage="modelica://Modelica/Resources/Images/Blocks/Sources/Sinc.png"));
     parameter SI.Frequency f(start=1) "Frequency of sine wave";
-    parameter Boolean continuous = false "Make output smooth by starting at offset + amplitude rather than just offset";
+    parameter Boolean continuous = false "Make output (continuously) differentiable by starting at offset + amplitude rather than just offset";
     extends Interfaces.SignalSource;
   protected
     SI.Angle x=2*pi*f*(time - startTime);

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -340,10 +340,16 @@ The Real output y is a sine signal:
     annotation(Dialog(groupImage="modelica://Modelica/Resources/Images/Blocks/Sources/Cosine.png"));
     parameter SI.Frequency f(start=1) "Frequency of cosine wave";
     parameter SI.Angle phase=0 "Phase of cosine wave";
+    parameter Boolean continuous = false "If we want a smooth signal, the output will start at offset + amplitude";
     extends Interfaces.SignalSource;
   equation
-    y = offset + (if time < startTime then 0 else amplitude*Modelica.Math.cos(2
-      *pi*f*(time - startTime) + phase));
+    if continuous then
+      y = offset + smooth(1, amplitude*(if time < startTime then 1 else Modelica.Math.cos(2
+        *pi*f*(time - startTime) + phase)));
+    else
+      y = offset + (if time < startTime then 0 else amplitude*Modelica.Math.cos(2
+        *pi*f*(time - startTime) + phase));
+    end if;
     annotation (
       Icon(coordinateSystem(
           preserveAspectRatio=true,
@@ -593,12 +599,18 @@ and that the parameter <code>startTime</code> is omitted since the voltage can b
     parameter Real amplitude=1 "Amplitude of sine wave"
     annotation(Dialog(groupImage="modelica://Modelica/Resources/Images/Blocks/Sources/Sinc.png"));
     parameter SI.Frequency f(start=1) "Frequency of sine wave";
+    parameter Boolean continuous = false "If we want a smooth signal, the output will start at offset + amplitude";
     extends Interfaces.SignalSource;
   protected
     SI.Angle x=2*pi*f*(time - startTime);
   equation
-    y = offset + (if time < startTime then 0 else amplitude*
-      (if noEvent(time - startTime < eps) then 1 else (sin(x))/x));
+    if continuous then
+     y = offset + amplitude*smooth(1, (if time < startTime then 1 else 
+        (if noEvent(time - startTime < eps) then 1 else (sin(x))/x)));
+    else
+      y = offset + (if time < startTime then 0 else amplitude*
+        (if noEvent(time - startTime < eps) then 1 else (sin(x))/x));
+    end if;
     annotation (
       Icon(coordinateSystem(
           preserveAspectRatio=true,
@@ -648,11 +660,18 @@ The Real output y is a sinc signal: <code> amplitude*(sin(2*&pi;*f*t))/((2*&pi;*
     parameter SI.Angle phase=0 "Phase of sine wave";
     parameter SI.Damping damping(start=1)
       "Damping coefficient of sine wave";
+   parameter Boolean continuous = false "If we want a smooth signal, the output will start at offset + amplitude";
     extends Interfaces.SignalSource;
   equation
-    y = offset + (if time < startTime then 0 else amplitude*Modelica.Math.exp(-
-      (time - startTime)*damping)*Modelica.Math.sin(2*pi*f*(time -
-      startTime) + phase));
+    if continuous then
+      y = offset + amplitude*smooth(1, (if time < startTime then 1 else Modelica.Math.exp(-
+        (time - startTime)*damping)*Modelica.Math.sin(2*pi*f*(time -
+        startTime) + phase)));
+    else
+      y = offset + (if time < startTime then 0 else amplitude*Modelica.Math.exp(-
+        (time - startTime)*damping)*Modelica.Math.sin(2*pi*f*(time -
+        startTime) + phase));
+    end if;
     annotation (
       Icon(coordinateSystem(
           preserveAspectRatio=true,

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -346,7 +346,7 @@ The Real output y is a sine signal:
     annotation(Dialog(groupImage="modelica://Modelica/Resources/Images/Blocks/Sources/Cosine.png"));
     parameter SI.Frequency f(start=1) "Frequency of cosine wave";
     parameter SI.Angle phase=0 "Phase of cosine wave";
-    parameter Boolean continuous = false "If we want a smooth signal, the output will start at offset + amplitude*cos(phase)";
+    parameter Boolean continuous = false "Make output continuous by starting at offset + amplitude*cos(phase)";
     extends Interfaces.SignalSource;
   equation
     if continuous then

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -660,18 +660,11 @@ The Real output y is a sinc signal: <code> amplitude*(sin(2*&pi;*f*t))/((2*&pi;*
     parameter SI.Angle phase=0 "Phase of sine wave";
     parameter SI.Damping damping(start=1)
       "Damping coefficient of sine wave";
-   parameter Boolean continuous = false "If we want a smooth signal, the output will start at offset + amplitude";
     extends Interfaces.SignalSource;
   equation
-    if continuous then
-      y = offset + amplitude*smooth(1, (if time < startTime then 1 else Modelica.Math.exp(-
-        (time - startTime)*damping)*Modelica.Math.sin(2*pi*f*(time -
-        startTime) + phase)));
-    else
-      y = offset + (if time < startTime then 0 else amplitude*Modelica.Math.exp(-
-        (time - startTime)*damping)*Modelica.Math.sin(2*pi*f*(time -
-        startTime) + phase));
-    end if;
+    y = offset + (if time < startTime then 0 else amplitude*Modelica.Math.exp(-
+      (time - startTime)*damping)*Modelica.Math.sin(2*pi*f*(time -
+      startTime) + phase));
     annotation (
       Icon(coordinateSystem(
           preserveAspectRatio=true,

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -299,7 +299,7 @@ If parameter duration is set to 0.0, the limiting case of a Step signal is achie
   equation
     if continuous then
       y = offset + amplitude*smooth(1, (if time < startTime then Modelica.Math.sin(phase)
-        else Modelica.Math.sin(2*pi*f*(time - startTime) + phase));
+        else Modelica.Math.sin(2*pi*f*(time - startTime) + phase)));
     else 
       y = offset + (if time < startTime then 0 else amplitude*Modelica.Math.sin(2
        *pi*f*(time - startTime) + phase));

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -605,7 +605,7 @@ and that the parameter <code>startTime</code> is omitted since the voltage can b
     parameter Real amplitude=1 "Amplitude of sine wave"
     annotation(Dialog(groupImage="modelica://Modelica/Resources/Images/Blocks/Sources/Sinc.png"));
     parameter SI.Frequency f(start=1) "Frequency of sine wave";
-    parameter Boolean continuous = false "If we want a smooth signal, the output will start at offset + amplitude";
+    parameter Boolean continuous = false "Make output smooth by starting at offset + amplitude rather than just offset";
     extends Interfaces.SignalSource;
   protected
     SI.Angle x=2*pi*f*(time - startTime);

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -294,7 +294,7 @@ If parameter duration is set to 0.0, the limiting case of a Step signal is achie
     annotation(Dialog(groupImage="modelica://Modelica/Resources/Images/Blocks/Sources/Sine.png"));
     parameter SI.Frequency f(start=1) "Frequency of sine wave";
     parameter SI.Angle phase=0 "Phase of sine wave";
-    parameter Boolean continuous = false "If we want a smooth signal, the output will start at offset + amplitude*sin(phase)";
+    parameter Boolean continuous = false "Make output continuous by starting at offset + amplitude*sin(phase)";
     extends Interfaces.SignalSource;
   equation
     if continuous then

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -294,10 +294,16 @@ If parameter duration is set to 0.0, the limiting case of a Step signal is achie
     annotation(Dialog(groupImage="modelica://Modelica/Resources/Images/Blocks/Sources/Sine.png"));
     parameter SI.Frequency f(start=1) "Frequency of sine wave";
     parameter SI.Angle phase=0 "Phase of sine wave";
+    parameter Boolean continuous = false "If we want a smooth signal, the output will start at offset + amplitude*sin(phase)";
     extends Interfaces.SignalSource;
   equation
-    y = offset + smooth(1, (if time < startTime then 0 else amplitude*Modelica.Math.sin(2
-      *pi*f*(time - startTime) + phase)));
+    if continuous then
+      y = offset + amplitude*smooth(1, (if time < startTime then Modelica.Math.sin(phase)
+        else Modelica.Math.sin(2*pi*f*(time - startTime) + phase));
+    else 
+      y = offset + (if time < startTime then 0 else amplitude*Modelica.Math.sin(2
+       *pi*f*(time - startTime) + phase));
+    end if;
     annotation (
       Icon(coordinateSystem(
           preserveAspectRatio=true,
@@ -340,12 +346,12 @@ The Real output y is a sine signal:
     annotation(Dialog(groupImage="modelica://Modelica/Resources/Images/Blocks/Sources/Cosine.png"));
     parameter SI.Frequency f(start=1) "Frequency of cosine wave";
     parameter SI.Angle phase=0 "Phase of cosine wave";
-    parameter Boolean continuous = false "If we want a smooth signal, the output will start at offset + amplitude";
+    parameter Boolean continuous = false "If we want a smooth signal, the output will start at offset + amplitude*cos(phase)";
     extends Interfaces.SignalSource;
   equation
     if continuous then
-      y = offset + smooth(1, amplitude*(if time < startTime then 1 else Modelica.Math.cos(2
-        *pi*f*(time - startTime) + phase)));
+      y = offset + smooth(1, amplitude*(if time < startTime then Modelica.Math.cos(phase)
+       else Modelica.Math.cos(2*pi*f*(time - startTime) + phase)));
     else
       y = offset + (if time < startTime then 0 else amplitude*Modelica.Math.cos(2
         *pi*f*(time - startTime) + phase));


### PR DESCRIPTION
Closes #3548
The idea is that it often makes sense to have continuous input signals, and Sine, Cosine, and Sinc-blocks didn't guarantee that.

That is now possible on a flag.