### PR TITLE
Revert adding unit to pi due to regressions

### DIFF
--- a/Modelica/Constants.mo
+++ b/Modelica/Constants.mo
@@ -8,7 +8,7 @@ package Constants
 
   // Mathematical constants
   final constant Real e(final unit="1") = Modelica.Math.exp(1.0);
-  final constant Real pi(final unit="1") = 2*Modelica.Math.asin(1.0); // 3.14159265358979;
+  final constant Real pi = 2*Modelica.Math.asin(1.0); // 3.14159265358979;
   final constant Real D2R(final unit="rad/deg") = pi/180 "Degree to Radian";
   final constant Real R2D(final unit="deg/rad") = 180/pi "Radian to Degree";
   final constant Real gamma(final unit="1") = 0.57721566490153286061


### PR DESCRIPTION
As indicated in #4046 it we need to revert part of #4155 since it is causing too many regressions for a minor release.

With proposed unit-checking in Dymola this reduces the warnings from 2301 to 1224 (Most - but not all are unit-related.)

Obviously many of them could be corrected, but I don't see that we have the resources to focus on that for this minor release. The first models found were CompareTransformers, SeriesResonance in Modelica.Electrical.Analog.Examples.