### PR TITLE
Remove redundant diagram text from Analog examples (second attempt)

### DIFF
--- a/Modelica/Electrical/Analog/Examples/CauerLowPassAnalog.mo
+++ b/Modelica/Electrical/Analog/Examples/CauerLowPassAnalog.mo
@@ -107,11 +107,7 @@ equation
           extent={{-62,-48},{-58,-52}},
           lineColor={0,0,255},
           fillColor={85,85,255},
-          fillPattern=FillPattern.Solid),
-        Text(
-          extent={{-120,100},{120,80}},
-          textString="CauerLowPassAnalog",
-          textColor={0,0,255})}),
+          fillPattern=FillPattern.Solid)}),
     experiment(StopTime=60),
     Documentation(revisions="<html>
 <ul>

--- a/Modelica/Electrical/Analog/Examples/CauerLowPassOPV.mo
+++ b/Modelica/Electrical/Analog/Examples/CauerLowPassOPV.mo
@@ -253,10 +253,7 @@ equation
   connect(V.n, R1.p) annotation (Line(points={{-240,-160},{-250,-160},
           {-250,-40},{-240,-40}}, color={0,0,255}));
   annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-250,
-            -200},{250,200}}), graphics={Text(
-          extent={{-130,172},{80,120}},
-          textString="CauerLowPassOPV",
-          textColor={0,0,255})}),
+            -200},{250,200}})),
     experiment(StopTime=60),
     Documentation(revisions="<html>
 <ul>

--- a/Modelica/Electrical/Analog/Examples/CauerLowPassSC.mo
+++ b/Modelica/Electrical/Analog/Examples/CauerLowPassSC.mo
@@ -264,10 +264,7 @@ equation
   connect(R11.p, p4) annotation (Line(
       points={{207.8,60},{190,60},{190,20}}, color={0,0,255}));
   annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-250,
-            -200},{250,200}}), graphics={Text(
-          extent={{-100,180},{94,140}},
-          textString="CauerLowPassSC",
-          textColor={0,0,255})}),
+            -200},{250,200}})),
     experiment(StopTime=60, Interval=0.04),
     Documentation(revisions="<html>
 <ul>

--- a/Modelica/Electrical/Analog/Examples/CharacteristicIdealDiodes.mo
+++ b/Modelica/Electrical/Analog/Examples/CharacteristicIdealDiodes.mo
@@ -74,10 +74,7 @@ equation
     annotation (Line(points={{-20,-50},{-20,-60},{-40,-60}}, color={0,0,255}));
   annotation (
     Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
-            100,100}}), graphics={Text(
-          extent={{-88,102},{92,48}},
-          textString="Characteristic Ideal Diodes",
-          textColor={0,0,255})}),
+            100,100}})),
     Documentation(info="<html>
 <p>Three examples of ideal diodes are shown:
 <br>the <strong>totally ideal diode</strong> (Ideal) with all parameters to be zero,

--- a/Modelica/Electrical/Analog/Examples/CharacteristicThyristors.mo
+++ b/Modelica/Electrical/Analog/Examples/CharacteristicThyristors.mo
@@ -84,10 +84,7 @@ equation
   connect(booleanPulse.y, IdealThyristor2.fire) annotation (Line(
       points={{-47,-20},{0,-20},{0,-28}},   color={255,0,255}));
 annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
-            {100,100}}), graphics={Text(
-          extent={{-96,100},{98,60}},
-          textString="Characteristic Thyristors",
-          textColor={0,0,255})}), Documentation(info="<html>
+            {100,100}})),         Documentation(info="<html>
 <p>This example compares the behavior of the <strong>ideal thyristor</strong> and the <strong>ideal GTO thyristor</strong> with <em>Vknee=1</em> both. The thyristors IdealThyristor1 and IdealGTOThyristor1 are controlled by an unregular Boolean fire signal. The aim is to show several cases for the fire signal in combination with the state (s&lt;0 or s&gt;0)of the thyristors. Please simulate until 6 seconds and compare IdealThyristor1.v with IdealGTOThyristor1.v, the same with IdealThyristor1.s and IdealGTOThyristor1.s (attention: s is a protected variable in each thyristor). Also compare IdealThyristor1.off and IdealGTOThyristor1.off and have a look at the fire signal (e.g. IdealThyristor1.fire). It can be seen that the IdealGTOThyristor1 reacts on switching off the fire signal whereas the IdealThyristor1 does not show this behavior.</p>
 <p>The other thyristors IdealThyristor2 and IdealGTOThyristor2 are controlled by an periodic Boolean fire signal to show a typical use case. Please compare IdealThyristor2.v with IdealGTOThyristor2.v</p>
 </html>",

--- a/Modelica/Electrical/Analog/Examples/ChuaCircuit.mo
+++ b/Modelica/Electrical/Analog/Examples/ChuaCircuit.mo
@@ -73,8 +73,5 @@ Christoph Clau&szlig;
 </html>"),
     experiment(StopTime=5e4, Interval=1),
     Diagram(coordinateSystem(preserveAspectRatio=true,  extent={{-100,-100},{
-            100,100}}), graphics={Text(
-          extent={{-98,104},{-32,72}},
-          textColor={0,0,255},
-          textString="Chua Circuit")}));
+            100,100}})));
 end ChuaCircuit;

