### PR TITLE
Update text annotations to not use deprecated features

### DIFF
--- a/Modelica/Blocks/Discrete.mo
+++ b/Modelica/Blocks/Discrete.mo
@@ -407,7 +407,7 @@ the initial value defined via parameter <strong>y0</strong>.
         Line(points={{-35.0,0.0},{28.0,-48.0}},
           color={0,0,127}),
         Text(extent={{-86.0,24.0},{82.0,82.0}},
-          color={0,0,127},
+          textColor={0,0,127},
           textString="max"),
         Ellipse(lineColor={0,0,127},
           fillColor={255,255,255},

--- a/Modelica/Clocked/ClockSignals/Clocks/Logical/PartialLogicalClock.mo
+++ b/Modelica/Clocked/ClockSignals/Clocks/Logical/PartialLogicalClock.mo
@@ -114,8 +114,6 @@ equation
       Text(
         extent={{-90,100},{-20,90}},
         textColor={238,46,47},
-        pattern=LinePattern.Dash,
-        lineThickness=1,
         textStyle={TextStyle.Bold},
           textString="array of input trackers"),
       Rectangle(
@@ -126,8 +124,6 @@ equation
       Text(
         extent = {{14,-26},{50,-40}},
         textColor = {28,108,200},
-        pattern = LinePattern.Dash,
-        lineThickness = 1,
         textString = "resetter",
         textStyle = {TextStyle.Bold})}));
 end PartialLogicalClock;

--- a/Modelica/Clocked/ClockSignals/Interfaces/ClockInput.mo
+++ b/Modelica/Clocked/ClockSignals/Interfaces/ClockInput.mo
@@ -24,9 +24,7 @@ connector ClockInput = input Clock "'input Clock' as connector"
           fillPattern=FillPattern.Solid), Text(
           extent={{-10,85},{-10,60}},
           textColor={0,0,255},
-          textString="%name",
-        fillPattern=FillPattern.Solid,
-        fillColor={128,0,255})}),
+          textString="%name")}),
     Documentation(info="<html>
 <p>
 Connector with one input signal of type Clock.

--- a/Modelica/Clocked/Examples/Systems/ControlledMixingUnit.mo
+++ b/Modelica/Clocked/Examples/Systems/ControlledMixingUnit.mo
@@ -130,8 +130,6 @@ equation
             {60,-44}}, lineColor={255,0,0}), Text(
         extent={{12,42},{58,34}},
         textColor={255,0,0},
-        fillColor={0,0,255},
-        fillPattern=FillPattern.Solid,
         textString="controller")}),
     experiment(StopTime=300),
     Documentation(info="<html>

--- a/Modelica/Clocked/Examples/Systems/Utilities/ComponentsThrottleControl/Engine.mo
+++ b/Modelica/Clocked/Examples/Systems/Utilities/ComponentsThrottleControl/Engine.mo
@@ -163,7 +163,5 @@ equation
         Text(
           extent={{-100,-50},{100,-90}},
           textColor={0,0,255},
-          fillColor={255,255,0},
-          fillPattern=FillPattern.Solid,
           textString="%name")}));
 end Engine;

--- a/Modelica/Clocked/RealSignals/Periodic/FIRbyCoefficients.mo
+++ b/Modelica/Clocked/RealSignals/Periodic/FIRbyCoefficients.mo
@@ -68,11 +68,8 @@ At the first clock tick i=1 the past values are filled with u at this clock tick
         Text(
           extent={{-26,86},{88,56}},
           textColor={175,175,175},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Backward,
           textString="FIR"),
         Text(
           extent={{-150,-110},{150,-150}},
-          fillPattern=FillPattern.Solid,
           textString="a=%a")}));
 end FIRbyCoefficients;

--- a/Modelica/Clocked/RealSignals/Periodic/MovingAverage.mo
+++ b/Modelica/Clocked/RealSignals/Periodic/MovingAverage.mo
@@ -75,11 +75,8 @@ contrary to a general FIR filter.
         Text(
           extent={{-26,88},{88,48}},
           textColor={175,175,175},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Backward,
           textString="MA"),
         Text(
           extent={{-150,-110},{150,-150}},
-          fillPattern=FillPattern.Solid,
           textString="n=%n")}));
 end MovingAverage;

