### PR TITLE
M_Oline example (new version) and support functions for C and Z multiconductor line matrices

### DIFF
--- a/Modelica/Electrical/Analog/Examples/Lines/CompareCmatrix.mo
+++ b/Modelica/Electrical/Analog/Examples/Lines/CompareCmatrix.mo
@@ -258,12 +258,10 @@ equation
 <p>where</p>
 <p>- <i><b>i</b></i> is the vector of currents entering a multiple-conductor lines (n conductors with a return wire gives rise to n currents)</p>
 <p>- <i><b>v</b></i> is the vector of voltages at a port of a multiple-conductor lines (n conductors with a return wire gives rise to n voltages)</p>
-<p>The <i><b>C</b></i> matrix is symmetrical, and therefore it has n(n+1) independent terms. the diacgonal terms of this matrix are negative.</p>
-<p>The capacitive coupling across conductors can be modelled equivalently through a network of n(n+1) capacitors, and simple conversion formulas exist, 
-which can for instance be found in <a   href=\"https://www.academia.edu/38437649/EMTP_Theory_Book\"\">EmtpTheoryBook</a>).</p>
-<p>This model uses those conversion formulas, and compares the modelling of capacitor coupling through C matrix or equivalent physical capacitors.</p>
-<p>It also uses function LineCmatrix to compute C matrix from the inputted line geometry, which is the same of example Electrical.Analog.Examples.Lines.PowerLineWithfence</p>
-<p>To see that the formulas give the same result, compare current through r1n (&quot;n&quot; stands for network) and r1.</p>
+<p>The <i><b>C</b></i> matrix is symmetrical, and therefore it has n(n+1) independent terms. the diagonal terms of this matrix are negative.</p>
+<p>The capacitive coupling across conductors can be modelled equivalently through a network of n(n+1) capacitors, and simple conversion formulas exist, which can for instance be found in [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>], page 3-12. </p>
+<p>The support function LineCmatrix already contains these formulas and puts these capacitance values in an array called <b>Ccompact</b>.</p>
+<p>This example is to show the perfect equivalence of capacitor matrix and Ccompact values (here stored in an array named <b>Ccomp</b>). Just check for equality r1n.i and r1.i.</p>
 </html>",                 revisions="<html>
 <p><i>June, 2023 Massimo Ceraolo of the University of Pisa </i></p>
 <p><i>originally created </i></p>

--- a/Modelica/Electrical/Analog/Examples/Lines/CompareCmatrix.mo
+++ b/Modelica/Electrical/Analog/Examples/Lines/CompareCmatrix.mo
@@ -259,7 +259,8 @@ equation
 <p>- <i><b>i</b></i> is the vector of currents entering a multiple-conductor lines (n conductors with a return wire gives rise to n currents)</p>
 <p>- <i><b>v</b></i> is the vector of voltages at a port of a multiple-conductor lines (n conductors with a return wire gives rise to n voltages)</p>
 <p>The <i><b>C</b></i> matrix is symmetrical, and therefore it has n(n+1) independent terms. the diacgonal terms of this matrix are negative.</p>
-<p>The capacitive coupling across conductors can be modelled equivalently through a network of n(n+1) capacitors, and simple conversion formulas exist, which an for instance found in <a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>).</p>
+<p>The capacitive coupling across conductors can be modelled equivalently through a network of n(n+1) capacitors, and simple conversion formulas exist, 
+which can for instance be found in <a   href=\"https://www.academia.edu/38437649/EMTP_Theory_Book\"\">EmtpTheoryBook</a>).</p>
 <p>This model uses those conversion formulas, and compares the modelling of capacitor coupling through C matrix or equivalent physical capacitors.</p>
 <p>It also uses function LineCmatrix to compute C matrix from the inputted line geometry, which is the same of example Electrical.Analog.Examples.Lines.PowerLineWithfence</p>
 <p>To see that the formulas give the same result, compare current through r1n (&quot;n&quot; stands for network) and r1.</p>

--- a/Modelica/Electrical/Analog/Examples/Lines/CompareCmatrix.mo
+++ b/Modelica/Electrical/Analog/Examples/Lines/CompareCmatrix.mo
@@ -251,9 +251,22 @@ equation
     annotation (Line(points={{-36,-12},{-36,-2},{-18,-2}}, color={0,0,255}));
   annotation (
     Diagram(coordinateSystem(extent={{-140,-60},{120,60}})),
-    Documentation(info= "<html><head></head><body><p>MSL uses, inside M_OLine, a network of physical capacitors to model capacitive effects across conductors.</p><p>Insstead, in typical PowerSystems approach, a capacitance matrix is used, corresponding th the vectore equation:</p><p><b>i</b>=<b><i>C&nbsp;</i></b>d<b>v</b>/dt&nbsp;</p><p>where</p><p>- <i><b>i</b></i> is the vector of currents entering a multiple-conductor lines (n conductors with a return wire gives rise to n currents)</p><p>- <b><i>v</i></b> is the vector of voltages at a port of a multiple-conductor lines (n conductors with a return wire gives rise to n voltages)</p><div>The <b><i>C</i></b> matrix is symmetrical, and therefore it has n(n+1) independent terms. the diacgonal terms of this matrix are negative.</div><div>the capacitive coupling across conductors can be modelled equivalently through a network of n(n+1) capacitors, and simple conversion formulas exist, which an for instance found in [Theory book, pag- 3-11).</div><div><br></div><div>This model uses those conversion formulas, and compares the modelling of capacitor coupling through C matrix or equivalent physical capacitors.</div><div>It also uses function LineCmatrix to compute C matrix from the inputted line geometry, which is the same of example Electrical.Analog.Examples.Lines.PowerLineWithfence</div><div><br></div><div>To see that the formulas give the same result, compare current though r1n (\"n stands for network) and r1.</div><div><br></div>
-</body></html>",          revisions= "<html><head></head><body><div><i><br></i></div>                
-</body></html>"),
+    Documentation(info="<html>
+<p>MSL uses, inside M_OLine, a network of physical capacitors to model capacitive effects across conductors.</p>
+<p>Insstead, in typical PowerSystems approach, a capacitance matrix is used, corresponding to the vector equation:</p>
+<p><b>i</b>=<i><b>C&nbsp;</b></i>d<b>v</b>/dt&nbsp;</p>
+<p>where</p>
+<p>- <i><b>i</b></i> is the vector of currents entering a multiple-conductor lines (n conductors with a return wire gives rise to n currents)</p>
+<p>- <i><b>v</b></i> is the vector of voltages at a port of a multiple-conductor lines (n conductors with a return wire gives rise to n voltages)</p>
+<p>The <i><b>C</b></i> matrix is symmetrical, and therefore it has n(n+1) independent terms. the diacgonal terms of this matrix are negative.</p>
+<p>The capacitive coupling across conductors can be modelled equivalently through a network of n(n+1) capacitors, and simple conversion formulas exist, which an for instance found in <a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>).</p>
+<p>This model uses those conversion formulas, and compares the modelling of capacitor coupling through C matrix or equivalent physical capacitors.</p>
+<p>It also uses function LineCmatrix to compute C matrix from the inputted line geometry, which is the same of example Electrical.Analog.Examples.Lines.PowerLineWithfence</p>
+<p>To see that the formulas give the same result, compare current through r1n (&quot;n&quot; stands for network) and r1.</p>
+</html>",                 revisions="<html>
+<p><i>June, 2023 Massimo Ceraolo of the University of Pisa </i></p>
+<p><i>originally created </i></p>
+</html>"),
     experiment(
       StopTime=0.04,
       Interval=1e-05,

--- a/Modelica/Electrical/Analog/Examples/Lines/CompareCmatrix.mo
+++ b/Modelica/Electrical/Analog/Examples/Lines/CompareCmatrix.mo
@@ -173,12 +173,12 @@ end MTL_Cmatrix;
         extent={{-8,-8},{8,8}},
         rotation=0)));
 initial algorithm
