### PR TITLE
Remove voltageSensor.v from the comparison list

### DIFF
--- a/Modelica/Resources/Reference/Modelica/Electrical/PowerConverters/Examples/DCAC/PolyphaseTwoLevel/PolyphaseTwoLevel_RL/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/PowerConverters/Examples/DCAC/PolyphaseTwoLevel/PolyphaseTwoLevel_RL/comparisonSignals.txt
@@ -43,6 +43,4 @@ inverter.ac.pin[6].i
 currentSensor.i[1]
 currentSensor.i[2]
 currentSensor.i[3]
-voltageSensor.v[1]
-voltageSensor.v[2]
-voltageSensor.v[3]
+


### PR DESCRIPTION
I have removed variables voltageSensors.v from the comparison list as per https://github.com/modelica/ModelicaStandardLibrary/issues/3523#issuecomment-760084305