### PR TITLE
Fix unit errors in ExternalCombiTimeTable constructor

### DIFF
--- a/Modelica/Blocks/Types.mo
+++ b/Modelica/Blocks/Types.mo
@@ -107,11 +107,11 @@ package Types
       input String tableName "Table name";
       input String fileName "File name";
       input Real table[:, :];
-      input SI.Time startTime;
+      input Real startTimeScaled(unit = "1");
       input Integer columns[:];
       input Modelica.Blocks.Types.Smoothness smoothness;
       input Modelica.Blocks.Types.Extrapolation extrapolation;
-      input SI.Time shiftTime=0.0;
+      input Real shiftTimeScaled(unit = "1")=0.0;
       input Modelica.Blocks.Types.TimeEvents timeEvents=Modelica.Blocks.Types.TimeEvents.Always;
       input Boolean verboseRead=true "= true: Print info message; = false: No info message";
       input String delimiter="," "Column delimiter character for CSV file";
@@ -123,12 +123,12 @@ package Types
             table,
             size(table, 1),
             size(table, 2),
-            startTime,
+            startTimeScaled,
             columns,
             size(columns, 1),
             smoothness,
             extrapolation,
-            shiftTime,
+            shiftTimeScaled,
             timeEvents,
             verboseRead,
             delimiter,

--- a/Modelica/Blocks/Types.mo
+++ b/Modelica/Blocks/Types.mo
@@ -107,11 +107,11 @@ package Types
       input String tableName "Table name";
       input String fileName "File name";
       input Real table[:, :];
-      input Real startTimeScaled(unit = "1");
+      input Real startTime;
       input Integer columns[:];
       input Modelica.Blocks.Types.Smoothness smoothness;
       input Modelica.Blocks.Types.Extrapolation extrapolation;
-      input Real shiftTimeScaled(unit = "1")=0.0;
+      input Real shiftTime=0.0;
       input Modelica.Blocks.Types.TimeEvents timeEvents=Modelica.Blocks.Types.TimeEvents.Always;
       input Boolean verboseRead=true "= true: Print info message; = false: No info message";
       input String delimiter="," "Column delimiter character for CSV file";
@@ -123,12 +123,12 @@ package Types
             table,
             size(table, 1),
             size(table, 2),
-            startTimeScaled,
+            startTime,
             columns,
             size(columns, 1),
             smoothness,
             extrapolation,
-            shiftTimeScaled,
+            shiftTime,
             timeEvents,
             verboseRead,
             delimiter,


### PR DESCRIPTION
The errors are in relation to how the constructor is called in Modelica.Blocks.Sources.CombiTimeTable:
https://github.com/modelica/ModelicaStandardLibrary/blob/ce36c079036c3ade1c2b9f6626daf358ca7fb05f/Modelica/Blocks/Sources.mo#L1639-L1643
