### PR TITLE
Remove redundant diagram text from Analog examples 

### DIFF
--- a/Modelica/Electrical/Analog/Examples/CauerLowPassAnalog.mo
+++ b/Modelica/Electrical/Analog/Examples/CauerLowPassAnalog.mo
@@ -107,11 +107,7 @@ equation
           extent={{-62,-48},{-58,-52}},
           lineColor={0,0,255},
           fillColor={85,85,255},
-          fillPattern=FillPattern.Solid),
-        Text(
-          extent={{-120,100},{120,80}},
-          textString="CauerLowPassAnalog",
-          textColor={0,0,255})}),
+          fillPattern=FillPattern.Solid)}),
     experiment(StopTime=60),
     Documentation(revisions="<html>
 <ul>

--- a/Modelica/Electrical/Analog/Examples/CauerLowPassOPV.mo
+++ b/Modelica/Electrical/Analog/Examples/CauerLowPassOPV.mo
@@ -252,11 +252,7 @@ equation
           -190}}, color={0,0,255}));
   connect(V.n, R1.p) annotation (Line(points={{-240,-160},{-250,-160},
           {-250,-40},{-240,-40}}, color={0,0,255}));
-  annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-250,
-            -200},{250,200}}), graphics={Text(
-          extent={{-130,172},{80,120}},
-          textString="CauerLowPassOPV",
-          textColor={0,0,255})}),
+  annotation (Diagram(coordinateSystem(preserveAspectRatio = true, extent = {{-250, -200}, {250, 200}})),
     experiment(StopTime=60),
     Documentation(revisions="<html>
 <ul>

--- a/Modelica/Electrical/Analog/Examples/CauerLowPassSC.mo
+++ b/Modelica/Electrical/Analog/Examples/CauerLowPassSC.mo
@@ -263,11 +263,7 @@ equation
       points={{228,60},{234,60},{234,60},{239,60}},     color={0,0,255}));
   connect(R11.p, p4) annotation (Line(
       points={{207.8,60},{190,60},{190,20}}, color={0,0,255}));
-  annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-250,
-            -200},{250,200}}), graphics={Text(
-          extent={{-100,180},{94,140}},
-          textString="CauerLowPassSC",
-          textColor={0,0,255})}),
+  annotation (Diagram(coordinateSystem(preserveAspectRatio = true, extent = {{-250, -200}, {250, 200}})),
     experiment(StopTime=60, Interval=0.04),
     Documentation(revisions="<html>
 <ul>

--- a/Modelica/Electrical/Analog/Examples/CharacteristicIdealDiodes.mo
+++ b/Modelica/Electrical/Analog/Examples/CharacteristicIdealDiodes.mo
@@ -73,11 +73,7 @@ equation
   connect(SineVoltage3.n, Ground1.p)
     annotation (Line(points={{-20,-50},{-20,-60},{-40,-60}}, color={0,0,255}));
   annotation (
-    Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
-            100,100}}), graphics={Text(
-          extent={{-88,102},{92,48}},
-          textString="Characteristic Ideal Diodes",
-          textColor={0,0,255})}),
+    Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}})),
     Documentation(info="<html>
 <p>Three examples of ideal diodes are shown:
 <br>the <strong>totally ideal diode</strong> (Ideal) with all parameters to be zero,

--- a/Modelica/Electrical/Analog/Examples/CharacteristicThyristors.mo
+++ b/Modelica/Electrical/Analog/Examples/CharacteristicThyristors.mo
@@ -83,11 +83,7 @@ equation
       points={{-40,-50},{-40,-40},{-20,-40}}, color={0,0,255}));
   connect(booleanPulse.y, IdealThyristor2.fire) annotation (Line(
       points={{-47,-20},{0,-20},{0,-28}},   color={255,0,255}));
-annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
-            {100,100}}), graphics={Text(
-          extent={{-96,100},{98,60}},
-          textString="Characteristic Thyristors",
-          textColor={0,0,255})}), Documentation(info="<html>
+annotation (Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}})), Documentation(info="<html>
 <p>This example compares the behavior of the <strong>ideal thyristor</strong> and the <strong>ideal GTO thyristor</strong> with <em>Vknee=1</em> both. The thyristors IdealThyristor1 and IdealGTOThyristor1 are controlled by an unregular Boolean fire signal. The aim is to show several cases for the fire signal in combination with the state (s&lt;0 or s&gt;0)of the thyristors. Please simulate until 6 seconds and compare IdealThyristor1.v with IdealGTOThyristor1.v, the same with IdealThyristor1.s and IdealGTOThyristor1.s (attention: s is a protected variable in each thyristor). Also compare IdealThyristor1.off and IdealGTOThyristor1.off and have a look at the fire signal (e.g. IdealThyristor1.fire). It can be seen that the IdealGTOThyristor1 reacts on switching off the fire signal whereas the IdealThyristor1 does not show this behavior.</p>
 <p>The other thyristors IdealThyristor2 and IdealGTOThyristor2 are controlled by an periodic Boolean fire signal to show a typical use case. Please compare IdealThyristor2.v with IdealGTOThyristor2.v</p>
 </html>",

--- a/Modelica/Electrical/Analog/Examples/ChuaCircuit.mo
+++ b/Modelica/Electrical/Analog/Examples/ChuaCircuit.mo
@@ -72,9 +72,5 @@ Christoph Clau&szlig;
 </dl>
 </html>"),
     experiment(StopTime=5e4, Interval=1),
-    Diagram(coordinateSystem(preserveAspectRatio=true,  extent={{-100,-100},{
-            100,100}}), graphics={Text(
-          extent={{-98,104},{-32,72}},
-          textColor={0,0,255},
-          textString="Chua Circuit")}));
+    Diagram(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}})));
 end ChuaCircuit;

--- a/Modelica/Electrical/Analog/Examples/ControlledSwitchWithArc.mo
+++ b/Modelica/Electrical/Analog/Examples/ControlledSwitchWithArc.mo
@@ -75,11 +75,7 @@ equation
       points={{-70,0},{-40,0},{-40,-30},{10,-30}}, color={0,0,255}));
   connect(sineVoltage.n, ground.p) annotation (Line(
       points={{-70,-20},{-70,-40}}, color={0,0,255}));
-  annotation (Diagram(coordinateSystem(preserveAspectRatio=true,  extent={{-100,
-            -100},{100,100}}), graphics={Text(
-          extent={{-100,80},{100,60}},
-          textColor={0,0,255},
-          textString="Compare voltage and current of inductor1 and inductor2")}),
+  annotation (Diagram(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}})),
     experiment(
       StopTime=6,
       Interval=0.00025,

--- a/Modelica/Electrical/Analog/Examples/DifferenceAmplifier.mo
+++ b/Modelica/Electrical/Analog/Examples/DifferenceAmplifier.mo
@@ -127,9 +127,5 @@ Christoph Clau&szlig;
 </dl>
 </html>"),
     experiment(StopTime=1e-8),
-    Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
-            100,100}}), graphics={Text(
-          extent={{-98,106},{22,60}},
-          textColor={0,0,255},
-          textString="Difference Amplifier")}));
+    Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}})));
 end DifferenceAmplifier;

--- a/Modelica/Electrical/Analog/Examples/HeatingMOSInverter.mo
+++ b/Modelica/Electrical/Analog/Examples/HeatingMOSInverter.mo
@@ -85,11 +85,7 @@ equation
       points={{-70,10},{-54,10},{-54,4},{-40,4}}, color={0,0,255}));
   connect(H_PMOS.G, Sin.p) annotation (Line(
       points={{-40,44},{-48,44},{-48,44},{-54,44},{-54,10},{-70,10}}, color={0,0,255}));
-annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-            -100},{100,100}}), graphics={Text(
-          extent={{-100,100},{-6,72}},
-          textString="Heating MOS Inverter",
-          textColor={0,0,255})}), Documentation(info="<html>
+annotation (Diagram(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}})), Documentation(info="<html>
 <p>The heating MOS inverter shows a heat flow always if a transistor is leading.</p>
 <p>Simulate until T=5 s. Plot in separate windows:<br> Sin.p.v and Capacitor1.p.v<br>HeatCapacitor1.port.T and H_PMOS.heatPort.T and H_NMOS.heatPort.T<br>H_PMOS.heatPort.Q_flow and H_NMOS.heatPort.Q_flow</p>
 </html>",

--- a/Modelica/Electrical/Analog/Examples/HeatingNPN_NORGate.mo
+++ b/Modelica/Electrical/Analog/Examples/HeatingNPN_NORGate.mo
@@ -179,11 +179,7 @@ equation
   connect(TC1.port_a, T1.heatPort)
                                  annotation (Line(points={{90,-40},{90,2},{-10,
           2},{-10,48}}, color={191,0,0}));
-annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-            -100},{100,100}}), graphics={Text(
-          extent={{-100,100},{-6,72}},
-          textString="Heating \"NPN NOR\" Gate",
-          textColor={0,0,255})}), Documentation(info="<html>
+annotation (Diagram(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}})), Documentation(info="<html>
 <p>The heating &quot;NPN NOR&quot; gate shows a heat flow always if a transistor is leading.</p>
 <p>Simulate until T=200 s. Plot in separate windows:
 <br>V1.v and V2.v and C2.v

--- a/Modelica/Electrical/Analog/Examples/HeatingPNP_NORGate.mo
+++ b/Modelica/Electrical/Analog/Examples/HeatingPNP_NORGate.mo
@@ -175,11 +175,7 @@ equation
     annotation (Line(points={{60,52},{60,68}}, color={0,0,255}));
   connect(C2.n, Gnd6.p)
     annotation (Line(points={{60,32},{60,26}}, color={0,0,255}));
-annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-            -100},{100,100}}), graphics={Text(
-          extent={{-98,100},{-4,72}},
-          textColor={0,0,255},
-          textString="Heating \"PNP NOR\" Gate")}),
+annotation (Diagram(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}})),
                                   Documentation(info="<html>
 <p>The heating &quot;PNP NOR&quot; gate shows a heat flow always if a transistor is conducting.</p>
 <p>Simulate until T=200 s. Plot V1.v and V2.v and C2.v to see the NOR-functionality. High potential is -6V which means logic &quot;true&quot;. Low potential is 0V which means logic &quot;false&quot;.</p>

--- a/Modelica/Electrical/Analog/Examples/HeatingRectifier.mo
+++ b/Modelica/Electrical/Analog/Examples/HeatingRectifier.mo
@@ -49,11 +49,7 @@ equation
   connect(R.n, Capacitor1.n)
   annotation (Line(points={{40,80},{40,50}}, color={0,0,255}));
 
-annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-            -100},{100,100}}), graphics={Text(
-          extent={{-94,102},{0,74}},
-          textString="HeatingRectifier",
-          textColor={0,0,255})}),
+annotation (Diagram(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}})),
                                 Documentation(info="<html>
 <p>The heating rectifier shows a heat flow always if the electrical capacitor is loaded.</p>
 <p>Simulate until T=5 s.Plot in separate windows:

--- a/Modelica/Electrical/Analog/Examples/NandGate.mo
+++ b/Modelica/Electrical/Analog/Examples/NandGate.mo
@@ -69,9 +69,5 @@ Christoph Clau&szlig;
 </dl>
 </html>"),
     experiment(StopTime=1e-007),
-    Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
-            100,100}}), graphics={Text(
-          extent={{-90,98},{-12,66}},
-          textColor={0,0,255},
-          textString="NAND Gate")}));
+    Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}})));
 end NandGate;

