### PR TITLE
Bump used Modelica language version to 3.6 for MapleSim moparser (CI)

### DIFF
--- a/.github/workflows/checkCI.yml
+++ b/.github/workflows/checkCI.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Check syntax
         run: |
           echo "::add-matcher::./.github/moparser.json"
-          ModelicaSyntaxChecker/Linux64/moparser -v 3.4 -r Complex.mo Modelica ModelicaReference ModelicaServices ModelicaTest ModelicaTestConversion4.mo ModelicaTestOverdetermined.mo ObsoleteModelica4.mo
+          ModelicaSyntaxChecker/Linux64/moparser -v 3.6 -r Complex.mo Modelica ModelicaReference ModelicaServices ModelicaTest ModelicaTestConversion4.mo ModelicaTestOverdetermined.mo ObsoleteModelica4.mo
           echo "::remove-matcher owner=moparser::"
   deprecation_checks:
     timeout-minutes: 5


### PR DESCRIPTION
According to #4175 this should not be merged right now.