--- a/Modelica/ComplexBlocks/ComplexMath/ComplexToReal.mo
+++ b/Modelica/ComplexBlocks/ComplexMath/ComplexToReal.mo
@@ -28,8 +28,6 @@ equation
               fillPattern=FillPattern.Solid),Text(
               extent={{-100,60},{-20,-60}},
               textColor={85,170,255},
-          fillColor={85,170,255},
-          fillPattern=FillPattern.Solid,
           textString="C")}),     Documentation(info="<html>
 <p>Converts the Complex input <em>u</em> to the Real outputs <em>re</em> (real part) and <em>im</em> (imaginary part).</p>
 </html>"));

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Buffer.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Buffer.mo
@@ -48,7 +48,5 @@ equation
         Text(
           extent={{-100,10},{100,-10}},
           textColor={0,0,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.None,
           textString="non-inverting")}));
 end Buffer;

--- a/Modelica/Electrical/Machines/Sensors/SinCosResolver.mo
+++ b/Modelica/Electrical/Machines/Sensors/SinCosResolver.mo
@@ -25,7 +25,6 @@ equation
         Text(
           extent={{-150,120},{150,80}},
           textColor={0,0,255},
-          fillColor={255,255,255},
           textString="%name"),
         Ellipse(extent={{-20,20},{20,-20}}, lineColor={95,95,95},
           fillColor={255,255,255},

--- a/Modelica/Electrical/Polyphase/Examples/PolyphaseRectifier.mo
+++ b/Modelica/Electrical/Polyphase/Examples/PolyphaseRectifier.mo
@@ -172,14 +172,10 @@ as well as DC values per subsystem (rectifier) and total (load):
           radius=5),                      Text(
           extent={{-24,10},{36,-10}},
           textColor={0,0,0},
-          fillColor={215,215,215},
-          fillPattern=FillPattern.None,
           textString="rectifiers[mSystems]"),
         Text(
           extent={{-58,10},{58,-10}},
           textColor={0,0,0},
-          fillColor={215,215,215},
-          fillPattern=FillPattern.Solid,
           origin={50,0},
           rotation=90,
           textString="connected in series / in parallel"),

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/ComparisonPolyphase/IMC_DOL_CommonLeakage.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/ComparisonPolyphase/IMC_DOL_CommonLeakage.mo
@@ -270,21 +270,15 @@ Only when fed by switching power electronics, parameter <code>ratioCommonLeakage
 </html>"),
     Diagram(graphics={       Text(
                 extent={{10,80},{90,72}},
-                fillColor={255,255,170},
-                fillPattern=FillPattern.Solid,
                 textStyle={TextStyle.Bold},
           textString="ratioCommonLeakage=0",
           textColor={0,0,0}),             Text(
                 extent={{10,22},{90,14}},
-                fillColor={255,255,170},
-                fillPattern=FillPattern.Solid,
                 textStyle={TextStyle.Bold},
           textColor={0,0,0},
           textString="ratioCommonLeakage=0.5"),
                                           Text(
                 extent={{10,-38},{90,-46}},
-                fillColor={255,255,170},
-                fillPattern=FillPattern.Solid,
                 textStyle={TextStyle.Bold},
           textColor={0,0,0},
           textString="ratioCommonLeakage=1")}));

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/ComparisonPolyphase/IMC_DOL_Polyphase.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/ComparisonPolyphase/IMC_DOL_Polyphase.mo
@@ -256,13 +256,9 @@ Simulate for 1.5 seconds and plot (versus time):
             -100},{100,100}}),
                          graphics={       Text(
                 extent={{20,88},{100,80}},
-                fillColor={255,255,170},
-                fillPattern=FillPattern.Solid,
                 textString="%m-phase machine",
                 textStyle={TextStyle.Bold}),Text(
                 extent={{20,-22},{100,-30}},
-                fillColor={255,255,170},
-                fillPattern=FillPattern.Solid,
                 textString="Three-phase machine",
                 textStyle={TextStyle.Bold})}));
 end IMC_DOL_Polyphase;

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/ComparisonPolyphase/IMS_Start_Polyphase.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/ComparisonPolyphase/IMS_Start_Polyphase.mo
@@ -288,13 +288,9 @@ Simulate for 1.5 seconds and plot (versus time):
             -100},{100,100}}),
                          graphics={       Text(
                 extent={{40,68},{100,60}},
-                fillColor={255,255,170},
-                fillPattern=FillPattern.Solid,
                 textString="%m-phase machine",
                 textStyle={TextStyle.Bold}),Text(
                 extent={{40,-32},{100,-40}},
-                fillColor={255,255,170},
-                fillPattern=FillPattern.Solid,
                 textString="Three-phase machine",
                 textStyle={TextStyle.Bold})}));
 end IMS_Start_Polyphase;

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/ComparisonPolyphase/SMEE_Generator_Polyphase.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/ComparisonPolyphase/SMEE_Generator_Polyphase.mo
@@ -356,14 +356,10 @@ Simulate for 30 seconds and plot (versus <code>rotorAngleM3.rotorDisplacementAng
                 fillPattern=FillPattern.Solid,
                 pattern=LinePattern.Dash),Text(
                 extent={{10,16},{70,8}},
-                fillColor={255,255,170},
-                fillPattern=FillPattern.Solid,
                 textStyle={TextStyle.Bold},
                 textString="%m-phase machine
 "),     Text(
           extent={{10,-52},{70,-60}},
-                fillColor={255,255,170},
-                fillPattern=FillPattern.Solid,
                 textStyle={TextStyle.Bold},
                 textString="Three-phase machine
 "),     Rectangle(

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/ComparisonPolyphase/SMPM_Inverter_Polyphase.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/ComparisonPolyphase/SMPM_Inverter_Polyphase.mo
@@ -300,14 +300,10 @@ and accelerate the inertias. Two equivalent machines with different numbers of p
                 fillPattern=FillPattern.Solid,
                 pattern=LinePattern.Dash),Text(
                 extent={{40,-54},{100,-62}},
-                fillColor={255,255,170},
-                fillPattern=FillPattern.Solid,
                 textStyle={TextStyle.Bold},
                 textString="Three-phase machine
 "),     Text(
           extent={{40,-44},{100,-52}},
-                fillColor={255,255,170},
-                fillPattern=FillPattern.Solid,
                 textStyle={TextStyle.Bold},
                 textString="%m-phase machine
 ")}));

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/ComparisonPolyphase/SMR_Inverter_Polyphase.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/ComparisonPolyphase/SMR_Inverter_Polyphase.mo
@@ -275,14 +275,10 @@ Simulate for 1.5 seconds and plot (versus time):
                 fillPattern=FillPattern.Solid,
                 pattern=LinePattern.Dash),Text(
                 extent={{40,-44},{100,-52}},
-                fillColor={255,255,170},
-                fillPattern=FillPattern.Solid,
                 textStyle={TextStyle.Bold},
                 textString="%m-phase machine
 "),     Text(
           extent={{40,-54},{100,-62}},
-                fillColor={255,255,170},
-                fillPattern=FillPattern.Solid,
                 textStyle={TextStyle.Bold},
                 textString="Three-phase machine
 "),     Rectangle(

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/ElectroMagneticConverter.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/ElectroMagneticConverter.mo
@@ -76,7 +76,6 @@ equation
       Text(
         extent={{-150,150},{150,110}},
         textString="%name",
-          pattern=LinePattern.None,
           textColor={0,0,255}),
         Line(
           points={{-15,-7},{-14,-1},{-7,7},{7,7},{14,-1},{15,-7}},

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/FixedShapes/CuboidSections.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Examples/FixedShapes/CuboidSections.mo
@@ -86,7 +86,6 @@ equation
 annotation (Diagram(coordinateSystem(preserveAspectRatio=false),          graphics={Text(
           extent={{-100,100},{100,80}},
           textColor={0,0,255},
-          pattern=LinePattern.Dash,
           textString="Added short and idle model for testing purposes only")}),
     Documentation(info="<html>
 <p>This model investigates a magnetic circuit consisting of four different cuboid sections. The circuit is operated at 50Hz and variable magnetic potential difference.</p>

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Interfaces/AbsoluteSensor.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Interfaces/AbsoluteSensor.mo
@@ -11,9 +11,6 @@ equation
         Text(
           extent={{-150,120},{150,80}},
           textColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={170,85,255},
-          fillPattern=FillPattern.Solid,
           textString="%name")}), Documentation(info="<html>
 <p>
 The absolute sensor partial model provides a single

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Interfaces/NegativeMagneticPort.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Interfaces/NegativeMagneticPort.mo
@@ -9,8 +9,6 @@ connector NegativeMagneticPort "Negative quasi-static magnetic port"
             graphics={Text(
               extent={{-100,100},{100,60}},
               textColor={255,170,85},
-              fillColor={0,0,255},
-              fillPattern=FillPattern.Solid,
               textString="%name"), Rectangle(
           extent={{-40,40},{40,-40}},
           lineColor={255,170,85},

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Interfaces/PositiveMagneticPort.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Interfaces/PositiveMagneticPort.mo
@@ -9,8 +9,6 @@ connector PositiveMagneticPort "Positive quasi-static magnetic port"
             graphics={Text(
               extent={{-100,100},{100,60}},
               textColor={255,170,85},
-              fillColor={0,0,255},
-              fillPattern=FillPattern.Solid,
               textString="%name"), Rectangle(
           extent={{-40,40},{40,-40}},
           lineColor={255,170,85},

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Interfaces/RelativeSensor.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Interfaces/RelativeSensor.mo
@@ -15,9 +15,6 @@ partial model RelativeSensor "Partial magnetic voltage or flux sensor"
         Text(
           extent={{-150,120},{150,80}},
           textColor={0,0,255},
-          pattern=LinePattern.None,
-          fillColor={170,85,255},
-          fillPattern=FillPattern.Solid,
           textString="%name"),
         Line(
           points={{0,-70},{0,-100}}, color={85,170,255})}),

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Sensors/Transient/Permeability.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Sensors/Transient/Permeability.mo
@@ -38,8 +38,6 @@ equation
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid), Text(
           extent={{60,-60},{-60,60}},
-          fillColor={255,170,85},
-          fillPattern=FillPattern.Solid,
           textString="μ")}),
   Documentation(info="<html>
 <p>This model determines the absolute and relative permeability from two real inputs:</p>

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/package.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/package.mo
@@ -11,8 +11,7 @@ package FluxTubes "Library for modelling of quasi-static electromagnetic devices
 This library is intended to provide models for the investigation of
 quasi-static electromagnetic devices with lumped magnetic networks.
 </p>
-</html>"),
-           Icon(coordinateSystem(preserveAspectRatio=false), graphics={
+</html>"), Icon(coordinateSystem(preserveAspectRatio=false), graphics={
     Polygon(
         origin={-3.75,0.0},
         fillColor={255,170,85},

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/package.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/package.mo
@@ -11,7 +11,8 @@ package FluxTubes "Library for modelling of quasi-static electromagnetic devices
 This library is intended to provide models for the investigation of
 quasi-static electromagnetic devices with lumped magnetic networks.
 </p>
-</html>"), Icon(coordinateSystem(preserveAspectRatio=false), graphics={
+</html>"),
+    Icon(coordinateSystem(preserveAspectRatio=false), graphics={
     Polygon(
         origin={-3.75,0.0},
         fillColor={255,170,85},

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Conveyor.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Conveyor.mo
@@ -214,8 +214,6 @@ The mechanical load is a constant torque like a conveyor (with regularization ar
           textString="%m phase quasi-static"),
                                             Text(
                   extent={{20,-40},{100,-48}},
-                  fillColor={255,255,170},
-                  fillPattern=FillPattern.Solid,
                   textStyle={TextStyle.Bold},
           textString="%m phase transient")}));
 end IMC_Conveyor;

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Initialize.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Initialize.mo
@@ -189,8 +189,6 @@ Default machine parameters of model <em>IM_SquirrelCage</em> are used.
           textString="%m phase quasi-static"),
                                             Text(
                   extent={{20,-92},{100,-100}},
-                  fillColor={255,255,170},
-                  fillPattern=FillPattern.Solid,
                   textStyle={TextStyle.Bold},
           textString="%m phase transient")}));
 end IMC_Initialize;

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Transformer.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_Transformer.mo
@@ -267,8 +267,6 @@ Simulate for 2.5 seconds and plot (versus time):</p>
           textString="%m phase quasi-static"),
                                             Text(
                   extent={{80,-92},{160,-100}},
-                  fillColor={255,255,170},
-                  fillPattern=FillPattern.Solid,
                   textStyle={TextStyle.Bold},
           textString="%m phase transient")}));
 end IMC_Transformer;

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_YD.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_YD.mo
@@ -196,8 +196,6 @@ Default machine parameters are used.</p>
                   textStyle={TextStyle.Bold},
           textString="%m phase quasi-static"), Text(
                   extent={{-60,-80},{20,-88}},
-                  fillColor={255,255,170},
-                  fillPattern=FillPattern.Solid,
                   textStyle={TextStyle.Bold},
                   textString="%m phase transient")}));
 end IMC_YD;

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMS_Characteristics.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMS_Characteristics.mo
@@ -149,8 +149,6 @@ Simulate for 1 second and plot (versus <code>imsQS.wMechanical</code> or <code>s
             -100},{100,100}}),
                          graphics={         Text(
                   extent={{20,8},{100,0}},
-                  fillColor={255,255,170},
-                  fillPattern=FillPattern.Solid,
                   textStyle={TextStyle.Bold},
           textString="%m phase quasi-static")}));
 end IMS_Characteristics;

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_CurrentSource.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_CurrentSource.mo
@@ -330,8 +330,6 @@ to numerically stabilize the simulation.</p>
                   textStyle={TextStyle.Bold},
           textString="%m phase quasi-static"),               Text(
                   extent={{30,-52},{110,-60}},
-                  fillColor={255,255,170},
-                  fillPattern=FillPattern.Solid,
                   textStyle={TextStyle.Bold},
                   textString="%m phase transient")}));
 end SMPM_CurrentSource;

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_Mains.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_Mains.mo
@@ -245,8 +245,6 @@ equation
                   textStyle={TextStyle.Bold},
           textString="%m phase quasi-static"),               Text(
                   extent={{20,-92},{100,-100}},
-                  fillColor={255,255,170},
-                  fillPattern=FillPattern.Solid,
                   textStyle={TextStyle.Bold},
                   textString="%m phase transient")}),
     Documentation(info="<html>

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_OpenCircuit.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_OpenCircuit.mo
@@ -162,8 +162,6 @@ Simulate for 0.1 second and plot (versus time):
                   textStyle={TextStyle.Bold},
           textString="%m phase quasi-static"),               Text(
                   extent={{-100,-92},{-20,-100}},
-                  fillColor={255,255,170},
-                  fillPattern=FillPattern.Solid,
                   textStyle={TextStyle.Bold},
                   textString="%m phase transient")}));
 end SMPM_OpenCircuit;

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMR_CurrentSource.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMR_CurrentSource.mo
@@ -205,8 +205,8 @@ model SMR_CurrentSource
         origin={0,60})));
   Modelica.Electrical.QuasiStatic.Polyphase.Sensors.VoltageQuasiRMSSensor voltageQuasiRMSSensorQS(m=m)
     annotation (Placement(transformation(extent={{-40,60},{-20,40}})));
