### PR TITLE
Protect internal ports of base class machines

### DIFF
--- a/Modelica/Magnetic/FundamentalWave/BaseClasses/Machine.mo
+++ b/Modelica/Magnetic/FundamentalWave/BaseClasses/Machine.mo
@@ -164,13 +164,13 @@ partial model Machine "Base model of machines"
       frictionParameters=frictionParameters, final useHeatPort=true)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}}, origin={90,
             -30})));
+protected
   replaceable
     Modelica.Electrical.Machines.Interfaces.InductionMachines.PartialThermalPortInductionMachines
     internalThermalPort(final m=m)
     annotation (Placement(transformation(extent={{-44,-94},{-36,-86}})));
   Modelica.Mechanics.Rotational.Interfaces.Support internalSupport
     annotation (Placement(transformation(extent={{56,-104},{64,-96}})));
-protected
   final parameter SI.Impedance ZsRef = 1 "Reference phase impedance based on nominal voltage 100 V and nominal current 100 A; per phase";
 initial algorithm
   assert(not Modelica.Math.isPowerOf2(m), String(m) +

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/BaseClasses/Machine.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/BaseClasses/Machine.mo
@@ -190,13 +190,13 @@ partial model Machine "Base model of machines"
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         origin={90,-30})));
+protected
   replaceable
     Modelica.Electrical.Machines.Interfaces.InductionMachines.PartialThermalPortInductionMachines
     internalThermalPort(final m=m)
     annotation (Placement(transformation(extent={{-44,-94},{-36,-86}})));
   Modelica.Mechanics.Rotational.Interfaces.Support internalSupport
     annotation (Placement(transformation(extent={{56,-104},{64,-96}})));
-protected
   final parameter SI.Impedance ZsRef = 1 "Reference phase impedance based on nominal voltage 100 V and nominal current 100 A; per phase";
 initial algorithm
   assert(not Modelica.Math.isPowerOf2(m), String(m) +


### PR DESCRIPTION
I just saw that the internal used ports of the optional mechanical housing port and the optional thermal port in Modelica.Magnetic.Fundamentalwave.BaseClasses.Machine and Modelica.Magnetic.QuasiStatic.Fundamentalwave.BaseClasses.Machine are visible. This is not intended and confusing for users. 
So I set these two internal ports protected. 
I think that should be back-ported, could anyone help please?