--- a/Modelica/Electrical/Analog/Examples/CompareTransformers.mo
+++ b/Modelica/Electrical/Analog/Examples/CompareTransformers.mo
@@ -122,30 +122,24 @@ equation
     annotation (Line(points={{80,-60},{80,-70}}, color={0,0,255}));
   connect(resistor22.n, load2.p)
     annotation (Line(points={{80,-30},{80,-40}}, color={0,0,255}));
-  connect(ground11.p, basicTransformer.n1) annotation (Line(points={{-80,20},
-          {-10,20},{-10,45}}, color={0,0,255}));
-  connect(basicTransformer.n2, ground12.p) annotation (Line(points={{10,45},{10,
+  connect(ground11.p, basicTransformer.n1) annotation (Line(points={{-80,20},{
+          -10,20},{-10,40}},  color={0,0,255}));
+  connect(basicTransformer.n2, ground12.p) annotation (Line(points={{10,40},{10,
           20},{80,20}}, color={0,0,255}));
-  connect(basicTransformer.p1, resistor11.n) annotation (Line(points={{-10,55},
+  connect(basicTransformer.p1, resistor11.n) annotation (Line(points={{-10,60},
           {-10,60},{-60,60}}, color={0,0,255}));
-  connect(basicTransformer.p2, resistor12.p) annotation (Line(points={{10,55},{
+  connect(basicTransformer.p2, resistor12.p) annotation (Line(points={{10,60},{
           10,60},{60,60}}, color={0,0,255}));
-  connect(ground21.p, idealTransformer.n1) annotation (Line(points={{-80,-70},
-          {-10,-70},{-10,-45}}, color={0,0,255}));
+  connect(ground21.p, idealTransformer.n1) annotation (Line(points={{-80,-70},{
+          -10,-70},{-10,-50}},  color={0,0,255}));
   connect(ground22.p, idealTransformer.n2) annotation (Line(points={{80,-70},{
-          10,-70},{10,-45}}, color={0,0,255}));
-  connect(idealTransformer.p1, inductor21.n) annotation (Line(points={{-10,
-          -35},{-10,-30},{-30,-30}}, color={0,0,255}));
-  connect(idealTransformer.p2, inductor22.p) annotation (Line(points={{10,-35},
+          10,-70},{10,-50}}, color={0,0,255}));
+  connect(idealTransformer.p1, inductor21.n) annotation (Line(points={{-10,-30},
+          {-10,-30},{-30,-30}},      color={0,0,255}));
+  connect(idealTransformer.p2, inductor22.p) annotation (Line(points={{10,-30},
           {10,-30},{30,-30}}, color={0,0,255}));
   annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-            -100},{100,100}}), graphics={Text(
-          extent={{-60,-80},{60,-100}},
-          textColor={0,0,255},
-          textString="try considerMagnetization=false/true"), Text(
-          extent={{-60,20},{60,0}},
-          textColor={0,0,255},
-          textString="Basic.Transformer (mutual inductance)")}),
+            -100},{100,100}})),
     experiment(StopTime=50, Interval=0.001),
     Documentation(revisions="<html>
 <dl>

--- a/Modelica/Electrical/Analog/Examples/ControlledSwitchWithArc.mo
+++ b/Modelica/Electrical/Analog/Examples/ControlledSwitchWithArc.mo
@@ -76,10 +76,7 @@ equation
   connect(sineVoltage.n, ground.p) annotation (Line(
       points={{-70,-20},{-70,-40}}, color={0,0,255}));
   annotation (Diagram(coordinateSystem(preserveAspectRatio=true,  extent={{-100,
-            -100},{100,100}}), graphics={Text(
-          extent={{-100,80},{100,60}},
-          textColor={0,0,255},
-          textString="Compare voltage and current of inductor1 and inductor2")}),
+            -100},{100,100}})),
     experiment(
       StopTime=6,
       Interval=0.00025,

--- a/Modelica/Electrical/Analog/Examples/DifferenceAmplifier.mo
+++ b/Modelica/Electrical/Analog/Examples/DifferenceAmplifier.mo
@@ -128,8 +128,5 @@ Christoph Clau&szlig;
 </html>"),
     experiment(StopTime=1e-8),
     Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
-            100,100}}), graphics={Text(
-          extent={{-98,106},{22,60}},
-          textColor={0,0,255},
-          textString="Difference Amplifier")}));
+            100,100}})));
 end DifferenceAmplifier;