-  Modelica.Electrical.QuasiStatic.Polyphase.Basic.Star starMQS(m=m) annotation
-    (Placement(transformation(
+  Modelica.Electrical.QuasiStatic.Polyphase.Basic.Star starMQS(m=m) annotation (
+     Placement(transformation(
         extent={{-10,10},{10,-10}},
         rotation=270,
         origin={-50,40})));
@@ -346,8 +346,6 @@ Simulate for 2 seconds and plot (versus time):
                   textStyle={TextStyle.Bold},
           textString="%m phase quasi-static"),               Text(
                   extent={{30,-52},{110,-60}},
-                  fillColor={255,255,170},
-                  fillPattern=FillPattern.Solid,
                   textStyle={TextStyle.Bold},
                   textString="%m phase transient")}));
 end SMR_CurrentSource;

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMR_CurrentSource.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMR_CurrentSource.mo
@@ -205,8 +205,8 @@ model SMR_CurrentSource
         origin={0,60})));
   Modelica.Electrical.QuasiStatic.Polyphase.Sensors.VoltageQuasiRMSSensor voltageQuasiRMSSensorQS(m=m)
     annotation (Placement(transformation(extent={{-40,60},{-20,40}})));
-  Modelica.Electrical.QuasiStatic.Polyphase.Basic.Star starMQS(m=m) annotation (
-     Placement(transformation(
+  Modelica.Electrical.QuasiStatic.Polyphase.Basic.Star starMQS(m=m) annotation
+    (Placement(transformation(
         extent={{-10,10},{10,-10}},
         rotation=270,
         origin={-50,40})));

--- a/Modelica/Mechanics/MultiBody/Visualizers/Rectangle.mo
+++ b/Modelica/Mechanics/MultiBody/Visualizers/Rectangle.mo
@@ -38,8 +38,7 @@ protected
     final r_0=frame_a.r_0,
     final nu=nu,
     final nv=nv,
-    redeclare function surfaceCharacteristic =
-        Advanced.SurfaceCharacteristics.rectangle (
+    redeclare function surfaceCharacteristic = Advanced.SurfaceCharacteristics.rectangle (
       lu=length_u, lv=length_v)) if world.enableAnimation and animation
     annotation (Placement(transformation(extent={{-20,-10},{0,10}})));
   Modelica.Mechanics.MultiBody.Forces.Internal.ZeroForceAndTorque zeroForceAndTorque annotation (Placement(transformation(extent={{-80,-10},{-60,10}})));

--- a/Modelica/Mechanics/MultiBody/Visualizers/Rectangle.mo
+++ b/Modelica/Mechanics/MultiBody/Visualizers/Rectangle.mo
@@ -38,7 +38,8 @@ protected
     final r_0=frame_a.r_0,
     final nu=nu,
     final nv=nv,
-    redeclare function surfaceCharacteristic = Advanced.SurfaceCharacteristics.rectangle (
+    redeclare function surfaceCharacteristic =
+        Advanced.SurfaceCharacteristics.rectangle (
       lu=length_u, lv=length_v)) if world.enableAnimation and animation
     annotation (Placement(transformation(extent={{-20,-10},{0,10}})));
   Modelica.Mechanics.MultiBody.Forces.Internal.ZeroForceAndTorque zeroForceAndTorque annotation (Placement(transformation(extent={{-80,-10},{-60,10}})));
@@ -67,9 +68,6 @@ equation
         Line(points={{-100,0},{0,0},{0,-20}}, color={95,95,95}),
         Text(
           extent={{-140,-60},{140,-90}},
-          lineThickness=0.5,
-          fillColor={95,95,95},
-          fillPattern=FillPattern.Solid,
           textString="%length_u x %length_v")}),
     Documentation(info="<html>
 <p>

--- a/Modelica/Mechanics/MultiBody/package.mo
+++ b/Modelica/Mechanics/MultiBody/package.mo
@@ -145,8 +145,8 @@ model World
     annotation (Dialog(tab="Defaults"));
 
   replaceable function gravityAcceleration =
-       Modelica.Mechanics.MultiBody.Forces.Internal.standardGravityAcceleration (
-           gravityType=gravityType, g=g*Modelica.Math.Vectors.normalizeWithAssert(n), mu=mu)
+       Modelica.Mechanics.MultiBody.Forces.Internal.standardGravityAcceleration
+        (  gravityType=gravityType, g=g*Modelica.Math.Vectors.normalizeWithAssert(n), mu=mu)
        constrainedby Modelica.Mechanics.MultiBody.Interfaces.partialGravityAcceleration
     "Function to compute the gravity acceleration, resolved in world frame"
        annotation(choicesAllMatching=true,Dialog(enable=gravityType==
@@ -335,7 +335,8 @@ protected
     final nu=2,
     final nv=2,
     redeclare function surfaceCharacteristic =
-      Modelica.Mechanics.MultiBody.Visualizers.Advanced.SurfaceCharacteristics.rectangle(
+      Modelica.Mechanics.MultiBody.Visualizers.Advanced.SurfaceCharacteristics.rectangle
+          (
       lu=groundLength_u, lv=groundLength_v)) if
       enableAnimation and animateGround and gravityType == GravityTypes.UniformGravity;
 equation

--- a/Modelica/Mechanics/MultiBody/package.mo
+++ b/Modelica/Mechanics/MultiBody/package.mo
@@ -145,8 +145,8 @@ model World
     annotation (Dialog(tab="Defaults"));
 
   replaceable function gravityAcceleration =
-       Modelica.Mechanics.MultiBody.Forces.Internal.standardGravityAcceleration
-        (  gravityType=gravityType, g=g*Modelica.Math.Vectors.normalizeWithAssert(n), mu=mu)
+       Modelica.Mechanics.MultiBody.Forces.Internal.standardGravityAcceleration (
+           gravityType=gravityType, g=g*Modelica.Math.Vectors.normalizeWithAssert(n), mu=mu)
        constrainedby Modelica.Mechanics.MultiBody.Interfaces.partialGravityAcceleration
     "Function to compute the gravity acceleration, resolved in world frame"
        annotation(choicesAllMatching=true,Dialog(enable=gravityType==
@@ -335,8 +335,7 @@ protected
     final nu=2,
     final nv=2,
     redeclare function surfaceCharacteristic =
-      Modelica.Mechanics.MultiBody.Visualizers.Advanced.SurfaceCharacteristics.rectangle
-          (
+      Modelica.Mechanics.MultiBody.Visualizers.Advanced.SurfaceCharacteristics.rectangle(
       lu=groundLength_u, lv=groundLength_v)) if
       enableAnimation and animateGround and gravityType == GravityTypes.UniformGravity;
 equation

--- a/Modelica/Mechanics/Translational/Components/Mass.mo
+++ b/Modelica/Mechanics/Translational/Components/Mass.mo
@@ -42,13 +42,9 @@ A negative force at flange flange_a moves the sliding mass to the negative direc
         Text(
           extent={{-150,85},{150,45}},
           textString="%name",
-          textColor={0,0,255},
-          fillColor={110,210,110},
-          fillPattern=FillPattern.Solid),
+          textColor={0,0,255}),
         Text(
           extent={{-150,-45},{150,-75}},
           textString="m=%m",
-          fillColor={110,221,110},
-          fillPattern=FillPattern.Solid,
           fontSize=0)}));
 end Mass;

--- a/Modelica/Mechanics/Translational/Examples/Friction.mo
+++ b/Modelica/Mechanics/Translational/Examples/Friction.mo
@@ -67,10 +67,10 @@ equation
             {100,100}}), graphics={Text(
               extent={{-100,80},{-80,60}},
               textString="1)",
-              lineColor={0,0,255}),Text(
+              textColor={0,0,255}),Text(
               extent={{-100,20},{-80,0}},
               textString="2)",
-              lineColor={0,0,255}),Text(
+              textColor={0,0,255}),Text(
               extent={{-100,-40},{-80,-60}},
               textColor={0,0,255},
               textString="3)")}),

