### PR TITLE
If the limits don't make sense use linear interpolation in Modelica.Fluid.Utilities.regfun3

### DIFF
--- a/Modelica/Fluid/Utilities.mo
+++ b/Modelica/Fluid/Utilities.mo
@@ -700,17 +700,22 @@ for a smooth transition from y1 to y2.
         eta_tilde := rho*eta;
         xi1 := x0 + mu_tilde;
         xi2 := x1 - eta_tilde;
-        a1 := (y0d - c)/max(mu_tilde^2, 100*Modelica.Constants.eps);
-        a2 := (y1d - c)/max(eta_tilde^2, 100*Modelica.Constants.eps);
-        const12 := y0 - a1/3*(x0 - xi1)^3 - c*x0;
-        const3 := y1 - a2/3*(x1 - xi2)^3 - c*x1;
-        // Do actual interpolation
-        if (x < xi1) then
-          y := a1/3*(x - xi1)^3 + c*x + const12;
-        elseif (x < xi2) then
-          y := c*x + const12;
+        if  xi1 < x0 or xi2>x1 then
+          // The limits don't make sense, just use linear interpolation
+          y := (y1-y0)*(x-x0)/(x1-x0) + y0;
         else
-          y := a2/3*(x - xi2)^3 + c*x + const3;
+          a1 := (y0d - c)/max(mu_tilde^2, 100*Modelica.Constants.eps);
+          a2 := (y1d - c)/max(eta_tilde^2, 100*Modelica.Constants.eps);
+          const12 := y0 - a1/3*(x0 - xi1)^3 - c*x0;
+          const3 := y1 - a2/3*(x1 - xi2)^3 - c*x1;
+          // Do actual interpolation
+          if (x < xi1) then
+            y := a1/3*(x - xi1)^3 + c*x + const12;
+          elseif (x < xi2) then
+            y := c*x + const12;
+          else
+            y := a2/3*(x - xi2)^3 + c*x + const3;
+          end if;
         end if;
       else
         // Cubic S0 is monotonic, use it as is


### PR DESCRIPTION
See https://github.com/modelica/ModelicaStandardLibrary/issues/4128#issuecomment-1589465543

I'm not saying that it fully corrects the issues with regfun3 - but at least it is a clear improvement that avoids the common failures.
Closes #3758
(Yes, I re-ran that example - the jump is gone).

Note I'm _not_ saying that it completes the investigation of regfun3 and thus I don't see it as closing #4128
It could be that after a proper investigation and correction that regfun3 will never generate out-of-bounds values for those variables.