--- a/Modelica/Electrical/Analog/Examples/HeatingMOSInverter.mo
+++ b/Modelica/Electrical/Analog/Examples/HeatingMOSInverter.mo
@@ -86,10 +86,7 @@ equation
   connect(H_PMOS.G, Sin.p) annotation (Line(
       points={{-40,44},{-48,44},{-48,44},{-54,44},{-54,10},{-70,10}}, color={0,0,255}));
 annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-            -100},{100,100}}), graphics={Text(
-          extent={{-100,100},{-6,72}},
-          textString="Heating MOS Inverter",
-          textColor={0,0,255})}), Documentation(info="<html>
+            -100},{100,100}})),   Documentation(info="<html>
 <p>The heating MOS inverter shows a heat flow always if a transistor is leading.</p>
 <p>Simulate until T=5 s. Plot in separate windows:<br> Sin.p.v and Capacitor1.p.v<br>HeatCapacitor1.port.T and H_PMOS.heatPort.T and H_NMOS.heatPort.T<br>H_PMOS.heatPort.Q_flow and H_NMOS.heatPort.Q_flow</p>
 </html>",

--- a/Modelica/Electrical/Analog/Examples/HeatingNPN_NORGate.mo
+++ b/Modelica/Electrical/Analog/Examples/HeatingNPN_NORGate.mo
@@ -180,10 +180,7 @@ equation
                                  annotation (Line(points={{90,-40},{90,2},{-10,
           2},{-10,48}}, color={191,0,0}));
 annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-            -100},{100,100}}), graphics={Text(
-          extent={{-100,100},{-6,72}},
-          textString="Heating \"NPN NOR\" Gate",
-          textColor={0,0,255})}), Documentation(info="<html>
+            -100},{100,100}})),   Documentation(info="<html>
 <p>The heating &quot;NPN NOR&quot; gate shows a heat flow always if a transistor is leading.</p>
 <p>Simulate until T=200 s. Plot in separate windows:
 <br>V1.v and V2.v and C2.v

--- a/Modelica/Electrical/Analog/Examples/HeatingPNP_NORGate.mo
+++ b/Modelica/Electrical/Analog/Examples/HeatingPNP_NORGate.mo
@@ -176,11 +176,7 @@ equation
   connect(C2.n, Gnd6.p)
     annotation (Line(points={{60,32},{60,26}}, color={0,0,255}));
 annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-            -100},{100,100}}), graphics={Text(
-          extent={{-98,100},{-4,72}},
-          textColor={0,0,255},
-          textString="Heating \"PNP NOR\" Gate")}),
-                                  Documentation(info="<html>
+            -100},{100,100}})),   Documentation(info="<html>
 <p>The heating &quot;PNP NOR&quot; gate shows a heat flow always if a transistor is conducting.</p>
 <p>Simulate until T=200 s. Plot V1.v and V2.v and C2.v to see the NOR-functionality. High potential is -6V which means logic &quot;true&quot;. Low potential is 0V which means logic &quot;false&quot;.</p>
 <p>To see which transistor is conducting one can have a look at the temperatures T1.heatPort.T and T2.heatPort.T and the heat flows T1.heatPort.Q_flow and T2.heatPort.Q_flow of the heatports of the transistors T1 and T2.</p>

--- a/Modelica/Electrical/Analog/Examples/HeatingRectifier.mo
+++ b/Modelica/Electrical/Analog/Examples/HeatingRectifier.mo
@@ -50,11 +50,7 @@ equation
   annotation (Line(points={{40,80},{40,50}}, color={0,0,255}));
 
 annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-            -100},{100,100}}), graphics={Text(
-          extent={{-94,102},{0,74}},
-          textString="HeatingRectifier",
-          textColor={0,0,255})}),
-                                Documentation(info="<html>
+            -100},{100,100}})), Documentation(info="<html>
 <p>The heating rectifier shows a heat flow always if the electrical capacitor is loaded.</p>
 <p>Simulate until T=5 s.Plot in separate windows:
 <br>SineVoltage1.v and Capacitor1.p.v

--- a/Modelica/Electrical/Analog/Examples/NandGate.mo
+++ b/Modelica/Electrical/Analog/Examples/NandGate.mo
@@ -70,8 +70,5 @@ Christoph Clau&szlig;
 </html>"),
     experiment(StopTime=1e-007),
     Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
-            100,100}}), graphics={Text(
-          extent={{-90,98},{-12,66}},
-          textColor={0,0,255},
-          textString="NAND Gate")}));
+            100,100}})));
 end NandGate;