--- a/Modelica/Electrical/Analog/Examples/Rectifier.mo
+++ b/Modelica/Electrical/Analog/Examples/Rectifier.mo
@@ -162,13 +162,9 @@ equation
     annotation (Line(points={{-40,-20},{20,-20},{20,30}}, color={0,0,255}));
 annotation (
   Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
-            100}}), graphics={
-        Text(
-          extent={{-80,90},{80,70}},
-          textString="Rectifier"),
-        Line(points={{-16,18},{-16,2},{-18,6},{-14,6},{-16,2}}),
-        Line(points={{-30,22},{-26,20},{-30,18},{-30,22}}),
-        Line(points={{32,30},{32,-30},{30,-26},{34,-26},{32,-30}}),
+            100}}), graphics={Line(points = {{-16, 18}, {-16, 2}, {-18, 6}, {-14, 6}, {-16, 2}}, thickness = 0.5),
+        Line(points = {{-30, 22}, {-26, 20}, {-30, 18}, {-30, 22}}, thickness = 0.5),
+        Line(points = {{32, 30}, {32, -30}, {30, -26}, {34, -26}, {32, -30}}, thickness = 0.5),
         Text(
           extent={{-38,16},{-22,8}},
           textString="iAC"),

--- a/Modelica/Electrical/Analog/Examples/ShowSaturatingInductor.mo
+++ b/Modelica/Electrical/Analog/Examples/ShowSaturatingInductor.mo
@@ -52,11 +52,7 @@ equation
   connect(Inductance1.n, SineVoltage1.n) annotation (Line(
       points={{20,-10},{20,-16},{-60,-16}}, color={0,0,255}));
   annotation (
-    Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,
-            100}}), graphics={Text(
-          extent={{-80,84},{70,38}},
-          textColor={0,0,255},
-          textString="Show Saturating Inductor")}),
+    Diagram(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}})),
     experiment(StopTime=6.2832, Interval=0.01),
     Documentation(info="<html>
 <p>This simple circuit uses the saturating inductor which has a changing inductance.</p>

--- a/Modelica/Electrical/Analog/Examples/ShowVariableResistor.mo
+++ b/Modelica/Electrical/Analog/Examples/ShowVariableResistor.mo
@@ -60,9 +60,5 @@ annotation (Documentation(info="<html>
 </ul>
 </html>"),
   experiment(StopTime=1),
-    Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
-            100,100}}), graphics={Text(
-          extent={{-100,112},{80,40}},
-          textColor={0,0,255},
-          textString="Example VariableResistor")}));
+    Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}})));
 end ShowVariableResistor;

--- a/Modelica/Electrical/Analog/Examples/SwitchWithArc.mo
+++ b/Modelica/Electrical/Analog/Examples/SwitchWithArc.mo
@@ -67,11 +67,7 @@ equation
           {-40,-20},{-40,60},{10,60},{10,47}}, color={255,0,255}));
   connect(booleanPulse.y, switch2.control) annotation (Line(points={{-59,-20},
           {10,-20},{10,-30}}, color={255,0,255}));
-  annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-            -100},{100,100}}), graphics={Text(
-          extent={{-100,80},{100,60}},
-          textColor={0,0,255},
-          textString="Compare voltage and current of inductor1 and inductor2")}),
+  annotation (Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}})),
     experiment(
       StopTime=2,
       Interval=0.00025,

--- a/Modelica/Electrical/Batteries/Examples/BatteryDischargeCharge.mo
+++ b/Modelica/Electrical/Batteries/Examples/BatteryDischargeCharge.mo
@@ -9,11 +9,12 @@ model BatteryDischargeCharge "Discharge and charge idealized battery"
     Tp=60,
     startTime=60)
     annotation (Placement(transformation(extent={{-80,-10},{-60,10}})));