--- a/Modelica/Mechanics/Translational/Examples/SignConvention.mo
+++ b/Modelica/Mechanics/Translational/Examples/SignConvention.mo
@@ -80,12 +80,12 @@ the two other examples).
             {100,100}}),graphics={Text(
               extent={{-100,80},{-82,60}},
               textString="1)",
-              lineColor={0,0,255}),Text(
+              textColor={0,0,255}),Text(
               extent={{-100,40},{-82,20}},
               textString="2)",
-              lineColor={0,0,255}),Text(
+              textColor={0,0,255}),Text(
               extent={{-100,-20},{-82,-40}},
               textString="3)",
-              lineColor={0,0,255})}),
+              textColor={0,0,255})}),
     experiment(StopTime=1.0, Interval=0.001));
 end SignConvention;

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -1187,8 +1187,6 @@ which is only valid in the rotor-fixed coordinate system.
     annotation (Icon(graphics={Text(
             extent={{-80,80},{80,-78}},
             textColor={128,128,128},
-            fillColor={128,128,128},
-            fillPattern=FillPattern.None,
             fontName="serif",
             textString="SI",
             textStyle={TextStyle.Italic})}),


### PR DESCRIPTION
Fixes #4180

Note that it both replaces textColor and removes deprecated attributes.
```
updateModelicaAnnotations("Modelica",renameTextColor=true)
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Clocked.ClockSignals.Clocks.Logical.PartialLogicalClock.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Clocked.ClockSignals.Interfaces.ClockInput.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Clocked.Examples.Systems.ControlledMixingUnit.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Clocked.Examples.Systems.Utilities.ComponentsThrottleControl.Engine.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Clocked.RealSignals.Periodic.FIRbyCoefficients.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Clocked.RealSignals.Periodic.MovingAverage.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.ComplexBlocks.ComplexMath.ComplexToReal.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits.Buffer.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Electrical.Machines.Sensors.SinCosResolver.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Electrical.Polyphase.Examples.PolyphaseRectifier.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.FundamentalWave.Examples.BasicMachines.InductionMachines.ComparisonPolyphase.IMC_DOL_CommonLeakage.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.FundamentalWave.Examples.BasicMachines.InductionMachines.ComparisonPolyphase.IMC_DOL_Polyphase.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.FundamentalWave.Examples.BasicMachines.InductionMachines.ComparisonPolyphase.IMS_Start_Polyphase.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.FundamentalWave.Examples.BasicMachines.SynchronousMachines.ComparisonPolyphase.SMEE_Generator_Polyphase.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.FundamentalWave.Examples.BasicMachines.SynchronousMachines.ComparisonPolyphase.SMPM_Inverter_Polyphase.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.FundamentalWave.Examples.BasicMachines.SynchronousMachines.ComparisonPolyphase.SMR_Inverter_Polyphase.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.QuasiStatic.FluxTubes.Basic.ElectroMagneticConverter.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.QuasiStatic.FluxTubes.Examples.FixedShapes.CuboidSections.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.QuasiStatic.FluxTubes.Interfaces.AbsoluteSensor.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.QuasiStatic.FluxTubes.Interfaces.NegativeMagneticPort.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.QuasiStatic.FluxTubes.Interfaces.PositiveMagneticPort.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.QuasiStatic.FluxTubes.Interfaces.RelativeSensor.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.QuasiStatic.FluxTubes.Sensors.Transient.Permeability.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.QuasiStatic.FundamentalWave.Examples.BasicMachines.InductionMachines.IMC_Conveyor.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.QuasiStatic.FundamentalWave.Examples.BasicMachines.InductionMachines.IMC_Initialize.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.QuasiStatic.FundamentalWave.Examples.BasicMachines.InductionMachines.IMC_Transformer.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.QuasiStatic.FundamentalWave.Examples.BasicMachines.InductionMachines.IMC_YD.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.QuasiStatic.FundamentalWave.Examples.BasicMachines.InductionMachines.IMS_Characteristics.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.QuasiStatic.FundamentalWave.Examples.BasicMachines.SynchronousMachines.SMPM_CurrentSource.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.QuasiStatic.FundamentalWave.Examples.BasicMachines.SynchronousMachines.SMPM_Mains.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.QuasiStatic.FundamentalWave.Examples.BasicMachines.SynchronousMachines.SMPM_OpenCircuit.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Magnetic.QuasiStatic.FundamentalWave.Examples.BasicMachines.SynchronousMachines.SMR_CurrentSource.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Mechanics.MultiBody.Visualizers.Rectangle.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Mechanics.Translational.Components.Mass.
 
Converting name Text.lineColor to Text.textColor
 in Modelica.Mechanics.Translational.Examples.Friction.
 
Converting name Text.lineColor to Text.textColor
 in Modelica.Mechanics.Translational.Examples.SignConvention.
 
Converting name Text.{fillColor,pattern,fillPattern} to nothing
 in Modelica.Units.SI.
```
(There might be few unneeded formatting changes, might clear up.)