### PR TITLE
Use eps in a proper way in ComplexRampPhasor; it's relative.

### DIFF
--- a/Modelica/ComplexBlocks/Sources/ComplexRampPhasor.mo
+++ b/Modelica/ComplexBlocks/Sources/ComplexRampPhasor.mo
@@ -16,14 +16,14 @@ equation
   magnitude = if not useLogRamp then
     magnitude1 + (if time < startTime then
       0 else
-      if time < (startTime + max(duration,eps)) then
-        (time - startTime)*(magnitude2-magnitude1)/max(duration,eps)
+      if time < (startTime + max(duration,100*eps*abs(startTime))) then
+        (time - startTime)*(magnitude2-magnitude1)/max(duration,100*eps*abs(startTime))
       else
       magnitude2-magnitude1)
   else
     if time < startTime then magnitude1 else
-    if time < (startTime + max(duration,eps)) then
-      10^(log10(magnitude1) + (log10(magnitude2) - log10(magnitude1))*min(1, (time-startTime)/max(duration,eps)))
+    if time < (startTime + max(duration,100*eps*abs(startTime))) then
+      10^(log10(magnitude1) + (log10(magnitude2) - log10(magnitude1))*min(1, (time-startTime)/max(duration,100*eps*abs(startTime))))
     else
       magnitude2;
 


### PR DESCRIPTION
Based on https://github.com/modelica/ModelicaStandardLibrary/pull/4042#discussion_r985480696

Note 
 - This correction is needed regardless of #4042
 - The factor 100 could be reduced (possibly down to 1) if desired.
 - Another possibility would be have an assert that `duration>=eps*abs(startTime)`.
 - I don't understand the eps in the current assert-statement; so that hasn't been changed, but it might be an error.