-  (Ccomp,C) :=LineCmatrix(
+  (Ccomp,C) :=Modelica.Electrical.Analog.Lines.Functions.LineCmatrix(
      n = g.n,
      x = g.x,
      y = g.y,
      r = g.r);
-  (Rcomp,Xcomp,Lcomp) :=LineZmatrix(
+  (Rcomp,Xcomp,Lcomp) :=Modelica.Electrical.Analog.Lines.Functions.LineZmatrix(
     n=g.n,
     x=g.x,
     y=g.y,

--- a/Modelica/Electrical/Analog/Examples/Lines/CompareCmatrix.mo
+++ b/Modelica/Electrical/Analog/Examples/Lines/CompareCmatrix.mo
@@ -1,0 +1,261 @@
+within Modelica.Electrical.Analog.Examples.Lines;
+model CompareCmatrix
+  extends Modelica.Icons.Example;
+
+//********************************************
+model MTL_Cmatrix
+  "Y-matrix with capacitive coupling for a multi-conductor line"
+  parameter Integer n(final min=1) = 3 "Number of conductors";
+  parameter Real C[n,n]( each final unit="F/m")  "Capacitance matrix; off-diagonal elements are negative";
+  parameter Modelica.Units.SI.Length len=100e3 "line length";
+  Modelica.Electrical.Analog.Interfaces.PositivePin p[n] "Vector pin"
+    annotation (Placement(transformation(extent={{-110,0},{-90,80}}),
+        iconTransformation(extent={{-110,0},{-90,80}})));
+  Modelica.Electrical.Analog.Interfaces.NegativePin pn "Reference pin"
+    annotation (Placement(transformation(extent={{-112,-84},{-90,-62}}),
+        iconTransformation(extent={{-112,-84},{-90,-62}})));
+  Modelica.Units.SI.Voltage v[n] "Conductor Voltages with respect to reference";
+  Modelica.Units.SI.Current i[n] "Current through conductors";
+equation
+  for j in 1:n loop
+    v[j] = p[j].v - pn.v;
+    i[j] = p[j].i;
+  end for;
+  0=sum(p[j].i for j in 1:n) + pn.i;
+  i = len*C*der(v);
+
+  annotation (Icon(graphics={
+        Rectangle(
+          extent={{-100,100},{100,-100}},
+          lineColor={0,0,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Text(
+          extent={{-96,8},{98,-14}},
+          textColor={0,0,0},
+          textStyle={TextStyle.Bold},
+          textString="i=C*der(v)"),
+        Text(
+          extent={{-94,136},{96,118}},
+          textColor={0,0,255},
+          textString="%name")}));
+end MTL_Cmatrix;
+//********************************************
+
+
+  Modelica.Electrical.Analog.Basic.Ground ground annotation (
+    Placement(visible = true, transformation(extent={{76,-52},{96,-32}},        rotation = 0)));
+  parameter Real Rcomp[div(g.n * (g.n + 1), 2)](each final unit="Ohm/m", each fixed=false) "Compact resistance matrix";
+  parameter Real Xcomp[div(g.n * (g.n + 1), 2)](each final unit="Ohm/m", each fixed=false) "Compact reactance matrix";
+  parameter Real Lcomp[div(g.n * (g.n + 1), 2)](each final unit="H/m",  each fixed=false) "Compact inductance";
+  parameter Real C[g.n,g.n](                   each final unit="F/m",  each fixed=false);
+  parameter Real Ccomp[div(g.n * (g.n + 1), 2)](each final unit="F/m",  each fixed=false);
+  parameter Modelica.Units.SI.Length len=100e3;
+  parameter Real CL[div(g.n * (g.n + 1), 2)]=Ccomp*len;
+  MTL_Cmatrix MTL_C(
+    n=g.n,
+    C=C,
+    len=len) annotation (Placement(transformation(extent={{92,0},{112,20}})));
+  Modelica.Electrical.Analog.Sources.SineVoltage v2(
+    V=v1.V,
+    phase=-2.0943951023932,
+    f=v1.f) annotation (Placement(visible=true, transformation(
+        origin={38,6},
+        extent={{10,10},{-10,-10}},
+        rotation=180)));
+  Modelica.Electrical.Analog.Sources.SineVoltage v3(
+    V=v1.V,
+    phase=2.0943951023932,
+    f=v1.f) annotation (Placement(visible=true, transformation(
+        origin={38,-12},
+        extent={{10,10},{-10,-10}},
+        rotation=180)));
+  Modelica.Electrical.Analog.Sources.SineVoltage v1(V=345e3*sqrt(2/3), f=60)
+    annotation (Placement(visible=true, transformation(
+        origin={38,26},
+        extent={{10,10},{-10,-10}},
+        rotation=180)));
+  Modelica.Electrical.Analog.Basic.Resistor r1(R=r1n.R) annotation (Placement(
+        visible=true, transformation(
+        origin={64,26},
+        extent={{-8,-8},{8,8}},
+        rotation=0)));
+  Modelica.Electrical.Analog.Basic.Resistor r2(R=r1.R) annotation (Placement(
+        visible=true, transformation(
+        origin={64,6},
+        extent={{-8,-8},{8,8}},
+        rotation=0)));
+  Modelica.Electrical.Analog.Basic.Resistor r3(R=r1.R) annotation (Placement(
+        visible=true, transformation(
+        origin={64,-12},
+        extent={{-8,-8},{8,8}},
+        rotation=0)));
+  Modelica.Electrical.Analog.Basic.Capacitor c12(C=CL[2])
+                                                 annotation (Placement(
+        transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=-90,
+        origin={-18,42})));
+  Modelica.Electrical.Analog.Basic.Capacitor c23(C=CL[5])
+                                                 annotation (Placement(
+        transformation(
+        extent={{10,10},{-10,-10}},
+        rotation=90,
+        origin={-18,8})));
+  Modelica.Electrical.Analog.Basic.Capacitor c10(C=CL[1])
+                                                 annotation (Placement(
+        transformation(
+        extent={{10,10},{-10,-10}},
+        rotation=90,
+        origin={-66,32})));
+  Modelica.Electrical.Analog.Basic.Capacitor c13(C=CL[3])
+                                                 annotation (Placement(
+        transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=-90,
+        origin={0,22})));
+  Modelica.Electrical.Analog.Basic.Capacitor c30(C=CL[6])
+                                                 annotation (Placement(
+        transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=-90,
+        origin={-36,-22})));
+  Modelica.Electrical.Analog.Basic.Capacitor c20(C=CL[4])
+                                                 annotation (Placement(
+        transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=-90,
+        origin={-54,-22})));
+  Modelica.Electrical.Analog.Basic.Ground ground1
+                                                 annotation (
+    Placement(visible = true, transformation(extent={{-28,-56},{-8,-36}},       rotation = 0)));
+  Modelica.Electrical.Analog.Sources.SineVoltage v2a(
+    V=v1.V,
+    phase=-2.0943951023932,
+    f=v1.f) annotation (Placement(visible=true, transformation(
+        origin={-114,18},
+        extent={{10,10},{-10,-10}},
+        rotation=180)));
+  Modelica.Electrical.Analog.Sources.SineVoltage v3a(
+    V=v1.V,
+    phase=2.0943951023932,
+    f=v1.f) annotation (Placement(visible=true, transformation(
+        origin={-114,-2},
+        extent={{10,10},{-10,-10}},
+        rotation=180)));
+  Modelica.Electrical.Analog.Sources.SineVoltage v1a(V=345e3*sqrt(2/3), f=60)
+    annotation (Placement(visible=true, transformation(
+        origin={-114,48},
+        extent={{10,10},{-10,-10}},
+        rotation=180)));
+  parameter Modelica.Electrical.Analog.Lines.Functions.LineGeometry g(
+    n=3,
+    x={0,-3.048,3.048},
+    y={12.192,12.192,12.192},
+    r=1e-3/2*{12.7,12.7,12.7},
+    R1=1e-3*{0.348,0.348,0.348},
+    k_s={0.287,0.287,0.287},
+    f=60)
+    annotation (Placement(transformation(extent={{82,38},{102,58}})));
+  Modelica.Electrical.Analog.Basic.Resistor r1n(R= 1000.0) annotation (
+      Placement(visible=true, transformation(
+        origin={-88,48},
+        extent={{-8,-8},{8,8}},
+        rotation=0)));
+  Modelica.Electrical.Analog.Basic.Resistor r2n(R=r1n.R) annotation (Placement(
+        visible=true, transformation(
+        origin={-88,18},
+        extent={{-8,-8},{8,8}},
+        rotation=0)));
+  Modelica.Electrical.Analog.Basic.Resistor r3n(R=r1n.R) annotation (Placement(
+        visible=true, transformation(
+        origin={-88,-2},
+        extent={{-8,-8},{8,8}},
+        rotation=0)));
+initial algorithm
+  (Ccomp,C) :=LineCmatrix(
+     n = g.n,
+     x = g.x,
+     y = g.y,
+     r = g.r);
+  (Rcomp,Xcomp,Lcomp) :=LineZmatrix(
+    n=g.n,
+    x=g.x,
+    y=g.y,
+    r=g.r,
+    R1=g.R1,
+    k_s=g.k_s,
+    rho=g.rho,
+    f=g.f);
+equation
+  connect(v1.n,r1. p)
+    annotation (Line(points={{48,26},{56,26}}, color={0,0,255}));
+  connect(v2.n, r2.p)
+    annotation (Line(points={{48,6},{56,6}}, color={0,0,255}));
+  connect(v3.n, r3.p)
+    annotation (Line(points={{48,-12},{56,-12}},          color={0,0,255}));
+  connect(r1.n, MTL_C.p[1]) annotation (Line(points={{72,26},{78,26},{78,20},
+          {92,20},{92,14}}, color={0,0,255}));
+  connect(r2.n, MTL_C.p[2]) annotation (Line(points={{72,6},{78,6},{78,16},{
+          92,16},{92,14}}, color={0,0,255}));
+  connect(r3.n, MTL_C.p[3]) annotation (Line(points={{72,-12},{80,-12},{80,12},
+          {92,12},{92,14}}, color={0,0,255}));
+  connect(v1.p, v2.p)
+    annotation (Line(points={{28,26},{20,26},{20,6},{28,6}},
+                                                           color={0,0,255}));
+  connect(v2.p, v3.p)
+    annotation (Line(points={{28,6},{20,6},{20,-12},{28,-12}},
+                                                             color={0,0,255}));
+  connect(MTL_C.pn, ground.p) annotation (Line(points={{91.9,2.7},{86,2.7},{
+          86,-32}}, color={0,0,255}));
+  connect(c30.n, ground1.p)
+    annotation (Line(points={{-36,-32},{-36,-36},{-18,-36}}, color={0,0,255}));
+  connect(c20.n, ground1.p)
+    annotation (Line(points={{-54,-32},{-54,-36},{-18,-36}}, color={0,0,255}));
+  connect(c10.n, ground1.p)
+    annotation (Line(points={{-66,22},{-66,-36},{-18,-36}}, color={0,0,255}));
+  connect(c10.p, c12.p)
+    annotation (Line(points={{-66,42},{-66,52},{-18,52}}, color={0,0,255}));
+  connect(c12.n, c23.p)
+    annotation (Line(points={{-18,32},{-18,18}}, color={0,0,255}));
+  connect(v1a.p, v2a.p) annotation (Line(points={{-124,48},{-132,48},{-132,18},{
+          -124,18}}, color={0,0,255}));
+  connect(v2a.p, v3a.p) annotation (Line(points={{-124,18},{-132,18},{-132,-2},
+          {-124,-2}},color={0,0,255}));
+  connect(c12.p, c13.p)
+    annotation (Line(points={{-18,52},{0,52},{0,32}},     color={0,0,255}));
+  connect(c13.n, c23.n)
+    annotation (Line(points={{0,12},{0,-2},{-18,-2}},     color={0,0,255}));
+  connect(v1a.n, r1n.p)
+    annotation (Line(points={{-104,48},{-96,48}}, color={0,0,255}));
+  connect(r1n.n, c12.p) annotation (Line(points={{-80,48},{-66,48},{-66,52},{
+          -18,52}}, color={0,0,255}));
+  connect(v3a.n, r3n.p)
+    annotation (Line(points={{-104,-2},{-96,-2}}, color={0,0,255}));
+  connect(v2a.n, r2n.p)
+    annotation (Line(points={{-104,18},{-96,18}}, color={0,0,255}));
+  connect(r2n.n, c23.p) annotation (Line(points={{-80,18},{-40,18},{-40,24},{
+          -18,24},{-18,18}},
+                         color={0,0,255}));
+  connect(r3n.n, c23.n)
+    annotation (Line(points={{-80,-2},{-18,-2}}, color={0,0,255}));
+  connect(c10.n, c20.n) annotation (Line(points={{-66,22},{-66,-36},{-54,-36},
+          {-54,-32}}, color={0,0,255}));
+  connect(ground1.p, v3a.p) annotation (Line(points={{-18,-36},{-132,-36},{
+          -132,-2},{-124,-2}}, color={0,0,255}));
+  connect(ground.p, v3.p) annotation (Line(points={{86,-32},{20,-32},{20,-12},
+          {28,-12}}, color={0,0,255}));
+  connect(c20.p, c23.p) annotation (Line(points={{-54,-12},{-54,18},{-40,18},
+          {-40,24},{-18,24},{-18,18}}, color={0,0,255}));
+  connect(c30.p, c23.n)
+    annotation (Line(points={{-36,-12},{-36,-2},{-18,-2}}, color={0,0,255}));
+  annotation (
+    Diagram(coordinateSystem(extent={{-140,-60},{120,60}})),
+    Documentation(info= "<html><head></head><body><p>MSL uses, inside M_OLine, a network of physical capacitors to model capacitive effects across conductors.</p><p>Insstead, in typical PowerSystems approach, a capacitance matrix is used, corresponding th the vectore equation:</p><p><b>i</b>=<b><i>C&nbsp;</i></b>d<b>v</b>/dt&nbsp;</p><p>where</p><p>- <i><b>i</b></i> is the vector of currents entering a multiple-conductor lines (n conductors with a return wire gives rise to n currents)</p><p>- <b><i>v</i></b> is the vector of voltages at a port of a multiple-conductor lines (n conductors with a return wire gives rise to n voltages)</p><div>The <b><i>C</i></b> matrix is symmetrical, and therefore it has n(n+1) independent terms. the diacgonal terms of this matrix are negative.</div><div>the capacitive coupling across conductors can be modelled equivalently through a network of n(n+1) capacitors, and simple conversion formulas exist, which an for instance found in [Theory book, pag- 3-11).</div><div><br></div><div>This model uses those conversion formulas, and compares the modelling of capacitor coupling through C matrix or equivalent physical capacitors.</div><div>It also uses function LineCmatrix to compute C matrix from the inputted line geometry, which is the same of example Electrical.Analog.Examples.Lines.PowerLineWithfence</div><div><br></div><div>To see that the formulas give the same result, compare current though r1n (\"n stands for network) and r1.</div><div><br></div>
+</body></html>",          revisions= "<html><head></head><body><div><i><br></i></div>                
+</body></html>"),
+    experiment(
+      StopTime=0.04,
+      Interval=1e-05,
+      Tolerance=1e-06));
+end CompareCmatrix;

--- a/Modelica/Electrical/Analog/Examples/Lines/PowerLineWithFence.mo
+++ b/Modelica/Electrical/Analog/Examples/Lines/PowerLineWithFence.mo
@@ -107,20 +107,21 @@ equation
           22,2},{18,2}},    color={0,0,255}));
   annotation (
     Diagram(coordinateSystem(extent={{-100,-60},{80,60}})),
-    Documentation(info= "<html><head></head><body><p>This example shows the usage of M_OLine in a overhead PowerLine. The line geometry is the one shown in figure 4.1 of [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>].</p>
+    Documentation(info="<html>
+<p>This example shows the usage of M_OLine in a overhead PowerLine. The line geometry is the one shown in figure 4.1 of [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>].</p>
 <p>A common rule-of-thumb states that for steady-state analysis at industrial frequency each segment (PI model) should be not longer than one tenth of the wave length. For 50 Hz, the wavelength is 6000 km, therefore each pi should not overcome 60 km. This is why for our 100 km line we have chosen just two trunks. </p>
 <p>This example has some limitations:</p>
-<p>- the results are valid only for their steady-state trend. If we want to simulate transients effectively, the number of trunks must be enlarged consistently. See example \"CompareLineTrunks\". </p>
+<p>- the results are valid only for their steady-state trend. If we want to simulate transients effectively, the number of trunks must be enlarged consistently. See example &quot;CompareLineTrunks&quot;. </p>
 <p>- since it is based on M_OLine, which requires zero-valued resistances on the off-diagonal elements of Z impedance matrix, it does not take into account the influence of the soil resistance into Z matrix; however, for simulations like this one in which the current through the soil is negligible and we analyse the results at power frequency where soil resistance is very low, this implies negligible errors</p>
 <p><br>The considered line is a three-phase line with a fence all along the line (conductor #4). An interesting result of this example is the fence steady-state voltage due to the capacitive coupling with the other wires.</p>
 <p><u>Test 1:</u></p>
-<p>Simulate the model as it is: a person (body) is supposed to be touching the fence, and absorbs the current body.i, around 1A, by large lethal</p>
+<p>Simulate the model as it is: a person (body) is supposed to be touching the fence, and absorbs the current body.i, around 1A, by large lethal.</p>
 <p><u>Test 2:</u></p>
 <p>Simulate the model changing the body resistance to 1e6 or removing body: the steady-state fence voltage line.n[4] has changed from 1390V to 5930 (peak). So there exists a marked difference between the open-circuit voltage and body voltage which, although being much lower, is still very dangerous.</p>
 <p><u>Test 3:</u></p>
 <p>Simulate the original model reducing the line length to 3 km. The body current has fallen slightly below 30 mA (RMS), which is considered the maximum safe current a body can resist over 5s.</p>
 <p>Note that the fence voltage before the human contact is roughtly the same for all lengths while the current flowing when contact occurs is very dependent on the line length. </p>
-</body></html>",          revisions="<html>
+</html>",                 revisions="<html>
 <p>June, 2023 Massimo Ceraolo of the University of Pisa </p>
 <p>originally created </p>
 </html>"),

--- a/Modelica/Electrical/Analog/Examples/Lines/PowerLineWithFence.mo
+++ b/Modelica/Electrical/Analog/Examples/Lines/PowerLineWithFence.mo
@@ -121,11 +121,8 @@ equation
 <p>Simulate the original model reducing the line length to 3 km. The body current has fallen slightly below 30 mA (RMS), which is considered the maximum safe current a body can resist over 5s.</p>
 <p>Note that the fence voltage before the human contact is roughtly the same for all lengths while the current flowing when contact occurs is very dependent on the line length. </p>
 </body></html>",          revisions="<html>
-<ul>
-<li><em>May, 2021</em> 
-      Massimo Ceraolo of the University of Pisa <br> 
-      originally created</li> 
-</ul>                
+<p>June, 2023 Massimo Ceraolo of the University of Pisa </p>
+<p>originally created </p>
 </html>"),
     experiment(
       StopTime=0.04,

--- a/Modelica/Electrical/Analog/Examples/Lines/PowerLineWithFence.mo
+++ b/Modelica/Electrical/Analog/Examples/Lines/PowerLineWithFence.mo
@@ -1,0 +1,134 @@
+within Modelica.Electrical.Analog.Examples.Lines;
+model PowerLineWithFence
+  extends Modelica.Icons.Example;
+  Modelica.Electrical.Analog.Lines.M_OLine line(
+    N=2,  c = Ccomp, g = fill(1e-12, div(g.n * (g.n + 1), 2)), l = Lcomp,
+    length=100e3,  lines = g.n, r = g.R1) annotation (
+    Placement(visible = true, transformation(origin={-28,22},     extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Electrical.Analog.Sources.SineVoltage v2(
+    V=v1.V,
+    phase=-2.0943951023932,
+    f=v1.f) annotation (Placement(visible=true, transformation(
+        origin={-62,22},
+        extent={{10,10},{-10,-10}},
+        rotation=180)));
+  Modelica.Electrical.Analog.Basic.Resistor rgUL(R = 1) annotation (
+    Placement(visible = true, transformation(origin={-86,-28},    extent = {{-8, 8}, {8, -8}}, rotation = 270)));
+  Modelica.Electrical.Analog.Basic.Ground ground annotation (
+    Placement(visible = true, transformation(extent={{-96,-60},{-76,-40}},      rotation = 0)));
+  Modelica.Electrical.Analog.Sources.SineVoltage v3(
+    V=v1.V,
+    phase=2.0943951023932,
+    f=v1.f) annotation (Placement(visible=true, transformation(
+        origin={-62,2},
+        extent={{10,10},{-10,-10}},
+        rotation=180)));
+  Modelica.Electrical.Analog.Basic.Resistor r1(R=500) annotation (Placement(
+        visible=true, transformation(
+        origin={10,38},
+        extent={{-8,-8},{8,8}},
+        rotation=0)));
+  Modelica.Electrical.Analog.Basic.Resistor r2(R=r1.R) annotation (Placement(
+        visible=true, transformation(
+        origin={10,22},
+        extent={{-8,-8},{8,8}},
+        rotation=0)));
+  Modelica.Electrical.Analog.Basic.Resistor r3(R=r1.R) annotation (Placement(
+        visible=true, transformation(
+        origin={10,2},
+        extent={{-8,-8},{8,8}},
+        rotation=0)));
+  parameter Modelica.Electrical.Analog.Lines.Functions.LineGeometry g(
+    n=4,
+    x={0,-3.048,3.048,-9.144},
+    y={12.192,12.192,12.192,3.048},
+    r=1e-3/2*{12.7,12.7,12.7,4.064},
+    R1=1e-3*{0.348,0.348,0.348,1.802},
+    k_s={0.287,0.287,0.287,0.779},
+    f=60)
+    annotation (Placement(transformation(extent={{42,10},{62,30}})));
+  Modelica.Electrical.Analog.Sources.SineVoltage v1(V=345e3*sqrt(2/3), f=60)
+    annotation (Placement(visible=true, transformation(
+        origin={-62,40},
+        extent={{10,10},{-10,-10}},
+        rotation=180)));
+  Modelica.Electrical.Analog.Basic.Resistor body(R=1000) annotation (
+      Placement(visible=true, transformation(
+        origin={-18,-18},
+        extent={{-8,8},{8,-8}},
+        rotation=270)));
+  parameter Real Rcomp[div(g.n * (g.n + 1), 2)](each final unit="Ohm/m", each fixed=false) "Compact resistance matrix";
+  parameter Real Xcomp[div(g.n * (g.n + 1), 2)](each final unit="Ohm/m", each fixed=false) "Compact reactance matrix";
+  parameter Real Lcomp[div(g.n * (g.n + 1), 2)](each final unit="H/m",  each fixed=false) "Compact inductance";
+  parameter Real Ccomp[div(g.n * (g.n + 1), 2)](each final unit="F/m")=
+    Modelica.Electrical.Analog.Lines.Functions.LineCmatrix(
+      n = g.n, x = g.x, y = g.y, r = g.r);
+initial algorithm
+  (Rcomp,Xcomp,Lcomp) :=Modelica.Electrical.Analog.Lines.Functions.LineZmatrix(
+    n=g.n,
+    x=g.x,
+    y=g.y,
+    r=g.r,
+    R1=g.R1,
+    k_s=g.k_s,
+    rho=g.rho,
+    f=g.f);
+equation
+  connect(ground.p, rgUL.n) annotation (
+    Line(points={{-86,-40},{-86,-36}},      color = {0, 0, 255}));
+  connect(r1.p, line.n[1])
+    annotation (Line(points={{2,38},{-18,38},{-18,22}}, color={0,0,255}));
+  connect(r2.p, line.n[2])
+    annotation (Line(points={{2,22},{-18,22}}, color={0,0,255}));
+  connect(r1.n, r2.n) annotation (Line(points={{18,38},{22,38},{22,22},{18,22}},
+        color={0,0,255}));
+  connect(r2.n, r3.n) annotation (Line(points={{18,22},{22,22},{22,2},{18,2}},
+        color={0,0,255}));
+  connect(r3.p, line.n[3])
+    annotation (Line(points={{2,2},{-14,2},{-14,18},{-18,18},{-18,22}},
+                                                        color={0,0,255}));
+  connect(v1.n, line.p[1])
+    annotation (Line(points={{-52,40},{-38,40},{-38,22}}, color={0,0,255}));
+  connect(v2.n, line.p[2])
+    annotation (Line(points={{-52,22},{-38,22}}, color={0,0,255}));
+  connect(v3.n, line.p[3])
+    annotation (Line(points={{-52,2},{-38,2},{-38,22}},   color={0,0,255}));
+  connect(v1.p, rgUL.p)
+    annotation (Line(points={{-72,40},{-86,40},{-86,-20}}, color={0,0,255}));
+  connect(v2.p, rgUL.p)
+    annotation (Line(points={{-72,22},{-86,22},{-86,-20}}, color={0,0,255}));
+  connect(v3.p, rgUL.p)
+    annotation (Line(points={{-72,2},{-86,2},{-86,-20}},   color={0,0,255}));
+  connect(body.p, line.n[4])
+    annotation (Line(points={{-18,-10},{-18,22}}, color={0,0,255}));
+  connect(body.n, ground.p) annotation (Line(points={{-18,-26},{-18,-40},{-86,
+          -40}}, color={0,0,255}));
+  connect(body.n, r3.n) annotation (Line(points={{-18,-26},{-18,-40},{22,-40},{
+          22,2},{18,2}},    color={0,0,255}));
+  annotation (
+    Diagram(coordinateSystem(extent={{-100,-60},{80,60}})),
+    Documentation(info= "<html><head></head><body><p>This example shows the usage of M_OLine in a overhead PowerLine. The line geometry is the one shown in figure 4.1 of [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>].</p>
+<p>A common rule-of-thumb states that for steady-state analysis at industrial frequency each segment (PI model) should be not longer than one tenth of the wave length. For 50 Hz, the wavelength is 6000 km, therefore each pi should not overcome 60 km. This is why for our 100 km line we have chosen just two trunks. </p>
+<p>This example has some limitations:</p>
+<p>- the results are valid only for their steady-state trend. If we want to simulate transients effectively, the number of trunks must be enlarged consistently. See example \"CompareLineTrunks\". </p>
+<p>- since it is based on M_OLine, which requires zero-valued resistances on the off-diagonal elements of Z impedance matrix, it does not take into account the influence of the soil resistance into Z matrix; however, for simulations like this one in which the current through the soil is negligible and we analyse the results at power frequency where soil resistance is very low, this implies negligible errors</p>
+<p><br>The considered line is a three-phase line with a fence all along the line (conductor #4). An interesting result of this example is the fence steady-state voltage due to the capacitive coupling with the other wires.</p>
+<p><u>Test 1:</u></p>
+<p>Simulate the model as it is: a person (body) is supposed to be touching the fence, and absorbs the current body.i, around 1A, by large lethal</p>
+<p><u>Test 2:</u></p>
+<p>Simulate the model changing the body resistance to 1e6 or removing body: the steady-state fence voltage line.n[4] has changed from 1390V to 5930 (peak). So there exists a marked difference between the open-circuit voltage and body voltage which, although being much lower, is still very dangerous.</p>
+<p><u>Test 3:</u></p>
+<p>Simulate the original model reducing the line length to 3 km. The body current has fallen slightly below 30 mA (RMS), which is considered the maximum safe current a body can resist over 5s.</p>
+<p>Note that the fence voltage before the human contact is roughtly the same for all lengths while the current flowing when contact occurs is very dependent on the line length. </p>
+</body></html>",          revisions="<html>
+<ul>
+<li><em>May, 2021</em> 
+      Massimo Ceraolo of the University of Pisa <br> 
+      originally created</li> 
+</ul>                
+</html>"),
+    experiment(
+      StopTime=0.04,
+      Interval=1e-05,
+      Tolerance=1e-06));
+end PowerLineWithFence;

--- a/Modelica/Electrical/Analog/Examples/Lines/PowerLineWithFence.mo
+++ b/Modelica/Electrical/Analog/Examples/Lines/PowerLineWithFence.mo
@@ -117,9 +117,9 @@ equation
 <p><u>Test 1:</u></p>
 <p>Simulate the model as it is: a person (body) is supposed to be touching the fence, and absorbs the current body.i, around 1A, by large lethal.</p>
 <p><u>Test 2:</u></p>
-<p>Simulate the model changing the body resistance to 1e6 or removing body: the steady-state fence voltage line.n[4] has changed from 1390V to 5930 (peak). So there exists a marked difference between the open-circuit voltage and body voltage which, although being much lower, is still very dangerous.</p>
+<p>Simulate the model changing the body resistance to 1e6 or removing body: the steady-state fence voltage line.n[4].v has changed from 1429V to 5594 (peak). So there exists a marked difference between the open-circuit voltage and actual body voltage which, although being much lower, is still very dangerous.</p>
 <p><u>Test 3:</u></p>
-<p>Simulate the original model reducing the line length to 3 km. The body current has fallen slightly below 30 mA (RMS), which is considered the maximum safe current a body can resist over 5s.</p>
+<p>Simulate the original model reducing the line length to 3 km. The body current has fallen to around 30 mA (RMS), which is considered the maximum safe current a body can resist over 5s.</p>
 <p>Note that the fence voltage before the human contact is roughtly the same for all lengths while the current flowing when contact occurs is very dependent on the line length. </p>
 </html>",                 revisions="<html>
 <p>June, 2023 Massimo Ceraolo of the University of Pisa </p>

--- a/Modelica/Electrical/Analog/Examples/Lines/package.order
+++ b/Modelica/Electrical/Analog/Examples/Lines/package.order
@@ -3,3 +3,5 @@ SmoothStep
 CompareLineTrunks
 LightningLosslessTransmissionLine
 LightningSegmentedTransmissionLine
+CompareCmatrix
+PowerLineWithFence

--- a/Modelica/Electrical/Analog/Lines/Functions/LineCmatrix.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/LineCmatrix.mo
@@ -1,0 +1,68 @@
+within Modelica.Electrical.Analog.Lines.Functions;
+function LineCmatrix
+  "Compute matrix of transverse capacitances per metre of a multi-conductor line"
+  // Function created by Massimo Ceraolo from the University of Pisa on May 2021
+  import Modelica.Constants.*;
+  import Modelica.ComplexMath;
+  import Modelica.Utilities.Streams;
+  input Integer n "number of conductors in bundle";
+  input Real x[n] "horizontal abscissas of conductors (m)";
+  input Real y[n] "vertical abscissas of conductors (m)";
+  input Real r[n] "conductors radii (m)";
+  output Real Ccompact[div(n*(n + 1), 2)] "Vector of capacitances (F/m)";
+  output Real Pself, Pmutual "Transposed line self and mutual impedance";
+protected
+  constant Complex j = Complex(0, 1) "Imaginary unit";
+  constant Real K = 1 / (2 * pi * epsilon_0);
+  Real p[n, n] "Maxwell's potential matrix";
+  Real C[n, n] "Computed matrix (F/m)";
+  Real D "generic larger distance";
+  Real d "generic smaller distance";
+  Integer k;
+algorithm
+//Diagonal elements of the potential matrix:
+  for i in 1:n loop
+    p[i, i] := K * log(2 * y[i] / r[i]);
+  end for;
+//Out-of Diagonal elements of the potential matrix:
+  for i in 1:n loop
+    for jj in 1:i - 1 loop
+      d := sqrt((x[i] - x[jj]) ^ 2 + (y[i] - y[jj]) ^ 2);
+      D := sqrt((x[i] - x[jj]) ^ 2 + (y[i] + y[jj]) ^ 2);
+      p[i, jj] := K * log(D / d);
+    end for;
+  end for;
+  for i in 1:n loop
+    for jj in i + 1:n loop
+      p[i, jj] := p[jj, i];
+    end for;
+  end for;
+//The capacitance function is the inverse of the matrix of potentials
+  C := Modelica.Math.Matrices.inv(p);
+//Select the elements needed by _Oline in a vetor which it can use directly
+  k := 0;
+  for i in 1:n loop
+    for j in i:n loop
+      k := k + 1;
+      Ccompact[k] := C[i, j];
+    end for;
+  end for;
+
+  if n == 3 then
+    Pself := 1 / 3 * (p[1, 1] + p[2, 2] + p[3, 3]);
+    Pmutual := 1 / 3 * (p[1, 2] + p[2, 3] + p[3, 1]);
+  else
+    Pself := 0;
+    Pmutual := 0;
+  end if;
+  annotation (
+    Documentation(info="<html>
+<p>This function computes Capacitances of multi-conductor transmission lines, according to John Carson&apos;s formulas as reported in [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">Ceraolo2018</a>, Appendix].</p>
+<p>The results obtained with this function have been checked with Fig. 4.1 of [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>], with good compliance.</p>
+<p>The output array contains the elements of the C matrix ordered as described in the M_OLine model, and is used in example Examples.Lines.PowerLineWithFence in conjunction with M_OLine.</p>
+</html>", revisions="<html>
+<li><em>May, 2021</em> 
+        Massimo Ceraolo of the University of Pisa <br> 
+        originally created</li> 
+</html>"));
+end LineCmatrix;

--- a/Modelica/Electrical/Analog/Lines/Functions/LineCmatrix.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/LineCmatrix.mo
@@ -59,7 +59,12 @@ algorithm
   end for;
   annotation (
     Documentation(info="<html>
-<p>This function computes Capacitances of multi-conductor transmission lines, according to the formulas as reported in [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">Ceraolo2018</a>, Appendix].</p>
+<p>This function computes Capacitances of multi-conductor transmission lines, according to the formulas as reported in 
+[<a href=\"https://ieeexplore.ieee.org/document/8076707\">Ceraolo2018</a>, Appendix].</p>
+<td><p>M. Ceraolo, <i>Modelling and Simulation of AC Railway Electric Supply Lines Including Ground Return</i>, 
+ IEEE Transactions on Transportation Electrification  Vol. 4, issue N. 1, pp. 202-210, March 2018</p></td>
+
+
 <p>The results obtained with this function have been checked with Fig. 4.1 of [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>], with good compliance.</p>
 <p>Internally, it computes the <b>C</b> matrix, which corresponds to the formulas <b>V=YI</b>,&nbsp;<b>Y=<span style=\"font-family: Symbol;\">w</span>C&nbsp;</b>where</p>
 <p>- <b>V</b> is the vector of voltages between conductors and the reference (the return conductor, usually ground)</p>

--- a/Modelica/Electrical/Analog/Lines/Functions/LineCmatrix.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/LineCmatrix.mo
@@ -1,4 +1,4 @@
-﻿within Modelica.Electrical.Analog.Lines.Functions;
+within Modelica.Electrical.Analog.Lines.Functions;
 function LineCmatrix
   "Compute matrix of transverse capacitances per metre of a multi-conductor line"
   import Modelica.Constants.epsilon_0;
@@ -11,13 +11,12 @@ function LineCmatrix
   input Modelica.Units.SI.Radius r[n] "Conductors radii (m)";
   output Real Ccompact[div(n*(n + 1), 2)](each final unit="F/m") "Vector of capacitances";
   output Real C[n, n](each final unit="F/m") "Capacitance matrix with negative off-diagonal conductances";
-  // Poi la seguente riga andrà cancellata e commentata la corrispodente nella sezione protected
-  output Real Cflat[n, n](each final unit="F/m") "Matrix with capacitances of a network reproducing the behaviour of C";
+//  output Real Cflat[n, n](each final unit="F/m") "Matrix with capacitances of a network reproducing the behaviour of C";
 protected
   constant Complex j = Complex(0, 1) "Imaginary unit";
   constant Real K(final unit="F/m") = 1 / (2 * pi * epsilon_0);
   Real p[n, n](each final unit="m/F") "Maxwell's potential matrix";
-//  Real Cflat[n, n](each final unit="F/m") "Matrix with capacitances of a network reproducing the behaviour of C";
+  Real Cflat[n, n](each final unit="F/m") "Matrix with capacitances of a network reproducing the behaviour of C";
   Modelica.Units.SI.Distance D "Generic larger distance";
   Modelica.Units.SI.Distance d "Generic smaller distance";
   Integer k;

--- a/Modelica/Electrical/Analog/Lines/Functions/LineCmatrix.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/LineCmatrix.mo
@@ -1,5 +1,4 @@
-within TestMultifile;
-
+﻿within Modelica.Electrical.Analog.Lines.Functions;
 function LineCmatrix
   "Compute matrix of transverse capacitances per metre of a multi-conductor line"
   import Modelica.Constants.epsilon_0;

--- a/Modelica/Electrical/Analog/Lines/Functions/LineCmatrix.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/LineCmatrix.mo
@@ -9,9 +9,9 @@ function LineCmatrix
   input Modelica.Units.SI.Length x[n] "Horizontal abscissas of conductors";
   input Modelica.Units.SI.Length y[n] "Vertical abscissas of conductors";
   input Modelica.Units.SI.Radius r[n] "Conductors radii (m)";
-  output Real Ccompact[div(n*(n + 1), 2)](each final unit="F/m") "Vector of capacitances";
   output Real C[n, n](each final unit="F/m") "Capacitance matrix with negative off-diagonal conductances";
 //  output Real Cflat[n, n](each final unit="F/m") "Matrix with capacitances of a network reproducing the behaviour of C";
+  output Real Ccompact[div(n*(n + 1), 2)](each final unit="F/m") "Vector of capacitances of network of capacitors equivalent to C";
 protected
   constant Complex j = Complex(0, 1) "Imaginary unit";
   constant Real K(final unit="F/m") = 1 / (2 * pi * epsilon_0);
@@ -59,22 +59,11 @@ algorithm
   end for;
   annotation (
     Documentation(info="<html>
-<p>This function computes Capacitances of multi-conductor transmission lines, according to the formulas as reported in 
-[<a href=\"https://ieeexplore.ieee.org/document/8076707\">Ceraolo2018</a>, Appendix].</p>
-<td><p>M. Ceraolo, <i>Modelling and Simulation of AC Railway Electric Supply Lines Including Ground Return</i>, 
- IEEE Transactions on Transportation Electrification  Vol. 4, issue N. 1, pp. 202-210, March 2018</p></td>
-
-
-<p>The results obtained with this function have been checked with Fig. 4.1 of [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>], with good compliance.</p>
-<p>Internally, it computes the <b>C</b> matrix, which corresponds to the formulas <b>V=YI</b>,&nbsp;<b>Y=<span style=\"font-family: Symbol;\">w</span>C&nbsp;</b>where</p>
-<p>- <b>V</b> is the vector of voltages between conductors and the reference (the return conductor, usually ground)</p>
-<p>-&nbsp;<b>I</b>&nbsp;is the vector of transverse currents (between conductors and the return conductor, usually ground) due to the capacitive coupling between the conductors</p>
-<p>- <b>Y</b> is the matrix of transverse admittances of the multiconductor line (S/m)</p>
-<p>-&nbsp;<span style=\"font-family: Symbol;\">w</span>&nbsp;is the angular frequency when constant-frequency steady-state operation of the line is considered</p>
-<p>This matrix&nbsp;<b>C</b>&nbsp;, has always negative off-diagonal values, and positive diagonal values.</p>
-<p>From <b>C</b> matrix, the internal <b>Cflat</b> matrix &nbsp;is computed, containing physical capacitors that can be imagined between conductors to model capacitive effects. For instance C12 is the capacitance (per unit length) to be put between conducturors 1 and 2. This&nbsp;<b>Cflat</b>&nbsp;matrix &nbsp;contains the elements needed by M_OLine for its simulations.&nbsp; </p>
-<p>The output array <b>Ccomp </b>contains the elements of the <b>Cflat</b> matrix ordered as described in the M_OLine model, and is used in example Examples.Lines.PowerLineWithFence in conjunction with M_OLine.</p>
-<p>For an example on how to use this function, consider model Electrical.Analog.Examples.Lines.TestCmatrix.</p>
+<p>This function computes Capacitances of multi-conductor transmission lines, according to the formulas as reported in [<a href=\"https://ieeexplore.ieee.org/document/8076707\">Ceraolo2018</a>, Appendix].</p>
+<table cellspacing=\"2\" cellpadding=\"0\" border=\"0\"><tr>
+<td><p>M. Ceraolo, <i>Modelling and Simulation of AC Railway Electric Supply Lines Including Ground Return</i>, IEEE Transactions on Transportation Electrification Vol. 4, issue N. 1, pp. 202-210, March 2018</p><p>The results obtained with this function have been checked with Fig. 4.1 of [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>], with good compliance.</p><p>Internally, it computes the <b>C</b> matrix, which corresponds to the formulas <b>V=YI</b>,&nbsp;<b>Y=<span style=\"font-family: Symbol;\">w</span>C&nbsp;</b>where</p><p>- <b>V</b> is the vector of voltages between conductors and the reference (the return conductor, usually ground)</p><p>-&nbsp;<b>I</b>&nbsp;is the vector of transverse currents (between conductors and the return conductor, usually ground) due to the capacitive coupling between the conductors</p><p>- <b>Y</b> is the matrix of transverse admittances of the multiconductor line (S/m)</p><p>-&nbsp;<span style=\"font-family: Symbol;\">w</span>&nbsp;is the angular frequency when constant-frequency steady-state operation of the line is considered</p><p>This matrix&nbsp;<b>C</b>&nbsp;, has always negative off-diagonal values, and positive diagonal values.</p><p>From <b>C</b> matrix, the internal <b>Cflat</b> matrix &nbsp;is computed, containing physical capacitors that can be imagined between conductors to model capacitive effects. For instance C12 is the capacitance (per unit length) to be put between conducturors 1 and 2. The output array <b>Ccompact </b>contains the elements of the Cflat matrix ordered as described in the M_OLine model, and is used in example Examples.Lines.PowerLineWithFence in conjunction with M_OLine.</p><p>For an example on how to use this function, consider model Electrical.Analog.Examples.Lines.TestCmatrix.</p></td>
+</tr>
+</table>
 </html>",          revisions="<html>
 <ul>
 <li><em>May, 2021</em> 

--- a/Modelica/Electrical/Analog/Lines/Functions/LineCmatrix.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/LineCmatrix.mo
@@ -1,30 +1,35 @@
-within Modelica.Electrical.Analog.Lines.Functions;
+within TestMultifile;
+
 function LineCmatrix
   "Compute matrix of transverse capacitances per metre of a multi-conductor line"
-  // Function created by Massimo Ceraolo from the University of Pisa on May 2021
-  import Modelica.Constants.*;
+  import Modelica.Constants.epsilon_0;
+  import Modelica.Constants.pi;
   import Modelica.ComplexMath;
   import Modelica.Utilities.Streams;
-  input Integer n "number of conductors in bundle";
-  input Real x[n] "horizontal abscissas of conductors (m)";
-  input Real y[n] "vertical abscissas of conductors (m)";
-  input Real r[n] "conductors radii (m)";
-  output Real Ccompact[div(n*(n + 1), 2)] "Vector of capacitances (F/m)";
-  output Real Pself, Pmutual "Transposed line self and mutual impedance";
+  input Integer n "Number of conductors";
+  input Modelica.Units.SI.Length x[n] "Horizontal abscissas of conductors";
+  input Modelica.Units.SI.Length y[n] "Vertical abscissas of conductors";
+  input Modelica.Units.SI.Radius r[n] "Conductors radii (m)";
+  output Real Ccompact[div(n*(n + 1), 2)](each final unit="F/m") "Vector of capacitances";
+  output Real C[n, n](each final unit="F/m") "Capacitance matrix with negative off-diagonal conductances";
+  // Poi la seguente riga andrà cancellata e commentata la corrispodente nella sezione protected
+  output Real Cflat[n, n](each final unit="F/m") "Matrix with capacitances of a network reproducing the behaviour of C";
 protected
   constant Complex j = Complex(0, 1) "Imaginary unit";
-  constant Real K = 1 / (2 * pi * epsilon_0);
-  Real p[n, n] "Maxwell's potential matrix";
-  Real C[n, n] "Computed matrix (F/m)";
-  Real D "generic larger distance";
-  Real d "generic smaller distance";
+  constant Real K(final unit="F/m") = 1 / (2 * pi * epsilon_0);
+  Real p[n, n](each final unit="m/F") "Maxwell's potential matrix";
+//  Real Cflat[n, n](each final unit="F/m") "Matrix with capacitances of a network reproducing the behaviour of C";
+  Modelica.Units.SI.Distance D "Generic larger distance";
+  Modelica.Units.SI.Distance d "Generic smaller distance";
   Integer k;
+  String sC;
+
 algorithm
-//Diagonal elements of the potential matrix:
+// Diagonal elements of the potential matrix:
   for i in 1:n loop
     p[i, i] := K * log(2 * y[i] / r[i]);
   end for;
-//Out-of Diagonal elements of the potential matrix:
+// Out-of diagonal elements of the potential matrix:
   for i in 1:n loop
     for jj in 1:i - 1 loop
       d := sqrt((x[i] - x[jj]) ^ 2 + (y[i] - y[jj]) ^ 2);
@@ -37,32 +42,41 @@ algorithm
       p[i, jj] := p[jj, i];
     end for;
   end for;
-//The capacitance function is the inverse of the matrix of potentials
+// The capacitance function is the inverse of the matrix of potentials
   C := Modelica.Math.Matrices.inv(p);
-//Select the elements needed by _Oline in a vetor which it can use directly
+// The off diagonal elements of Cflat are the opposite of corresponding elements of C.
+// We first generate the opposite of C, then will redefine its diagonal elements:
+  Cflat:=-C;
+// The diagonal elements of Cflat contain the sum of all the values the corresponding row in C:
+  for i in 1:n loop
+    Cflat[i,i]:=sum(C[i,j] for j in 1:n);
+  end for;
+// Select the elements needed by M_Oline in a vector which it can use directly
   k := 0;
   for i in 1:n loop
     for j in i:n loop
       k := k + 1;
-      Ccompact[k] := C[i, j];
+      Ccompact[k] := Cflat[i, j];
     end for;
   end for;
-
-  if n == 3 then
-    Pself := 1 / 3 * (p[1, 1] + p[2, 2] + p[3, 3]);
-    Pmutual := 1 / 3 * (p[1, 2] + p[2, 3] + p[3, 1]);
-  else
-    Pself := 0;
-    Pmutual := 0;
-  end if;
   annotation (
     Documentation(info="<html>
-<p>This function computes Capacitances of multi-conductor transmission lines, according to John Carson&apos;s formulas as reported in [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">Ceraolo2018</a>, Appendix].</p>
+<p>This function computes Capacitances of multi-conductor transmission lines, according to the formulas as reported in [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">Ceraolo2018</a>, Appendix].</p>
 <p>The results obtained with this function have been checked with Fig. 4.1 of [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>], with good compliance.</p>
-<p>The output array contains the elements of the C matrix ordered as described in the M_OLine model, and is used in example Examples.Lines.PowerLineWithFence in conjunction with M_OLine.</p>
-</html>", revisions="<html>
+<p>Internally, it computes the <b>C</b> matrix, which corresponds to the formulas <b>V=YI</b>,&nbsp;<b>Y=<span style=\"font-family: Symbol;\">w</span>C&nbsp;</b>where</p>
+<p>- <b>V</b> is the vector of voltages between conductors and the reference (the return conductor, usually ground)</p>
+<p>-&nbsp;<b>I</b>&nbsp;is the vector of transverse currents (between conductors and the return conductor, usually ground) due to the capacitive coupling between the conductors</p>
+<p>- <b>Y</b> is the matrix of transverse admittances of the multiconductor line (S/m)</p>
+<p>-&nbsp;<span style=\"font-family: Symbol;\">w</span>&nbsp;is the angular frequency when constant-frequency steady-state operation of the line is considered</p>
+<p>This matrix&nbsp;<b>C</b>&nbsp;, has always negative off-diagonal values, and positive diagonal values.</p>
+<p>From <b>C</b> matrix, the internal <b>Cflat</b> matrix &nbsp;is computed, containing physical capacitors that can be imagined between conductors to model capacitive effects. For instance C12 is the capacitance (per unit length) to be put between conducturors 1 and 2. This&nbsp;<b>Cflat</b>&nbsp;matrix &nbsp;contains the elements needed by M_OLine for its simulations.&nbsp; </p>
+<p>The output array <b>Ccomp </b>contains the elements of the <b>Cflat</b> matrix ordered as described in the M_OLine model, and is used in example Examples.Lines.PowerLineWithFence in conjunction with M_OLine.</p>
+<p>For an example on how to use this function, consider model Electrical.Analog.Examples.Lines.TestCmatrix.</p>
+</html>",          revisions="<html>
+<ul>
 <li><em>May, 2021</em> 
-        Massimo Ceraolo of the University of Pisa <br> 
-        originally created</li> 
+      Massimo Ceraolo of the University of Pisa <br> 
+      originally created</li> 
+</ul>                
 </html>"));
 end LineCmatrix;

--- a/Modelica/Electrical/Analog/Lines/Functions/LineGeometry.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/LineGeometry.mo
@@ -1,0 +1,21 @@
+within Modelica.Electrical.Analog.Lines.Functions;
+record LineGeometry
+ extends Modelica.Icons.Record;
+  parameter Integer n=3 "Number of wires" annotation (Evaluate=true);
+  parameter Modelica.Units.SI.Length x[n] "Horizontal abscissas of conductors";
+  parameter Modelica.Units.SI.Length y[n] "Vertical abscissas of conductors";
+  parameter Modelica.Units.SI.Length r[n] "Conductor radii";
+  parameter Real R1[n]   "Resistance per length of conductors (ohm/m)";
+  parameter Real k_s[n]=fill(0.7,n) "ratio of GMR to actual conductor radius";
+  parameter Modelica.Units.SI.Resistivity rho=100 "earth resistivity";
+  parameter Modelica.Units.SI.Frequency f=50 "line frequency";
+  annotation (Documentation(info="<html>
+<p>This record contains the line geometry and resistances of a multi-conductor line.</p>
+<p>It will be used by functions LineZmatrix and LineCmatrix that compute longitudinal (flow) and transverse (cross) line matrices.</p>
+<p>Even though frequency is not part of the line geometry, it is a parameter needed by LineZmatrix and therefore it is included here.</p>
+</html>", revisions="<html>
+<li><em>May, 2021</em> 
+        Massimo Ceraolo of the University of Pisa <br> 
+        originally created</li> 
+</html>"));
+end LineGeometry;

--- a/Modelica/Electrical/Analog/Lines/Functions/LineZmatrix.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/LineZmatrix.mo
@@ -71,7 +71,7 @@ algorithm
     end for;
   end for;
   annotation (Documentation(info="<html>
-<p>This function computes resistances, reactances, inductances of multi-conductor transmission lines, taking into account ground characteristics according to John Carson&apos;s formulas as reported in [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">Ceraolo2018</a>, Appendix], but upgraded in accuracy (more digits in constants and more added terms in the evaluation of Q).</p>
+<p>This function computes resistances, reactances, inductances of multi-conductor transmission lines, taking into account ground characteristics according to John Carson&apos;s formulas as reported in [<a href=\"https://ieeexplore.ieee.org/document/8076707\">Ceraolo2018</a>, Appendix], but upgraded in accuracy (more digits in constants and more added terms in the evaluation of Q).</p>
 <p>When used in conjunction with M_OLine from its output just the inductances are used; the resistances could instead be used when ground resistance is to be taken into account.</p>
 <p>The results obtained with this function have been checked with Fig. 4.1 of [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>], in model Examples.TestM_OLineZ, with good agreement.</p>
 <p>The output arrays contain the elements of the Z matrix ordered as described in the M_OLine model and are used in example Examples.Lines.PowerLineWithFence in conjunction with M_OLine.</p>

--- a/Modelica/Electrical/Analog/Lines/Functions/LineZmatrix.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/LineZmatrix.mo
@@ -1,0 +1,85 @@
+within Modelica.Electrical.Analog.Lines.Functions;
+function LineZmatrix
+ "Compute matrix of longitudinal impedances per metre of a multi-conductor line"
+  import Modelica.Constants.*;
+  import Modelica.ComplexMath;
+  import Modelica.Utilities.Streams;
+  input Integer n "number of conductors in line";
+  input Real x[n] "horizontal abscissas of conductors (m)";
+  input Real y[n] "vertical abscissas of conductors (m)";
+  input Real r[n] "conductors radii (m)";
+  input Real R1[n] "conductors lineic resistance (ohm/m)";
+  input Real k_s[n]=fill(0.7,n) "ratio of equivalent shell radius to actual radius";
+  //  in case of cylindric conductor this is equal to exp(-mu_r/4)=exp(-0.25)
+  input Real rho=100 "ground resistivity";
+  input Real f=50 "frequency";
+  output Real Rcomp[div(n * (n + 1), 2)] "Compact resistance matrix (ohm/m)";
+  output Real Xcomp[div(n * (n + 1), 2)] "Compact reactance matrix (ohm/m)";
+  output Real Lcomp[div(n * (n + 1), 2)] "Compact inductance (H/m)";
+protected
+  constant Complex j=Complex(0, 1) "Imaginary unit";
+  Real D "generic larger distance";
+  Real d "generic smaller distance";
+  Real Theta "Theta angle for Carson's formulas";
+  Real L "generic inductance";
+  Real P "P coefficient from Carson's original paper";
+  Real Q "Q coefficient from Carson's original paper";
+
+  Complex Z[n, n] "Computed matrix (ohm/m)";
+
+  parameter Real a0=4*pi*sqrt(5)*1e-4*sqrt(f/rho)
+    "multiplies D in a-pameter from EMTPs Theory Book";
+  //  a0*D=a; a is the same as "r" in Carson's paper
+  // where D=2h for self impedanze, D=Dik for mutual impedance
+  Real R_g=pi^2*f*1e-7;
+  Real w=2*pi*f;
+  Real a;
+  Integer k;
+algorithm
+//self impedances with ground return:
+  for i in 1:n loop
+    a:=a0*2*y[i];
+    assert(a<0.25,"parameter a="+String(a)+
+                  " >0.25 will result in inadequate precision of Carson's formulas",
+                  AssertionLevel.warning);
+    P := pi/8 - sqrt(2)/6*a + a^2/16*(0.672784 + log(2/a));
+    Q := (-0.03860784) + 0.5*log(2/a) + sqrt(2)/6*a-pi/64*a*a;
+    L := mu_0/(2*pi)*log(2*y[i]/(k_s[i]*r[i])) "L when soil is pure conductive";
+    Z[i, i] := R1[i] + 4*w*P/1.e7 + j*w*(L + 4*Q/1.e7); //Carson (25) and (30)
+  end for;
+//mutual impedances with ground return:
+  for i in 1:n loop
+    for jj in 1:i - 1 loop
+      Theta := atan(abs((x[i] - x[jj])/(y[i] + y[jj])));
+      d := sqrt((x[i] - x[jj])^2 + (y[i] - y[jj])^2); //distanza fra conduttore i e jj
+      D := sqrt((x[i] - x[jj])^2 + (y[i] + y[jj])^2);  //distanza fra conduttore i e immagine di jj
+      a:=a0*D;
+      P := pi/8 - sqrt(2)/6*a*cos(Theta) + a^2/16*(0.672784
+         + log(2/a))*cos(2*Theta)+a^2/16*Theta*sin(2*Theta);
+      Q := (-0.03860784) + 0.5*log(2/a) + sqrt(2)/6*a*cos(Theta)-pi/64*a*a*cos(2*Theta);
+      L := mu_0/(2*pi)*log(D/d) "L when soil is pure conductive";
+      Z[i, jj] := 4*w*P/1.e7 + j*w*(L + 4*Q/1.e7); //Carson (26) and (31)
+    end for;
+  end for;
+  k := 0;
+  for i in 1:n loop
+    for j in i:n loop
+      k := k + 1;
+      Rcomp[k] := Z[j, i].re;
+      Xcomp[k] := Z[j, i].im;
+      Lcomp[k] := Xcomp[k]/w;
+    end for;
+  end for;
+  annotation (Documentation(info="<html>
+<p>This function computes resistances, reactances, inductances of multi-conductor transmission lines, taking into account ground characteristics according to John Carson&apos;s formulas as reported in [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">Ceraolo2018</a>, Appendix], but upgraded in accuracy (more digits in constants and more added terms in the evaluation of Q).</p>
+<p>When used in conjunction with M_OLine from its output just the inductances are used; the resistances could instead be used when ground resistance is to be taken into account.</p>
+<p>The results obtained with this function have been checked with Fig. 4.1 of [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>], in model Examples.TestM_OLineZ, with good agreement.</p>
+<p>The output arrays contain the elements of the Z matrix ordered as described in the M_OLine model and are used in example Examples.Lines.PowerLineWithFence in conjunction with M_OLine.</p>
+<p>Parameter k_s is 0.778 for a solid non-magnetic conductor; can be between 0.35 and 0.8 for real-life power line conductors (they are stranded and often have an iron core).</p>
+<p>Note that according to Carson&apos;s theory the line impedances depend on the frequency of signal, and therefore this function is run for a given frequency. The formulas inside have adequate precision only for a limited range of frequency (up to several hundred hertz); if a larger than acceptable frequency is requested, given the line geometry, a warning is issued.</p>
+</html>", revisions="<html>
+<li><em>May, 2021</em> 
+        Massimo Ceraolo of the University of Pisa <br> 
+        originally created</li> 
+</html>"));
+end LineZmatrix;

--- a/Modelica/Electrical/Analog/Lines/Functions/TestLineCmatrix.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/TestLineCmatrix.mo
@@ -1,0 +1,62 @@
+within Modelica.Electrical.Analog.Lines.Functions;
+model TestLineCmatrix
+  extends Modelica.Icons.Example;
+  import Modelica.Utilities.*;
+
+  parameter LineGeometry g(
+    n=4,
+    x={0,-3.048,3.048,-9.144},
+    y={12.192,12.192,12.192,3.048},
+    r=1e-3/2*{12.7,12.7,12.7,4.064},
+    R1=1e-3*{0.348,0.348,0.348,1.802})
+    annotation (Placement(transformation(extent={{-10,-6},{10,14}})));
+
+  String sC;
+  Real Ccomp[div(g.n*(g.n + 1), 2)] "Compacted matrix";
+protected
+  Integer k;
+algorithm
+  when initial() then
+    Ccomp :=LineCmatrix(
+      n=g.n,
+      x=g.x,
+      y=g.y,
+      r=g.r);
+    Streams.print("\n *****              Using LineCmatrix, RESULTS in nF/km               *****");
+    Streams.print(  " *** (one row per matrix row; numbers should be intended right-aligned) ***");
+    k:=0;
+    for i in 1:g.n loop  //matrix row
+      sC := "";
+      for j in 1:g.n-i+1 loop  // matrix column
+        k:=k+1;
+        sC := sC + String(1e12*Ccomp[k]) + "  ";
+      end for;
+      Streams.print(sC);
+    end for;
+/*    
+    Streams.print("\n *** Vector stream ***");
+    for i in 1:div(g.n*(g.n + 1),2) loop 
+      Streams.print(String(1e12*Ccomp[i]));
+    end for;
+*/
+    end when;
+  annotation (Diagram(coordinateSystem(preserveAspectRatio=
+           false, extent={{-60,-40},{60,40}})),
+    Documentation(info="<html>
+<p>This model tests the C matrix as computed with function LineCmatrix, with the geometry of fig. 4.11 of [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>]. </p>
+<p>The results are given textually in the log and show a good agreement with the reference.</p>
+<p>This simulation runs correctly with both Dymola and OpenModelica. Computation result using Dymola 2020:<span style=\"font-family: Courier New;\"> </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\"><pre>*****              Using LineCmatrix, RESULTS in nF/km               *****</pre></span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">     *** (one row per matrix row; numbers should be intended right-aligned) ***</span> </p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">7.57087&nbsp; -1.62658&nbsp; -1.63038&nbsp; -0.168826&nbsp; </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">7.30876&nbsp; -0.834876&nbsp; -0.275822&nbsp; </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">7.29987&nbsp; -0.118934&nbsp; </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">6.97273&nbsp; </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">... &quot;TestLineCmatrix.mat&quot; creating (simulation result file)</span> </p>
+</html>", revisions="<html>
+<li><em>May, 2021</em> 
+        Massimo Ceraolo of the University of Pisa <br> 
+        originally created</li> 
+</html>"),
+    experiment(StopTime=0));
+end TestLineCmatrix;

--- a/Modelica/Electrical/Analog/Lines/Functions/TestLineZmatrix.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/TestLineZmatrix.mo
@@ -1,0 +1,65 @@
+within Modelica.Electrical.Analog.Lines.Functions;
+model TestLineZmatrix
+  extends Modelica.Icons.Example;
+  import Modelica.Utilities.*;
+  parameter LineGeometry g(
+    n=4,
+    x={0,-3.048,3.048,-9.144},
+    y={12.192,12.192,12.192,3.048},
+    r=1e-3/2*{12.7,12.7,12.7,4.064},
+    R1=1e-3*{0.348,0.348,0.348,1.802},
+    k_s={0.287,0.287,0.287,0.779},
+    f=60)    annotation (Placement(transformation(extent={{-10,-6},{10,14}})));
+
+  String sC;
+  Real Rcomp[div(g.n*(g.n + 1), 2)] "Compacted matrix";
+  Real Xcomp[div(g.n*(g.n + 1), 2)] "Compacted matrix";
+
+protected
+  Integer k;
+algorithm
+  when initial() then
+    (Rcomp,Xcomp) :=LineZmatrix(
+      n=g.n,
+      x=g.x,
+      y=g.y,
+      r=g.r,
+      R1=g.R1,
+      k_s=g.k_s,
+      rho=g.rho,
+      f=g.f);
+
+    Streams.print("\n *****              Using LineZmatrix, RESULTS in ohm/km              *****");
+    Streams.print(  " *** (one row per matrix row; numbers should be intended right-aligned) ***");
+    k:=0;
+    for i in 1:g.n loop  //matrix row
+      sC := "";
+      for j in 1:g.n-i+1 loop  // matrix column
+        k:=k+1;
+        sC := sC + String(1000*Rcomp[k]) +"+j"+String(1000*Xcomp[k])+ "   ";
+      end for;
+      Streams.print(sC);
+      end for;
+  end when;
+
+  annotation (Diagram(coordinateSystem(preserveAspectRatio=
+           false, extent={{-60,-40},{60,40}})),
+    Documentation(info="<html>
+<p>This model tests the Z matrix as computed with function LineZmatrix, with the geometry of fig. 4.11 of [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">EmtpTheoryBook</a>]. </p>
+<p>The results are given textually in the log and show a good agreement with the reference.</p>
+<p>This simulation runs correctly with both Dymola and OpenModelica. Computation result using Dymola 2020:<span style=\"font-family: Courier New;\"> </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\"><pre>*****              Using LineZmatrix, RESULTS in ohm/km              *****</pre></span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">     *** (one row per matrix row; numbers should be intended right-aligned) ***</span> </p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">0.405445+j0.986077 0.0574443+j0.426468 0.0574443+j0.426468 0.058076+j0.316811 </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">0.405445+j0.986077 0.0574408+j0.374207 0.0580827+j0.329078 </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">0.405445+j0.986077 0.0580667+j0.304429 </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">1.86076+j0.995306 </span></p>
+<p><span style=\"font-family: Courier New; font-size: 9pt;\">... &quot;TestLineZmatrix.mat&quot; creating (simulation result file)</span> </p>
+<p>&nbsp; </p>
+</html>", revisions="<html>
+<li><em>May, 2021</em> 
+        Massimo Ceraolo of the University of Pisa <br> 
+        originally created</li> 
+</html>"),
+    experiment(StopTime=0));
+end TestLineZmatrix;

--- a/Modelica/Electrical/Analog/Lines/Functions/package.mo
+++ b/Modelica/Electrical/Analog/Lines/Functions/package.mo
@@ -1,0 +1,9 @@
+within Modelica.Electrical.Analog.Lines;
+package Functions "Functions and records"
+  annotation (Icon(graphics={Rectangle(
+          lineColor={200,200,200},
+          fillColor={255,215,136},
+          fillPattern=FillPattern.HorizontalCylinder,
+          extent={{-100.0,-100.0},{100.0,100.0}},
+          radius=25.0)}));
+end Functions;

--- a/Modelica/Electrical/Analog/Lines/Functions/package.order
+++ b/Modelica/Electrical/Analog/Lines/Functions/package.order
@@ -1,0 +1,5 @@
+LineGeometry
+LineCmatrix
+LineZmatrix
+TestLineZmatrix
+TestLineCmatrix

--- a/Modelica/Electrical/Analog/Lines/package.order
+++ b/Modelica/Electrical/Analog/Lines/package.order
@@ -5,3 +5,4 @@ TLine
 TLine1
 TLine2
 TLine3
+Functions

--- a/Modelica/Electrical/Analog/UsersGuide/References.mo
+++ b/Modelica/Electrical/Analog/UsersGuide/References.mo
@@ -35,6 +35,15 @@ class References "References"
     <td>H. Spiro, H, <em>Simulation integrierter Schaltungen</em>, R. Oldenbourg Verlag M&uuml;nchen Wien, 1990</td>
   </tr>
 
+
+  <tr>
+    <td>[<a href=\"https://www.academia.edu/38437649/EMTP_Theory_Book\">Theory Book</a>]</td>
+    <td>Various authors, &quot;Emtp theory book&quot;, <em>Proceedings of the IEEE</em>,
+        vol. 55, pp. 2012-2013, 1967</td>
+  </tr>
+
+
+
   <tr>
     <td>[Vlach1983]</td>
     <td>J. Vlach, K. Singal, <em>Computer methods for circuit analysis and design</em>, Van Nostrand Reinhold, New York 1983</td>

--- a/Modelica/Electrical/Analog/UsersGuide/References.mo
+++ b/Modelica/Electrical/Analog/UsersGuide/References.mo
@@ -2,52 +2,39 @@ within Modelica.Electrical.Analog.UsersGuide;
 class References "References"
   extends Modelica.Icons.References;
   annotation (preferredView="info",Documentation(info="<html>
-
-<table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
-
-  <tr>
-    <td>[<a href=\"https://ieeexplore.ieee.org/document/1447963\">Branin1967</a>]</td>
-    <td>F. H. Branin Jr., &quot;Transient analysis of lossless transmission lines&quot;, <em>Proceedings of the IEEE</em>,
-        vol. 55, pp. 2012-2013, 1967</td>
-  </tr>
-
-  <tr>
-    <td>[Conelly1992]</td>
-    <td>J.A. Conelly, <em>Macromodelling with SPICE</em>, Englewood Cliffs: Prentice-Hall, 1992</td>
-  </tr>
-
-  <tr>
-    <td>[<a href=\"https://www.springer.com/us/book/9783540151609\">Hoefer1985</a>]</td>
-    <td>E. E. E. Hoefer, H. Nielinger, <em>SPICE: Analyseprogramm f&uuml;r elektronische Schaltungen</em>,
-        Springer-Verlag, Berlin, Heidelberg, New York, Tokyo, 1985</td>
-  </tr>
-
-  <tr>
-    <td>[Johnson1991]</td>
-    <td>B. Johnson, T. Quarles, A. R. Newton, D. O. Pederson, A. Sangiovanni-Vincentelli,
-        <em>SPICE3 Version 3e User&#39;s Manual</em>,
-        Department of Electrical Engineering and Computer Sciences,
-        University of California, Berkeley p. 12, p. 106 - 107, April 1, 1991</td>
-  </tr>
-
-  <tr>
-    <td>[Spiro1990]</td>
-    <td>H. Spiro, H, <em>Simulation integrierter Schaltungen</em>, R. Oldenbourg Verlag M&uuml;nchen Wien, 1990</td>
-  </tr>
-
-
-  <tr>
-    <td>[<a href=\"https://www.academia.edu/38437649/EMTP_Theory_Book\">Theory Book</a>]</td>
-    <td>Various authors, &quot;Emtp theory book&quot;, <em>Proceedings of the IEEE</em>,
-        vol. 55, pp. 2012-2013, 1967</td>
-  </tr>
-
-
-
-  <tr>
-    <td>[Vlach1983]</td>
-    <td>J. Vlach, K. Singal, <em>Computer methods for circuit analysis and design</em>, Van Nostrand Reinhold, New York 1983</td>
-  </tr>
+<table cellspacing=\"0\" cellpadding=\"2\" border=\"0\"><tr>
+<td><p>[<a href=\"https://ieeexplore.ieee.org/document/1447963\">Branin1967</a>]</p></td>
+<td><p>F. H. Branin Jr., &quot;Transient analysis of lossless transmission lines&quot;, <i>Proceedings of the IEEE</i>, vol. 55, pp. 2012-2013, 1967</p></td>
+</tr>
+<tr>
+<td><p>[<a href=\"https://ieeexplore.ieee.org/document/8076707\">Cerolo2018</a>]</p></td>
+<td><p>M. Ceraolo, <i>Modelling and Simulation of AC Railway Electric Supply Lines Including Ground Return</i>, 
+ IEEE Transactions on Transportation Electrification  Vol. 4, issue N. 1, pp. 202-210, March 2018</p></td>
+</tr>
+<tr>
+<td><p>[Conelly1992]</p></td>
+<td><p>J.A. Conelly, <i>Macromodelling with SPICE</i>, Englewood Cliffs: Prentice-Hall, 1992</p></td>
+</tr>
+<tr>
+<td><p>[<a href=\"https://www.springer.com/us/book/9783540151609\">Hoefer1985</a>]</p></td>
+<td><p>E. E. E. Hoefer, H. Nielinger, <i>SPICE: Analyseprogramm f&uuml;r elektronische Schaltungen</i>, Springer-Verlag, Berlin, Heidelberg, New York, Tokyo, 1985</p></td>
+</tr>
+<tr>
+<td><p>[Johnson1991]</p></td>
+<td><p>B. Johnson, T. Quarles, A. R. Newton, D. O. Pederson, A. Sangiovanni-Vincentelli, <i>SPICE3 Version 3e User&apos;s Manual</i>, Department of Electrical Engineering and Computer Sciences, University of California, Berkeley p. 12, p. 106 - 107, April 1, 1991</p></td>
+</tr>
+<tr>
+<td><p>[Spiro1990]</p></td>
+<td><p>H. Spiro, H, <i>Simulation integrierter Schaltungen</i>, R. Oldenbourg Verlag M&uuml;nchen Wien, 1990</p></td>
+</tr>
+<tr>
+<td><p>[<a href=\"https://www.academia.edu/38437649/EMTP_Theory_Book\">Theory Book</a>]</p></td>
+<td><p>Various authors, &quot;Emtp theory book&quot;, <i>Proceedings of the IEEE</i>, vol. 55, pp. 2012-2013, 1967</p></td>
+</tr>
+<tr>
+<td><p>[Vlach1983]</p></td>
+<td><p>J. Vlach, K. Singal, <i>Computer methods for circuit analysis and design</i>, Van Nostrand Reinhold, New York 1983</p></td>
+</tr>
 </table>
 </html>"));
 end References;

--- a/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/Lines/CompareCmatrix/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/Lines/CompareCmatrix/comparisonSignals.txt
@@ -1,0 +1,3 @@
+time
+r1n.i
+r1.i


### PR DESCRIPTION
This PR logically follows PR [#3819](https://github.com/modelica/ModelicaStandardLibrary/pull/3819), since It takes advantage of the folder Modelica.Electrical.Analog.Examples.Lines created in that PR.
________________________________________
This PR contains an example of the usage of M_OLine to analyse the behaviour of a power line, including ground return.

To ease this usage, I created two utility functions LineZmatrix and LineCmatrix that compute Z and C matrices from the geometry of conductors.

The function LineZMatrix is able to compute all the elements of the Z matrix correctly (according to Carson's theory for ground return and only for a given frequency), with non-zero value of resistances of off-diagonal elements, even though M_Oline does not allow including off-diagonal resistances in simulations. Therefore, it can be used in future for further models able to consider these resistances. These further models may be possibly included in the Electrical-Polyphase or QuasiStatic-Polyphase sub-library. They could be based on cascaded-pi as M_OLine, or be a multiphase extension of MSL TLine model, e.g. similar to the one available in https://it.mathworks.com/help/sps/powersys/ref/distributedparametersline.html.

In M_OLine, capacitive couplings between conductors are simulated through physical capacitors to be put across them, instead of a capacitance matrix. Therefore, to use M_OLine the elements of the conductor C-matrix must be first converted into a set of capacitances for physical capacitors across conductors. This conversion is made inside LineCmatrix as well, and its effectiveness is demonstrated by the model CompareCmatrix, included in this PR.

The theory behind LineCMatrix and LineZmatrix is available in the Appendix of a paper of mine [M. Ceraolo, “Modelling and Simulation of AC Railway Electric Supply Lines Including Ground Return”,  IEEE Transactions on Transportation Electrification  Vol. 4, issue N. 1, pp. 202-210], which in turn is a compact version of a much larger work I did in  past years. I can discuss details this theory in case it is requested.

**Important note**. This PR substitutes previous PR 3846 that I deleted by mistake! It takes into account everything already discussed under that PR, available in: https://github.com/modelica/ModelicaStandardLibrary/pull/3846