--- a/Modelica/Electrical/Analog/Examples/Rectifier.mo
+++ b/Modelica/Electrical/Analog/Examples/Rectifier.mo
@@ -163,9 +163,6 @@ equation
 annotation (
   Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
             100}}), graphics={
-        Text(
-          extent={{-80,90},{80,70}},
-          textString="Rectifier"),
         Line(points={{-16,18},{-16,2},{-18,6},{-14,6},{-16,2}}),
         Line(points={{-30,22},{-26,20},{-30,18},{-30,22}}),
         Line(points={{32,30},{32,-30},{30,-26},{34,-26},{32,-30}}),

--- a/Modelica/Electrical/Analog/Examples/ShowSaturatingInductor.mo
+++ b/Modelica/Electrical/Analog/Examples/ShowSaturatingInductor.mo
@@ -53,10 +53,7 @@ equation
       points={{20,-10},{20,-16},{-60,-16}}, color={0,0,255}));
   annotation (
     Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,
-            100}}), graphics={Text(
-          extent={{-80,84},{70,38}},
-          textColor={0,0,255},
-          textString="Show Saturating Inductor")}),
+            100}})),
     experiment(StopTime=6.2832, Interval=0.01),
     Documentation(info="<html>
 <p>This simple circuit uses the saturating inductor which has a changing inductance.</p>

--- a/Modelica/Electrical/Analog/Examples/ShowVariableResistor.mo
+++ b/Modelica/Electrical/Analog/Examples/ShowVariableResistor.mo
@@ -61,8 +61,5 @@ annotation (Documentation(info="<html>
 </html>"),
   experiment(StopTime=1),
     Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
-            100,100}}), graphics={Text(
-          extent={{-100,112},{80,40}},
-          textColor={0,0,255},
-          textString="Example VariableResistor")}));
+            100,100}})));
 end ShowVariableResistor;

--- a/Modelica/Electrical/Analog/Examples/SwitchWithArc.mo
+++ b/Modelica/Electrical/Analog/Examples/SwitchWithArc.mo
@@ -63,15 +63,12 @@ equation
     annotation (Line(points={{20,-40},{40,-40}}, color={0,0,255}));
   connect(constantVoltage2.p,switch2. p) annotation (Line(points={{-20,-50},{
           -20,-40},{0,-40}}, color={0,0,255}));
-  connect(booleanPulse.y, switch1.control) annotation (Line(points={{-59,-20},
-          {-40,-20},{-40,60},{10,60},{10,47}}, color={255,0,255}));
-  connect(booleanPulse.y, switch2.control) annotation (Line(points={{-59,-20},
-          {10,-20},{10,-30}}, color={255,0,255}));
+  connect(booleanPulse.y, switch1.control) annotation (Line(points={{-59,-20},{
+          -40,-20},{-40,60},{10,60},{10,52}},  color={255,0,255}));
+  connect(booleanPulse.y, switch2.control) annotation (Line(points={{-59,-20},{
+          10,-20},{10,-29}},  color={255,0,255}));
   annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-            -100},{100,100}}), graphics={Text(
-          extent={{-100,80},{100,60}},
-          textColor={0,0,255},
-          textString="Compare voltage and current of inductor1 and inductor2")}),
+            -100},{100,100}})),
     experiment(
       StopTime=2,
       Interval=0.00025,


### PR DESCRIPTION
This PR replaces #4205.

The full description is provided in https://github.com/modelica/ModelicaStandardLibrary/issues/4186

Redundant text is removed from Analog simulation examples.