+  parameter Modelica.Units.SI.Current Isc = 1200 "Short-circuit current of cell at OCVmax";
   parameter Modelica.Electrical.Batteries.ParameterRecords.CellData cellData1(
     Qnom=18000,
     OCVmax=4.2,
     OCVmin=2.5,
-    Ri=cellData1.OCVmax/1200)
+    Ri=cellData1.OCVmax/Isc)
     annotation (Placement(transformation(extent={{60,20},{80,40}})));
   Modelica.Electrical.Batteries.BatteryStacks.CellStack battery1(
     Ns=10,
@@ -38,7 +39,7 @@ model BatteryDischargeCharge "Discharge and charge idealized battery"
   parameter Modelica.Electrical.Batteries.ParameterRecords.TransientData.ExampleData cellData2(
     Qnom=18000,
     useLinearSOCDependency=false,
-    Ri=cellData2.OCVmax/1200,
+    Ri=cellData2.OCVmax/Isc,
     Idis=0.1,
     nRC=2,
     rcData={Modelica.Electrical.Batteries.ParameterRecords.TransientData.RCData(

--- a/Modelica/Electrical/Batteries/Examples/CCCV_Cell.mo
+++ b/Modelica/Electrical/Batteries/Examples/CCCV_Cell.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.Batteries.Examples;
 model CCCV_Cell
   "Charge a cell with constant current - constant voltage characteristic"
   extends Modelica.Icons.Example;
-    parameter Modelica.Units.SI.Current Isc = 1200 "Short-circuit current of cell at OCVmax";
+  parameter Modelica.Units.SI.Current Isc = 1200 "Short-circuit current of cell at OCVmax";
   parameter Modelica.Electrical.Batteries.ParameterRecords.ExampleData cellData(
     Qnom=18000,
     useLinearSOCDependency=false,

--- a/Modelica/Electrical/Batteries/Examples/CCCV_Cell.mo
+++ b/Modelica/Electrical/Batteries/Examples/CCCV_Cell.mo
@@ -2,10 +2,11 @@ within Modelica.Electrical.Batteries.Examples;
 model CCCV_Cell
   "Charge a cell with constant current - constant voltage characteristic"
   extends Modelica.Icons.Example;
+    parameter Modelica.Units.SI.Current Isc = 1200 "Short-circuit current of cell at OCVmax";
   parameter Modelica.Electrical.Batteries.ParameterRecords.ExampleData cellData(
     Qnom=18000,
     useLinearSOCDependency=false,
-    Ri=4.2/1200,
+    Ri=cellData.OCVmax/Isc,
     Idis=0.001) "Cell data"
     annotation (Placement(transformation(extent={{-10,-60},{10,-40}})));
   Modelica.Electrical.Batteries.Utilities.CCCVcharger cccvCharger(I=25, Vend=4.2) annotation (Placement(

--- a/Modelica/Electrical/Batteries/Examples/CCCV_CellRC.mo
+++ b/Modelica/Electrical/Batteries/Examples/CCCV_CellRC.mo
@@ -2,10 +2,11 @@ within Modelica.Electrical.Batteries.Examples;
 model CCCV_CellRC
   "Charge a transient cell with constant current - constant voltage characteristic"
   extends Modelica.Icons.Example;
+  parameter Modelica.Units.SI.Current Isc = 1200 "Short-circuit current of cell at OCVmax";
   parameter Modelica.Electrical.Batteries.ParameterRecords.TransientData.ExampleData cellData(
     Qnom=18000,
     useLinearSOCDependency=false,
-    Ri=4.2/1200,
+    Ri=cellData.OCVmax/Isc,
     Idis=0.001) "Cell data"
     annotation (Placement(transformation(extent={{-10,-60},{10,-40}})));
   Modelica.Electrical.Batteries.Utilities.CCCVcharger cccvCharger(I=25, Vend=4.2) annotation (Placement(

--- a/Modelica/Electrical/Batteries/Examples/CCCV_Stack.mo
+++ b/Modelica/Electrical/Batteries/Examples/CCCV_Stack.mo
@@ -6,13 +6,13 @@ model CCCV_Stack
   parameter Modelica.Electrical.Batteries.ParameterRecords.ExampleData cellDataOriginal(
     Qnom=18000,
     useLinearSOCDependency=false,
-    Ri=cellData.OCVmax/Isc,
+    Ri=cellDataOriginal.OCVmax/Isc,
     Idis=0.001) "Original cell data"
     annotation (Placement(transformation(extent={{-40,-60},{-20,-40}})));
   parameter Modelica.Electrical.Batteries.ParameterRecords.ExampleData cellDataDegraded(
     Qnom=18000,
     useLinearSOCDependency=false,
-    Ri=2*cellData.OCVmax/Isc,
+    Ri=2*cellDataDegraded.OCVmax/Isc,
     Idis=0.001) "Degraded cell data"
     annotation (Placement(transformation(extent={{20,-60},{40,-40}})));
   parameter Modelica.Electrical.Batteries.ParameterRecords.StackData

--- a/Modelica/Electrical/Batteries/Examples/CCCV_Stack.mo
+++ b/Modelica/Electrical/Batteries/Examples/CCCV_Stack.mo
@@ -2,16 +2,17 @@ within Modelica.Electrical.Batteries.Examples;
 model CCCV_Stack
   "Charge a stack with constant current - constant voltage characteristic"
   extends Modelica.Icons.Example;
+  parameter Modelica.Units.SI.Current Isc = 1200 "Short-circuit current of cell at OCVmax";
   parameter Modelica.Electrical.Batteries.ParameterRecords.ExampleData cellDataOriginal(
     Qnom=18000,
     useLinearSOCDependency=false,
-    Ri=4.2/1200,
+    Ri=cellData.OCVmax/Isc,
     Idis=0.001) "Original cell data"
     annotation (Placement(transformation(extent={{-40,-60},{-20,-40}})));
   parameter Modelica.Electrical.Batteries.ParameterRecords.ExampleData cellDataDegraded(
     Qnom=18000,
     useLinearSOCDependency=false,
-    Ri=2*4.2/1200,
+    Ri=2*cellData.OCVmax/Isc,
     Idis=0.001) "Degraded cell data"
     annotation (Placement(transformation(extent={{20,-60},{40,-40}})));
   parameter Modelica.Electrical.Batteries.ParameterRecords.StackData

--- a/Modelica/Electrical/Batteries/Examples/CCCV_StackRC.mo
+++ b/Modelica/Electrical/Batteries/Examples/CCCV_StackRC.mo
@@ -6,13 +6,13 @@ model CCCV_StackRC
   parameter Modelica.Electrical.Batteries.ParameterRecords.TransientData.ExampleData cellDataOriginal(
     Qnom=18000,
     useLinearSOCDependency=false,
-    Ri=cellData.OCVmax/Isc,
+    Ri=cellDataOriginal.OCVmax/Isc,
     Idis=0.001) "Original cell data"
     annotation (Placement(transformation(extent={{-40,-60},{-20,-40}})));
   parameter Modelica.Electrical.Batteries.ParameterRecords.TransientData.ExampleData cellDataDegraded(
     Qnom=18000,
     useLinearSOCDependency=false,
-    Ri=cellData.OCVmax/Isc,
+    Ri=cellDataDegraded.OCVmax/Isc,
     Idis=0.001) "Degraded cell data"
     annotation (Placement(transformation(extent={{20,-60},{40,-40}})));
   parameter Modelica.Electrical.Batteries.ParameterRecords.TransientData.StackData

--- a/Modelica/Electrical/Batteries/Examples/CCCV_StackRC.mo
+++ b/Modelica/Electrical/Batteries/Examples/CCCV_StackRC.mo
@@ -2,16 +2,17 @@ within Modelica.Electrical.Batteries.Examples;
 model CCCV_StackRC
   "Charge a transient stack with constant current - constant voltage characteristic"
   extends Modelica.Icons.Example;
+  parameter Modelica.Units.SI.Current Isc = 1200 "Short-circuit current of cell at OCVmax";
   parameter Modelica.Electrical.Batteries.ParameterRecords.TransientData.ExampleData cellDataOriginal(
     Qnom=18000,
     useLinearSOCDependency=false,
-    Ri=4.2/1200,
+    Ri=cellData.OCVmax/Isc,
     Idis=0.001) "Original cell data"
     annotation (Placement(transformation(extent={{-40,-60},{-20,-40}})));
   parameter Modelica.Electrical.Batteries.ParameterRecords.TransientData.ExampleData cellDataDegraded(
     Qnom=18000,
     useLinearSOCDependency=false,
-    Ri=2*4.2/1200,
+    Ri=cellData.OCVmax/Isc,
     Idis=0.001) "Degraded cell data"
     annotation (Placement(transformation(extent={{20,-60},{40,-40}})));
   parameter Modelica.Electrical.Batteries.ParameterRecords.TransientData.StackData

--- a/Modelica/Electrical/Batteries/Examples/CCCVcharging.mo
+++ b/Modelica/Electrical/Batteries/Examples/CCCVcharging.mo
@@ -3,7 +3,6 @@ model CCCVcharging
   "Charge a battery with constant current - constant voltage characteristic"
   extends Modelica.Icons.Example;
   parameter Modelica.Units.SI.Current Isc = 1200 "Short-circuit current of cell at OCVmax";
-public
   parameter Modelica.Electrical.Batteries.ParameterRecords.TransientData.ExampleData cellData(
     Qnom=18000,
     useLinearSOCDependency=false,

--- a/Modelica/Electrical/Batteries/Examples/CCCVcharging.mo
+++ b/Modelica/Electrical/Batteries/Examples/CCCVcharging.mo
@@ -8,7 +8,7 @@ public
   parameter Modelica.Electrical.Batteries.ParameterRecords.TransientData.ExampleData cellData(
     Qnom=18000,
     useLinearSOCDependency=false,
-    Ri=cellData.OCVmax/RiCurrent,
+    Ri=cellData.OCVmax/Isc,
     Idis=0.001)
     annotation (Placement(transformation(extent={{20,-20},{40,0}})));
   Modelica.Electrical.Batteries.BatteryStacks.CellRCStack battery(

--- a/Modelica/Electrical/Batteries/Examples/CCCVcharging.mo
+++ b/Modelica/Electrical/Batteries/Examples/CCCVcharging.mo
@@ -3,7 +3,7 @@ model CCCVcharging
   "Charge a battery with constant current - constant voltage characteristic"
   extends Modelica.Icons.Example;
 protected
-  parameter Modelica.Units.SI.Current RiCurrent = 1200 "Current relating OCVmax to Ri in cellData";
+  parameter Modelica.Units.SI.Current Isc = 1200 "Short-circuit current of cell at OCVmax";
 public
   parameter Modelica.Electrical.Batteries.ParameterRecords.TransientData.ExampleData cellData(
     Qnom=18000,

--- a/Modelica/Electrical/Batteries/Examples/CCCVcharging.mo
+++ b/Modelica/Electrical/Batteries/Examples/CCCVcharging.mo
@@ -2,10 +2,13 @@ within Modelica.Electrical.Batteries.Examples;
 model CCCVcharging
   "Charge a battery with constant current - constant voltage characteristic"
   extends Modelica.Icons.Example;
+protected
+  parameter Modelica.Units.SI.Current RiCurrent = 1200 "Current relating OCVmax to Ri in cellData";
+public
   parameter Modelica.Electrical.Batteries.ParameterRecords.TransientData.ExampleData cellData(
     Qnom=18000,
     useLinearSOCDependency=false,
-    Ri=cellData.OCVmax/1200,
+    Ri=cellData.OCVmax/RiCurrent,
     Idis=0.001)
     annotation (Placement(transformation(extent={{20,-20},{40,0}})));
   Modelica.Electrical.Batteries.BatteryStacks.CellRCStack battery(

--- a/Modelica/Electrical/Batteries/Examples/CCCVcharging.mo
+++ b/Modelica/Electrical/Batteries/Examples/CCCVcharging.mo
@@ -2,7 +2,6 @@ within Modelica.Electrical.Batteries.Examples;
 model CCCVcharging
   "Charge a battery with constant current - constant voltage characteristic"
   extends Modelica.Icons.Example;
-protected
   parameter Modelica.Units.SI.Current Isc = 1200 "Short-circuit current of cell at OCVmax";
 public
   parameter Modelica.Electrical.Batteries.ParameterRecords.TransientData.ExampleData cellData(


### PR DESCRIPTION
The full description is provided in #4186

Redundant text is removed from analog simulation examples. 