### PR TITLE
R_s for each ideal gas record now calculated with R_NASA

### DIFF
--- a/Modelica/Media/IdealGases/Common/SingleGasesData.mo
+++ b/Modelica/Media/IdealGases/Common/SingleGasesData.mo
@@ -13,7 +13,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-330992.637,982.0086420000001,1.381179917,0.0006170899989999999,-1.6881146e-007,
         2.008826848e-011,-5.627285655e-016},
     bhigh={27267.19171,14.56862733},
-    R_s=77.07991789980736);
+    R_s=77.08027018157344);
 
   constant IdealGases.Common.DataRecord Agplus(
     name="Agplus",
@@ -27,7 +27,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-53274323.49999999,131071.0631,-109.8820208,0.0482600276,-1.093661557e-005,
         1.26383591e-009,-5.852542535e-014},
     bhigh={-743912.2509999999,844.6266189999999},
-    R_s=77.08030991764042);
+    R_s=77.08066220119817);
 
   constant IdealGases.Common.DataRecord Agminus(
     name="Agminus",
@@ -39,7 +39,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={17665.65919,5.8696798},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={17665.65919,5.8696798},
-    R_s=77.07952588596174);
+    R_s=77.07987816593619);
 
   constant IdealGases.Common.DataRecord Air(
     name="Air",
@@ -53,7 +53,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={241521.443,-1257.8746,5.14455867,-0.000213854179,7.06522784e-008,-1.07148349e-011,
         6.57780015e-016},
     bhigh={6462.26319,-8.147411905},
-    R_s=287.0512249529787);
+    R_s=287.0525368759184);
 
   constant IdealGases.Common.DataRecord AL(
     name="AL",
@@ -67,7 +67,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-29208.20938,116.7751876,2.356906505,7.73723152e-005,-1.529455262e-008,
         -9.97167026e-013,5.053278264e-016},
     bhigh={38232.8865,6.600920155},
-    R_s=308.1541163442944);
+    R_s=308.1555247147142);
 
   constant IdealGases.Common.DataRecord ALplus(
     name="ALplus",
@@ -80,7 +80,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4181.18325,-9.94855727,2.548615878,-5.878760040000001e-005,
         3.132291294e-008,-7.74889463e-012,7.27444769e-016},
     bhigh={109101.1485,3.48866729},
-    R_s=308.1603819910326);
+    R_s=308.1617903900885);
 
   constant IdealGases.Common.DataRecord ALminus(
     name="ALminus",
@@ -94,7 +94,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={633981.432,-2383.438463,5.46997113,-0.001299840355,2.88830547e-007,-3.25324051e-011,
         1.472436088e-015},
     bhigh={47803.0654,-15.36906816},
-    R_s=308.1478509523426);
+    R_s=308.1492592941274);
 
   constant IdealGases.Common.DataRecord ALBr(
     name="ALBr",
@@ -108,7 +108,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-610339.5599999999,2010.066834,1.769617961,0.001929888914,-6.64104783e-007,
         1.172854627e-010,-7.17874276e-015},
     bhigh={-12178.12867,22.04450764},
-    R_s=77.7885591968485);
+    R_s=77.7889147173493);
 
   constant IdealGases.Common.DataRecord ALBr2(
     name="ALBr2",
@@ -122,7 +122,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-352378.29,467.154417,7.11190819,-0.00055517092,3.16630113e-007,-5.52102833e-011,
         3.17672595e-015},
     bhigh={-22650.04078,-2.69561036},
-    R_s=44.51251440003026);
+    R_s=44.51271783754827);
 
   constant IdealGases.Common.DataRecord ALBr3(
     name="ALBr3",
@@ -136,7 +136,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-89355.2744,-26.78035134,10.02063997,-8.458764399999999e-006,
         1.904243317e-009,-2.215195785e-013,1.038219389e-017},
     bhigh={-52492.4764,-15.79666403},
-    R_s=31.17612845947546);
+    R_s=31.17627094511754);
 
   constant IdealGases.Common.DataRecord ALC(
     name="ALC",
@@ -150,7 +150,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1937001.487,-6749.117789999999,13.47525643,-0.00585080265,
         1.926461091e-006,-2.585922351e-010,1.222659806e-014},
     bhigh={122536.3649,-61.52244872},
-    R_s=213.2340287828567);
+    R_s=213.2350033357921);
 
   constant IdealGases.Common.DataRecord ALC2(
     name="ALC2",
@@ -164,7 +164,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={146601.7895,-1362.764489,8.457759149999999,-0.000367890168,
         7.9031745e-008,-8.880023720000001e-012,4.05363395e-016},
     bhigh={87059.24230000001,-21.27956728},
-    R_s=163.019471544953);
+    R_s=163.020216600071);
 
   constant IdealGases.Common.DataRecord ALCL(
     name="ALCL",
@@ -178,7 +178,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-899346.1220000001,2765.942061,1.003500696,0.002267806833,-7.2805416e-007,
         1.182380673e-010,-6.66049813e-015},
     bhigh={-24961.64448,26.1692548},
-    R_s=133.1710342759323);
+    R_s=133.1716429134144);
 
   constant IdealGases.Common.DataRecord ALCLplus(
     name="ALCLplus",
@@ -192,7 +192,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-754724.0819999999,1251.545253,4.44242491,-0.0009786116429999999,
         6.347511329999999e-007,-1.158320344e-010,6.870022460000001e-015},
     bhigh={93183.32699999999,4.047521108},
-    R_s=133.1722044338881);
+    R_s=133.1728130767181);
 
   constant IdealGases.Common.DataRecord ALCL2(
     name="ALCL2",
@@ -206,7 +206,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={430345.306,-1552.370585,8.760657419999999,-0.0009467450059999999,
         2.40184488e-007,-2.427836709e-011,8.390123470000001e-016},
     bhigh={-21458.84709,-18.03641668},
-    R_s=84.93902461823076);
+    R_s=84.93941281882071);
 
   constant IdealGases.Common.DataRecord ALCL3(
     name="ALCL3",
@@ -220,7 +220,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-137863.0916,-55.7920729,10.04190387,-1.682165339e-005,
         3.72466466e-009,-4.27552678e-013,1.982341329e-017},
     bhigh={-73434.0747,-20.45130429},
-    R_s=62.35517063835456);
+    R_s=62.35545562295541);
 
   constant IdealGases.Common.DataRecord ALF(
     name="ALF",
@@ -234,7 +234,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-711122.905,1903.013316,2.191607179,0.001421471467,-4.17963477e-007,
         6.1538044e-011,-2.945403999e-015},
     bhigh={-45407.2896,16.13163743},
-    R_s=180.8282434254179);
+    R_s=180.8290698727558);
 
   constant IdealGases.Common.DataRecord ALFplus(
     name="ALFplus",
@@ -248,7 +248,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1505101.126,-2236.668821,3.098216724,0.00311541393,-1.168427068e-006,
         1.773587168e-010,-9.665841379999999e-015},
     bhigh={98850.8385,5.99189459},
-    R_s=180.8304009653229);
+    R_s=180.8312274225215);
 
   constant IdealGases.Common.DataRecord ALFCL(
     name="ALFCL",
@@ -262,7 +262,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={69706.36350000001,-622.4485910000001,7.57347541,-0.0002236155999,
         2.382317949e-008,4.44378576e-012,-5.486977849999999e-016},
     bhigh={-51009.43199999999,-10.91164505},
-    R_s=102.1020716859482);
+    R_s=102.1025383275730);
 
   constant IdealGases.Common.DataRecord ALFCL2(
     name="ALFCL2",
@@ -276,7 +276,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-172036.0526,-119.3340759,10.08894431,-3.55099381e-005,
         7.83095261e-009,-8.961734229999999e-013,4.14533026e-017},
     bhigh={-98041.8547,-21.27046859},
-    R_s=71.13320827671959);
+    R_s=71.13353337997505);
 
   constant IdealGases.Common.DataRecord ALF2(
     name="ALF2",
@@ -290,7 +290,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-214689.6245,30.9684015,6.81639962,0.0001820129379,-7.79367744e-008,
         1.472534201e-011,-8.803695299999999e-016},
     bhigh={-78840.02680000001,-7.915370474},
-    R_s=127.9575845887511);
+    R_s=127.9581693989729);
 
   constant IdealGases.Common.DataRecord ALF2minus(
     name="ALF2minus",
@@ -304,7 +304,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-159007.6965,-206.0486516,7.15528938,-6.260167690000001e-005,
         1.391935746e-008,-1.603901265e-012,7.461508519999999e-017},
     bhigh={-104047.9429,-11.22696648},
-    R_s=127.9565042759347);
+    R_s=127.9570890812191);
 
   constant IdealGases.Common.DataRecord ALF2CL(
     name="ALF2CL",
@@ -318,7 +318,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-211542.2988,-195.9188681,10.1457685,-5.81321935e-005,
         1.281071982e-008,-1.465366277e-012,6.77600245e-017},
     bhigh={-122715.311,-23.59853398},
-    R_s=82.78762023621782);
+    R_s=82.78799860414892);
 
   constant IdealGases.Common.DataRecord ALF3(
     name="ALF3",
@@ -332,7 +332,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-249397.216,-291.1202519,10.21662932,-8.64298597e-005,
         1.905713108e-008,-2.181058411e-012,1.009055287e-016},
     bhigh={-147569.4276,-27.03983244},
-    R_s=99.00921668940654);
+    R_s=99.00966919561910);
 
   constant IdealGases.Common.DataRecord ALF4minus(
     name="ALF4minus",
@@ -346,7 +346,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-321741.161,-261.2097043,13.19792654,-8.01013541e-005,
         1.786204421e-008,-2.062751964e-012,9.61258177e-017},
     bhigh={-238157.7915,-42.31634321999999},
-    R_s=80.74207845584199);
+    R_s=80.74244747494282);
 
   constant IdealGases.Common.DataRecord ALH(
     name="ALH",
@@ -360,7 +360,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6802018.430000001,-21784.16933,30.32713047,-0.01503343597,
         4.49214236e-006,-6.17845037e-010,3.11520526e-014},
     bhigh={165830.1221,-187.6766425},
-    R_s=297.0570583702919);
+    R_s=297.0584160233356);
 
   constant IdealGases.Common.DataRecord ALHCL(
     name="ALHCL",
@@ -374,7 +374,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-168391.533,-886.230179,8.062379399999999,-0.0009200551470000001,
         3.94981722e-007,-6.40108676e-011,3.5783541e-015},
     bhigh={3641.50485,-18.00686894},
-    R_s=131.0552844420737);
+    R_s=131.0558834098504);
 
   constant IdealGases.Common.DataRecord ALHCL2(
     name="ALHCL2",
@@ -388,7 +388,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={96080.63939999999,-1485.540161,11.03592709,-0.00039569552,
         8.46584373e-008,-9.48333652e-012,4.31903353e-016},
     bhigh={-36692.1639,-32.36862171},
-    R_s=84.07332840840307);
+    R_s=84.07371265246324);
 
   constant IdealGases.Common.DataRecord ALHF(
     name="ALHF",
@@ -402,7 +402,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={734216.9250000001,-3462.16413,10.39714588,-0.001750737965,
         4.615687860000001e-007,-5.39041474e-011,2.340478515e-015},
     bhigh={-2965.279722,-37.13172313},
-    R_s=176.9492853829723);
+    R_s=176.9500941021363);
 
   constant IdealGases.Common.DataRecord ALHFCL(
     name="ALHFCL",
@@ -416,7 +416,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={40689.8713,-1502.129854,11.05214126,-0.000403158773,8.64525222e-008,
         -9.70065952e-012,4.423629509999999e-016},
     bhigh={-61298.8811,-34.03564016},
-    R_s=100.8537497292059);
+    R_s=100.8542106655696);
 
   constant IdealGases.Common.DataRecord ALHF2(
     name="ALHF2",
@@ -430,7 +430,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4419.9473,-1612.826324,11.13336052,-0.000435181266,9.34439616e-008,
         -1.049431425e-011,4.78833398e-016},
     bhigh={-86069.16189999999,-36.76383785},
-    R_s=126.0030334425073);
+    R_s=126.0036093197574);
 
   constant IdealGases.Common.DataRecord ALH2(
     name="ALH2",
@@ -444,7 +444,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={143291.0601,-2365.907684,9.085667190000001,-0.001308536612,
         4.77719136e-007,-7.32472189e-011,3.99790094e-015},
     bhigh={44859.5185,-32.20814285},
-    R_s=286.7314600217164);
+    R_s=286.7327704832203);
 
   constant IdealGases.Common.DataRecord ALH2CL(
     name="ALH2CL",
@@ -458,7 +458,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={316692.993,-3094.037914,12.1587202,-0.0008248269589999999,
         1.765027123e-007,-1.977372723e-011,9.00617628e-016},
     bhigh={2411.845642,-47.18390855},
-    R_s=129.0057110257997);
+    R_s=129.0063006263202);
 
   constant IdealGases.Common.DataRecord ALH2F(
     name="ALH2F",
@@ -472,7 +472,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={271151.4962,-3169.62348,12.21401118,-0.000846560026,1.812341995e-007,
         -2.030947985e-011,9.251825820000001e-016},
     bhigh={-22592.17746,-49.41337333},
-    R_s=173.2332480645211);
+    R_s=173.2340398001149);
 
   constant IdealGases.Common.DataRecord ALH3(
     name="ALH3",
@@ -486,7 +486,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={588545.855,-4595.78566,13.20893344,-0.001226849004,2.626580824e-007,
         -2.943725869e-011,1.341177648e-015},
     bhigh={39917.1695,-61.81829295},
-    R_s=277.0995766822712);
+    R_s=277.1008431227516);
 
   constant IdealGases.Common.DataRecord ALI(
     name="ALI",
@@ -500,7 +500,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={475281.792,-1198.028588,5.43368536,-0.0001004479306,-1.005928846e-007,
         4.568173190000001e-011,-3.960201360000001e-015},
     bhigh={14646.27816,-3.141199746},
-    R_s=54.03007140194319);
+    R_s=54.03031833797392);
 
   constant IdealGases.Common.DataRecord ALI2(
     name="ALI2",
@@ -514,7 +514,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-335599.902,474.334794,7.10650139,-0.0005529965340000001,
         3.161480314e-007,-5.51548916e-011,3.17415582e-015},
     bhigh={-9785.48885,-0.5602275943999999},
-    R_s=29.61094713475291);
+    R_s=29.61108246697739);
 
   constant IdealGases.Common.DataRecord ALI3(
     name="ALI3",
@@ -528,7 +528,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-63574.2747,-15.7877228,10.01249733,-5.22867312e-006,1.19617352e-009,
         -1.40919449e-013,6.67127639e-018},
     bhigh={-26114.55525,-12.47999813},
-    R_s=20.39385584930034);
+    R_s=20.39394905624389);
 
   constant IdealGases.Common.DataRecord ALN(
     name="ALN",
@@ -542,7 +542,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3821214.22,-10677.76595,14.49174222,-0.00372722713,
         7.922770960000001e-007,-8.086892210000001e-011,2.893539736e-015},
     bhigh={120523.634,-72.88585119000001},
-    R_s=202.8501932676394);
+    R_s=202.8511203628709);
 
   constant IdealGases.Common.DataRecord ALO(
     name="ALO",
@@ -556,7 +556,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={15657.21161,3855.74101,-5.92607978,0.009050960419999999,-2.930661549e-006,
         4.238529070000001e-010,-2.280655341e-014},
     bhigh={-13316.94655,68.30663436},
-    R_s=193.4455688240215);
+    R_s=193.4464529368810);
 
   constant IdealGases.Common.DataRecord ALOplus(
     name="ALOplus",
@@ -570,7 +570,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={27108.46446,-699.8653420000001,5.78781584,-0.000687189546,
         2.075047303e-007,-2.655281004e-011,1.28312966e-015},
     bhigh={121868.2226,-7.05103588},
-    R_s=193.4480379556543);
+    R_s=193.4489220797986);
 
   constant IdealGases.Common.DataRecord ALOminus(
     name="ALOminus",
@@ -584,7 +584,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-69719.4829,-232.0553036,4.67278433,-4.26644704e-005,
         1.632506336e-008,-1.727134051e-012,8.136840640000001e-017},
     bhigh={-33077.1893,-2.155922595},
-    R_s=193.4430997554189);
+    R_s=193.4439838569940);
 
   constant IdealGases.Common.DataRecord ALOCL(
     name="ALOCL",
@@ -598,7 +598,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-125802.7706,-242.0565961,7.68113002,-7.268741699999999e-005,
         1.611337534e-008,1.852889749e-012,8.60727822e-017},
     bhigh={-37543.2605,-14.7581832},
-    R_s=106.0060505950881);
+    R_s=106.0065350792408);
 
   constant IdealGases.Common.DataRecord ALOCL2(
     name="ALOCL2",
@@ -612,7 +612,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-170771.3922,-118.0013804,10.08798517,-3.51385804e-005,
         7.751187029999999e-009,-8.8724706e-013,4.10481544e-017},
     bhigh={-51249.4414,-20.5925296},
-    R_s=73.00637058132162);
+    R_s=73.00670424557380);
 
   constant IdealGases.Common.DataRecord ALOF(
     name="ALOF",
@@ -626,7 +626,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-164102.0297,-327.777029,7.74451974,-9.78864944e-005,
         2.165743208e-008,-2.486541919e-012,1.153633944e-016},
     bhigh={-69740.85090000001,-17.17253748},
-    R_s=134.1490864378533);
+    R_s=134.1496995453705);
 
   constant IdealGases.Common.DataRecord ALOF2(
     name="ALOF2",
@@ -640,7 +640,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-249668.1413,-283.7821503,10.21108125,-8.418303430000001e-005,
         1.855520828e-008,-2.122974022e-012,9.8193191e-017},
     bhigh={-95218.0419,-25.22534812},
-    R_s=102.6760137813866);
+    R_s=102.6764830461244);
 
   constant IdealGases.Common.DataRecord ALOF2minus(
     name="ALOF2minus",
@@ -654,7 +654,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-238988.1459,-288.0143725,10.2170024,-8.747061999999999e-005,
         1.944846334e-008,-2.241045051e-012,1.042591053e-016},
     bhigh={-119057.6566,-26.00779629},
-    R_s=102.6753181868134);
+    R_s=102.6757874483721);
 
   constant IdealGases.Common.DataRecord ALOH(
     name="ALOH",
@@ -668,7 +668,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={788206.811,-2263.671626,7.82395488,0.0001821171456,-8.26372932e-008,
         1.265414876e-011,-6.87597253e-016},
     bhigh={-10398.08093,-22.09032458},
-    R_s=189.0130500714294);
+    R_s=189.0139139261520);
 
   constant IdealGases.Common.DataRecord ALOHCL(
     name="ALOHCL",
@@ -682,7 +682,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={796711.551,-2843.470502,10.9555997,-0.0001099328162,-1.344506283e-008,
         4.41589377e-012,-2.973546112e-016},
     bhigh={-29698.61461,-32.96113996},
-    R_s=104.661070575396);
+    R_s=104.661548912527);
 
   constant IdealGases.Common.DataRecord ALOHCL2(
     name="ALOHCL2",
@@ -696,7 +696,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={738592.976,-2863.204228,13.97062327,-0.0001160311527,-1.208248796e-008,
         4.25832763e-012,-2.900049181e-016},
     bhigh={-72930.48,-46.81834857},
-    R_s=72.36590651151568);
+    R_s=72.36623724862652);
 
   constant IdealGases.Common.DataRecord ALOHF(
     name="ALOHF",
@@ -710,7 +710,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={755711.3130000001,-2936.702803,11.02455104,-0.000137307803,-7.432816159999999e-009,
         3.72998122e-012,-2.657027781e-016},
     bhigh={-53401.309,-35.27397302},
-    R_s=132.0023954296348);
+    R_s=132.0029987260349);
 
   constant IdealGases.Common.DataRecord ALOHF2(
     name="ALOHF2",
@@ -724,7 +724,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={653011.992,-3034.017232,14.09719788,-0.0001663681799,-1.011564183e-009,
         2.993805003e-012,-2.315956955e-016},
     bhigh={-122305.2213,-51.5121069},
-    R_s=101.4137048540635);
+    R_s=101.4141683496150);
 
   constant IdealGases.Common.DataRecord ALO2(
     name="ALO2",
@@ -738,7 +738,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={118721.6642,-833.56254,8.309301189999999,-0.000353866722,
         5.96706946e-008,4.0148977e-014,-3.51570252e-016},
     bhigh={-2033.107586,-17.15063884},
-    R_s=140.9702331648218);
+    R_s=140.9708774473283);
 
   constant IdealGases.Common.DataRecord ALO2minus(
     name="ALO2minus",
@@ -752,7 +752,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-187241.0758,-233.8853263,7.67607002,-7.093570299999999e-005,
         1.576717569e-008,-1.816494162e-012,8.449707959999999e-017},
     bhigh={-55946.40560000001,-17.73751567},
-    R_s=140.9689219558121);
+    R_s=140.9695662323259);
 
   constant IdealGases.Common.DataRecord AL_OH_2(
     name="AL_OH_2",
@@ -766,7 +766,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1669643.735,-5924.73828,15.49480264,-0.000538348808,
         5.413044529999999e-008,-1.196022328e-012,-1.082001733e-016},
     bhigh={-26975.25061,-66.17911543},
-    R_s=136.3112709709314);
+    R_s=136.3118939603764);
 
   constant IdealGases.Common.DataRecord AL_OH_2CL(
     name="AL_OH_2CL",
@@ -780,7 +780,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1603911.487,-5767.23224,18.17772266,-0.000369181615,1.137918702e-008,
         4.0830794e-012,-3.64132343e-016},
     bhigh={-71186.9985,-77.57541774000001},
-    R_s=86.20569634893255);
+    R_s=86.20609033864847);
 
   constant IdealGases.Common.DataRecord AL_OH_2F(
     name="AL_OH_2F",
@@ -794,7 +794,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1559238.236,-5841.27303,18.23229919,-0.000390780542,1.610928938e-008,
         3.54478406e-012,-3.39345388e-016},
     bhigh={-96231.0089,-79.71351802},
-    R_s=103.9378882639174);
+    R_s=103.9383632958562);
 
   constant IdealGases.Common.DataRecord AL_OH_3(
     name="AL_OH_3",
@@ -808,7 +808,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2477063.616,-8968.617249999999,22.80320998,-0.0008320292249999999,
         8.66349443e-008,-2.420287082e-012,-1.331746442e-016},
     bhigh={-70152.7864,-112.1899198},
-    R_s=106.5909326854039);
+    R_s=106.5914198426692);
 
   constant IdealGases.Common.DataRecord ALS(
     name="ALS",
@@ -822,7 +822,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={8909844.290000001,-25076.77454,28.93456134,-0.00983976682,
         2.045319809e-006,-2.08797089e-010,8.152792520000001e-015},
     bhigh={188576.1615,-178.6036457},
-    R_s=140.8121844501705);
+    R_s=140.8128280103399);
 
   constant IdealGases.Common.DataRecord ALS2(
     name="ALS2",
@@ -836,7 +836,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-68525.6354,-26.71667739,7.52019386,-8.148565100000001e-006,
         1.811865152e-009,-2.086958125e-013,9.703246379999999e-018},
     bhigh={27583.62737,-7.873490263},
-    R_s=91.25597243238283);
+    R_s=91.25638950359944);
 
   constant IdealGases.Common.DataRecord AL2(
     name="AL2",
@@ -850,7 +850,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2320724.102,9218.70789,-9.44695187,0.00999992001,-3.154798085e-006,
         4.36154481e-010,-2.24115724e-014},
     bhigh={2904.589544,99.60320745000001},
-    R_s=154.0770581721472);
+    R_s=154.0777623573571);
 
   constant IdealGases.Common.DataRecord AL2Br6(
     name="AL2Br6",
@@ -864,7 +864,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-173182.949,-43.42299780000001,22.0341421,-1.421187503e-005,
         3.23863134e-009,-3.80387976e-013,1.796525455e-017},
     bhigh={-120233.8355,-62.0105495},
-    R_s=15.58806422973773);
+    R_s=15.58813547255877);
 
   constant IdealGases.Common.DataRecord AL2C2(
     name="AL2C2",
@@ -878,7 +878,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={159765.1967,-1644.007203,11.64643675,-0.000437921543,9.36964011e-008,
         -1.049615854e-011,4.78046893e-016},
     bhigh={72048.89810000001,-36.48164252},
-    R_s=106.6170143914284);
+    R_s=106.6175016678961);
 
   constant IdealGases.Common.DataRecord AL2CL6(
     name="AL2CL6",
@@ -892,7 +892,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-275297.5554,-92.48235969999999,22.07058224,-2.870537915e-005,
         6.42332569e-009,-7.4365852e-013,3.47206467e-017},
     bhigh={-162915.7014,-70.91602129},
-    R_s=31.17758531917728);
+    R_s=31.17772781147771);
 
   constant IdealGases.Common.DataRecord AL2F6(
     name="AL2F6",
@@ -906,7 +906,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-585298.2609999999,-545.0571990000001,22.4068632,-0.0001627323704,
         3.59522504e-008,-4.12120144e-012,1.909095384e-016},
     bhigh={-321968.391,-85.89867941},
-    R_s=49.50460834470327);
+    R_s=49.50483459780955);
 
   constant IdealGases.Common.DataRecord AL2I6(
     name="AL2I6",
@@ -920,7 +920,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-121011.2399,-24.67542774,22.0199265,-8.46202259e-006,
         1.957831901e-009,-2.326573151e-013,1.108910373e-017},
     bhigh={-65485.2375,-55.28536481},
-    R_s=10.19692792465017);
+    R_s=10.19697452812194);
 
   constant IdealGases.Common.DataRecord AL2O(
     name="AL2O",
@@ -934,7 +934,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-117107.4351,-178.3009166,7.63321536,-5.33593177e-005,
         1.180702791e-008,-1.355444579e-012,6.28732389e-017},
     bhigh={-19475.80149,-14.15764167},
-    R_s=118.8418774658576);
+    R_s=118.8424206141590);
 
   constant IdealGases.Common.DataRecord AL2Oplus(
     name="AL2Oplus",
@@ -948,7 +948,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-110222.5105,-121.4571732,7.59159595,-3.69453916e-005,
         8.21852032e-009,-9.473649719999999e-013,4.40862135e-017},
     bhigh={76149.43580000001,-12.82233856},
-    R_s=118.842809353477);
+    R_s=118.843352506037);
 
   constant IdealGases.Common.DataRecord AL2O2(
     name="AL2O2",
@@ -962,7 +962,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-194061.1656,-460.975243,10.84375637,-0.0001376042893,
         3.044733119e-008,-3.49619392e-012,1.622305079e-016},
     bhigh={-49630.5578,-29.4653809},
-    R_s=96.72278441201074);
+    R_s=96.72322646844050);
 
   constant IdealGases.Common.DataRecord AL2O2plus(
     name="AL2O2plus",
@@ -976,7 +976,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-165200.5184,-60.2160697,10.04626917,-1.892194088e-005,
         4.2533012e-009,-4.942390419999999e-013,2.314507373e-017},
     bhigh={63862.19,-23.45753361},
-    R_s=96.72340169097949);
+    R_s=96.72384375023042);
 
   constant IdealGases.Common.DataRecord AL2O3(
     name="AL2O3",
@@ -990,7 +990,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-277778.4969,-491.746593,13.86703888,-0.000146938194,3.25040649e-008,
         -3.73086735e-012,1.730444284e-016},
     bhigh={-67907.5785,-43.75559873},
-    R_s=81.54538983996238);
+    R_s=81.54576253047284);
 
   constant IdealGases.Common.DataRecord AL2S(
     name="AL2S",
@@ -1004,7 +1004,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-70434.3737,-26.76376869,7.52023382,-8.16612306e-006,1.81602604e-009,
         -2.091989298e-013,9.727537699999999e-018},
     bhigh={24227.18377,-10.66580982},
-    R_s=96.64835466040181);
+    R_s=96.64879637666198);
 
   constant IdealGases.Common.DataRecord AL2S2(
     name="AL2S2",
@@ -1018,7 +1018,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-137780.6456,-77.050325,10.55723566,-2.277554487e-005,
         5.00768285e-009,-5.715862119999999e-013,2.63799924e-017},
     bhigh={13133.36091,-22.56851594},
-    R_s=70.40609222508525);
+    R_s=70.40641400516995);
 
   constant IdealGases.Common.DataRecord Ar(
     name="Ar",
@@ -1031,7 +1031,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={20.10538475,-0.05992661069999999,2.500069401,-3.99214116e-008,
         1.20527214e-011,-1.819015576e-015,1.078576636e-019},
     bhigh={-744.993961,4.37918011},
-    R_s=208.1323720837088);
+    R_s=208.1333233203164);
 
   constant IdealGases.Common.DataRecord Arplus(
     name="Arplus",
@@ -1045,7 +1045,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-383596.54,816.20197,2.301342628,-4.95298377e-006,1.205108477e-008,-2.185050286e-012,
         1.265493898e-016},
     bhigh={177181.1455,7.94750748},
-    R_s=208.135230374171);
+    R_s=208.136181623842);
 
   constant IdealGases.Common.DataRecord B(
     name="B",
@@ -1059,7 +1059,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-107265.961,322.530716,2.126407232,0.0002106579339,-5.93712916e-008,
         7.37742799e-012,-2.282443381e-016},
     bhigh={66434.13099999999,6.87706967},
-    R_s=769.0752011839794);
+    R_s=769.0787161224679);
 
   constant IdealGases.Common.DataRecord Bplus(
     name="Bplus",
@@ -1073,7 +1073,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-8911.54803,4.58779009,2.531500086,-4.9039491e-005,2.853326582e-008,
         -7.38217591e-012,7.12072156e-016},
     bhigh={165452.6303,2.23866978},
-    R_s=769.1142295871198);
+    R_s=769.1177447039815);
 
   constant IdealGases.Common.DataRecord Bminus(
     name="Bminus",
@@ -1087,7 +1087,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={21.18018248,0.0002070697496,2.499999729,1.456693631e-010,-3.88857176e-014,
         5.09059863e-018,-2.601566168e-022},
     bhigh={64517.8914,4.61645583},
-    R_s=769.0361767416002);
+    R_s=769.0396915017336);
 
   constant IdealGases.Common.DataRecord BBr(
     name="BBr",
@@ -1101,7 +1101,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={253685.8027,-640.59095,4.66682347,0.000417548639,-2.963714868e-007,
         7.51911954e-011,-4.83536832e-015},
     bhigh={31890.8434,-0.8255870910000001},
-    R_s=91.65487515846331);
+    R_s=91.65529405280273);
 
   constant IdealGases.Common.DataRecord BBr2(
     name="BBr2",
@@ -1115,7 +1115,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-419163.337,415.768847,7.14816983,-0.000568959075,3.19544177e-007,-5.55317699e-011,
         3.19113676e-015},
     bhigh={6118.98205,-5.50275962},
-    R_s=48.73121985241972);
+    R_s=48.73144257087429);
 
   constant IdealGases.Common.DataRecord BBr3(
     name="BBr3",
@@ -1129,7 +1129,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-190104.6795,-150.3627687,10.10999896,-4.32309511e-005,
         9.409696190000001e-009,-1.06521847e-012,4.883048770000001e-017},
     bhigh={-27425.53062,-19.97496003},
-    R_s=33.18845774639455);
+    R_s=33.18860942907438);
 
   constant IdealGases.Common.DataRecord BC(
     name="BC",
@@ -1143,7 +1143,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2346280.674,6450.7513,-2.619532384,0.0033391605,-4.50802214e-007,
         1.351919576e-011,8.265104270000001e-016},
     bhigh={57866.8507,50.37884876},
-    R_s=364.323078473558);
+    R_s=364.324743555476);
 
   constant IdealGases.Common.DataRecord BC2(
     name="BC2",
@@ -1157,7 +1157,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1525485.889,-5987.862380000001,14.08384855,-0.0037474998,
         1.081927223e-006,-1.378744645e-010,6.473822e-015},
     bhigh={131120.4013,-63.37215498},
-    R_s=238.6993718491979);
+    R_s=238.7004627875197);
 
   constant IdealGases.Common.DataRecord BCL(
     name="BCL",
@@ -1171,7 +1171,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-74212.6254,263.8090127,3.60022765,0.001018866266,-4.666184119999999e-007,
         9.849002029999999e-011,-6.46881817e-015},
     bhigh={19127.2648,5.235317877},
-    R_s=179.7179664533979);
+    R_s=179.7187878263877);
 
   constant IdealGases.Common.DataRecord BCLplus(
     name="BCLplus",
@@ -1185,7 +1185,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-216942.3542,358.997516,4.03520837,0.000327445243,-8.63457845e-008,
         1.207061044e-011,-5.262253270000001e-016},
     bhigh={144547.7224,3.488222017},
-    R_s=179.7200975800954);
+    R_s=179.7209189628252);
 
   constant IdealGases.Common.DataRecord BCLOH(
     name="BCLOH",
@@ -1199,7 +1199,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={702773.844,-2857.391274,10.9117584,-8.10770934e-005,-2.124440337e-008,
         5.40991244e-012,-3.46415384e-016},
     bhigh={-13072.21888,-35.85168799},
-    R_s=131.4097662543578);
+    R_s=131.4103668422385);
 
   constant IdealGases.Common.DataRecord BCL_OH_2(
     name="BCL_OH_2",
@@ -1213,7 +1213,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1423878.191,-5849.70407,17.92165219,-0.0002009909087,-3.39343578e-008,
         9.838560759999999e-012,-6.47267882e-016},
     bhigh={-64742.6176,-81.00399519},
-    R_s=103.5701135095894);
+    R_s=103.5705868606709);
 
   constant IdealGases.Common.DataRecord BCL2(
     name="BCL2",
@@ -1227,7 +1227,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={350140.313,-1662.20359,8.83953472,-0.000977254411,2.467356248e-007,-2.501151018e-011,
         8.722954559999999e-016},
     bhigh={568.2909440000001,-21.48348344},
-    R_s=101.7471517554487);
+    R_s=101.7476167749673);
 
   constant IdealGases.Common.DataRecord BCL2plus(
     name="BCL2plus",
@@ -1241,7 +1241,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={302929.3331,-1305.533159,8.920390060000001,-0.000728991964,
         1.727833266e-007,-1.523567337e-011,4.22691144e-016},
     bhigh={86534.15770000001,-22.67466616},
-    R_s=101.747834830723);
+    R_s=101.748299853363);
 
   constant IdealGases.Common.DataRecord BCL2OH(
     name="BCL2OH",
@@ -1255,7 +1255,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={587811.379,-2982.969317,14.00662004,-0.0001194189832,-1.269775742e-008,
         4.42289219e-012,-3.004089365e-016},
     bhigh={-58241.6807,-51.50858228},
-    R_s=84.2190689752902);
+    R_s=84.2194538854349);
 
   constant IdealGases.Common.DataRecord BF(
     name="BF",
@@ -1269,7 +1269,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-374638.978,560.449391,3.60918611,0.000618721693,-1.77893877e-007,
         2.426601527e-011,-9.394651579999999e-016},
     bhigh={-18191.79292,3.71660929},
-    R_s=278.9211157370638);
+    R_s=278.9223905026049);
 
   constant IdealGases.Common.DataRecord BFCL(
     name="BFCL",
@@ -1283,7 +1283,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-108630.9561,-523.343848,7.29750474,-3.054410701e-005,-3.154598306e-008,
         1.052290533e-011,-7.615432260000001e-016},
     bhigh={-33058.9121,-11.86586595},
-    R_s=127.4006409865091);
+    R_s=127.4012232513068);
 
   constant IdealGases.Common.DataRecord BFCL2(
     name="BFCL2",
@@ -1297,7 +1297,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-223361.3309,-644.060296,10.47861848,-0.0001911892367,
         4.22488779e-008,-4.84726692e-012,2.247974725e-016},
     bhigh={-77406.2648,-28.14630564},
-    R_s=82.5541251469666);
+    R_s=82.5545024477448);
 
   constant IdealGases.Common.DataRecord BFOH(
     name="BFOH",
@@ -1311,7 +1311,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={725131.809,-3215.62085,11.17909777,-0.0001883881929,2.57970808e-009,
         2.6651581e-012,-2.186647438e-016},
     bhigh={-37168.0808,-39.7846349},
-    R_s=177.5961212099008);
+    R_s=177.5969328853272);
 
   constant IdealGases.Common.DataRecord BF_OH_2(
     name="BF_OH_2",
@@ -1325,7 +1325,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1422037.64,-6257.297570000001,18.22460686,-0.000322139645,-7.1267399e-009,
         6.75869977e-012,-5.04255454e-016},
     bhigh={-91862.5419,-85.27895049999999},
-    R_s=130.2717028295677);
+    R_s=130.2722982161066);
 
   constant IdealGases.Common.DataRecord BF2(
     name="BF2",
@@ -1339,7 +1339,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-115309.1296,-810.9800119999999,7.60270923,-0.0002409209242,
         5.32847186e-008,-6.11879794e-012,2.839984178e-016},
     bhigh={-57962.2217,-16.55644047},
-    R_s=170.3512739716162);
+    R_s=170.3520525355961);
 
   constant IdealGases.Common.DataRecord BF2plus(
     name="BF2plus",
@@ -1353,7 +1353,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-176940.9966,-534.368518,7.72805291,-1.958622052e-006,-2.419680893e-008,
         5.73253381e-012,-3.21635423e-016},
     bhigh={39087.4505,-19.36560315},
-    R_s=170.3531887423513);
+    R_s=170.3539673150824);
 
   constant IdealGases.Common.DataRecord BF2minus(
     name="BF2minus",
@@ -1367,7 +1367,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-170992.0627,-615.621979,7.45887137,-0.0001836703248,
         4.064363959999999e-008,-4.66770095e-012,2.16626484e-016},
     bhigh={-87414.0453,-16.20604664},
-    R_s=170.3493592439245);
+    R_s=170.3501377991535);
 
   constant IdealGases.Common.DataRecord BF2CL(
     name="BF2CL",
@@ -1381,7 +1381,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-206681.7398,-1024.447292,10.75843981,-0.0003023235319,
         6.67252147e-008,-7.6499419e-012,3.5462245e-016},
     bhigh={-104693.6725,-32.29995036},
-    R_s=98.67543826402306);
+    R_s=98.67588924475329);
 
   constant IdealGases.Common.DataRecord BF2OH(
     name="BF2OH",
@@ -1395,7 +1395,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={576075.9250000001,-3611.90019,14.4689764,-0.0003028293733,
         2.764337508e-008,-1.90549317e-013,-8.69497194e-017},
     bhigh={-113358.9041,-58.9698151},
-    R_s=126.3306769762044);
+    R_s=126.3312543508982);
 
   constant IdealGases.Common.DataRecord BF3(
     name="BF3",
@@ -1409,7 +1409,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-181976.7014,-1405.347931,11.03412258,-0.000410459105,
         9.031277570000001e-008,-1.03305736e-011,4.780551830000001e-016},
     bhigh={-132313.6863,-37.3838608},
-    R_s=122.6210998822739);
+    R_s=122.6216603029231);
 
   constant IdealGases.Common.DataRecord BF4minus(
     name="BF4minus",
@@ -1423,7 +1423,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-437324.171,-775.928941,13.58222575,-0.0002341024178,5.19691594e-008,
         -5.982245780000001e-012,2.781163206e-016},
     bhigh={-212725.1877,-49.533697},
-    R_s=95.783152359878);
+    R_s=95.783590121866);
 
   constant IdealGases.Common.DataRecord BH(
     name="BH",
@@ -1437,7 +1437,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1098531.663,-174.5890126,8.442426810000001,-0.00544019667,
         2.718307052e-006,-4.83981221e-010,2.868523222e-014},
     bhigh={50167.3567,-29.71030686},
-    R_s=703.4871147497153);
+    R_s=703.4903299280646);
 
   constant IdealGases.Common.DataRecord BHCL(
     name="BHCL",
@@ -1451,7 +1451,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={349999.172,-2238.404757,8.71110605,-0.001088882906,4.18930109e-007,-6.56871126e-011,
         3.6200676e-015},
     bhigh={28412.40364,-25.89566225},
-    R_s=175.8859907166916);
+    R_s=175.8867945762328);
 
   constant IdealGases.Common.DataRecord BHCL2(
     name="BHCL2",
@@ -1465,7 +1465,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={411099.606,-2858.027441,11.79547506,-0.000632281797,1.269551549e-007,
         -1.352862344e-011,5.92165351e-016},
     bhigh={-16172.8876,-42.17900972},
-    R_s=100.5074406823384);
+    R_s=100.5079000359505);
 
   constant IdealGases.Common.DataRecord BHF(
     name="BHF",
@@ -1479,7 +1479,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1184821.3,-4677.43518,10.67328148,-0.001606366598,3.7045347e-007,-3.79788275e-011,
         1.432441145e-015},
     bhigh={18026.40937,-42.85931169999999},
-    R_s=269.798468545465);
+    R_s=269.799701617367);
 
   constant IdealGases.Common.DataRecord BHFCL(
     name="BHFCL",
@@ -1493,7 +1493,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={439077.892,-3137.181709,12.00286161,-0.000715366934,1.453878608e-007,
         -1.56519707e-011,6.910075059999999e-016},
     bhigh={-42323.6834,-44.66542881},
-    R_s=125.4629386014708);
+    R_s=125.4635120103015);
 
   constant IdealGases.Common.DataRecord BHF2(
     name="BHF2",
@@ -1507,7 +1507,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={466087.6960000001,-3728.10049,12.44152658,-0.000890684319,
         1.841732568e-007,-2.010774349e-011,8.979196590000001e-016},
     bhigh={-69781.4293,-51.0321804},
-    R_s=166.904495081499);
+    R_s=166.905257892512);
 
   constant IdealGases.Common.DataRecord BH2(
     name="BH2",
@@ -1521,7 +1521,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1360117.365,-4917.70449,9.75897103,-0.000741587064,1.269760019e-007,
         -1.187742442e-011,4.68255251e-016},
     bhigh={68902.92660000001,-41.9049012},
-    R_s=648.2068905298874);
+    R_s=648.2098530585770);
 
   constant IdealGases.Common.DataRecord BH2CL(
     name="BH2CL",
@@ -1535,7 +1535,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1427215.437,-6265.56434,13.82183005,-0.001313843556,2.587131606e-007,
         -2.71384527e-011,1.172827257e-015},
     bhigh={26393.87516,-63.99725308},
-    R_s=172.2140154449431);
+    R_s=172.2148025222930);
 
   constant IdealGases.Common.DataRecord BH2F(
     name="BH2F",
@@ -1549,7 +1549,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1435082.111,-6625.32017,14.09165008,-0.00142246906,2.828724718e-007,
         -2.992498948e-011,1.302618926e-015},
     bhigh={-793.719267,-68.013564},
-    R_s=261.2536689068646);
+    R_s=261.2548629260902);
 
   constant IdealGases.Common.DataRecord BH3(
     name="BH3",
@@ -1563,7 +1563,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1855778.95,-8002.492370000001,15.05692199,-0.001790456689,
         3.6125111e-007,-3.86603591e-011,1.698508879e-015},
     bhigh={59675.3707,-79.94046159999999},
-    R_s=600.9815812565686);
+    R_s=600.9843279493336);
 
   constant IdealGases.Common.DataRecord BH3NH3(
     name="BH3NH3",
@@ -1577,7 +1577,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4354925.96,-18242.35232,31.6299983,-0.00320824361,5.88507545e-007,-5.80853553e-011,
         2.3825786e-015},
     bhigh={94381.18030000001,-189.7865799},
-    R_s=269.3789214698429);
+    R_s=269.3801526242705);
 
   constant IdealGases.Common.DataRecord BH4(
     name="BH4",
@@ -1591,7 +1591,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1354714.146,-7870.76275,18.2617061,-0.001948275329,4.07270689e-007,-4.4827109e-011,
         2.014115885e-015},
     bhigh={74702.49489999999,-96.8608689},
-    R_s=560.1702109311207);
+    R_s=560.1727711018706);
 
   constant IdealGases.Common.DataRecord BI(
     name="BI",
@@ -1605,7 +1605,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2132872.626,-6283.684960000001,11.23964343,-0.00325885675,
         7.06428215e-007,-4.23006893e-011,-4.20807847e-016},
     bhigh={77976.3481,-46.6404261},
-    R_s=60.37427748676311);
+    R_s=60.37455341800017);
 
   constant IdealGases.Common.DataRecord BI2(
     name="BI2",
@@ -1619,7 +1619,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-392402.223,442.290235,7.12962358,-0.000561963406,3.18076052e-007,-5.537079720000001e-011,
         3.1839597e-015},
     bhigh={22919.72638,-3.20179324},
-    R_s=31.42042886110548);
+    R_s=31.42057246328451);
 
   constant IdealGases.Common.DataRecord BI3(
     name="BI3",
@@ -1633,7 +1633,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-150617.6506,-81.67210609999999,10.05937867,-2.319396215e-005,
         5.01996673e-009,-5.65434963e-013,2.580651348e-017},
     bhigh={-426.168791,-16.17962779},
-    R_s=21.23615230018481);
+    R_s=21.23624935671316);
 
   constant IdealGases.Common.DataRecord BN(
     name="BN",
@@ -1647,7 +1647,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-227693.2705,-102.5649298,4.41458681,0.0002561670989,-1.612994942e-008,
         -6.526052929999999e-013,5.74946612e-017},
     bhigh={67844.6513,-0.6778568656},
-    R_s=335.0218593987356);
+    R_s=335.0233905639926);
 
   constant IdealGases.Common.DataRecord BO(
     name="BO",
@@ -1661,7 +1661,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={17886.00589,-630.901963,4.5745284,0.0001988001643,-9.70296348e-008,
         1.870854291e-011,-1.030218131e-015},
     bhigh={4841.311089999999,-3.39889058},
-    R_s=310.1211470175753);
+    R_s=310.1225643780026);
 
   constant IdealGases.Common.DataRecord BOminus(
     name="BOminus",
@@ -1676,7 +1676,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={212280.4369,-1262.124688,5.38316731,-0.00031810491,7.28898825e-008,-8.141708919999999e-012,
         3.71536439e-016},
     bhigh={-27068.92261,-9.77375367},
-    R_s=310.1148013837899);
+    R_s=310.1162187152155);
 
   constant IdealGases.Common.DataRecord BOCL(
     name="BOCL",
@@ -1690,7 +1690,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={155714.8487,-1446.254968,8.50944805,-0.000385900738,8.26226882e-008,
         -9.261027459999999e-012,4.21999801e-016},
     bhigh={-32035.8904,-23.72713292},
-    R_s=133.5370699319344);
+    R_s=133.5376802423253);
 
   constant IdealGases.Common.DataRecord BOCL2(
     name="BOCL2",
@@ -1704,7 +1704,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-229752.7041,-619.456793,10.46075518,-0.0001841620739,
         4.07121543e-008,-4.67224655e-012,2.167237536e-016},
     bhigh={-43715.3842,-27.43570215},
-    R_s=85.08778465027366);
+    R_s=85.08817353074818);
 
   constant IdealGases.Common.DataRecord BOF(
     name="BOF",
@@ -1718,7 +1718,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={193702.0297,-1739.112297,8.695650860000001,-0.000451889557,
         9.59101908e-008,-1.067806769e-011,4.840007660000001e-016},
     bhigh={-63301.5239,-27.02458617},
-    R_s=181.5038031816557);
+    R_s=181.5046327165343);
 
   constant IdealGases.Common.DataRecord BOF2(
     name="BOF2",
@@ -1732,7 +1732,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-220502.8861,-1254.23869,10.9255138,-0.0003680144,8.10716494e-008,-9.28127506e-012,
         4.2975493e-016},
     bhigh={-96804.47579999999,-34.8285333},
-    R_s=128.2954853613317);
+    R_s=128.2960717158763);
 
   constant IdealGases.Common.DataRecord BOH(
     name="BOH",
@@ -1746,7 +1746,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={844749.8570000001,-3016.982887,8.0838647,-0.0001609855388,-2.191830959e-009,
         3.127133119e-012,-2.376665451e-016},
     bhigh={16476.98495,-26.03227947},
-    R_s=298.8845488264217);
+    R_s=298.8859148317262);
 
   constant IdealGases.Common.DataRecord BO2(
     name="BO2",
@@ -1760,7 +1760,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-38344.5234,-956.326114,8.200962779999999,-0.0002062130802,
         9.87228899e-009,8.15836676e-012,-7.52751966e-016},
     bhigh={-34235.6402,-22.24772278},
-    R_s=194.2188938046896);
+    R_s=194.2197814519105);
 
   constant IdealGases.Common.DataRecord BO2minus(
     name="BO2minus",
@@ -1774,7 +1774,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={119922.6372,-1715.766982,8.701038219999999,-0.000460124212,
         9.867011870000001e-008,-1.107288516e-011,5.05018324e-016},
     bhigh={-78257.89689999999,-28.39356505},
-    R_s=194.2164049558802);
+    R_s=194.2172925917263);
 
   constant IdealGases.Common.DataRecord B_OH_2(
     name="B_OH_2",
@@ -1788,7 +1788,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1557023.406,-5784.71076,14.87391235,-0.0001821804765,-3.80354164e-008,
         1.030332746e-011,-6.68588983e-016},
     bhigh={-18068.10301,-65.902689},
-    R_s=185.4845704515805);
+    R_s=185.4854181799361);
 
   constant IdealGases.Common.DataRecord BS(
     name="BS",
@@ -1802,7 +1802,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1358760.165,-4364.03596,9.034307589999999,-0.002114548699,
         4.18927531e-007,-1.354787322e-011,-1.360684605e-015},
     bhigh={59130.6545,-33.36696868},
-    R_s=193.9190222968561);
+    R_s=193.9199085735610);
 
   constant IdealGases.Common.DataRecord BS2(
     name="BS2",
@@ -1816,7 +1816,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={512040.251,-1938.581076,9.814873459999999,-0.001339731606,
         3.75430116e-007,-4.40038378e-011,1.887662968e-015},
     bhigh={17365.35,-27.57546712},
-    R_s=110.9469048985202);
+    R_s=110.9474119640784);
 
   constant IdealGases.Common.DataRecord B2(
     name="B2",
@@ -1830,7 +1830,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1094594.495,-2602.735739,6.90945621,-0.0006405949889999999,
         1.951732355e-007,-2.555902119e-011,1.053557323e-015},
     bhigh={118780.7611,-19.49045025},
-    R_s=384.5376005919897);
+    R_s=384.5393580612339);
 
   constant IdealGases.Common.DataRecord B2C(
     name="B2C",
@@ -1844,7 +1844,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1159241.019,-4567.79881,12.28672097,-0.002500830701,6.40997985e-007,
         -6.932935770000001e-011,2.672933741e-015},
     bhigh={122244.2137,-51.99066186},
-    R_s=247.2139316795856);
+    R_s=247.2150615323777);
 
   constant IdealGases.Common.DataRecord B2CL4(
     name="B2CL4",
@@ -1858,7 +1858,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-642798.703,507.856299,14.86725022,2.026983515e-006,6.27271881e-009,
         -1.218822573e-012,7.241208409999999e-017},
     bhigh={-68200.66,-41.39110669},
-    R_s=50.87357587772434);
+    R_s=50.87380838748363);
 
   constant IdealGases.Common.DataRecord B2F4(
     name="B2F4",
@@ -1872,7 +1872,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={38558.6589,-2928.842655,17.92063736,-0.000952399827,1.614708845e-007,
         -1.428613504e-011,5.21873967e-016},
     bhigh={-161305.1924,-71.8480325},
-    R_s=85.17563698580808);
+    R_s=85.17602626779802);
 
   constant IdealGases.Common.DataRecord B2H(
     name="B2H",
@@ -1886,7 +1886,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={617554.5750000001,-2627.897466,9.08490507,-0.000538941833,
         1.0507147e-007,-1.092459556e-011,4.68485466e-016},
     bhigh={109953.7555,-31.6402991},
-    R_s=367.4102538495462);
+    R_s=367.4119330409184);
 
   constant IdealGases.Common.DataRecord B2H2(
     name="B2H2",
@@ -1900,7 +1900,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1240614.592,-5368.96502,13.79292454,-0.001136749748,2.245617156e-007,
         -2.361530467e-011,1.022604572e-015},
     bhigh={85065.1149,-64.354613},
-    R_s=351.7435573748576);
+    R_s=351.7451649640323);
 
   constant IdealGases.Common.DataRecord B2H3(
     name="B2H3",
@@ -1914,7 +1914,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1771506.902,-7872.26093,17.89447015,-0.001709304785,3.40957543e-007,
         -3.61454368e-011,1.575671409e-015},
     bhigh={87377.1189,-90.5462946},
-    R_s=337.3583025437985);
+    R_s=337.3598443874053);
 
   constant IdealGases.Common.DataRecord B2H3_db(
     name="B2H3_db",
@@ -1928,7 +1928,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1497731.017,-7219.31414,17.50463766,-0.0015796988,3.16410347e-007,-3.36722515e-011,
         1.472919654e-015},
     bhigh={83243.4967,-87.79549259999999},
-    R_s=337.3583025437985);
+    R_s=337.3598443874053);
 
   constant IdealGases.Common.DataRecord B2H4(
     name="B2H4",
@@ -1942,7 +1942,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2292078.842,-10598.32517,22.68612155,-0.002363586598,4.76217307e-007,
         -5.0901004e-011,2.23391159e-015},
     bhigh={86385.91979999999,-124.6794566},
-    R_s=324.1034452649437);
+    R_s=324.1049265292885);
 
   constant IdealGases.Common.DataRecord B2H4_db(
     name="B2H4_db",
@@ -1956,7 +1956,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1886854.256,-10100.45614,22.47110812,-0.002319968667,4.73187996e-007,
         -5.11067303e-011,2.262693782e-015},
     bhigh={82334.87,-123.7455797},
-    R_s=324.1034452649437);
+    R_s=324.1049265292885);
 
   constant IdealGases.Common.DataRecord B2H5(
     name="B2H5",
@@ -1970,7 +1970,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2696691.012,-13200.19835,27.35260413,-0.002961879012,5.98499943e-007,
         -6.41374855e-011,2.821187823e-015},
     bhigh={106452.4901,-155.9654379},
-    R_s=311.8507822081863);
+    R_s=311.8522074736420);
 
   constant IdealGases.Common.DataRecord B2H5_db(
     name="B2H5_db",
@@ -1984,7 +1984,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2571729.448,-13568.29858,27.81376038,-0.00319236503,6.56116526e-007,
         -7.12733394e-011,3.16949265e-015},
     bhigh={110637.0527,-159.7214457},
-    R_s=311.8507822081863);
+    R_s=311.8522074736420);
 
   constant IdealGases.Common.DataRecord B2H6(
     name="B2H6",
@@ -1998,7 +1998,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2835765.414,-15676.00163,32.2612233,-0.00373860973,7.71880646e-007,-8.41445454e-011,
         3.75222338e-015},
     bhigh={93583.7855,-192.0223395},
-    R_s=300.4907906282843);
+    R_s=300.4921639746668);
 
   constant IdealGases.Common.DataRecord B2O(
     name="B2O",
@@ -2012,7 +2012,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-162872.322,-387.628981,7.78772352,-0.0001146822108,2.528097612e-008,
         -2.893783941e-012,1.339210475e-016},
     bhigh={22630.35354,-19.08513011},
-    R_s=221.0037903958917);
+    R_s=221.0048004593131);
 
   constant IdealGases.Common.DataRecord B2O2(
     name="B2O2",
@@ -2026,7 +2026,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={460578.966,-2990.079203,12.56764079,-0.000785097495,1.672537624e-007,
         -1.86769478e-011,8.486190669999999e-016},
     bhigh={-40157.4815,-48.7441371},
-    R_s=155.0605735087876);
+    R_s=155.0612821890013);
 
   constant IdealGases.Common.DataRecord B2O3(
     name="B2O3",
@@ -2040,7 +2040,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={390503.53,-3691.34821,15.55502598,-0.0009707645510000001,
         2.068887872e-007,-2.310858356e-011,1.050136734e-015},
     bhigh={-82630.5441,-63.9086344},
-    R_s=119.4261435617824);
+    R_s=119.4266893803810);
 
   constant IdealGases.Common.DataRecord B2_OH_4(
     name="B2_OH_4",
@@ -2054,7 +2054,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2983925.656,-12074.69577,31.6261057,-0.000516368244,-4.23209397e-008,
         1.67197728e-011,-1.156366726e-015},
     bhigh={-82809.76969999999,-165.3010498},
-    R_s=92.74228522579023);
+    R_s=92.74270908996807);
 
   constant IdealGases.Common.DataRecord B2S(
     name="B2S",
@@ -2068,7 +2068,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-121150.1483,-64.73398450000001,7.54682561,-1.82054145e-005,
         3.92395117e-009,-4.40386238e-013,2.003651718e-017},
     bhigh={72585.3187,-13.94971229},
-    R_s=154.8693724737832);
+    R_s=154.8700802801423);
 
   constant IdealGases.Common.DataRecord B2S2(
     name="B2S2",
@@ -2082,7 +2082,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-164153.5014,-774.286564,11.07731737,-0.0002313278554,
         5.12561429e-008,-5.89408123e-012,2.738673834e-016},
     bhigh={17330.03515,-33.59766998},
-    R_s=96.95951114842804);
+    R_s=96.95995428678049);
 
   constant IdealGases.Common.DataRecord B2S3(
     name="B2S3",
@@ -2096,7 +2096,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-190585.5086,-934.8342479999999,13.69333613,-0.000276664725,
         6.1101558e-008,-7.00804857e-012,3.24952462e-016},
     bhigh={2906.43376,-39.46870479},
-    R_s=70.57107208637125);
+    R_s=70.57139462047073);
 
   constant IdealGases.Common.DataRecord B3H7_C2v(
     name="B3H7_C2v",
@@ -2110,7 +2110,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3598592.14,-18637.01968,39.9399883,-0.00427541016,
         8.705358820000001e-007,-9.38510502e-011,4.14786531e-015},
     bhigh={127215.4092,-237.9769856},
-    R_s=210.5538360710869);
+    R_s=210.5547983746187);
 
   constant IdealGases.Common.DataRecord B3H7_Cs(
     name="B3H7_Cs",
@@ -2124,7 +2124,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3281576.45,-18110.96595,39.6383246,-0.00417842411,8.52682906e-007,-9.20960024e-011,
         4.076496770000001e-015},
     bhigh={121362.2564,-235.7090217},
-    R_s=210.5538360710869);
+    R_s=210.5547983746187);
 
   constant IdealGases.Common.DataRecord B3H9(
     name="B3H9",
@@ -2138,7 +2138,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3863999.5,-22294.33407,48.7504615,-0.00541844926,1.125767651e-006,-1.233226406e-010,
         5.52034818e-015},
     bhigh={142218.7123,-295.8240102},
-    R_s=200.3271937521895);
+    R_s=200.3281093164445);
 
   constant IdealGases.Common.DataRecord B3N3H6(
     name="B3N3H6",
@@ -2152,7 +2152,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3739245.17,-19412.38951,44.4507003,-0.00321030805,5.71746542e-007,-5.48669214e-011,
         2.191943197e-015},
     bhigh={47584.2616,-264.1156625},
-    R_s=103.2844170128126);
+    R_s=103.2848890581627);
 
   constant IdealGases.Common.DataRecord B3O3CL3(
     name="B3O3CL3",
@@ -2166,7 +2166,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-741405.981,-2527.447455,26.87263667,-0.000746338936,1.64633411e-007,
         -1.886231553e-011,8.737926310000001e-016},
     bhigh={-192350.9858,-118.5636255},
-    R_s=44.51235664397812);
+    R_s=44.51256008077512);
 
   constant IdealGases.Common.DataRecord B3O3FCL2(
     name="B3O3FCL2",
@@ -2180,7 +2180,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-716236.083,-2851.210308,27.10953133,-0.000840091964,
         1.852318684e-007,-2.121694694e-011,9.827291560000002e-016},
     bhigh={-220272.9252,-121.0679365},
-    R_s=48.81229668842362);
+    R_s=48.81251977742726);
 
   constant IdealGases.Common.DataRecord B3O3F2CL(
     name="B3O3F2CL",
@@ -2194,7 +2194,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-681078.749,-3370.00902,27.48953579,-0.000990544256,2.18290844e-007,
         -2.49957348e-011,1.157532106e-015},
     bhigh={-247211.4785,-126.1501548},
-    R_s=54.03182754333741);
+    R_s=54.03207448739431);
 
   constant IdealGases.Common.DataRecord B3O3F3(
     name="B3O3F3",
@@ -2208,7 +2208,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-662982.291,-3784.94687,27.79526578,-0.001112096232,2.450806704e-007,
         -2.80648498e-011,1.299750466e-015},
     bhigh={-274886.5475,-131.5605015},
-    R_s=60.50126772721858);
+    R_s=60.50154423884477);
 
   constant IdealGases.Common.DataRecord B4H4(
     name="B4H4",
@@ -2222,7 +2222,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1937200.886,-10781.85932,28.79625241,-0.002401547707,4.83775678e-007,
         -5.17049023e-011,2.269138182e-015},
     bhigh={98365.95389999999,-156.1814117},
-    R_s=175.8717786874288);
+    R_s=175.8725824820162);
 
   constant IdealGases.Common.DataRecord B4H10(
     name="B4H10",
@@ -2236,7 +2236,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4030474.13,-25606.29762,56.8723366,-0.00617856786,1.280621032e-006,-1.400254585e-010,
         6.258866560000001e-015},
     bhigh={150600.9087,-352.07142},
-    R_s=155.9253911040931);
+    R_s=155.9261037368210);
 
   constant IdealGases.Common.DataRecord B4H12(
     name="B4H12",
@@ -2250,7 +2250,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6158360.8,-32020.8673,66.60443599999999,-0.00740636928,
         1.512993908e-006,-1.635619071e-010,7.24538514e-015},
     bhigh={205458.6275,-414.210686},
-    R_s=150.2453953141421);
+    R_s=150.2460819873334);
 
   constant IdealGases.Common.DataRecord B5H9(
     name="B5H9",
@@ -2264,7 +2264,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3169017.62,-22825.03203,55.1200898,-0.005563411420000001,
         1.157837073e-006,-1.270332301e-010,5.69426203e-015},
     bhigh={133445.2571,-337.106046},
-    R_s=131.7113616065276);
+    R_s=131.7119635728029);
 
   constant IdealGases.Common.DataRecord Ba(
     name="Ba",
@@ -2278,7 +2278,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-19265792.28,60065.0104,-66.3396413,0.0350756593,-7.80760183e-006,
         8.0851268e-010,-3.199486918e-014},
     bhigh={-358966.372,500.75834},
-    R_s=60.54506397139674);
+    R_s=60.54534068318684);
 
   constant IdealGases.Common.DataRecord Baplus(
     name="Baplus",
@@ -2292,7 +2292,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={8794971.85,-19518.17883,14.85542861,-0.00094042335,-7.03125779e-007,
         1.667412753e-010,-1.07011731e-014},
     bhigh={214680.0732,-92.28264190000002},
-    R_s=60.54530584047409);
+    R_s=60.54558255336962);
 
   constant IdealGases.Common.DataRecord BaBr(
     name="BaBr",
@@ -2306,7 +2306,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1056014.042,1034.740207,6.73572938,-0.0037840263,1.952196896e-006,-3.34783188e-010,
         1.893189803e-014},
     bhigh={-19502.33645,-5.06927964},
-    R_s=38.27479503385797);
+    R_s=38.27496996285061);
 
   constant IdealGases.Common.DataRecord BaBr2(
     name="BaBr2",
@@ -2320,7 +2320,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-8928.25121,-0.753655889,7.00065821,-2.94982171e-007,
         7.092392109999999e-011,-8.670038099999999e-015,4.22174231e-019},
     bhigh={-51726.6949,1.910185706},
-    R_s=27.98213606609791);
+    R_s=27.98226395409494);
 
   constant IdealGases.Common.DataRecord BaCL(
     name="BaCL",
@@ -2334,7 +2334,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1075410.089,1209.303069,6.2725586,-0.00328811031,1.717751087e-006,-2.910607065e-010,
         1.632658438e-014},
     bhigh={-27791.73737,-3.574185216},
-    R_s=48.12172705174211);
+    R_s=48.12194698460470);
 
   constant IdealGases.Common.DataRecord BaCLplus(
     name="BaCLplus",
@@ -2348,7 +2348,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-18291.98157,-2.931616688,4.50228071,3.67178849e-005,
         2.396147871e-009,5.4794586e-014,1.174342316e-018},
     bhigh={40551.00150000001,4.503765564},
-    R_s=48.12187984525572);
+    R_s=48.12209977881664);
 
   constant IdealGases.Common.DataRecord BaCL2(
     name="BaCL2",
@@ -2362,7 +2362,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-22165.98768,-4.00248381,7.00342674,-1.515820808e-006,
         3.61184921e-010,-4.38675906e-014,2.125803293e-018},
     bhigh={-62190.9527,-1.132439694},
-    R_s=39.92869525963705);
+    R_s=39.92887774752321);
 
   constant IdealGases.Common.DataRecord BaF(
     name="BaF",
@@ -2376,7 +2376,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1868380.434,-7071.099600000001,14.66959284,-0.0069959502,
         2.366313845e-006,-3.2877343e-010,1.647896238e-014},
     bhigh={3571.78068,-66.6239092},
-    R_s=53.18695381429856);
+    R_s=53.18719689699160);
 
   constant IdealGases.Common.DataRecord BaFplus(
     name="BaFplus",
@@ -2390,7 +2390,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-40544.2367,-17.01997704,4.51305534,2.632753508e-005,
         2.612088236e-009,-9.502197929999999e-014,6.515176160000001e-018},
     bhigh={14744.8657,2.783167711},
-    R_s=53.18714046640156);
+    R_s=53.18738354994766);
 
   constant IdealGases.Common.DataRecord BaF2(
     name="BaF2",
@@ -2404,7 +2404,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-55086.3366,-16.91114228,7.01356488,-5.73190977e-006,
         1.321203959e-009,-1.565528167e-013,7.444983019999999e-018},
     bhigh={-99835.29700000001,-4.38958149},
-    R_s=47.42351977592018);
+    R_s=47.42373651773511);
 
   constant IdealGases.Common.DataRecord BaH(
     name="BaH",
@@ -2418,7 +2418,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-6755466.57,17307.00212,-11.36812458,0.00561774474,-3.18078885e-007,
         -1.052342502e-010,1.111101879e-014},
     bhigh={-89540.70379999999,118.2377538},
-    R_s=60.10391879303957);
+    R_s=60.10419348864431);
 
   constant IdealGases.Common.DataRecord BaI(
     name="BaI",
@@ -2432,7 +2432,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3533859.66,7394.258,1.285151488,-0.002303429302,2.214839289e-006,-4.68109681e-010,
         3.011371472e-014},
     bhigh={-53402.2959,37.1044387},
-    R_s=31.46662280613282);
+    R_s=31.46676661943409);
 
   constant IdealGases.Common.DataRecord BaI2(
     name="BaI2",
@@ -2446,7 +2446,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-6048.2248,-0.362272945,7.00031745,-1.425793502e-007,3.43334942e-011,
         -4.201754979999999e-015,2.047703474e-019},
     bhigh={-36796.5075,3.61547532},
-    R_s=21.25724370918203);
+    R_s=21.25734086210538);
 
   constant IdealGases.Common.DataRecord BaO(
     name="BaO",
@@ -2460,7 +2460,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={13184816.98,-38542.5325,46.8674161,-0.02188646633,
         5.335677450000001e-006,-5.1523043e-010,1.4330834e-014},
     bhigh={230690.2396,-302.8332772},
-    R_s=54.22726940696449);
+    R_s=54.22751724425800);
 
   constant IdealGases.Common.DataRecord BaOplus(
     name="BaOplus",
@@ -2474,7 +2474,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-331767.923,1594.253495,3.22724781,0.00057226415,-1.147415658e-007,
         1.382873231e-011,-6.38443703e-016},
     bhigh={50252.4761,14.09092365},
-    R_s=54.22746343217109);
+    R_s=54.22771127035138);
 
   constant IdealGases.Common.DataRecord BaOH(
     name="BaOH",
@@ -2488,7 +2488,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2637336.694,-8365.410400000001,15.99803975,-0.005098446049999999,
         1.594657431e-006,-2.180478542e-010,1.084610688e-014},
     bhigh={23935.50647,-74.9070579},
-    R_s=53.87311728549849);
+    R_s=53.87336350419486);
 
   constant IdealGases.Common.DataRecord BaOHplus(
     name="BaOHplus",
@@ -2502,7 +2502,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={876673.843,-2335.8196,7.97316606,0.0001038679898,-6.31948578e-008,
         1.028729445e-011,-5.74180857e-016},
     bhigh={37725.1747,-19.30805001},
-    R_s=53.87330878466322);
+    R_s=53.87355500423480);
 
   constant IdealGases.Common.DataRecord Ba_OH_2(
     name="Ba_OH_2",
@@ -2516,7 +2516,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1762908.112,-4676.205419999999,13.95135494,0.0002051842928,-1.25726553e-007,
         2.048917625e-011,-1.144045777e-015},
     bhigh={-45459.6441,-49.2945719},
-    R_s=48.52568271771352);
+    R_s=48.52590449679261);
 
   constant IdealGases.Common.DataRecord BaS(
     name="BaS",
@@ -2530,7 +2530,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6104262.07,-22276.17479,35.9751351,-0.0215779374,7.31987235e-006,-1.089038636e-009,
         5.88410195e-014},
     bhigh={140413.8006,-214.1776331},
-    R_s=49.08420704637764);
+    R_s=49.08443137810523);
 
   constant IdealGases.Common.DataRecord Ba2(
     name="Ba2",
@@ -2544,7 +2544,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={216011.4547,195.0676877,2.253699771,0.0001507750613,-4.742515e-008,
         7.04895196e-012,-3.54744017e-016},
     bhigh={41677.6297,23.75906459},
-    R_s=30.27253198569837);
+    R_s=30.27267034159342);
 
   constant IdealGases.Common.DataRecord Be(
     name="Be",
@@ -2558,7 +2558,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-692628.584,2466.773005,-0.9776613340000001,0.002458939515,-9.047950419999999e-007,
         1.587880407e-010,-9.415600603e-015},
     bhigh={23002.12917,26.23234754},
-    R_s=922.581456965694);
+    R_s=922.585673480629);
 
   constant IdealGases.Common.DataRecord Beplus(
     name="Beplus",
@@ -2571,7 +2571,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-94781.35979999999,276.8325398,2.191388413,0.0001648824289,-4.28016682e-008,
         4.54235047e-012,-6.270417825e-017},
     bhigh={145385.0986,5.05550384},
-    R_s=922.6376208335329);
+    R_s=922.6418376051561);
 
   constant IdealGases.Common.DataRecord Beplusplus(
     name="Beplusplus",
@@ -2583,7 +2583,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={359227.916,2.145990203},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={359227.916,2.145990203},
-    R_s=922.6937915399486);
+    R_s=922.6980085682912);
 
   constant IdealGases.Common.DataRecord BeBr(
     name="BeBr",
@@ -2597,7 +2597,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={821723.8139999999,-2850.509348,8.017266019999999,-0.002105663212,
         6.84913634e-007,-9.98912932e-011,5.192456840000001e-015},
     bhigh={32293.7287,-23.26810811},
-    R_s=93.50909826515043);
+    R_s=93.50952563392791);
 
   constant IdealGases.Common.DataRecord BeBr2(
     name="BeBr2",
@@ -2611,7 +2611,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-104133.1811,-154.3443092,7.61446541,-4.55670063e-005,
         1.003180548e-008,-1.146879501e-012,5.30179538e-017},
     bhigh={-29845.27608,-11.4936098},
-    R_s=49.25046224627338);
+    R_s=49.25068733784448);
 
   constant IdealGases.Common.DataRecord BeCL(
     name="BeCL",
@@ -2625,7 +2625,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={280884.5146,-1103.100122,5.67118983,-0.0005443000450000001,
         1.459036606e-007,-1.230971735e-011,9.90080476e-017},
     bhigh={12246.49804,-8.38237137},
-    R_s=186.9883721604918);
+    R_s=186.9892267617391);
 
   constant IdealGases.Common.DataRecord BeCL2(
     name="BeCL2",
@@ -2639,7 +2639,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-115408.746,-248.4300053,7.68567214,-7.44496037e-005,
         1.649479787e-008,-1.895997075e-012,8.804973950000001e-017},
     bhigh={-44687.4728,-15.00337407},
-    R_s=104.0373015492269);
+    R_s=104.0377770355186);
 
   constant IdealGases.Common.DataRecord BeF(
     name="BeF",
@@ -2653,7 +2653,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-185794.1543,47.76082770000001,4.26998602,0.0002310668473,-6.657214920000001e-008,
         1.152149888e-011,-6.33558644e-016},
     bhigh={-22579.5096,-0.218478727},
-    R_s=296.8332128955307);
+    R_s=296.8345695255235);
 
   constant IdealGases.Common.DataRecord BeF2(
     name="BeF2",
@@ -2667,7 +2667,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-64820.1807,-768.455606,8.062860840000001,-0.0002227502549,
         4.89159866e-008,-5.58788672e-012,2.583409761e-016},
     bhigh={-93954.9549,-21.25660266},
-    R_s=176.8698345357289);
+    R_s=176.8706428917751);
 
   constant IdealGases.Common.DataRecord BeH(
     name="BeH",
@@ -2681,7 +2681,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2424081.636,6597.39846,-3.62631648,0.00457963435,-1.163329056e-006,
         1.297785691e-010,-5.29188581e-015},
     bhigh={-2489.846221,52.1601869},
-    R_s=829.7775216708938);
+    R_s=829.7813140398890);
 
   constant IdealGases.Common.DataRecord BeHplus(
     name="BeHplus",
@@ -2695,7 +2695,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={462234.1589999999,-1760.169629,5.37990555,2.742462444e-005,-1.16720817e-007,
         3.55717791e-011,-2.569695765e-015},
     bhigh={151585.9734,-13.69222641},
-    R_s=829.822954338555);
+    R_s=829.826746915193);
 
   constant IdealGases.Common.DataRecord BeH2(
     name="BeH2",
@@ -2709,7 +2709,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={607426.201,-3407.53425,9.79237036,-0.000825461482,1.915656246e-007,-1.962774813e-011,
         8.929908660000001e-016},
     bhigh={37931.052,-42.5465358},
-    R_s=753.9377272271411);
+    R_s=753.9411729821613);
 
   constant IdealGases.Common.DataRecord BeI(
     name="BeI",
@@ -2723,7 +2723,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-532820.662,1139.497861,3.62917166,0.0001704033769,1.067048688e-007,
         -3.58945788e-011,2.72276956e-015},
     bhigh={15854.74307,9.370951270000001},
-    R_s=61.17331377468009);
+    R_s=61.17359335778813);
 
   constant IdealGases.Common.DataRecord BeI2(
     name="BeI2",
@@ -2737,7 +2737,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-93923.72840000001,-89.5921438,7.56555479,-2.577727326e-005,
         5.61426533e-009,-6.35966385e-013,2.917080336e-017},
     bhigh={-9814.768620000001,-9.03204281},
-    R_s=31.63547867359002);
+    R_s=31.63562325862074);
 
   constant IdealGases.Common.DataRecord BeN(
     name="BeN",
@@ -2751,7 +2751,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-59096.9616,-307.8649431,4.72795915,-3.92815883e-005,
         2.006201069e-008,-2.300018068e-012,1.066101831e-016},
     bhigh={51560.9571,-3.031380625},
-    R_s=361.2022512648529);
+    R_s=361.2039020835156);
 
   constant IdealGases.Common.DataRecord BeO(
     name="BeO",
@@ -2765,7 +2765,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-35034724.5,105585.9473,-116.5011722,0.0647736948,-1.649656058e-005,
         2.0055584e-009,-9.426891790000001e-014},
     bhigh={-657001.8000000001,864.0898030000001},
-    R_s=332.4248742042786);
+    R_s=332.4263935004191);
 
   constant IdealGases.Common.DataRecord BeOH(
     name="BeOH",
@@ -2779,7 +2779,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={855033.031,-2646.537838,8.204784630000001,1.110814513e-005,-4.265364e-008,
         7.926511920000001e-012,-4.64541952e-016},
     bhigh={3121.216271,-25.71641308},
-    R_s=319.5474536388486);
+    R_s=319.5489140807429);
 
   constant IdealGases.Common.DataRecord BeOHplus(
     name="BeOHplus",
@@ -2793,7 +2793,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={813487.439,-2814.653683,8.381145009999999,-6.94207328e-005,-2.369535806e-008,
         5.67810638e-012,-3.58325356e-016},
     bhigh={107312.9932,-29.01093335},
-    R_s=319.5541911734304);
+    R_s=319.5556516461176);
 
   constant IdealGases.Common.DataRecord Be_OH_2(
     name="Be_OH_2",
@@ -2807,7 +2807,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1722889.403,-5242.47719,14.86877785,3.93149836e-005,-8.92027631e-008,
         1.630912925e-011,-9.505371139999999e-016},
     bhigh={-46428.2384,-64.7680402},
-    R_s=193.2390979383995);
+    R_s=193.2399811076160);
 
   constant IdealGases.Common.DataRecord BeS(
     name="BeS",
@@ -2821,7 +2821,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-16557083.61,54314.6612,-63.5185925,0.0396409199,-1.078978696e-005,
         1.394030343e-009,-6.93695504e-014},
     bhigh={-312155.9628,480.3454935},
-    R_s=202.4109638290182);
+    R_s=202.4118889168201);
 
   constant IdealGases.Common.DataRecord Be2(
     name="Be2",
@@ -2835,7 +2835,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={101003.4484,141.4207488,2.292070182,0.0001543331824,-5.801043e-008,
         1.003129697e-011,-5.68281834e-016},
     bhigh={75501.3973,12.38758616},
-    R_s=461.290728482847);
+    R_s=461.292836740314);
 
   constant IdealGases.Common.DataRecord Be2CL4(
     name="Be2CL4",
@@ -2849,7 +2849,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-335492.008,-231.6199283,16.17047912,-6.73440595e-005,
         1.472073032e-008,-1.672352806e-012,7.68877397e-017},
     bhigh={-103107.5197,-50.47009374},
-    R_s=52.01865077461346);
+    R_s=52.01888851775932);
 
   constant IdealGases.Common.DataRecord Be2F4(
     name="Be2F4",
@@ -2863,7 +2863,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-368183.495,-943.919148,16.70099855,-0.0002797974015,
         6.178061719999999e-008,-7.08308019e-012,3.28279104e-016},
     bhigh={-208904.5725,-60.9266576},
-    R_s=88.43491726786446);
+    R_s=88.43532144588757);
 
   constant IdealGases.Common.DataRecord Be2O(
     name="Be2O",
@@ -2877,7 +2877,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-141264.6378,-349.864459,7.76093268,-0.0001044953518,
         2.313342334e-008,-2.657722263e-012,1.233820439e-016},
     bhigh={-5172.38549,-18.54887619},
-    R_s=244.3724921205073);
+    R_s=244.3736089869422);
 
   constant IdealGases.Common.DataRecord Be2OF2(
     name="Be2OF2",
@@ -2891,7 +2891,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-228182.6506,-1130.355396,13.83400563,-0.000331608064,
         7.30492101e-008,-8.36270438e-012,3.87218498e-016},
     bhigh={-143139.0587,-47.3915023},
-    R_s=115.4457949141708);
+    R_s=115.4463225412055);
 
   constant IdealGases.Common.DataRecord Be2O2(
     name="Be2O2",
@@ -2905,7 +2905,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-396057.6640000001,-907.4948830000001,10.67160422,-0.0002670905218,
         5.87762999e-008,-6.71866409e-012,3.105949075e-016},
     bhigh={-48611.1433,-36.1654689},
-    R_s=166.2124371021393);
+    R_s=166.2131967502096);
 
   constant IdealGases.Common.DataRecord Be3O3(
     name="Be3O3",
@@ -2919,7 +2919,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-589080.936,-1392.823588,17.03450699,-0.000412733074,9.10752915e-008,
         -1.043465231e-011,4.83305377e-016},
     bhigh={-121904.5534,-70.0061451},
-    R_s=110.8082914014262);
+    R_s=110.8087978334731);
 
   constant IdealGases.Common.DataRecord Be4O4(
     name="Be4O4",
@@ -2933,7 +2933,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-884133.8459999999,-2726.394165,24.02941774,-0.0008114675460000001,
         1.794255972e-007,-2.059359498e-011,9.552905330000001e-016},
     bhigh={-192371.0587,-113.662075},
-    R_s=83.10621855106966);
+    R_s=83.10659837510478);
 
   constant IdealGases.Common.DataRecord Br(
     name="Br",
@@ -2947,7 +2947,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4789717.399999999,16920.51999,-20.24085357,0.01395620355,-3.65623056e-006,
         4.489781e-010,-2.122507526e-014},
     bhigh={-92070.54960000001,166.1695929},
-    R_s=104.0557669203044);
+    R_s=104.0562424909892);
 
   constant IdealGases.Common.DataRecord Brplus(
     name="Brplus",
@@ -2961,7 +2961,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1741149.829,-5455.46567,8.470663350000001,-0.002683465574,
         6.59045456e-007,-7.9537703e-011,3.735898818e-015},
     bhigh={185178.1643,-36.3790903},
-    R_s=104.0564813449348);
+    R_s=104.0569569188848);
 
   constant IdealGases.Common.DataRecord Brminus(
     name="Brminus",
@@ -2973,7 +2973,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={-27084.92743,5.41955617},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={-27084.92743,5.41955617},
-    R_s=104.055052505484);
+    R_s=104.055528072904);
 
   constant IdealGases.Common.DataRecord BrCL(
     name="BrCL",
@@ -2987,7 +2987,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-128486.3067,-1138.379626,7.9640408,-0.00343805667,1.524999514e-006,
         -2.761469114e-010,1.694450407e-014},
     bhigh={5938.264260000001,-19.25044389},
-    R_s=72.07600752446753);
+    R_s=72.07633693664017);
 
   constant IdealGases.Common.DataRecord BrF(
     name="BrF",
@@ -3001,7 +3001,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3771388.47,-12674.9343,20.8055593,-0.0102635936,3.30820359e-006,-4.90319225e-010,
         2.64827508e-014},
     bhigh={70626.0972,-113.02536},
-    R_s=84.06744154827575);
+    R_s=84.06782576543095);
 
   constant IdealGases.Common.DataRecord BrF3(
     name="BrF3",
@@ -3015,7 +3015,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-188653.224,-82.45232970000001,10.06180694,-2.477319092e-005,
         5.47857686e-009,-6.28265526e-013,2.910628214e-017},
     bhigh={-33868.0037,-22.98937369},
-    R_s=60.73425861474075);
+    R_s=60.73453619121553);
 
   constant IdealGases.Common.DataRecord BrF5(
     name="BrF5",
@@ -3029,7 +3029,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-375764.764,-157.5896472,16.11869838,-4.776497799999999e-005,
         1.059755365e-008,-1.218527723e-012,5.65753545e-017},
     bhigh={-56672.66800000001,-55.4083931},
-    R_s=47.53951628034798);
+    R_s=47.53973355230688);
 
   constant IdealGases.Common.DataRecord BrO(
     name="BrO",
@@ -3043,7 +3043,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2392612.795,6932.79313,-2.513183892,0.00344654456,-7.569536839999999e-007,
         6.51429134e-011,-1.715768736e-015},
     bhigh={-30844.99064,53.6104836},
-    R_s=86.6963215068496);
+    R_s=86.6967177388914);
 
   constant IdealGases.Common.DataRecord OBrO(
     name="OBrO",
@@ -3057,7 +3057,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-162450.466,-145.3689372,7.10582213,-4.14136207e-005,
         8.981833259999999e-009,-1.013712869e-012,4.63513314e-017},
     bhigh={16500.75386,-9.11181792},
-    R_s=74.300839657274);
+    R_s=74.301179237696);
 
   constant IdealGases.Common.DataRecord BrOO(
     name="BrOO",
@@ -3071,7 +3071,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6172.483480000001,-658.504966,7.48395533,-0.0001920530746,
         4.22694617e-008,-4.83739261e-012,2.23974132e-016},
     bhigh={14603.5347,-9.85038024},
-    R_s=74.300839657274);
+    R_s=74.301179237696);
 
   constant IdealGases.Common.DataRecord BrO3(
     name="BrO3",
@@ -3085,7 +3085,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-282285.1113,-235.8973461,10.17525279,-6.97845105e-005,
         1.535701661e-008,-1.75445495e-012,8.10410015e-017},
     bhigh={24011.4014,-25.88197197},
-    R_s=65.00648151478239);
+    R_s=65.00677861678689);
 
   constant IdealGases.Common.DataRecord Br2(
     name="Br2",
@@ -3099,7 +3099,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4311698.57,11112.68634,-5.55577561,0.00363051659,-2.754164226e-007,
         -6.21750676e-011,7.37534162e-015},
     bhigh={-70365.8416,78.7847802},
-    R_s=52.02788346015218);
+    R_s=52.02812124549460);
 
   constant IdealGases.Common.DataRecord BrBrO(
     name="BrBrO",
@@ -3113,7 +3113,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-85371.0175,-64.8704607,7.04715935,-1.843088186e-005,3.99226786e-009,
         -4.50068795e-013,2.055867395e-017},
     bhigh={18215.66655,-3.162186125},
-    R_s=47.29307185021791);
+    R_s=47.29328799584091);
 
   constant IdealGases.Common.DataRecord BrOBr(
     name="BrOBr",
@@ -3127,7 +3127,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-96866.60249999999,-39.5739527,7.02943438,-1.171881908e-005,
         2.576958549e-009,-2.941186078e-013,1.357198784e-017},
     bhigh={10769.42321,-5.69777938},
-    R_s=47.29307185021791);
+    R_s=47.29328799584091);
 
   constant IdealGases.Common.DataRecord C(
     name="C",
@@ -3141,7 +3141,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-128913.6472,171.9528572,2.646044387,-0.000335306895,1.74209274e-007,
         -2.902817829e-011,1.642182385e-015},
     bhigh={84105.9785,4.130047418},
-    R_s=692.2554055966764);
+    R_s=692.2585694422474);
 
   constant IdealGases.Common.DataRecord Cplus(
     name="Cplus",
@@ -3155,7 +3155,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={12551.12551,-34.1187467,2.543383218,-2.805120849e-005,
         9.751641969999999e-009,-1.736855394e-012,1.246191931e-016},
     bhigh={217100.1786,4.063913515},
-    R_s=692.2870264566357);
+    R_s=692.2901904467250);
 
   constant IdealGases.Common.DataRecord Cminus(
     name="Cminus",
@@ -3169,7 +3169,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4.25317572,0.0005778186479999999,2.499999424,2.836136231e-010,-7.32725342e-014,
         9.478507810000001e-018,-4.830487319999999e-022},
     bhigh={70012.17170000001,4.879624211},
-    R_s=692.22378762521);
+    R_s=692.22695132628);
 
   constant IdealGases.Common.DataRecord CBr(
     name="CBr",
@@ -3183,7 +3183,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1021862.102,-3243.48436,8.38822656,-0.002242155508,
         6.988355369999999e-007,-9.719134370000001e-011,4.71697624e-015},
     bhigh={78059.24059999999,-25.18386915},
-    R_s=90.45856647522105);
+    R_s=90.45897990201784);
 
   constant IdealGases.Common.DataRecord CBr2(
     name="CBr2",
@@ -3197,7 +3197,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-744143.141,421.542783,8.796797740000001,-0.002726562507,
         1.336438546e-006,-2.304854483e-010,1.337493953e-014},
     bhigh={33646.1814,-15.99565135},
-    R_s=48.39096093731357);
+    R_s=48.39118210066774);
 
   constant IdealGases.Common.DataRecord CBr3(
     name="CBr3",
@@ -3211,7 +3211,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-192649.8949,-132.4072178,10.09808665,-3.89504082e-005,
         8.55044501e-009,-9.747493679999999e-013,4.49424559e-017},
     bhigh={25415.76129,-18.66868947},
-    R_s=33.03028292641069);
+    R_s=33.03043388617713);
 
   constant IdealGases.Common.DataRecord CBr4(
     name="CBr4",
@@ -3225,7 +3225,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-205978.5072,-104.8517002,13.0777255,-3.086857556e-005,
         6.77530981e-009,-7.72183754e-013,3.55921824e-017},
     bhigh={5615.89394,-32.8378763},
-    R_s=25.0717810116013);
+    R_s=25.0718955982736);
 
   constant IdealGases.Common.DataRecord CCL(
     name="CCL",
@@ -3239,7 +3239,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={590050.763,-2075.31146,6.88001723,-0.001294796228,3.88313798e-007,-5.00698163e-011,
         2.218229619e-015},
     bhigh={63589.2205,-16.10664472},
-    R_s=175.1753866639137);
+    R_s=175.1761872757497);
 
   constant IdealGases.Common.DataRecord CCL2(
     name="CCL2",
@@ -3253,7 +3253,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-6437455.17,19584.13353,-16.04038625,0.01238833906,-3.013367274e-006,
         3.47346892e-010,-1.553272793e-014},
     bhigh={-99612.42159999999,155.6949315},
-    R_s=100.2749988844225);
+    R_s=100.2754571756956);
 
   constant IdealGases.Common.DataRecord CCL2Br2(
     name="CCL2Br2",
@@ -3267,7 +3267,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-255334.7012,-159.8005477,13.1186093,-4.717443870000001e-005,
         1.036912808e-008,-1.183321687e-012,5.46061269e-017},
     bhigh={-2588.63698,-34.61705319},
-    R_s=34.25474210082452);
+    R_s=34.25489865679101);
 
   constant IdealGases.Common.DataRecord CCL3(
     name="CCL3",
@@ -3281,7 +3281,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-542757.254,680.902062,9.047723619999999,0.0001324277766,
         6.30126304e-008,-2.6566392e-011,2.105668053e-015},
     bhigh={386.621615,-15.28745849},
-    R_s=70.24155674974254);
+    R_s=70.24187777784348);
 
   constant IdealGases.Common.DataRecord CCL3Br(
     name="CCL3Br",
@@ -3295,7 +3295,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-277232.4186,-184.0310333,13.13673812,-5.44391001e-005,
         1.197658923e-008,-1.367818632e-012,6.316164790000001e-017},
     bhigh={-8895.857689999999,-36.69528209},
-    R_s=41.93431604897675);
+    R_s=41.93450770324052);
 
   constant IdealGases.Common.DataRecord CCL4(
     name="CCL4",
@@ -3309,7 +3309,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-304307.8255,-216.8170491,13.16132386,-6.43112489e-005,
         1.416482497e-008,-1.61934332e-012,7.48397435e-017},
     bhigh={-15123.2007,-39.968443},
-    R_s=54.05230827439643);
+    R_s=54.05255531205732);
 
   constant IdealGases.Common.DataRecord CF(
     name="CF",
@@ -3323,7 +3323,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-132980.71,-121.4340891,4.45241362,0.0001293786948,-3.67055059e-008,
         6.590212389999999e-012,-3.73126161e-016},
     bhigh={28159.34108,-0.664046873},
-    R_s=268.1300373756052);
+    R_s=268.1312628222025);
 
   constant IdealGases.Common.DataRecord CFplus(
     name="CFplus",
@@ -3337,7 +3337,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-80537.6278,-339.027509,4.7083735,-3.96314831e-005,2.497996218e-008,
         -5.23679043e-012,5.31394913e-016},
     bhigh={138133.7068,-3.92051473},
-    R_s=268.1347811032766);
+    R_s=268.1360065715543);
 
   constant IdealGases.Common.DataRecord CFBr3(
     name="CFBr3",
@@ -3351,7 +3351,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-272915.8956,-332.816465,13.24822519,-9.92707754e-005,
         2.193640054e-008,-2.515424945e-012,1.165680878e-016},
     bhigh={-17301.85479,-36.2681843},
-    R_s=30.71231574384335);
+    R_s=30.71245610970161);
 
   constant IdealGases.Common.DataRecord CFCL(
     name="CFCL",
@@ -3365,7 +3365,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-268163.0077,-2.328091539,6.83463383,0.0001565270633,-5.967755160000001e-008,
         9.82092446e-012,-5.05889721e-016},
     bhigh={301.7669604,-9.005085128999999},
-    R_s=125.1009462487188);
+    R_s=125.1015180031197);
 
   constant IdealGases.Common.DataRecord CFCLBr2(
     name="CFCLBr2",
@@ -3379,7 +3379,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-296081.1596,-353.12762,13.26346169,-0.0001053860298,2.32908508e-008,
         -2.670979639e-012,1.237844667e-016},
     bhigh={-23875.94306,-36.84977271},
-    R_s=36.74578250689551);
+    R_s=36.74595044777440);
 
   constant IdealGases.Common.DataRecord CFCL2(
     name="CFCL2",
@@ -3393,7 +3393,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-265311.8323,-446.972417,10.33334881,-0.0001333673368,
         2.948755634e-008,-3.3833062e-012,1.568746348e-016},
     bhigh={-13931.60489,-25.56817972},
-    R_s=81.58233410884678);
+    R_s=81.58270696820529);
 
   constant IdealGases.Common.DataRecord CFCL2Br(
     name="CFCL2Br",
@@ -3407,7 +3407,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-321545.505,-388.412962,13.28990796,-0.0001160048581,
         2.564498787e-008,-2.941639768e-012,1.363542881e-016},
     bhigh={-30974.21144,-38.71356695},
-    R_s=45.72936426187367);
+    R_s=45.72957326081455);
 
   constant IdealGases.Common.DataRecord CFCL3(
     name="CFCL3",
@@ -3421,7 +3421,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-345046.478,-417.782145,13.31196736,-0.0001248759531,
         2.761391353e-008,-3.16820764e-012,1.468834601e-016},
     bhigh={-36740.6719,-41.56886057000001},
-    R_s=60.52694771430753);
+    R_s=60.52722434330010);
 
   constant IdealGases.Common.DataRecord CF2(
     name="CF2",
@@ -3435,7 +3435,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-108642.8547,-585.498914,7.01864895,0.000392918615,-2.603822675e-007,
         6.142196389999999e-011,-4.17283326e-015},
     bhigh={-21529.45157,-13.56143285},
-    R_s=166.2644790462898);
+    R_s=166.2652389322096);
 
   constant IdealGases.Common.DataRecord CF2plus(
     name="CF2plus",
@@ -3449,7 +3449,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-64889.6607,-1064.283593,7.7857021,-0.0003158347626,
         7.130804079999999e-008,-8.53318359e-012,4.25163882e-016},
     bhigh={117844.6465,-18.19424707},
-    R_s=166.2663030463333);
+    R_s=166.2670629405895);
 
   constant IdealGases.Common.DataRecord CF2Br2(
     name="CF2Br2",
@@ -3463,7 +3463,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-332766.93,-618.435249,13.46170049,-0.0001849172548,4.09259134e-008,
         -4.69981043e-012,2.180811799e-016},
     bhigh={-47151.8661,-41.0536924},
-    R_s=39.62753822469625);
+    R_s=39.62771933619107);
 
   constant IdealGases.Common.DataRecord CF2CL(
     name="CF2CL",
@@ -3477,7 +3477,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-280234.6654,-686.031485,10.51143635,-0.0002046954963,
         4.52889718e-008,-5.20022903e-012,2.41297145e-016},
     bhigh={-33081.7948,-28.74899785},
-    R_s=97.29022621377774);
+    R_s=97.29067086361192);
 
   constant IdealGases.Common.DataRecord CF2CLBr(
     name="CF2CLBr",
@@ -3491,7 +3491,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-359282.884,-653.928359,13.48831524,-0.0001956099469,4.32977597e-008,
         -4.97264437e-012,2.30757505e-016},
     bhigh={-53651.4117,-42.24913908000001},
-    R_s=50.27966509262958);
+    R_s=50.27989488801207);
 
   constant IdealGases.Common.DataRecord CF2CL2(
     name="CF2CL2",
@@ -3505,7 +3505,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-382744.855,-693.37748,13.51791274,-0.0002075114435,4.59402161e-008,
         -5.276874600000001e-012,2.449037044e-016},
     bhigh={-60215.2777,-44.79580046},
-    R_s=68.76379858255437);
+    R_s=68.76411285679166);
 
   constant IdealGases.Common.DataRecord CF3(
     name="CF3",
@@ -3519,7 +3519,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-299730.5557,-1046.989457,10.77923191,-0.0003116087076,
         6.89135143e-008,-7.91122564e-012,3.67059302e-016},
     bhigh={-54253.044,-34.1703879},
-    R_s=120.489274733073);
+    R_s=120.489825410547);
 
   constant IdealGases.Common.DataRecord CF3plus(
     name="CF3plus",
@@ -3533,7 +3533,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-29109.19531,-1996.658183,11.44279678,-0.000565339304,
         1.232297113e-007,-1.399758046e-011,6.44301795e-016},
     bhigh={59023.458,-40.80349990000001},
-    R_s=120.4902326356934);
+    R_s=120.4907833175454);
 
   constant IdealGases.Common.DataRecord CF3Br(
     name="CF3Br",
@@ -3547,7 +3547,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-383408.851,-971.9093300000001,13.72477396,-0.0002901710612,
         6.421892200000001e-008,-7.37568877e-012,3.42315425e-016},
     bhigh={-77653.0631,-47.1736721},
-    R_s=55.83558557206995);
+    R_s=55.83584075992214);
 
   constant IdealGases.Common.DataRecord CF3CL(
     name="CF3CL",
@@ -3561,7 +3561,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-406604.2119999999,-1022.626507,13.76252628,-0.0003052722979,
         6.75596604e-008,-7.75931525e-012,3.60119229e-016},
     bhigh={-84105.5937,-49.13411939},
-    R_s=79.59562311954289);
+    R_s=79.59598689894807);
 
   constant IdealGases.Common.DataRecord CF4(
     name="CF4",
@@ -3575,7 +3575,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-416445.678,-1414.797167,14.05124837,-0.000419909386,9.27892161e-008,
         -1.06457583e-011,4.937099680000001e-016},
     bhigh={-109469.1149,-54.87105},
-    R_s=94.47800608244737);
+    R_s=94.47843787946721);
 
   constant IdealGases.Common.DataRecord CHplus(
     name="CHplus",
@@ -3589,7 +3589,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-7102094.67,18283.54883,-13.12691402,0.006191717360000001,-2.909421253e-007,
         -1.134243575e-010,1.105962085e-014},
     bhigh={75412.9604,124.3984829},
-    R_s=638.6859443927395);
+    R_s=638.6888634074271);
 
   constant IdealGases.Common.DataRecord CHBr3(
     name="CHBr3",
@@ -3603,7 +3603,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={627423.495,-3378.7111,14.87852612,-0.000593274527,1.082421577e-007,-1.061012665e-011,
         4.31915245e-016},
     bhigh={18772.34659,-53.1190965},
-    R_s=32.89855159627658);
+    R_s=32.89870195398548);
 
   constant IdealGases.Common.DataRecord CHCL(
     name="CHCL",
@@ -3617,7 +3617,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-954806.1900000001,2174.413794,4.86764537,0.0008321641859999999,-1.536948638e-007,
         1.529236537e-011,-6.596159359999999e-016},
     bhigh={18801.2181,2.674761385},
-    R_s=171.5327147998293);
+    R_s=171.5334987634006);
 
   constant IdealGases.Common.DataRecord CHCLBr2(
     name="CHCLBr2",
@@ -3631,7 +3631,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={604286.53,-3438.24101,14.94162631,-0.000622842797,1.153724426e-007,-1.147291377e-011,
         4.733482859999999e-016},
     bhigh={18224.60958,-54.07258924},
-    R_s=39.91975403836881);
+    R_s=39.91993648539051);
 
   constant IdealGases.Common.DataRecord CHCL2(
     name="CHCL2",
@@ -3645,7 +3645,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={884939.3709999999,-3526.96973,11.86372153,-0.000500237612,
         6.1338604e-008,-1.885433405e-012,-1.234221421e-016},
     bhigh={30711.36475,-40.88905858},
-    R_s=99.0706900857722);
+    R_s=99.0711428729393);
 
   constant IdealGases.Common.DataRecord CHCL2Br(
     name="CHCL2Br",
@@ -3659,7 +3659,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={592487.644,-3509.47561,14.99349593,-0.000643306257,1.198581809e-007,
         -1.198476716e-011,4.96994807e-016},
     bhigh={11972.51405,-56.02687781},
-    R_s=50.75102863577455);
+    R_s=50.75126058545075);
 
   constant IdealGases.Common.DataRecord CHCL3(
     name="CHCL3",
@@ -3673,7 +3673,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={613605.274,-3715.08717,15.10777247,0.0002362584336,1.297140438e-007,
         -1.267494791e-011,5.259022309999999e-016},
     bhigh={6203.31345,-59.92576539},
-    R_s=69.64848693607949);
+    R_s=69.64880525364717);
 
   constant IdealGases.Common.DataRecord CHF(
     name="CHF",
@@ -3687,7 +3687,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3994085.42,-7962.756200000001,6.75559509,0.00494983657,-2.101763812e-006,
         3.34823295e-010,-1.88682505e-014},
     bhigh={67061.34940000001,-23.81240379},
-    R_s=259.6889396707313);
+    R_s=259.6901265386055);
 
   constant IdealGases.Common.DataRecord CHFBr2(
     name="CHFBr2",
@@ -3701,7 +3701,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={593575.1630000001,-3742.65658,15.17184031,-0.0007158039030000001,
         1.360636972e-007,-1.385897355e-011,5.844209110000001e-016},
     bhigh={-2347.676027,-57.6578343},
-    R_s=43.34403819907494);
+    R_s=43.34423629625436);
 
   constant IdealGases.Common.DataRecord CHFCL(
     name="CHFCL",
@@ -3715,7 +3715,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={662216.358,-3809.00798,12.23880469,-0.000746718275,1.43476785e-007,-1.475406631e-011,
         6.27378068e-016},
     bhigh={10189.87746,-46.58365563},
-    R_s=123.2320538961801);
+    R_s=123.2326171090995);
 
   constant IdealGases.Common.DataRecord CHFCLBr(
     name="CHFCLBr",
@@ -3729,7 +3729,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={580011.7509999999,-3823.33785,15.22809062,-0.000737390631,
         1.407097155e-007,-1.438245319e-011,6.08386715e-016},
     bhigh={-8552.249899999999,-59.03677705},
-    R_s=56.41747908562503);
+    R_s=56.41773693293094);
 
   constant IdealGases.Common.DataRecord CHFCL2(
     name="CHFCL2",
@@ -3743,7 +3743,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={564011.302,-3887.0833,15.27760246,-0.0007576487420000001,
         1.452498792e-007,-1.490796515e-011,6.3289985e-016},
     bhigh={-14847.36185,-61.67535516},
-    R_s=80.78338670809922);
+    R_s=80.78375591599298);
 
   constant IdealGases.Common.DataRecord CHF2(
     name="CHF2",
@@ -3757,7 +3757,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={552680.655,-3696.00917,12.08610573,-0.00064985881,1.12084622e-007,-9.814147009999999e-012,
         3.34919239e-016},
     bhigh={-9437.06842,-47.044162},
-    R_s=162.9795010477454);
+    R_s=162.9802459201847);
 
   constant IdealGases.Common.DataRecord CHF2Br(
     name="CHF2Br",
@@ -3771,7 +3771,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={576770.684,-4177.71608,15.50150581,-0.000849014729,1.657177491e-007,
         -1.727828054e-011,7.43562723e-016},
     bhigh={-29661.47348,-63.4938014},
-    R_s=63.50830398867315);
+    R_s=63.50859424349048);
 
   constant IdealGases.Common.DataRecord CHF2CL(
     name="CHF2CL",
@@ -3785,7 +3785,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={562949.373,-4298.673049999999,15.58191398,-0.000878927848,
         1.720248689e-007,-1.797910869e-011,7.753391699999999e-016},
     bhigh={-36340.6716,-66.11261479999999},
-    R_s=96.15613956491762);
+    R_s=96.15657903158532);
 
   constant IdealGases.Common.DataRecord CHF3(
     name="CHF3",
@@ -3799,7 +3799,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={568523.2020000001,-4728.3617,15.86728516,-0.000738234865,
         1.970841706e-007,-2.062115571e-011,8.970599639999999e-016},
     bhigh={-59231.9637,-71.6127322},
-    R_s=118.7546756463453);
+    R_s=118.7552183961043);
 
   constant IdealGases.Common.DataRecord CHI3(
     name="CHI3",
@@ -3813,7 +3813,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={629420.543,-3184.06157,14.79622178,-0.00057495555,1.062025541e-007,-1.052804696e-011,
         4.32972002e-016},
     bhigh={41036.098,-49.0135739},
-    R_s=21.11708203586678);
+    R_s=21.11717854820303);
 
   constant IdealGases.Common.DataRecord CH2(
     name="CH2",
@@ -3827,7 +3827,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2550418.031,-7971.62539,12.28924487,-0.001699122922,2.991728605e-007,
         -2.767007492e-011,1.051341740e-015},
     bhigh={9.642216890e+004,-6.094739910e+001},
-    R_s=592.7654495964092);
+    R_s=592.7681587386234);
 
   constant IdealGases.Common.DataRecord CH2Br2(
     name="CH2Br2",
@@ -3841,7 +3841,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1528284.441,-6673.414949999999,16.70213316,-0.001166351237,
         2.122634493e-007,-2.07547224e-011,8.4285777e-016},
     bhigh={36007.0664,-74.48065490000001},
-    R_s=47.82979312861688);
+    R_s=47.83001172724092);
 
   constant IdealGases.Common.DataRecord CH2CL(
     name="CH2CL",
@@ -3855,7 +3855,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1662438.334,-6441.12572,13.59753722,-0.00114053681,2.087760159e-007,
         -2.052347186e-011,8.37577227e-016},
     bhigh={52129.0612,-61.48586271},
-    R_s=168.0384514177364);
+    R_s=168.0392194113208);
 
   constant IdealGases.Common.DataRecord CH2CLBr(
     name="CH2CLBr",
@@ -3869,7 +3869,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1525016.309,-6823.33416,16.82769102,-0.001219735119,2.244964495e-007,
         -2.219063248e-011,9.104705129999999e-016},
     bhigh={33202.3992,-76.37571062000001},
-    R_s=64.26218844771493);
+    R_s=64.26248214804383);
 
   constant IdealGases.Common.DataRecord CH2CL2(
     name="CH2CL2",
@@ -3883,7 +3883,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1529279.337,-6976.95476,16.94154931,-0.001265053995,2.344766734e-007,
         -2.333227421e-011,9.632834730000001e-016},
     bhigh={28063.18171,-79.49453509999999},
-    R_s=97.89496563038588);
+    R_s=97.89541304408743);
 
   constant IdealGases.Common.DataRecord CH2F(
     name="CH2F",
@@ -3897,7 +3897,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2535399.502,-9358.43902,17.00366206,-0.003062919929,
         7.612869080000001e-007,-9.664554980000001e-011,4.8447681e-015},
     bhigh={52283.9131,-87.0755157},
-    R_s=251.7630955221803);
+    R_s=251.7642461662176);
 
   constant IdealGases.Common.DataRecord CH2FBr(
     name="CH2FBr",
@@ -3911,7 +3911,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1539975.462,-7231.55136,17.14566439,-0.001350184394,2.538022824e-007,
         -2.558977386e-011,1.069310946e-015},
     bhigh={15096.04224,-80.62053710000001},
-    R_s=73.62566955265032);
+    R_s=73.62600604731205);
 
   constant IdealGases.Common.DataRecord CH2FCL(
     name="CH2FCL",
@@ -3925,7 +3925,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1536120.418,-7378.93973,17.25797178,-0.001395645457,2.639247747e-007,
         -2.675653563e-011,1.123582778e-015},
     bhigh={9813.71046,-83.13642553},
-    R_s=121.4181786825755);
+    R_s=121.4187336054605);
 
   constant IdealGases.Common.DataRecord CH2F2(
     name="CH2F2",
@@ -3939,7 +3939,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1546609.496,-7876.88333,17.68770469,-0.001581298721,3.068917255e-007,
         -3.18340546e-011,1.363827177e-015},
     bhigh={-9800.13596,-89.0742036},
-    R_s=159.8218142908129);
+    R_s=159.8225447315363);
 
   constant IdealGases.Common.DataRecord CH2I2(
     name="CH2I2",
@@ -3953,7 +3953,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1512892.716,-6442.9124,16.59026137,-0.00113555152,2.07375025e-007,-2.033902231e-011,
         8.282283700000001e-016},
     bhigh={50582.1903,-71.2523514},
-    R_s=31.0432014394506);
+    R_s=31.0433433175704);
 
   constant IdealGases.Common.DataRecord CH3(
     name="CH3",
@@ -3967,7 +3967,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2760802.663,-9336.53117,14.87729606,-0.001439429774,2.444477951e-007,
         -2.224555778e-011,8.395065760e-016},
     bhigh={7.481809480e+004,-7.919682400e+001},
-    R_s=553.0254374599256);
+    R_s=553.0279649766005);
 
   constant IdealGases.Common.DataRecord CH3Br(
     name="CH3Br",
@@ -3981,7 +3981,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2524874.348,-10118.76098,18.65902163,-0.00179767369,3.29852011e-007,
         -3.25091203e-011,1.330179925e-015},
     bhigh={55405.7639,-97.7866446},
-    R_s=87.57743432275962);
+    R_s=87.57783458179041);
 
   constant IdealGases.Common.DataRecord CH3CL(
     name="CH3CL",
@@ -3995,7 +3995,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2522463.305,-10301.15447,18.82725852,-0.001872291294,3.47337286e-007,
         -3.45888722e-011,1.428941079e-015},
     bhigh={51114.1741,-100.6571389},
-    R_s=164.6837079737725);
+    R_s=164.6844606350243);
 
   constant IdealGases.Common.DataRecord CH3F(
     name="CH3F",
@@ -4009,7 +4009,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2561903.188,-10860.52758,19.2944692,-0.002070973131,3.92912453e-007,
         -3.99450342e-011,1.681447081e-015},
     bhigh={35635.0851,-106.1158456},
-    R_s=244.3067247305985);
+    R_s=244.3078412964538);
 
   constant IdealGases.Common.DataRecord CH3I(
     name="CH3I",
@@ -4023,7 +4023,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2511915.982,-9960.289989999999,18.56907132,-0.001768191331,
         3.24220626e-007,-3.19294201e-011,1.305407821e-015},
     bhigh={60669.29949999999,-95.9077704},
-    R_s=58.57778754097095);
+    R_s=58.57805526163038);
 
   constant IdealGases.Common.DataRecord CH2OH(
     name="CH2OH",
@@ -4037,7 +4037,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2250349.506,-8173.186060000001,15.99639179,-0.0008704133719999999,
         6.06918395e-008,4.40834946e-012,-5.7023095e-016},
     bhigh={46453.1343,-78.3515845},
-    R_s=267.9156226477351);
+    R_s=267.9168471143832);
 
   constant IdealGases.Common.DataRecord CH2OHplus(
     name="CH2OHplus",
@@ -4051,7 +4051,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2603333.487,-10099.5381,17.30843898,-0.000694639032,3.009715083e-008,
         5.22148598e-012,-5.09018379e-016},
     bhigh={146540.2426,-92.2395528},
-    R_s=267.9203587915685);
+    R_s=267.9215832798624);
 
   constant IdealGases.Common.DataRecord CH3O(
     name="CH3O",
@@ -4065,7 +4065,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2101188.243,-8841.968800000001,18.22645731,-0.001743485034,
         3.34043427e-007,-3.43067316e-011,1.473897771e-015},
     bhigh={53095.82060000001,-94.2250059},
-    R_s=267.9156226477351);
+    R_s=267.9168471143832);
 
   constant IdealGases.Common.DataRecord CH4(
     name="CH4",
@@ -4079,7 +4079,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3730042.76,-13835.01485,20.49107091,-0.001961974759,4.72731304e-007,
         -3.72881469e-011,1.623737207e-015},
     bhigh={75320.6691,-121.9124889},
-    R_s=518.2791167938085);
+    R_s=518.2814855078335);
 
   constant IdealGases.Common.DataRecord CH3OH(
     name="CH3OH",
@@ -4093,7 +4093,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3411570.76,-13455.00201,22.61407623,-0.002141029179,3.73005054e-007,
         -3.49884639e-011,1.366073444e-015},
     bhigh={56360.8156,-127.7814279},
-    R_s=259.4878075117987);
+    R_s=259.4889934604296);
 
   constant IdealGases.Common.DataRecord CH3OOH(
     name="CH3OOH",
@@ -4107,7 +4107,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3060740.61,-12829.59627,25.41021168,-0.002394481095,4.44342991e-007,
         -4.4166595e-011,1.819673372e-015},
     bhigh={5.837492360e+004,-1.387713096e+002},
-    R_s=173.069399095694);
+    R_s=173.070190082442);
 
   constant IdealGases.Common.DataRecord CI(
     name="CI",
@@ -4121,7 +4121,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-240822.9894,344.738704,4.9769687,-0.000844481539,
         5.061239719999999e-007,-1.047700525e-010,6.74084314e-015},
     bhigh={64513.4202,1.090913159},
-    R_s=59.85287279999731);
+    R_s=59.85314634823540);
 
   constant IdealGases.Common.DataRecord CI2(
     name="CI2",
@@ -4135,7 +4135,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-702865.553,308.2750393,9.04642705,-0.002946736644,1.424347233e-006,
         -2.45318341e-010,1.425270291e-014},
     bhigh={50211.34209999999,-15.60349377},
-    R_s=31.27862185051489);
+    R_s=31.27876480458705);
 
   constant IdealGases.Common.DataRecord CI3(
     name="CI3",
@@ -4149,7 +4149,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-153651.1918,-83.5704437,10.06203125,-2.466447336e-005,
         5.41905475e-009,-6.181417e-013,2.851262022e-017},
     bhigh={45825.8953,-14.94825345},
-    R_s=21.17127975667193);
+    R_s=21.17137651671042);
 
   constant IdealGases.Common.DataRecord CI4(
     name="CI4",
@@ -4163,7 +4163,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-144676.277,-52.8036517,13.03985589,-1.606214814e-005,
         3.56755047e-009,-4.10536698e-013,1.907272766e-017},
     bhigh={28177.46618,-28.10414436},
-    R_s=16.0007981085259);
+    R_s=16.0008712376829);
 
   constant IdealGases.Common.DataRecord CN(
     name="CN",
@@ -4177,7 +4177,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2228006.27,5040.733389999999,-0.2121897722,0.001354901134,
         1.325929798e-007,-6.93700637e-011,5.49495227e-015},
     bhigh={17844.96132,32.82563919},
-    R_s=319.5735161853222);
+    R_s=319.5749767463313);
 
   constant IdealGases.Common.DataRecord CNplus(
     name="CNplus",
@@ -4191,7 +4191,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-7153463.08,18572.50421,-10.84534159,0.00610668143,-1.191208566e-006,
         1.184848778e-010,-4.799838730000001e-015},
     bhigh={92426.44959999999,113.5340573},
-    R_s=319.5802548189978);
+    R_s=319.5817154108049);
 
   constant IdealGases.Common.DataRecord CNminus(
     name="CNminus",
@@ -4205,7 +4205,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={351796.472,-1630.477359,5.60987575,-0.000397560597,
         8.856147079999999e-008,-9.722872320000001e-012,4.43420569e-016},
     bhigh={16479.76581,-11.75502699},
-    R_s=319.5667778358206);
+    R_s=319.5682383660332);
 
   constant IdealGases.Common.DataRecord CNN(
     name="CNN",
@@ -4219,7 +4219,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-181714.8765,-672.986349,7.85794834,-6.13688072e-005,-1.088178985e-008,
         4.45665581e-012,-2.836496278e-016},
     bhigh={77234.8898,-19.66012324},
-    R_s=207.7366386751982);
+    R_s=207.7375881031678);
 
   constant IdealGases.Common.DataRecord CO(
     name="CO",
@@ -4233,7 +4233,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={461919.725,-1944.704863,5.91671418,-0.0005664282830000001,
         1.39881454e-007,-1.787680361e-011,9.62093557e-016},
     bhigh={-2466.261084,-13.87413108},
-    R_s=296.8383547363272);
+    R_s=296.8397113898201);
 
   constant IdealGases.Common.DataRecord COplus(
     name="COplus",
@@ -4247,7 +4247,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={231684.7506,-1057.646148,4.55425778,0.000449552032,-2.489507047e-007,
         5.26756642e-011,-3.28951027e-015},
     bhigh={155505.0724,-3.87346264},
-    R_s=296.8441686645506);
+    R_s=296.8455253446152);
 
   constant IdealGases.Common.DataRecord COCL(
     name="COCL",
@@ -4261,7 +4261,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={344372.024,-1793.14347,8.392755899999999,-0.000537476959,
         9.113555710000001e-008,-3.111441728e-012,-2.040435218e-016},
     bhigh={6914.470149999999,-19.98919104},
-    R_s=131.0126987178376);
+    R_s=131.0132974909830);
 
   constant IdealGases.Common.DataRecord COCL2(
     name="COCL2",
@@ -4275,7 +4275,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-25458.81891,-1305.958516,10.92922584,-0.000360121016,
         7.78701765e-008,-8.79245203e-012,4.02869661e-016},
     bhigh={-22198.4734,-32.3330345},
-    R_s=84.05580082514373);
+    R_s=84.05618498909682);
 
   constant IdealGases.Common.DataRecord COFCL(
     name="COFCL",
@@ -4289,7 +4289,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-53168.8791,-1581.009678,11.12696501,-0.00043730008,
         9.464190710000001e-008,-1.069291346e-011,4.901756640000001e-016},
     bhigh={-45996.6723,-35.25879824},
-    R_s=100.8285281901095);
+    R_s=100.8289890112020);
 
   constant IdealGases.Common.DataRecord COF2(
     name="COF2",
@@ -4303,7 +4303,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-40738.0685,-1974.009812,11.40363654,-0.000543711147,
         1.175232744e-007,-1.326564192e-011,6.07677213e-016},
     bhigh={-69077.9541,-40.09695},
-    R_s=125.9636673413314);
+    R_s=125.9642430386648);
 
   constant IdealGases.Common.DataRecord COHCL(
     name="COHCL",
@@ -4317,7 +4317,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={831895.285,-4416.87084,12.70661114,-0.0009361408629999999,
         1.855335611e-007,-1.958378539e-011,8.512046829999999e-016},
     bhigh={4330.49644,-51.45071542},
-    R_s=128.9644466724905);
+    R_s=128.9650360844187);
 
   constant IdealGases.Common.DataRecord COHF(
     name="COHF",
@@ -4331,7 +4331,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={857885.316,-4791.95912,12.93975218,-0.001018285299,2.021278474e-007,
         -2.136698091e-011,9.299588910000002e-016},
     bhigh={-18789.33107,-55.2744914},
-    R_s=173.1588482172291);
+    R_s=173.1596396127900);
 
   constant IdealGases.Common.DataRecord COS(
     name="COS",
@@ -4345,7 +4345,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={195909.8567,-1756.167688,8.71043034,-0.000413942496,1.015243648e-007,
         -1.159609663e-011,5.691053860000001e-016},
     bhigh={-8927.09669,-26.36328016},
-    R_s=138.4013010382005);
+    R_s=138.4019335798026);
 
   constant IdealGases.Common.DataRecord CO2(
     name="CO2",
@@ -4359,7 +4359,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={117696.2419,-1788.791477,8.29152319,-9.22315678e-005,4.86367688e-009,
         -1.891053312e-012,6.330036589999999e-016},
     bhigh={-39083.5059,-26.52669281},
-    R_s=188.9244822140674);
+    R_s=188.9253456640044);
 
   constant IdealGases.Common.DataRecord CO2plus(
     name="CO2plus",
@@ -4373,7 +4373,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-169505.1682,-806.646973,8.00282846,-0.0001577214041,
         2.566759314e-008,-2.404195965e-012,1.6774468e-016},
     bhigh={115438.9478,-21.33567772},
-    R_s=188.9268372797449);
+    R_s=188.9277007404453);
 
   constant IdealGases.Common.DataRecord COOH(
     name="COOH",
@@ -4387,7 +4387,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={929318.873,-4483.030570000001,12.42199567,-0.0007463139639999999,
         1.332996131e-007,-1.28271055e-011,5.1379979e-016},
     bhigh={-851.8232680000001,-50.6806551},
-    R_s=184.694465078423);
+    R_s=184.695309195725);
 
   constant IdealGases.Common.DataRecord CP(
     name="CP",
@@ -4401,7 +4401,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-5449937.15,16883.45926,-15.956922,0.01136028761,-2.84654133e-006,
         3.37936404e-010,-1.554457397e-014},
     bhigh={-45545.17739999999,145.1324059},
-    R_s=193.429714054109);
+    R_s=193.430598094507);
 
   constant IdealGases.Common.DataRecord CS(
     name="CS",
@@ -4415,7 +4415,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-971957.476,2339.201284,1.709390402,0.001577178949,-4.146335910000001e-007,
         4.50475708e-011,-5.94545773e-016},
     bhigh={16810.20727,18.7404822},
-    R_s=188.6407249346012);
+    R_s=188.6415870876696);
 
   constant IdealGases.Common.DataRecord CS2(
     name="CS2",
@@ -4429,7 +4429,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1390419.724,3354.9755,3.019247723,0.002876437543,-9.076812719999999e-007,
         1.374091042e-010,-6.99957557e-015},
     bhigh={-10138.98046,15.65113703},
-    R_s=109.1987859318341);
+    R_s=109.1992850078867);
 
   constant IdealGases.Common.DataRecord C2(
     name="C2",
@@ -4443,7 +4443,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-968926.793,3561.09299,-0.5064138930000001,0.002945154879,-7.13944119e-007,
         8.67065725e-011,-4.07690681e-015},
     bhigh={76817.96829999999,33.3998524},
-    R_s=346.1277027983382);
+    R_s=346.1292847211237);
 
   constant IdealGases.Common.DataRecord C2plus(
     name="C2plus",
@@ -4457,7 +4457,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3836292.81,-6242.062449999999,2.779245639,0.006065865859999999,-2.452799858e-006,
         3.8829425e-010,-2.190639912e-014},
     bhigh={285744.7553,0.729738349},
-    R_s=346.1356078327848);
+    R_s=346.1371897916990);
 
   constant IdealGases.Common.DataRecord C2minus(
     name="C2minus",
@@ -4471,7 +4471,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4478136.25,-11541.45714,13.10143499,-0.001862700578,4.00693125e-008,
         3.7102136e-011,-3.33726687e-015},
     bhigh={132535.6168,-69.75964399999999},
-    R_s=346.1197981249531);
+    R_s=346.1213800116116);
 
   constant IdealGases.Common.DataRecord C2CL(
     name="C2CL",
@@ -4485,7 +4485,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={213736.8408,-1630.519518,8.62349025,-0.000425351786,9.04001864e-008,
         -1.007541495e-011,4.570764750000001e-016},
     bhigh={71710.9328,-24.13014598},
-    R_s=139.7991740984356);
+    R_s=139.7998130287990);
 
   constant IdealGases.Common.DataRecord C2CL2(
     name="C2CL2",
@@ -4499,7 +4499,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2.961995390e+005,-2.044290845e+003,1.187529729e+001,-5.115031340e-004,1.072666588e-007,
         -1.183417569e-011,5.326530480e-016},
     bhigh={3.636802500e+004,-4.000826050e+001},
-    R_s=87.58824694396103);
+    R_s=87.58864725240922);
 
   constant IdealGases.Common.DataRecord C2CL3(
     name="C2CL3",
@@ -4513,7 +4513,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-220402.8219,-1072.926248,13.78367377,-0.0003093322915,
         6.77752895e-008,-7.72730182e-012,3.56669022e-016},
     bhigh={24310.20015,-43.42161815},
-    R_s=63.77087353620636);
+    R_s=63.77116499105693);
 
   constant IdealGases.Common.DataRecord C2CL4(
     name="C2CL4",
@@ -4527,7 +4527,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3.001289625e+005,-1.132413909e+003,1.683073063e+001,-3.288820170e-004,7.220975400e-008,
        -8.245417760e-012,3.810154710e-016},
     bhigh={-2.292758158e+003,-5.980164420e+001},
-    R_s=50.13786224870682);
+    R_s=50.13809139600150);
 
   constant IdealGases.Common.DataRecord C2CL6(
     name="C2CL6",
@@ -4541,7 +4541,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-5.577351940e+005,-4.976576790e+002,2.237042798e+001,-1.477797229e-004,3.257641460e-008,
        -3.727218070e-012,1.723860648e-016},
     bhigh={-2.335217699e+004,-8.381736910e+001},
-    R_s=35.12104541061496);
+    R_s=35.12120592588587);
 
   constant IdealGases.Common.DataRecord C2F(
     name="C2F",
@@ -4555,7 +4555,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={289877.6676,-2016.644658,8.87504571,-0.000516684113,1.092094306e-007,
         -1.212216787e-011,5.48228768e-016},
     bhigh={52412.8792,-27.7308958},
-    R_s=193.2708051067979);
+    R_s=193.2716884209271);
 
   constant IdealGases.Common.DataRecord C2FCL(
     name="C2FCL",
@@ -4569,7 +4569,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={347145.489,-2348.4611,12.06875617,-0.000580469823,1.21273434e-007,-1.334214186e-011,
         5.99255661e-016},
     bhigh={15020.61224,-42.52445687},
-    R_s=105.9535490125068);
+    R_s=105.9540332567093);
 
   constant IdealGases.Common.DataRecord C2FCL3(
     name="C2FCL3",
@@ -4583,7 +4583,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-282950.5545,-1473.853145,17.07879074,-0.000426521339,
         9.357199850000001e-008,-1.067932796e-011,4.93326161e-016},
     bhigh={-17384.33314,-61.97054796},
-    R_s=55.66032008482446);
+    R_s=55.66057447165302);
 
   constant IdealGases.Common.DataRecord C2F2(
     name="C2F2",
@@ -4597,7 +4597,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={419389.094,-2715.359989,12.30403413,-0.0006649305540000001,
         1.385254301e-007,-1.520813764e-011,6.81982103e-016},
     bhigh={-4179.221939999999,-46.7038623},
-    R_s=134.0650186878026);
+    R_s=134.0656314111012);
 
   constant IdealGases.Common.DataRecord C2F2CL2(
     name="C2F2CL2",
@@ -4611,7 +4611,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-870256.566,726.472448,15.30689121,0.0003045597224,-7.04546804e-008,
         8.28592434e-012,-3.89858107e-016},
     bhigh={-52088.8871,-49.98300753},
-    R_s=62.55047312435939);
+    R_s=62.55075900155986);
 
   constant IdealGases.Common.DataRecord C2F3(
     name="C2F3",
@@ -4625,7 +4625,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-124260.3837,-2137.292446,14.55051371,-0.0006093891980000001,
         1.331427672e-007,-1.515124358e-011,6.98411206e-016},
     bhigh={-19771.46179,-54.21039870000001},
-    R_s=102.6267581555277);
+    R_s=102.6272271951504);
 
   constant IdealGases.Common.DataRecord C2F3CL(
     name="C2F3CL",
@@ -4639,7 +4639,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-216272.4659,-2195.103372,17.59605428,-0.000628261729,
         1.37416661e-007,-1.565004037e-011,7.218309900000001e-016},
     bhigh={-55151.095,-69.21931823999999},
-    R_s=71.38748063597872);
+    R_s=71.38780690134639);
 
   constant IdealGases.Common.DataRecord C2F4(
     name="C2F4",
@@ -4653,7 +4653,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-162991.5758,-2603.903955,17.88488423,-0.000739703801,
         1.61446034e-007,-1.835820392e-011,8.45764107e-016},
     bhigh={-70063.7166,-74.54165860000001},
-    R_s=83.13223952314488);
+    R_s=83.13261946610480);
 
   constant IdealGases.Common.DataRecord C2F6(
     name="C2F6",
@@ -4667,7 +4667,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1011551.484,-942.2140710000001,22.02553906,-0.000131451875,
         1.8660453e-008,-3.46711861e-012,2.488311205e-016},
     bhigh={-165743.4402,-93.02161150000001},
-    R_s=60.24463736653651);
+    R_s=60.24491270527358);
 
   constant IdealGases.Common.DataRecord C2H(
     name="C2H",
@@ -4681,7 +4681,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3922334.57,-12047.51703,17.5617292,-0.00365544294,6.98768543e-007,-6.82516201e-011,
         2.719262793e-015},
     bhigh={143326.6627,-95.6163438},
-    R_s=332.1890229626511);
+    R_s=332.1905411808701);
 
   constant IdealGases.Common.DataRecord C2HCL(
     name="C2HCL",
@@ -4695,7 +4695,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1.152149855e+006,-4.461204350e+003,1.281367818e+001,-6.797397460e-004,1.151395389e-007,
         -1.046657798e-011,3.949939170e-016},
     bhigh={5.233955000e+004,-5.320661700e+001},
-    R_s=137.4700985614903);
+    R_s=137.4707268471765);
 
   constant IdealGases.Common.DataRecord C2HCL3(
     name="C2HCL3",
@@ -4709,7 +4709,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6.049298240e+005,-4.237003190e+003,1.846274582e+001,-8.137243260e-004,1.551223511e-007,
         -1.584645594e-011,6.701006540e-016},
     bhigh={1.848292676e+004,-7.698375250e+001},
-    R_s=63.28209149976589);
+    R_s=63.28238072071425);
 
   constant IdealGases.Common.DataRecord C2HF(
     name="C2HF",
@@ -4723,7 +4723,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1234347.179,-4819.58196,13.02337752,-0.000749543582,1.285452942e-007,
         -1.184559365e-011,4.53678476e-016},
     bhigh={32368.1171,-56.4079182},
-    R_s=188.8462000477917);
+    R_s=188.8470631399522);
 
   constant IdealGases.Common.DataRecord C2HFCL2(
     name="C2HFCL2",
@@ -4737,7 +4737,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={407124.352,-3808.20452,18.2114405,-0.000727896606,1.381532849e-007,-1.405342513e-011,
         5.92000972e-016},
     bhigh={-2676.849943,-75.67353566999999},
-    R_s=72.34143575687527);
+    R_s=72.34176638214635);
 
   constant IdealGases.Common.DataRecord C2HF2CL(
     name="C2HF2CL",
@@ -4751,7 +4751,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={583037.47,-3810.31741,17.99003171,-0.000588821086,1.002861284e-007,-9.149788100000001e-012,
         3.45998516e-016},
     bhigh={-22058.75409,-75.90948533},
-    R_s=84.42875780247421);
+    R_s=84.42914367096910);
 
   constant IdealGases.Common.DataRecord C2HF3(
     name="C2HF3",
@@ -4765,7 +4765,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={691741.378,-5260.30164,19.15276614,-0.001072493938,2.099276744e-007,
         -2.195126633e-011,9.472702399999999e-016},
     bhigh={-32476.4021,-87.5045695},
-    R_s=101.3656526070093);
+    R_s=101.3661158829454);
 
   constant IdealGases.Common.DataRecord C2H2_vinylidene(
     name="C2H2_vinylidene",
@@ -4779,7 +4779,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1940838.725,-6892.718150000001,13.39582494,-0.0009368968669999999,
         1.470804368e-007,-1.220040365e-011,4.12239166e-016},
     bhigh={91071.1293,-63.3750293},
-    R_s=319.3295152181795);
+    R_s=319.3309746640202);
 
   constant IdealGases.Common.DataRecord C2H2CL2(
     name="C2H2CL2",
@@ -4793,7 +4793,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1561121.185,-7358.096350000001,20.11869185,-0.001310978834,
         2.411885716e-007,-2.38416674e-011,9.78541575e-016},
     bhigh={41222.009,-95.50252712000001},
-    R_s=85.76635739991467);
+    R_s=85.76674938170031);
 
   constant IdealGases.Common.DataRecord C2H2FCL(
     name="C2H2FCL",
@@ -4807,7 +4807,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1527690.968,-6689.712229999999,19.5055383,-0.001040920895,
         1.780587502e-007,-1.633098515e-011,6.213465560000001e-016},
     bhigh={17052.66451,-91.94078300999999},
-    R_s=103.2998884991077);
+    R_s=103.3003606151678);
 
   constant IdealGases.Common.DataRecord C2H2F2(
     name="C2H2F2",
@@ -4821,7 +4821,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-822719.275,-2915.718833,18.30163995,-0.001039630129,
         2.546725128e-007,-3.157578705e-011,1.55154096e-015},
     bhigh={-31100.28589,-84.00834700000002},
-    R_s=129.8444698353657);
+    R_s=129.8450632693028);
 
   constant IdealGases.Common.DataRecord CH2CO_ketene(
     name="CH2CO_ketene",
@@ -4835,7 +4835,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2013564.915,-8200.88746,17.59694074,-0.001464544521,2.695886969e-007,
        -2.66567484e-011,1.094204522e-015},
     bhigh={4.177776880e+004,-8.725803580e+001},
-    R_s=197.7908816776206);
+    R_s=197.7917856500561);
 
   constant IdealGases.Common.DataRecord O_CH_2O(
     name="O_CH_2O",
@@ -4849,7 +4849,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={267806.3593,-4436.61748,17.81696797,-0.000709717378,1.272621878e-007,
         -1.237226678e-011,5.025057520e-016},
     bhigh={-4.479608280e+003,-8.156700640e+001},
-    R_s=143.2638455250596);
+    R_s=143.2645002901643);
 
   constant IdealGases.Common.DataRecord HO_CO_2OH(
     name="HO_CO_2OH",
@@ -4863,7 +4863,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1805560.696,-9240.33315,26.25742604,-0.001418458557,2.526840574e-007,
         -2.521005198e-011,1.040036111e-015},
     bhigh={-3.754286460e+004,-1.326879788e+002},
-    R_s=92.34723253921148);
+    R_s=92.34765459786253);
 
   constant IdealGases.Common.DataRecord C2H3_vinyl(
     name="C2H3_vinyl",
@@ -4877,7 +4877,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2718080.093,-10309.56829,18.36579807,-0.001580131153,
         2.680594939e-007,-2.439003999e-011,9.20909639e-016},
     bhigh={97650.55589999999,-97.6008686},
-    R_s=307.4285215649937);
+    R_s=307.4299266191956);
 
   constant IdealGases.Common.DataRecord CH2BrminusCOOH(
     name="CH2BrminusCOOH",
@@ -4891,7 +4891,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2486349.85,-11402.56346,27.56020307,-0.00184318701,3.26539274e-007,
         -3.122663159e-011,1.223452495e-015},
     bhigh={1.837013127e+004,-1.420040888e+002},
-    R_s=59.83872242296076);
+    R_s=59.83899590652677);
 
   constant IdealGases.Common.DataRecord C2H3CL(
     name="C2H3CL",
@@ -4905,7 +4905,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2.456178566e+006,-1.047452720e+004,2.178736544e+001,-1.816893523e-003,3.296374030e-007,
         -3.214400710e-011,1.302256512e-015},
     bhigh={6.346231290e+004,-1.149890773e+002},
-    R_s=133.0359794373957);
+    R_s=133.0365874576306);
 
   constant IdealGases.Common.DataRecord CH2CLminusCOOH(
     name="CH2CLminusCOOH",
@@ -4919,7 +4919,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2.472881709e+006,-1.152275613e+004,2.766275288e+001,-1.886429520e-003,3.361772590e-007,
         -3.231268060e-011,1.273273865e-015},
     bhigh={1.370384800e+004,-1.443191119e+002},
-    R_s=87.98688462414359);
+    R_s=87.98728675450323);
 
   constant IdealGases.Common.DataRecord C2H3F(
     name="C2H3F",
@@ -4933,7 +4933,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2478832.34,-10759.32307,21.94796688,-0.00186911411,3.39528067e-007,-3.31538293e-011,
         1.345081799e-015},
     bhigh={45634.5555,-118.0410277},
-    R_s=180.5781435549581);
+    R_s=180.5789688592535);
 
   constant IdealGases.Common.DataRecord CH3CN(
     name="CH3CN",
@@ -4947,7 +4947,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2923231.393,-12337.92258,23.24477222,-0.002411565845,
         4.622157170000001e-007,-4.74060124e-011,2.010639467e-015},
     bhigh={80585.65550000001,-129.2249102},
-    R_s=202.5355208721054);
+    R_s=202.5364465291757);
 
   constant IdealGases.Common.DataRecord CH3CO_acetyl(
     name="CH3CO_acetyl",
@@ -4961,7 +4961,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2485388.15,-11207.14204,22.77525438,-0.00231426055,4.53618917e-007,-4.74263555e-011,
         2.044663903e-015},
     bhigh={63800.8841,-121.5350925},
-    R_s=193.1593774088376);
+    R_s=193.1602602137039);
 
   constant IdealGases.Common.DataRecord C2H4(
     name="C2H4",
@@ -4975,7 +4975,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3408763.67,-13748.47903,23.65898074,-0.002423804419,4.43139566e-007,
         -4.35268339e-011,1.775410633e-015},
     bhigh={88204.2938,-137.1278108},
-    R_s=296.3827247982046);
+    R_s=296.3840793693117);
 
   constant IdealGases.Common.DataRecord C2H4O_ethylen_o(
     name="C2H4O_ethylen_o",
@@ -4989,7 +4989,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3151809.957,-14236.46316,27.08080476,-0.002606238456,
         4.853891929999999e-007,-4.85214476e-011,2.011778721e-015},
     bhigh={76625.61440000001,-156.3952401},
-    R_s=188.7398144398419);
+    R_s=188.7406770457835);
 
   constant IdealGases.Common.DataRecord CH3CHO_ethanal(
     name="CH3CHO_ethanal",
@@ -5003,7 +5003,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3321176.59,-14497.19957,27.08421279,-0.002879320054,5.55630992e-007,
         -5.73267488e-011,2.443965239e-015},
     bhigh={65077.5564,-153.6236027},
-    R_s=188.7398144398419);
+    R_s=188.7406770457835);
 
   constant IdealGases.Common.DataRecord CH3COOH(
     name="CH3COOH",
@@ -5017,7 +5017,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2103514.223,-14678.22192,33.8280283,-0.00569485868,1.343221353e-006,
         -1.606041158e-010,7.652794250000001e-015},
     bhigh={29242.28407,-193.527885},
-    R_s=138.4546316223484);
+    R_s=138.4552644076896);
 
   constant IdealGases.Common.DataRecord OHCH2COOH(
     name="OHCH2COOH",
@@ -5031,7 +5031,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1946628.253,-9804.020200000001,28.44111243,-0.000787640475,
         6.416275950000001e-008,1.069321262e-012,-3.23717828e-016},
     bhigh={-16946.5047,-147.4109363},
-    R_s=109.3270652885103);
+    R_s=109.3275649508438);
 
   constant IdealGases.Common.DataRecord C2H5(
     name="C2H5",
@@ -5045,7 +5045,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4169220.4,-16629.82142,27.95442134,-0.003051715761,
         5.685160040000001e-007,-5.6828636e-011,2.355648561e-015},
     bhigh={113701.0087,-163.9357995},
-    R_s=286.1031413126138);
+    R_s=286.1044489024848);
 
   constant IdealGases.Common.DataRecord C2H5Br(
     name="C2H5Br",
@@ -5059,7 +5059,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2378649.403,-12670.33647,27.77558646,-0.002010898783,4.43608341e-007,
         -5.34819809e-011,2.63983585e-015},
     bhigh={64140.6205,-152.8277085},
-    R_s=76.30399091085127);
+    R_s=76.30433964636384);
 
   constant IdealGases.Common.DataRecord C2H6(
     name="C2H6",
@@ -5073,7 +5073,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5025782.13,-20330.22397,33.2255293,-0.00383670341,7.23840586e-007,-7.3191825e-011,
         3.065468699e-015},
     bhigh={111596.395,-203.9410584},
-    R_s=276.5127187299628);
+    R_s=276.5139824883003);
 
   constant IdealGases.Common.DataRecord CH3N2CH3(
     name="CH3N2CH3",
@@ -5087,7 +5087,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4993357.09,-21609.96161,39.6444992,-0.00419645011,
         8.023361980000001e-007,-8.212260020000001e-011,3.47723744e-015},
     bhigh={144996.261,-237.2109745},
-    R_s=143.1494957856454);
+    R_s=143.1501500281324);
 
   constant IdealGases.Common.DataRecord C2H5OH(
     name="C2H5OH",
@@ -5101,7 +5101,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4694817.65,-19297.98213,34.4758404,-0.00323616598,5.78494772e-007,-5.56460027e-011,
         2.2262264e-015},
     bhigh={86016.22709999999,-203.4801732},
-    R_s=180.4808671619877);
+    R_s=180.4816920216964);
 
   constant IdealGases.Common.DataRecord CH3OCH3(
     name="CH3OCH3",
@@ -5115,7 +5115,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4933577.19,-20830.94065,36.2905061,-0.004108351640000001,
         7.90322031e-007,-8.13143563e-011,3.45816611e-015},
     bhigh={101330.1012,-218.5447466},
-    R_s=180.4808671619877);
+    R_s=180.4816920216964);
 
   constant IdealGases.Common.DataRecord CH3O2CH3(
     name="CH3O2CH3",
@@ -5129,7 +5129,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5316368.47,-22212.67874,40.3433509,-0.00461274809,
         8.792987200000001e-007,-9.068221189999999e-011,3.865664890000001e-015},
     bhigh={116159.6028,-239.5296055},
-    R_s=133.9578113238676);
+    R_s=133.9584235571916);
 
   constant IdealGases.Common.DataRecord CCN(
     name="CCN",
@@ -5143,7 +5143,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={79486.74890000001,-1344.786906,8.309986459999999,-0.0002220105361,
         1.753683113e-008,2.545998719e-012,-2.645649117e-016},
     bhigh={102318.7495,-22.5979394},
-    R_s=218.6402160507625);
+    R_s=218.6412153118352);
 
   constant IdealGases.Common.DataRecord CNC(
     name="CNC",
@@ -5157,7 +5157,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-90313.13559999999,-831.32365,8.11473595,-0.0002447691991,
         5.39750877e-008,-6.18398486e-012,2.865172411e-016},
     bhigh={84518.33600000001,-21.02937255},
-    R_s=218.6402160507625);
+    R_s=218.6412153118352);
 
   constant IdealGases.Common.DataRecord OCCN(
     name="OCCN",
@@ -5171,7 +5171,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={935913.1680000001,-4441.082289999999,13.68959297,-0.001647530917,
         3.81987344e-007,-3.945161e-011,1.509598839e-015},
     bhigh={49512.2278,-54.1708968},
-    R_s=153.8932181624409);
+    R_s=153.8939215074386);
 
   constant IdealGases.Common.DataRecord C2N2(
     name="C2N2",
@@ -5185,7 +5185,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={793442.372,-3997.37627,13.1449743,-0.0008747782000000001,
         2.059156733e-007,-2.200469389e-011,9.97448577e-016},
     bhigh={58636.323,-54.73201251},
-    R_s=159.7867580926611);
+    R_s=159.7874883731657);
 
   constant IdealGases.Common.DataRecord C2O(
     name="C2O",
@@ -5199,7 +5199,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-634805.659,1184.133091,4.87917334,0.001757538773,-3.95755227e-007,
         3.98917994e-011,-1.546043135e-015},
     bhigh={24898.03938,0.980904059},
-    R_s=207.7537680406189);
+    R_s=207.7547175468756);
 
   constant IdealGases.Common.DataRecord C3(
     name="C3",
@@ -5213,7 +5213,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4508098.93,-14610.33761,22.81974644,-0.008544340610000001,
         2.146069341e-006,-2.103867761e-010,6.351589060000001e-015},
     bhigh={191197.6065,-127.1869723},
-    R_s=230.7518018655588);
+    R_s=230.7528564807491);
 
   constant IdealGases.Common.DataRecord C3H3_1_propynl(
     name="C3H3_1_propynl",
@@ -5227,7 +5227,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4550654.87,-16405.74172,27.12605991,-0.00447460038,1.037712415e-006,
         -1.250211369e-010,6.02658205e-015},
     bhigh={153408.7662,-156.5931809},
-    R_s=212.8863434787863);
+    R_s=212.8873164426801);
 
   constant IdealGases.Common.DataRecord C3H3_2_propynl(
     name="C3H3_2_propynl",
@@ -5241,7 +5241,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2989723.833,-11189.54446,22.22225052,-0.002068106902,4.12188364e-007,
         -4.43898059e-011,1.970824701e-015},
     bhigh={106187.8289,-118.6744583},
-    R_s=212.8863434787863);
+    R_s=212.8873164426801);
 
   constant IdealGases.Common.DataRecord C3H4_allene(
     name="C3H4_allene",
@@ -5255,7 +5255,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3479355.1,-14304.12453,27.02534756,-0.002557412369,4.70664675e-007,-4.65168807e-011,
         1.908219044e-015},
     bhigh={107231.2354,-154.8846158},
-    R_s=207.5304775925235);
+    R_s=207.5314260782661);
 
   constant IdealGases.Common.DataRecord C3H4_propyne(
     name="C3H4_propyne",
@@ -5269,7 +5269,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3710441.42,-14891.45507,27.32397127,-0.00264526477,
         4.858300350000001e-007,-4.79412848e-011,1.964338121e-015},
     bhigh={110489.8462,-156.7992462},
-    R_s=207.5304775925235);
+    R_s=207.5314260782661);
 
   constant IdealGases.Common.DataRecord C3H4_cyclo(
     name="C3H4_cyclo",
@@ -5283,7 +5283,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3168399.58,-13710.44699,26.64303646,-0.00242040805,4.42799413e-007,-4.3518202e-011,
         1.775948955e-015},
     bhigh={113368.3702,-152.2619086},
-    R_s=207.5304775925235);
+    R_s=207.5314260782661);
 
   constant IdealGases.Common.DataRecord C3H5_allyl(
     name="C3H5_allyl",
@@ -5297,7 +5297,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4094570.59,-16766.76186,31.23006342,-0.002885449982,5.21134354e-007,
         -5.05828422e-011,2.039932554e-015},
     bhigh={118572.0481,-182.3070197},
-    R_s=202.437487521852);
+    R_s=202.438412730876);
 
   constant IdealGases.Common.DataRecord C3H6_propylene(
     name="C3H6_propylene",
@@ -5311,7 +5311,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5017620.34,-20860.84035,36.4415634,-0.00388119117,7.27867719e-007,-7.321204500000001e-011,
         3.052176369e-015},
     bhigh={126124.5355,-219.5715757},
-    R_s=197.588483198803);
+    R_s=197.589386246208);
 
   constant IdealGases.Common.DataRecord C3H6_cyclo(
     name="C3H6_cyclo",
@@ -5325,7 +5325,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4785000.67,-20421.18175,36.3149578,-0.00356131944,6.47624124e-007,-6.328430100000001e-011,
         2.568705857e-015},
     bhigh={126827.4126,-222.3729099},
-    R_s=197.588483198803);
+    R_s=197.589386246208);
 
   constant IdealGases.Common.DataRecord C3H6O_propylox(
     name="C3H6O_propylox",
@@ -5339,7 +5339,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4789729.989999999,-21068.95971,39.5464773,-0.00391092998,
         7.32553151e-007,-7.35708597e-011,3.0606185e-015},
     bhigh={112034.454,-237.2004192},
-    R_s=143.1576294001599);
+    R_s=143.1582836798203);
 
   constant IdealGases.Common.DataRecord C3H6O_acetone(
     name="C3H6O_acetone",
@@ -5353,7 +5353,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5001601.92,-21701.55542,39.6449399,-0.00417994505,7.96242953e-007,-8.122558050000001e-011,
         3.42878096e-015},
     bhigh={101514.5028,-236.8533477},
-    R_s=143.1576294001599);
+    R_s=143.1582836798203);
 
   constant IdealGases.Common.DataRecord C3H6O_propanal(
     name="C3H6O_propanal",
@@ -5367,7 +5367,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4830933.489999999,-20754.51152,39.2485518,-0.004095514,
         7.88169216e-007,-8.107684080000001e-011,3.43710543e-015},
     bhigh={99449.37879999999,-231.6690627},
-    R_s=143.1576294001599);
+    R_s=143.1582836798203);
 
   constant IdealGases.Common.DataRecord C3H7_n_propyl(
     name="C3H7_n_propyl",
@@ -5381,7 +5381,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5646512.94,-22910.87136,39.8727518,-0.004106232870000001,
         7.56255777e-007,-7.47826302e-011,3.068983677e-015},
     bhigh={148300.6853,-240.378119},
-    R_s=192.9663421191394);
+    R_s=192.9672240417678);
 
   constant IdealGases.Common.DataRecord C3H7_i_propyl(
     name="C3H7_i_propyl",
@@ -5395,7 +5395,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5807002.520000001,-24112.19997,40.852884,-0.00451785133,
         8.499427170000001e-007,-8.573514339999999e-011,3.58338396e-015},
     bhigh={154650.405,-248.7098372},
-    R_s=192.9663421191394);
+    R_s=192.9672240417678);
 
   constant IdealGases.Common.DataRecord C3H8(
     name="C3H8",
@@ -5409,7 +5409,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6420731.680000001,-26597.91134,45.3435684,-0.00502066392,
         9.471216939999999e-007,-9.57540523e-011,4.00967288e-015},
     bhigh={145558.2459,-281.8374734},
-    R_s=188.5555073270316);
+    R_s=188.5563690906262);
 
   constant IdealGases.Common.DataRecord C3H8O_1propanol(
     name="C3H8O_1propanol",
@@ -5423,7 +5423,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6308672.12,-26422.10376,47.1511259,-0.004642511930000001,
         8.59346536e-007,-8.68209182e-011,3.64222401e-015},
     bhigh={125500.3155,-285.9463804},
-    R_s=138.3554244594644);
+    R_s=138.3560567913947);
 
   constant IdealGases.Common.DataRecord C3H8O_2propanol(
     name="C3H8O_2propanol",
@@ -5437,7 +5437,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6001074.75,-25058.7683,46.22096120000001,-0.00427246631,
         7.69367877e-007,-7.45058484e-011,2.998959935e-015},
     bhigh={114851.8732,-279.6132222},
-    R_s=138.3554244594644);
+    R_s=138.3560567913947);
 
   constant IdealGases.Common.DataRecord CNCOCN(
     name="CNCOCN",
@@ -5451,7 +5451,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={700052.2440000001,-5086.002009999999,19.4675349,-0.001302852727,
         2.75360075e-007,-3.056290852e-011,1.382140838e-015},
     bhigh={55393.3888,-86.2755086},
-    R_s=103.8724976881748);
+    R_s=103.8729724212562);
 
   constant IdealGases.Common.DataRecord C3O2(
     name="C3O2",
@@ -5465,7 +5465,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={696869.9889999999,-4624.73319,16.63905725,-0.001175486554,
         2.478106444e-007,-2.745165984e-011,1.239566766e-015},
     bhigh={12525.80069,-72.75968780000001},
-    R_s=122.2161106203211);
+    R_s=122.2166691900298);
 
   constant IdealGases.Common.DataRecord C4(
     name="C4",
@@ -5479,7 +5479,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={920068.513,-1530.3118,6.0500692,0.00525274367,-1.779154772e-006,
         2.589873632e-010,-1.385553481e-014},
     bhigh={133438.9611,-7.26114882},
-    R_s=173.0638513991691);
+    R_s=173.0646423605619);
 
   constant IdealGases.Common.DataRecord C4H2_butadiyne(
     name="C4H2_butadiyne",
@@ -5493,7 +5493,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2328179.913,-8925.186090000001,21.14326883,-0.001368871276,
         2.327503159e-007,-2.124517624e-011,8.053313019999999e-016},
     bhigh={105778.8416,-108.8313574},
-    R_s=166.0945114813255);
+    R_s=166.0952705904351);
 
   constant IdealGases.Common.DataRecord C4H4_1_3minuscyclo(
     name="C4H4_1_3minuscyclo",
@@ -5507,7 +5507,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2991498.949,-14167.81502,30.01978876,-0.002579200423,4.78999045e-007,
         -4.77532971e-011,1.974923662e-015},
     bhigh={127466.692,-172.7532057},
-    R_s=159.6647576090898);
+    R_s=159.6654873320101);
 
   constant IdealGases.Common.DataRecord C4H6_butadiene(
     name="C4H6_butadiene",
@@ -5521,7 +5521,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-23619031.88,56513.2337,-32.7573832,0.02293070572,-2.297106441e-006,
         4.29259621e-011,4.23676604e-015},
     bhigh={-367135.862,301.3437302},
-    R_s=153.7142607824969);
+    R_s=153.7149633095978);
 
   constant IdealGases.Common.DataRecord C4H6_1butyne(
     name="C4H6_1butyne",
@@ -5535,7 +5535,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6364402.7,-23920.87731,40.7375041,-0.00317672649,1.199856984e-007,
         3.20180251e-011,-2.854392633e-015},
     bhigh={163433.5546,-246.0284791},
-    R_s=153.7142607824969);
+    R_s=153.7149633095978);
 
   constant IdealGases.Common.DataRecord C4H6_2butyne(
     name="C4H6_2butyne",
@@ -5549,7 +5549,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3981304.33,-18730.32899,36.5456149,-0.002369686378,3.99021181e-007,-3.69870727e-011,
         1.442072006e-015},
     bhigh={126146.0214,-215.5866205},
-    R_s=153.7142607824969);
+    R_s=153.7149633095978);
 
   constant IdealGases.Common.DataRecord C4H6_cyclo(
     name="C4H6_cyclo",
@@ -5563,7 +5563,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4517367.819999999,-20973.11985,40.0803917,-0.00394979398,
         7.44848499e-007,-7.52975417e-011,3.153253502e-015},
     bhigh={140646.9848,-243.4836999},
-    R_s=153.7142607824969);
+    R_s=153.7149633095978);
 
   constant IdealGases.Common.DataRecord C4H8_1_butene(
     name="C4H8_1_butene",
@@ -5577,7 +5577,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6257948.609999999,-26603.76305,47.6492005,-0.00438326711,
         7.12883844e-007,-5.991020839999999e-011,2.051753504e-015},
     bhigh={156925.2657,-291.3869761},
-    R_s=148.1913623991023);
+    R_s=148.1920396846559);
 
   constant IdealGases.Common.DataRecord C4H8_cis2_buten(
     name="C4H8_cis2_buten",
@@ -5591,7 +5591,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6461018.35,-27753.76432,48.6353236,-0.00486238635,
         8.412626100000001e-007,-7.63389037e-011,2.861702826e-015},
     bhigh={163085.6187,-300.3105998},
-    R_s=148.1913623991023);
+    R_s=148.1920396846559);
 
   constant IdealGases.Common.DataRecord C4H8_isobutene(
     name="C4H8_isobutene",
@@ -5605,7 +5605,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6484970.99,-27325.04764,48.3632108,-0.00476800405,8.23387584e-007,-7.449252999999999e-011,
         2.782303056e-015},
     bhigh={159594.1773,-298.2986237},
-    R_s=148.1913623991023);
+    R_s=148.1920396846559);
 
   constant IdealGases.Common.DataRecord C4H8_cyclo(
     name="C4H8_cyclo",
@@ -5619,7 +5619,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4456213.810000001,-23010.18492,44.9244846,-0.003080145176,
         5.317165260000001e-007,-5.08107938e-011,2.048919092e-015},
     bhigh={135548.7603,-277.1801965},
-    R_s=148.1913623991023);
+    R_s=148.1920396846559);
 
   constant IdealGases.Common.DataRecord C4H9_n_butyl(
     name="C4H9_n_butyl",
@@ -5633,7 +5633,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7198686.94,-29592.41524,52.4204281,-0.00544157244,
         9.917758369999999e-007,-9.464455870000001e-011,3.72948704e-015},
     bhigh={183456.6472,-321.420917},
-    R_s=145.5761135660341);
+    R_s=145.5767788990000);
 
   constant IdealGases.Common.DataRecord C4H9_i_butyl(
     name="C4H9_i_butyl",
@@ -5647,7 +5647,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6752936.06,-28374.23721,51.4068761,-0.00498239901,8.80150663e-007,-8.12573869e-011,
         3.099140009e-015},
     bhigh={174344.848,-314.9940745},
-    R_s=145.5761135660341);
+    R_s=145.5767788990000);
 
   constant IdealGases.Common.DataRecord C4H9_s_butyl(
     name="C4H9_s_butyl",
@@ -5661,7 +5661,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7224744.35,-30352.91099,52.8855183,-0.00565208355,1.060032692e-006,-1.066129835e-010,
         4.443810960000001e-015},
     bhigh={188349.4279,-325.571988},
-    R_s=145.5761135660341);
+    R_s=145.5767788990000);
 
   constant IdealGases.Common.DataRecord C4H9_t_butyl(
     name="C4H9_t_butyl",
@@ -5675,7 +5675,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7151064.95,-31712.2441,54.4251032,-0.006392331160000001,
         1.241097612e-006,-1.2872483e-010,5.51261874e-015},
     bhigh={193450.6997,-339.9325290000001},
-    R_s=145.5761135660341);
+    R_s=145.5767788990000);
 
   constant IdealGases.Common.DataRecord C4H10_n_butane(
     name="C4H10_n_butane",
@@ -5689,7 +5689,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7682322.45,-32560.5151,57.3673275,-0.00619791681,1.180186048e-006,-1.221893698e-010,
         5.250635250000001e-015},
     bhigh={177452.656,-358.791876},
-    R_s=143.0515706563069);
+    R_s=143.0522244512424);
 
   constant IdealGases.Common.DataRecord C4H10_isobutane(
     name="C4H10_isobutane",
@@ -5703,7 +5703,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7528018.92,-32025.1706,57.00161,-0.00606001309,1.143975809e-006,-1.157061835e-010,
         4.84604291e-015},
     bhigh={172850.0802,-357.617689},
-    R_s=143.0515706563069);
+    R_s=143.0522244512424);
 
   constant IdealGases.Common.DataRecord C4N2(
     name="C4N2",
@@ -5717,7 +5717,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1167686.152,-6198.644179999999,20.62070093,-0.001518619449,
         3.16236168e-007,-3.4699228e-011,1.555154128e-015},
     bhigh={96674.09389999999,-96.69734738000001},
-    R_s=109.3201080253812);
+    R_s=109.3206076559176);
 
   constant IdealGases.Common.DataRecord C5(
     name="C5",
@@ -5731,7 +5731,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={217205.5356,-2958.510027,15.61080967,-0.0008200361920000001,
         1.776898025e-007,-2.009853583e-011,9.222677770000001e-016},
     bhigh={139520.8064,-64.33077179999999},
-    R_s=138.4510811193353);
+    R_s=138.4517138884495);
 
   constant IdealGases.Common.DataRecord C5H6_1_3cyclo(
     name="C5H6_1_3cyclo",
@@ -5745,7 +5745,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4428478.19,-21235.47976,43.0981901,-0.003914783460000001,
         7.31184701e-007,-7.32724119e-011,3.044403403e-015},
     bhigh={138254.2782,-260.5959678},
-    R_s=125.78409389006);
+    R_s=125.78466876668);
 
   constant IdealGases.Common.DataRecord C5H8_cyclo(
     name="C5H8_cyclo",
@@ -5759,7 +5759,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4569848.1,-24060.18294,48.8100646,-0.00341305498,6.04700166e-007,-5.927495780000001e-011,
         2.44786539e-015},
     bhigh={141398.3093,-298.9533527},
-    R_s=122.0615934167408);
+    R_s=122.0621512802527);
 
   constant IdealGases.Common.DataRecord C5H10_1_pentene(
     name="C5H10_1_pentene",
@@ -5773,7 +5773,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3744014.97,-21044.85321,47.3612699,-0.00042442012,-3.89897505e-008,
         1.367074243e-011,-9.31319423e-016},
     bhigh={115409.1373,-278.6177449000001},
-    R_s=118.5530899192818);
+    R_s=118.5536317477247);
 
   constant IdealGases.Common.DataRecord C5H10_cyclo(
     name="C5H10_cyclo",
@@ -5787,7 +5787,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7501938.73,-35058.6485,63.2248075,-0.00694035658,1.337306593e-006,-1.377905033e-010,
         5.86735764e-015},
     bhigh={195492.5511,-402.65509},
-    R_s=118.5530899192818);
+    R_s=118.5536317477247);
 
   constant IdealGases.Common.DataRecord C5H11_pentyl(
     name="C5H11_pentyl",
@@ -5801,7 +5801,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5697252.899999999,-28917.06175,58.1102968,-0.00359399501,
         4.41996763e-007,-1.509664551e-011,-6.62696443e-016},
     bhigh={171700.955,-352.247712},
-    R_s=116.873402113329);
+    R_s=116.873936265020);
 
   constant IdealGases.Common.DataRecord C5H11_t_pentyl(
     name="C5H11_t_pentyl",
@@ -5815,7 +5815,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={8602108.26,-38052.05770000001,66.4969037,-0.007533860630000001,
         1.451612787e-006,-1.495593207e-010,6.368022329999999e-015},
     bhigh={228185.8805,-416.940855},
-    R_s=116.873402113329);
+    R_s=116.873936265020);
 
   constant IdealGases.Common.DataRecord C5H12_n_pentane(
     name="C5H12_n_pentane",
@@ -5829,7 +5829,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2530779.286,-8972.59326,45.3622326,-0.002626989916,3.135136419e-006,
         -5.31872894e-010,2.886896868e-014},
     bhigh={14846.16529,-251.6550384},
-    R_s=115.2406457877736);
+    R_s=115.2411724772061);
 
   constant IdealGases.Common.DataRecord C5H12_i_pentane(
     name="C5H12_i_pentane",
@@ -5843,7 +5843,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={11568885.94,-45562.4687,74.9544363,-0.007845415580000001,
         1.444393314e-006,-1.464370213e-010,6.230285000000001e-015},
     bhigh={254492.7135,-480.198578},
-    R_s=115.2406457877736);
+    R_s=115.2411724772061);
 
   constant IdealGases.Common.DataRecord CH3C_CH3_2CH3(
     name="CH3C_CH3_2CH3",
@@ -5857,7 +5857,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={16847055.2,-59794.3057,86.85451479999999,-0.0096219176,
         1.653363091e-006,-1.674727926e-010,7.37211936e-015},
     bhigh={345849.682,-576.046697},
-    R_s=115.2406457877736);
+    R_s=115.2411724772061);
 
   constant IdealGases.Common.DataRecord C6D5_phenyl(
     name="C6D5_phenyl",
@@ -5871,7 +5871,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1411628.125,-13625.69472,40.2898494,-0.00349098927,7.37961213e-007,-8.19224405e-011,
         3.70533097e-015},
     bhigh={108807.3731,-229.3621057},
-    R_s=101.2296993560944);
+    R_s=101.2301620106773);
 
   constant IdealGases.Common.DataRecord C6D6(
     name="C6D6",
@@ -5885,7 +5885,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1758057.871,-15721.21558,44.6816249,-0.004003361919999999,
         8.4454344e-007,-9.36055698e-011,4.22847553e-015},
     bhigh={89620.45359999999,-261.5332268},
-    R_s=98.80676627971884);
+    R_s=98.80721786066331);
 
   constant IdealGases.Common.DataRecord C6H2(
     name="C6H2",
@@ -5899,7 +5899,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2592848.577,-10833.61978,28.47459495,-0.001876727704,3.41213428e-007,
         -3.33739289e-011,1.356853889e-015},
     bhigh={141851.7294,-149.4853494},
-    R_s=112.2362718830757);
+    R_s=112.2367848414851);
 
   constant IdealGases.Common.DataRecord C6H5_phenyl(
     name="C6H5_phenyl",
@@ -5913,7 +5913,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3670279.23,-18946.01209,41.8058182,-0.00350391415,6.56182174e-007,-6.594714449999999e-011,
         2.748094212e-015},
     bhigh={147674.4628,-247.5301142},
-    R_s=107.8346490903833);
+    R_s=107.8351419318608);
 
   constant IdealGases.Common.DataRecord C6H5O_phenoxy(
     name="C6H5O_phenoxy",
@@ -5927,7 +5927,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3678640.34,-19729.80806,45.4118441,-0.00375106439,7.11445078e-007,-7.233328850000001e-011,
         3.045637067e-015},
     bhigh={116359.5961,-268.1058539},
-    R_s=89.30373037260763);
+    R_s=89.30413852140579);
 
   constant IdealGases.Common.DataRecord C6H6(
     name="C6H6",
@@ -5941,7 +5941,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4538575.72,-22605.02547,46.940073,-0.004206676830000001,
         7.90799433e-007,-7.9683021e-011,3.32821208e-015},
     bhigh={139146.4686,-286.8751333},
-    R_s=106.4431717393932);
+    R_s=106.4436582213401);
 
   constant IdealGases.Common.DataRecord C6H5OH_phenol(
     name="C6H5OH_phenol",
@@ -5955,7 +5955,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4462081.569999999,-21655.21026,48.1501505,-0.00356828243,
         6.32717573e-007,-6.039905720000001e-011,2.399168678e-015},
     bhigh={111372.6204,-286.0454446},
-    R_s=88.34727924103434);
+    R_s=88.34768301852149);
 
   constant IdealGases.Common.DataRecord C6H10_cyclo(
     name="C6H10_cyclo",
@@ -5969,7 +5969,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7510128.98,-35568.5821,67.03034940000001,-0.00704535187,
         1.3581664e-006,-1.400074492e-010,5.964551700000001e-015},
     bhigh={206027.4332,-423.819766},
-    R_s=101.218743760926);
+    R_s=101.219206365438);
 
   constant IdealGases.Common.DataRecord C6H12_1_hexene(
     name="C6H12_1_hexene",
@@ -5983,7 +5983,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={733290.696,-14488.48641,46.7121549,0.00317297847,-5.24264652e-007,
         4.28035582e-011,-1.472353254e-015},
     bhigh={66977.4041,-262.3643854},
-    R_s=98.79424159940152);
+    R_s=98.79469312310390);
 
   constant IdealGases.Common.DataRecord C6H12_cyclo(
     name="C6H12_cyclo",
@@ -5997,7 +5997,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5225149.47,-33641.9458,71.74607469999999,-0.006698979119999999,
         1.318443254e-006,-1.390794789e-010,6.06010224e-015},
     bhigh={173253.7609,-454.681417},
-    R_s=98.79424159940152);
+    R_s=98.79469312310390);
 
   constant IdealGases.Common.DataRecord C6H13_n_hexyl(
     name="C6H13_n_hexyl",
@@ -6011,7 +6011,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5967938.62,-32990.2316,68.6907344,-0.00422500906,
         5.496523820000001e-007,-2.292851471e-011,-5.08634189e-016},
     bhigh={190697.8683,-418.5362},
-    R_s=97.62503079229123);
+    R_s=97.62547697229762);
 
   constant IdealGases.Common.DataRecord C6H14_n_hexane(
     name="C6H14_n_hexane",
@@ -6025,7 +6025,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3106625.684,-7346.087920000001,46.94131760000001,0.001693963977,
         2.068996667e-006,-4.21214168e-010,2.452345845e-014},
     bhigh={523.750312,-254.9967718},
-    R_s=96.48317105956971);
+    R_s=96.48361202088394);
 
   constant IdealGases.Common.DataRecord C7H7_benzyl(
     name="C7H7_benzyl",
@@ -6039,7 +6039,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5297322.16,-25999.09398,55.0975079,-0.00497766147,9.46315243e-007,-9.639008860000001e-011,
         4.06447042e-015},
     bhigh={173838.2912,-334.382955},
-    R_s=91.23700434805129);
+    R_s=91.23742133257720);
 
   constant IdealGases.Common.DataRecord C7H8(
     name="C7H8",
@@ -6053,7 +6053,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6184538.350000001,-29902.84056,59.8200597,-0.00569698396,
         1.080748416e-006,-1.098702235e-010,4.62474022e-015},
     bhigh={178204.7857,-369.808225},
-    R_s=90.23892530390688);
+    R_s=90.23933772686790);
 
   constant IdealGases.Common.DataRecord C7H8O_cresol_mx(
     name="C7H8O_cresol_mx",
@@ -6067,7 +6067,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6017373.45,-28498.82774,60.81543070000001,-0.004996807109999999,
         9.13427995e-007,-8.979444109999999e-011,3.66775697e-015},
     bhigh={147221.84,-367.485014},
-    R_s=76.88773455947235);
+    R_s=76.88808596289439);
 
   constant IdealGases.Common.DataRecord C7H14_1_heptene(
     name="C7H14_1_heptene",
@@ -6081,7 +6081,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1927608.174,-9125.024420000002,47.4817797,0.00606766053,-8.684859080000001e-007,
         5.81399526e-011,-1.473979569e-015},
     bhigh={26009.14656,-256.2880707},
-    R_s=84.68077851377274);
+    R_s=84.68116553408906);
 
   constant IdealGases.Common.DataRecord C7H15_n_heptyl(
     name="C7H15_n_heptyl",
@@ -6095,7 +6095,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5444527.57,-34568.2929,76.38651949999999,-0.003298972,
         2.343496957e-007,2.467674021e-011,-3.162012849e-015},
     bhigh={193907.9354,-464.142466},
-    R_s=83.82031171240196);
+    R_s=83.82069480008872);
 
   constant IdealGases.Common.DataRecord C7H16_n_heptane(
     name="C7H16_n_heptane",
@@ -6109,7 +6109,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={9135632.469999999,-39233.1969,78.8978085,-0.00465425193,
         2.071774142e-006,-3.4425393e-010,1.976834775e-014},
     bhigh={205070.8295,-485.110402},
-    R_s=82.97715593131233);
+    R_s=82.97753516548681);
 
   constant IdealGases.Common.DataRecord C7H16_2_methylh(
     name="C7H16_2_methylh",
@@ -6123,7 +6123,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1289912.969,-1784.340963,10.83537673,0.05270609239999999,-1.886832314e-005,
         2.432255843e-009,-1.135553789e-013},
     bhigh={-16375.29884,-29.8186241},
-    R_s=82.97715593131233);
+    R_s=82.97753516548681);
 
   constant IdealGases.Common.DataRecord C8H8_styrene(
     name="C8H8_styrene",
@@ -6137,7 +6137,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-6629183.62,15145.94166,1.609822364,0.033833186,-1.093737395e-005,
         1.338825116e-009,-6.03253492e-014},
     bhigh={-89973.2415,43.1128279},
-    R_s=79.83237880454487);
+    R_s=79.83274366600506);
 
   constant IdealGases.Common.DataRecord C8H10_ethylbenz(
     name="C8H10_ethylbenz",
@@ -6151,7 +6151,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5551564.100000001,-28313.80598,60.6124072,0.001042112857,-1.327426719e-006,
         2.166031743e-010,-1.142545514e-014},
     bhigh={164224.1062,-369.176982},
-    R_s=78.31650732350586);
+    R_s=78.31686525691141);
 
   constant IdealGases.Common.DataRecord C8H16_1_octene(
     name="C8H16_1_octene",
@@ -6165,7 +6165,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4409336.07,-4383.678800000001,49.39154259999999,
         0.007912339629999999,-7.88866951e-007,9.97021235e-012,1.913144872e-015},
     bhigh={-11226.19342,-257.7650649},
-    R_s=74.09568119955115);
+    R_s=74.09601984232792);
 
   constant IdealGases.Common.DataRecord C8H17_n_octyl(
     name="C8H17_n_octyl",
@@ -6179,7 +6179,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5632173.390000001,-38211.4367,86.37927500000001,-0.00360893158,
         2.544260445e-007,2.908638837e-011,-3.67954974e-015},
     bhigh={210313.547,-526.242283},
-    R_s=73.43604846398067);
+    R_s=73.43638409200872);
 
   constant IdealGases.Common.DataRecord C8H18_n_octane(
     name="C8H18_n_octane",
@@ -6193,7 +6193,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6365406.949999999,-31053.64657,69.6916234,0.01048059637,-4.12962195e-006,
         5.543226319999999e-010,-2.651436499e-014},
     bhigh={150096.8785,-416.989565},
-    R_s=72.78805678301707);
+    R_s=72.78838944950000);
 
   constant IdealGases.Common.DataRecord C8H18_isooctane(
     name="C8H18_isooctane",
@@ -6207,7 +6207,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={13527650.32,-46633.7034,77.95313179999999,0.01423729984,-5.073593909999999e-006,
         7.24823297e-010,-3.81919011e-014},
     bhigh={254117.8017,-493.388719},
-    R_s=72.78805678301707);
+    R_s=72.78838944950000);
 
   constant IdealGases.Common.DataRecord C9H19_n_nonyl(
     name="C9H19_n_nonyl",
@@ -6221,7 +6221,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5277361.74,-40257.0196,94.57296720000001,-0.002940301447,
         6.97810699e-009,6.80525024e-011,-5.90709533e-015},
     bhigh={216532.0614,-575.44495},
-    R_s=65.34112038335474);
+    R_s=65.34141901477409);
 
   constant IdealGases.Common.DataRecord C10H8_naphthale(
     name="C10H8_naphthale",
@@ -6235,7 +6235,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5906172.11,-31632.2924,70.3034203,-0.00601886554,1.142052144e-006,-1.161605689e-010,
         4.89284402e-015},
     bhigh={196256.7046,-434.7848950000001},
-    R_s=64.87039297336079);
+    R_s=64.87068945339381);
 
   constant IdealGases.Common.DataRecord C10H21_n_decyl(
     name="C10H21_n_decyl",
@@ -6249,7 +6249,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4967237.76,-42424.6844,102.8853417,-0.00232484818,-2.2842339e-007,
         1.056127364e-010,-8.0680659e-015},
     bhigh={223542.989,-625.5191159999999},
-    R_s=58.85362700810497);
+    R_s=58.85389598944574);
 
   constant IdealGases.Common.DataRecord C12H9_o_bipheny(
     name="C12H9_o_bipheny",
@@ -6263,7 +6263,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6736469.42,-36321.9435,82.102396,-0.00750234286,1.456251733e-006,-1.507145019e-010,
         6.43647043e-015},
     bhigh={255552.4521,-504.246297},
-    R_s=54.27206003974155);
+    R_s=54.27230808174368);
 
   constant IdealGases.Common.DataRecord C12H10_biphenyl(
     name="C12H10_biphenyl",
@@ -6277,7 +6277,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7480385.359999999,-39280.8723,86.61482219999999,-0.007946398570000001,
         1.531868544e-006,-1.576450171e-010,6.70060273e-015},
     bhigh={243805.0641,-538.138149},
-    R_s=53.91732454519163);
+    R_s=53.91757096593039);
 
   constant IdealGases.Common.DataRecord Ca(
     name="Ca",
@@ -6290,7 +6290,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7547341.239999999,-21486.42662,25.30849567,-0.01103773705,
         2.293249636e-006,-1.209075383e-010,-4.015333268e-015},
     bhigh={158586.2323,-160.9512955},
-    R_s=207.4572583462249);
+    R_s=207.4582064973302);
 
   constant IdealGases.Common.DataRecord Caplus(
     name="Caplus",
@@ -6303,7 +6303,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3747070.82,-11747.07738,16.72546969,-0.00833479771,2.394593294e-006,
         -2.988243468e-010,1.356563002e-014},
     bhigh={166432.9088,-95.8282126},
-    R_s=207.4600981239042);
+    R_s=207.4610462879883);
 
   constant IdealGases.Common.DataRecord CaBr(
     name="CaBr",
@@ -6317,7 +6317,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2783236.402,-8458.203729999999,14.3175656,-0.00543078168,
         1.522218659e-006,-1.831824807e-010,7.86428866e-015},
     bhigh={49312.7068,-65.37001100000001},
-    R_s=69.29766131586405);
+    R_s=69.29797803003784);
 
   constant IdealGases.Common.DataRecord CaBr2(
     name="CaBr2",
@@ -6331,7 +6331,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-22198.46426,-4.46315533,7.50375511,-1.641654626e-006,
         3.87942806e-010,-4.68342426e-014,2.259325541e-018},
     bhigh={-48854.3682,-5.59032425},
-    R_s=41.59606975976306);
+    R_s=41.59625986812483);
 
   constant IdealGases.Common.DataRecord CaCL(
     name="CaCL",
@@ -6345,7 +6345,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1629182.545,-4766.22302,9.65892977,-0.002523044131,5.83354216e-007,-4.10172699e-011,
         8.813177639999999e-017},
     bhigh={16625.99241,-33.98731174},
-    R_s=110.0802584369332);
+    R_s=110.0807615416187);
 
   constant IdealGases.Common.DataRecord CaCLplus(
     name="CaCLplus",
@@ -6359,7 +6359,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={177028.0396,-589.137239,5.1033688,-0.0002356761168,5.48373287e-008,
         2.137973112e-014,-5.57288731e-016},
     bhigh={58534.17249999999,-2.191253644},
-    R_s=110.0810579823968);
+    R_s=110.0815610907364);
 
   constant IdealGases.Common.DataRecord CaCL2(
     name="CaCL2",
@@ -6373,7 +6373,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-35957.6878,-8.796495630000001,7.50725691,-3.129465934e-006,
         7.322886480000001e-010,-8.776403220000001e-014,4.21048604e-018},
     bhigh={-60667.7966,-8.553523451},
-    R_s=74.91595184891516);
+    R_s=74.91629424061126);
 
   constant IdealGases.Common.DataRecord CaF(
     name="CaF",
@@ -6387,7 +6387,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={519588.2669999999,-1512.321567,5.86927625,-0.000388252448,-2.484582298e-008,
         3.74991596e-011,-3.47097645e-015},
     bhigh={-24888.14584,-8.6146637},
-    R_s=140.7409989374573);
+    R_s=140.7416421722845);
 
   constant IdealGases.Common.DataRecord CaFplus(
     name="CaFplus",
@@ -6401,7 +6401,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-139867.0845,219.1526375,4.21432434,0.0002142798048,-5.7786726e-008,
         9.98575631e-012,-6.05962188e-016},
     bhigh={28416.05897,2.740342729},
-    R_s=140.7423059098666);
+    R_s=140.7429491506670);
 
   constant IdealGases.Common.DataRecord CaF2(
     name="CaF2",
@@ -6415,7 +6415,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-82804.0944,-31.15950071,7.02357737,-9.521000020000001e-006,
         2.118160895e-009,-2.440713888e-013,1.135135468e-017},
     bhigh={-97294.66770000001,-7.54624334},
-    R_s=106.4936614431362);
+    R_s=106.4941481558384);
 
   constant IdealGases.Common.DataRecord CaH(
     name="CaH",
@@ -6429,7 +6429,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2696952.529,8607.05975,-7.02745482,0.007467916309999999,-2.318610699e-006,
         3.42307242e-010,-1.892679792e-014},
     bhigh={-27738.19107,78.45822010000001},
-    R_s=202.367817311713);
+    R_s=202.368742202320);
 
   constant IdealGases.Common.DataRecord CaI(
     name="CaI",
@@ -6443,7 +6443,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1771071.309,-5683.64373,11.53857476,-0.0041940202,1.291359961e-006,-1.730043579e-010,
         8.38076235e-015},
     bhigh={35832.932,-44.0591757},
-    R_s=49.79248420507854);
+    R_s=49.79271177387663);
 
   constant IdealGases.Common.DataRecord CaI2(
     name="CaI2",
@@ -6457,7 +6457,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-16237.27104,-2.859530722,7.50243219,-1.071178707e-006,
         2.544559095e-010,-3.083631004e-014,1.491836724e-018},
     bhigh={-33463.4117,-3.56730574},
-    R_s=28.29139668472509);
+    R_s=28.29152598614964);
 
   constant IdealGases.Common.DataRecord CaO(
     name="CaO",
@@ -6471,7 +6471,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-49131061.7,149586.595,-168.1654149,0.09381950259999999,-2.455529428e-005,
         3.07498072e-009,-1.485914237e-013},
     bhigh={-946151.172,1235.694769},
-    R_s=148.2677870229362);
+    R_s=148.2684646577766);
 
   constant IdealGases.Common.DataRecord CaOplus(
     name="CaOplus",
@@ -6485,7 +6485,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={939784.313,-2993.362243,8.33619182,-0.002303295087,7.37396753e-007,-1.052888279e-010,
         5.25713841e-015},
     bhigh={102809.8401,-24.61547836},
-    R_s=148.2692375271269);
+    R_s=148.2699151685966);
 
   constant IdealGases.Common.DataRecord CaOH(
     name="CaOH",
@@ -6499,7 +6499,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1979972.994,-5598.88099,11.51348706,-0.001668264707,3.31257391e-007,
         -1.789056647e-011,-3.58071641e-016},
     bhigh={13401.96822,-46.46084260000001},
-    R_s=145.6498638704788);
+    R_s=145.6505295405090);
 
   constant IdealGases.Common.DataRecord CaOHplus(
     name="CaOHplus",
@@ -6513,7 +6513,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={863761.537,-2347.302046,7.9819112,0.0001003160947,-6.24007417e-008,
         1.019540904e-011,-5.69892528e-016},
     bhigh={58305.80119999999,-21.52181937},
-    R_s=145.6512636043372);
+    R_s=145.6519292807646);
 
   constant IdealGases.Common.DataRecord Ca_OH_2(
     name="Ca_OH_2",
@@ -6527,7 +6527,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1721854.884,-4702.21767,13.96947691,0.0001983791405,-1.243050592e-007,
         2.033402404e-011,-1.137157819e-015},
     bhigh={-44437.6135,-52.8744486},
-    R_s=112.2171852873995);
+    R_s=112.2176981585765);
 
   constant IdealGases.Common.DataRecord CaS(
     name="CaS",
@@ -6541,7 +6541,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-15683532.14,52938.5581,-63.2246724,0.0402772638,-1.114855081e-005,
         1.464389344e-009,-7.37607897e-014},
     bhigh={-317202.267,479.9606012},
-    R_s=115.2498787131115);
+    R_s=115.2504054447417);
 
   constant IdealGases.Common.DataRecord Ca2(
     name="Ca2",
@@ -6555,7 +6555,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={240596.6267,57.7580382,2.347436675,0.0001199275034,-4.32915031e-008,
         7.01530269e-012,-3.70566032e-016},
     bhigh={40818.754,18.95399607},
-    R_s=103.7286291731124);
+    R_s=103.7291032486651);
 
   constant IdealGases.Common.DataRecord Cd(
     name="Cd",
@@ -6569,7 +6569,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-269975.7467,786.600114,1.628169079,0.000459412329,-1.150420443e-007,
         1.074836707e-011,8.790199554999999e-017},
     bhigh={7675.14826,12.20006052},
-    R_s=73.96493225751928);
+    R_s=73.96527030272838);
 
   constant IdealGases.Common.DataRecord Cdplus(
     name="Cdplus",
@@ -6583,7 +6583,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={14848.80812,-46.6915368,2.557883006,-3.6247017e-005,1.21374757e-008,
         -2.072802814e-012,1.420665367e-016},
     bhigh={118107.0109,6.21641448},
-    R_s=73.96529323073246);
+    R_s=73.96563127759133);
 
   constant IdealGases.Common.DataRecord CL(
     name="CL",
@@ -6597,7 +6597,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-169793.293,608.172646,2.12866409,0.0001307367034,-2.644883596e-008,
         2.842504775e-012,-1.252911731e-016},
     bhigh={9934.3874,8.844772103},
-    R_s=234.5209714269596);
+    R_s=234.5220432685527);
 
   constant IdealGases.Common.DataRecord CLplus(
     name="CLplus",
@@ -6611,7 +6611,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={40564.0948,-49.6016572,3.10165363,-0.000586873829,2.252039316e-007,-3.29970302e-011,
         1.708780842e-015},
     bhigh={165298.2337,2.574942598},
-    R_s=234.5246004624662);
+    R_s=234.5256723206452);
 
   constant IdealGases.Common.DataRecord CLminus(
     name="CLminus",
@@ -6623,7 +6623,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={-28883.89093,4.200642023},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={-28883.89093,4.200642023},
-    R_s=234.5173425037629);
+    R_s=234.5184143287705);
 
   constant IdealGases.Common.DataRecord CLCN(
     name="CLCN",
@@ -6637,7 +6637,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={346757.312,-1957.85737,8.807806149999999,-0.0004388362779999999,
         1.024761895e-007,-1.110675026e-011,4.98617942e-016},
     bhigh={25819.23944,-26.36885363},
-    R_s=135.2597673026367);
+    R_s=135.2603854863479);
 
   constant IdealGases.Common.DataRecord CLF(
     name="CLF",
@@ -6651,7 +6651,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3045867.173,-9979.32826,16.84162254,-0.007465850620000001,
         2.336213612e-006,-3.36586546e-010,1.763082415e-014},
     bhigh={54471.20800000001,-87.07987094000001},
-    R_s=152.6952752615198);
+    R_s=152.6959731315060);
 
   constant IdealGases.Common.DataRecord CLF3(
     name="CLF3",
@@ -6665,7 +6665,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-229495.6235,-122.0741,10.09124644,-3.64972475e-005,8.05891075e-009,
         -9.23084995e-013,4.27256949e-017},
     bhigh={-22828.40447,-25.11605479},
-    R_s=89.93653891161999);
+    R_s=89.93694995257107);
 
   constant IdealGases.Common.DataRecord CLF5(
     name="CLF5",
@@ -6679,7 +6679,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-426932.7449999999,-205.805739,16.15465278,-6.21268818e-005,
         1.376637959e-008,-1.581335709e-012,7.33642249e-017},
     bhigh={-33614.666,-57.57531175},
-    R_s=63.73928460402045);
+    R_s=63.73957591449872);
 
   constant IdealGases.Common.DataRecord CLO(
     name="CLO",
@@ -6693,7 +6693,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={409376.052,-1765.985112,7.08790063,-0.001828450169,7.1038181e-007,-1.209332942e-010,
         7.07644104e-015},
     bhigh={21518.91784,-16.68645548},
-    R_s=161.5954163459819);
+    R_s=161.5961548926775);
 
   constant IdealGases.Common.DataRecord CLO2(
     name="CLO2",
@@ -6707,7 +6707,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-163379.3802,-316.148067,7.00978726,0.0002837971144,-1.179925338e-007,
         2.920383252e-011,-2.024030202e-015},
     bhigh={11849.46452,-10.91168827},
-    R_s=123.2653835776065);
+    R_s=123.2659469428540);
 
   constant IdealGases.Common.DataRecord CL2(
     name="CL2",
@@ -6721,7 +6721,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6092569.42,-19496.27662,28.54535795,-0.01449968764,4.46389077e-006,-6.35852586e-010,
         3.32736029e-014},
     bhigh={121211.7724,-169.0778824},
-    R_s=117.2604857134798);
+    R_s=117.2610216342763);
 
   constant IdealGases.Common.DataRecord CL2O(
     name="CL2O",
@@ -6735,7 +6735,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-127174.3461,-67.4196322,7.05002245,-1.988084386e-005,
         4.366209050000001e-009,-4.978580680000001e-013,2.295679186e-017},
     bhigh={7387.2893,-8.797477254},
-    R_s=95.67267396502405);
+    R_s=95.67311122208747);
 
   constant IdealGases.Common.DataRecord Co(
     name="Co",
@@ -6749,7 +6749,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1381841.305,-3756.03668,6.65713065,-0.001269246675,1.464092329e-007,
         6.57494657e-012,-1.102384178e-015},
     bhigh={74944.42909999999,-22.58500836},
-    R_s=141.0829888755405);
+    R_s=141.0836336733794);
 
   constant IdealGases.Common.DataRecord Coplus(
     name="Coplus",
@@ -6763,7 +6763,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2907386.174,-8619.705749999999,11.88134934,-0.00351064742,
         5.74800468e-007,-2.534065135e-011,2.976607469e-016},
     bhigh={197741.9221,-60.9653344},
-    R_s=141.0843022073838);
+    R_s=141.0849470112251);
 
   constant IdealGases.Common.DataRecord Cominus(
     name="Cominus",
@@ -6777,7 +6777,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-574139.417,1763.109207,1.415561988,0.000377686969,-7.53417998e-008,
         7.99570154e-012,-3.49044e-016},
     bhigh={30834.93114,16.34360353},
-    R_s=141.0816755681481);
+    R_s=141.0823203599847);
 
   constant IdealGases.Common.DataRecord Cr(
     name="Cr",
@@ -6791,7 +6791,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-11202207.89,34011.63690000001,-36.5706217,0.02110296902,-5.51818014e-006,
         7.17360171e-010,-3.505127367e-014},
     bhigh={-168899.344,286.4481267},
-    R_s=159.9056852340849);
+    R_s=159.9064160581274);
 
   constant IdealGases.Common.DataRecord Crplus(
     name="Crplus",
@@ -6805,7 +6805,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3342330.79,-10642.61051,15.57884307,-0.00770897148,2.158300274e-006,
         -2.36810811e-010,8.952805604e-015},
     bhigh={193299.767,-86.0435667},
-    R_s=159.9073723833997);
+    R_s=159.9081032151531);
 
   constant IdealGases.Common.DataRecord Crminus(
     name="Crminus",
@@ -6817,7 +6817,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={38586.2787,6.56683537},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={38586.2787,6.56683537},
-    R_s=159.9039981203712);
+    R_s=159.9047289367030);
 
   constant IdealGases.Common.DataRecord CrN(
     name="CrN",
@@ -6831,7 +6831,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1110672.49,-3690.47854,8.59905668,-0.002125587223,5.28235848e-007,-4.92113915e-011,
         1.404331106e-015},
     bhigh={82548.04580000001,-27.99968411},
-    R_s=125.9715042392141);
+    R_s=125.9720799723648);
 
   constant IdealGases.Common.DataRecord CrO(
     name="CrO",
@@ -6845,7 +6845,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1092367.332,-3749.75865,9.00787021,-0.002545445236,
         6.928051680000001e-007,-6.390831950000001e-011,1.659741645e-015},
     bhigh={44470.9821,-29.42600453},
-    R_s=122.2797391003817);
+    R_s=122.2802979608945);
 
   constant IdealGases.Common.DataRecord CrO2(
     name="CrO2",
@@ -6859,7 +6859,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-432710.914,191.5584657,7.18824737,-0.000569484619,3.54636613e-007,-5.65512306e-011,
         2.908946349e-015},
     bhigh={-17433.39545,-10.0642472},
-    R_s=98.9878194985648);
+    R_s=98.9882719069848);
 
   constant IdealGases.Common.DataRecord CrO3(
     name="CrO3",
@@ -6873,7 +6873,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-628331.401,692.8158179999999,8.971274599999999,0.000682336564,-2.235048825e-007,
         3.36678579e-011,-1.614026492e-015},
     bhigh={-47238.802,-19.45305345},
-    R_s=83.1494595191926);
+    R_s=83.1498395408538);
 
   constant IdealGases.Common.DataRecord CrO3minus(
     name="CrO3minus",
@@ -6887,7 +6887,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-649968.203,452.201762,9.9805759,-0.000421413673,2.631277945e-007,-4.594543650000001e-011,
         2.659097549e-015},
     bhigh={-83500.1973,-24.648109},
-    R_s=83.14900333775795);
+    R_s=83.14938335733427);
 
   constant IdealGases.Common.DataRecord Cs(
     name="Cs",
@@ -6901,7 +6901,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6166040.899999999,-18961.75522,24.83229903,-0.01251977234,
         3.30901739e-006,-3.35401202e-010,9.626500908000001e-015},
     bhigh={128511.1231,-152.2942188},
-    R_s=62.559300615588);
+    R_s=62.559586533133);
 
   constant IdealGases.Common.DataRecord Csplus(
     name="Csplus",
@@ -6913,7 +6913,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={54387.3782,6.182757992},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={54387.3782,6.182757992},
-    R_s=62.55955884558522);
+    R_s=62.55984476431055);
 
   constant IdealGases.Common.DataRecord Csminus(
     name="Csminus",
@@ -6925,7 +6925,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={2237.029001,6.182770382},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={2237.029001,6.182770382},
-    R_s=62.5590423877226);
+    R_s=62.5593283040876);
 
   constant IdealGases.Common.DataRecord CsBO2(
     name="CsBO2",
@@ -6939,7 +6939,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={89755.79890000001,-1656.134283,11.16468934,-0.000447636699,
         9.621091809999999e-008,-1.081470115e-011,4.93844674e-016},
     bhigh={-76104.79670000001,-30.36616012},
-    R_s=47.31787366207544);
+    R_s=47.31808992105125);
 
   constant IdealGases.Common.DataRecord CsBr(
     name="CsBr",
@@ -6953,7 +6953,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-152832.9963,1259.712657,1.704268408,0.002776255318,-1.228389838e-006,
         2.698111786e-010,-1.98353448e-014},
     bhigh={-33278.4203,24.84116659},
-    R_s=39.07003189942927);
+    R_s=39.07021046292822);
 
   constant IdealGases.Common.DataRecord CsCL(
     name="CsCL",
@@ -6967,7 +6967,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3674923.48,11861.52941,-10.63287842,0.009804117919999999,-3.27779746e-006,
         5.53423339e-010,-3.4012315e-014},
     bhigh={-104865.8658,111.4096064},
-    R_s=49.38553425741328);
+    R_s=49.38575996630998);
 
   constant IdealGases.Common.DataRecord CsF(
     name="CsF",
@@ -6981,7 +6981,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1850863.231,5625.298800000001,-2.250022212,0.00410924354,-1.250243837e-006,
         1.941483152e-010,-1.071166179e-014},
     bhigh={-80798.2779,51.3555945},
-    R_s=54.73509608115722);
+    R_s=54.73534623939349);
 
   constant IdealGases.Common.DataRecord CsH(
     name="CsH",
@@ -6995,7 +6995,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-911214.6649999999,3576.47275,-1.258058765,0.00431485515,-1.407820502e-006,
         2.154598897e-010,-1.254525606e-014},
     bhigh={-9158.717270000001,39.0880003},
-    R_s=62.08842894650043);
+    R_s=62.08871271199990);
 
   constant IdealGases.Common.DataRecord CsI(
     name="CsI",
@@ -7009,7 +7009,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4511259.05,-13417.06362,19.80984712,-0.008359855550000002,
         2.348201245e-006,-2.874285248e-010,1.20808775e-014},
     bhigh={65734.3913,-102.1032592},
-    R_s=32.0021344835486);
+    R_s=32.0022807443226);
 
   constant IdealGases.Common.DataRecord CsLi(
     name="CsLi",
@@ -7023,7 +7023,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7481630.23,-28852.97839,46.3110499,-0.02784288108,8.78741349e-006,-1.264901197e-009,
         6.72018628e-014},
     bhigh={194513.7819,-285.7846194},
-    R_s=59.45429433496524);
+    R_s=59.45456606156252);
 
   constant IdealGases.Common.DataRecord CsNO2(
     name="CsNO2",
@@ -7037,7 +7037,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-163350.3154,-846.8879579999999,10.62853461,-0.0002508799215,
         5.54125577e-008,-6.35559195e-012,2.946880031e-016},
     bhigh={-24030.40739,-24.43488888},
-    R_s=46.4726837569193);
+    R_s=46.4728961530862);
 
   constant IdealGases.Common.DataRecord CsNO3(
     name="CsNO3",
@@ -7051,7 +7051,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-314751.7676,-1367.011655,14.01012848,-0.000401864713,8.8536147e-008,
         -1.013466457e-011,4.69175873e-016},
     bhigh={-35490.2667,-45.00692791},
-    R_s=42.65792965843015);
+    R_s=42.65812461985728);
 
   constant IdealGases.Common.DataRecord CsNa(
     name="CsNa",
@@ -7065,7 +7065,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3879556.79,-17801.67288,34.913558,-0.02320080793,
         7.861975840000001e-006,-1.171011257e-009,6.323927369999999e-014},
     bhigh={119577.6556,-200.1754433},
-    R_s=53.33371991777555);
+    R_s=53.33396367124021);
 
   constant IdealGases.Common.DataRecord CsO(
     name="CsO",
@@ -7079,7 +7079,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={837554.4350000001,-2418.205772,8.908065349999999,-0.00337818004,
         1.312755917e-006,-2.150508925e-010,1.21913898e-014},
     bhigh={18094.93447,-24.6085858},
-    R_s=55.83748279522124);
+    R_s=55.83773799174439);
 
   constant IdealGases.Common.DataRecord CsOH(
     name="CsOH",
@@ -7093,7 +7093,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={896717.113,-2323.978587,7.95964487,0.0001101149275,-6.466013969999999e-008,
         1.045968201e-011,-5.82251417e-016},
     bhigh={-17362.58234,-18.64239624},
-    R_s=55.46205897442107);
+    R_s=55.46231245512809);
 
   constant IdealGases.Common.DataRecord CsRb(
     name="CsRb",
@@ -7107,7 +7107,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-13286933.78,34145.7947,-23.73696406,0.0070704654,3.86345097e-007,-3.158132986e-010,
         2.667747207e-014},
     bhigh={-212400.8997,223.9970251},
-    R_s=38.07459017988696);
+    R_s=38.07476419387448);
 
   constant IdealGases.Common.DataRecord Cs2(
     name="Cs2",
@@ -7121,7 +7121,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-25927395.9,75398.1891,-74.840868,0.0369286679,-8.08249724e-006,
         8.171850729999999e-010,-3.0892859e-014},
     bhigh={-471504.572,586.093375},
-    R_s=31.279650307794);
+    R_s=31.279793266567);
 
   constant IdealGases.Common.DataRecord Cs2Br2(
     name="Cs2Br2",
@@ -7135,7 +7135,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-7545.84665,-0.2087093009,10.00018042,-8.03426073e-008,
         1.923604258e-011,-2.34469814e-015,1.139365834e-019},
     bhigh={-71058.8354,-7.25179304},
-    R_s=19.53501594971464);
+    R_s=19.53510523146411);
 
   constant IdealGases.Common.DataRecord Cs2CO3(
     name="Cs2CO3",
@@ -7149,7 +7149,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-303714.9985,-1517.0784,17.11941656,-0.000444970012,
         9.798325240000001e-008,-1.121256063e-011,5.189734780000001e-016},
     bhigh={-94204.1477,-56.8200626},
-    R_s=25.51862102917011);
+    R_s=25.51873765805516);
 
   constant IdealGases.Common.DataRecord Cs2CL2(
     name="Cs2CL2",
@@ -7163,7 +7163,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-16251.43966,-0.900613735,10.00077173,-3.41619408e-007,
         8.14496808e-011,-9.897475279999999e-015,4.79833081e-019},
     bhigh={-80565.13219999999,-10.81977337},
-    R_s=24.69276712870664);
+    R_s=24.69287998315499);
 
   constant IdealGases.Common.DataRecord Cs2F2(
     name="Cs2F2",
@@ -7177,7 +7177,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-36779.4642,-4.35575348,10.00366687,-1.603814186e-006,
         3.79146974e-010,-4.57868743e-014,2.209385787e-018},
     bhigh={-110345.6448,-14.15086452},
-    R_s=27.36754804057861);
+    R_s=27.36767311969674);
 
   constant IdealGases.Common.DataRecord Cs2I2(
     name="Cs2I2",
@@ -7191,7 +7191,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4983.37601,-0.09461179879999999,10.00008229,-3.68096204e-008,
         8.844660910000001e-012,-1.081178562e-015,5.26614198e-020},
     bhigh={-57605.01040000001,-5.14486489},
-    R_s=16.0010672417743);
+    R_s=16.0011403721613);
 
   constant IdealGases.Common.DataRecord Cs2O(
     name="Cs2O",
@@ -7205,7 +7205,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-41191.4741,-10.79255391,7.00850047,-3.54295578e-006,8.08169912e-010,
         -9.499419930000001e-014,4.48912254e-018},
     bhigh={-19343.7785,-1.20397045},
-    R_s=29.503790315684);
+    R_s=29.503925158165);
 
   constant IdealGases.Common.DataRecord Cs2Oplus(
     name="Cs2Oplus",
@@ -7219,7 +7219,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-31530.85844,-5.77155903,7.00448263,-1.848241331e-006,4.1808823e-010,
         -4.88237627e-014,2.295419936e-018},
     bhigh={31962.2731,-0.0543435069},
-    R_s=29.50384775081279);
+    R_s=29.50398259355620);
 
   constant IdealGases.Common.DataRecord Cs2O2(
     name="Cs2O2",
@@ -7233,7 +7233,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-119003.2094,-92.6107526,10.06915777,-2.766227147e-005,
         6.11075296e-009,-7.003595480000001e-013,3.24374252e-017},
     bhigh={-32556.1074,-17.24868948},
-    R_s=27.91874139761062);
+    R_s=27.91886899587220);
 
   constant IdealGases.Common.DataRecord Cs2O2H2(
     name="Cs2O2H2",
@@ -7247,7 +7247,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1802857.941,-4656.35475,16.93566597,0.0002117402535,-1.272249096e-007,
         2.066555839e-011,-1.152390667e-015},
     bhigh={-51908.1369,-58.4971916},
-    R_s=27.73102948721054);
+    R_s=27.73115622756404);
 
   constant IdealGases.Common.DataRecord Cs2SO4(
     name="Cs2SO4",
@@ -7261,7 +7261,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-522339.752,-944.415525,19.70476453,-0.000282122599,
         6.240792279999999e-008,-7.16346407e-012,3.32266719e-016},
     bhigh={-136417.9983,-68.20406795},
-    R_s=22.97618366639171);
+    R_s=22.97628867546256);
 
   constant IdealGases.Common.DataRecord Cu(
     name="Cu",
@@ -7275,7 +7275,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2308090.411,-8503.261,14.67859102,-0.00846713652,2.887821016e-006,-4.27065918e-010,
         2.304265084e-014},
     bhigh={92075.3562,-78.5470156},
-    R_s=130.8417839045731);
+    R_s=130.8423818965788);
 
   constant IdealGases.Common.DataRecord Cuplus(
     name="Cuplus",
@@ -7289,7 +7289,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2181443.016,7217.85819,-6.94115475,0.00620824892,-2.139340497e-006,
         3.56643144e-010,-2.081198501e-014},
     bhigh={85164.56659999999,71.16800670000001},
-    R_s=130.842913486645);
+    R_s=130.843511483813);
 
   constant IdealGases.Common.DataRecord Cuminus(
     name="Cuminus",
@@ -7301,7 +7301,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={24838.64954,5.07596603},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={24838.64954,5.07596603},
-    R_s=130.8406543420047);
+    R_s=130.8412523288480);
 
   constant IdealGases.Common.DataRecord CuCL(
     name="CuCL",
@@ -7315,7 +7315,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-25771.2241,-7.10634606,4.50562318,5.39454827e-005,5.38641796e-010,-6.348482770000001e-014,
         3.006622062e-018},
     bhigh={9566.192870000001,2.680067564},
-    R_s=83.98541399408076);
+    R_s=83.98579783634179);
 
   constant IdealGases.Common.DataRecord CuF(
     name="CuF",
@@ -7329,7 +7329,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={509415.483,-1415.00987,5.63234938,-0.000162912841,-1.156611499e-007,
         5.06603408e-011,-4.15320511e-015},
     bhigh={6305.506600000001,-7.40777361},
-    R_s=100.7272652981032);
+    R_s=100.7277256563895);
 
   constant IdealGases.Common.DataRecord CuF2(
     name="CuF2",
@@ -7343,7 +7343,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1650355.082,3775.36212,3.88911655,0.000682191264,1.875979026e-007,-5.67736811e-011,
         3.82324873e-015},
     bhigh={-59533.717,15.22659664},
-    R_s=81.88144778318831);
+    R_s=81.88182200959929);
 
   constant IdealGases.Common.DataRecord CuO(
     name="CuO",
@@ -7357,7 +7357,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={358228.017,-913.9366409999999,5.13689867,6.240577240000001e-005,-1.558613495e-007,
         5.23680312e-011,-4.026745619999999e-015},
     bhigh={41507.9286,-2.63407096},
-    R_s=104.5248625313343);
+    R_s=104.5253402459476);
 
   constant IdealGases.Common.DataRecord Cu2(
     name="Cu2",
@@ -7371,7 +7371,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-86993.995,320.910387,3.97380288,0.000508080967,-1.707470385e-007,
         3.21910819e-011,-1.958830868e-015},
     bhigh={55060.9019,6.91450217},
-    R_s=65.42089195228652);
+    R_s=65.42119094828942);
 
   constant IdealGases.Common.DataRecord Cu3CL3(
     name="Cu3CL3",
@@ -7385,7 +7385,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-91885.59679999999,-15.7193643,16.0129417,-5.57299237e-006,
         1.302748507e-009,-1.560175322e-013,7.48082757e-018},
     bhigh={-36087.6074,-40.13211395},
-    R_s=27.99513799802692);
+    R_s=27.99526594544726);
 
   constant IdealGases.Common.DataRecord D(
     name="D",
@@ -7398,7 +7398,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={60.50019210000001,-0.1810766064,2.500210817,-1.220711706e-007,
         3.71517217e-011,-5.66068021e-015,3.393920393e-019},
     bhigh={25922.43752,0.590212537},
-    R_s=4128.128565484767);
+    R_s=4128.147432453769);
 
   constant IdealGases.Common.DataRecord Dplus(
     name="Dplus",
@@ -7410,7 +7410,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={184512.0037,-0.1018414521},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={184512.0037,-0.1018414521},
-    R_s=4129.253289234842);
+    R_s=4129.272161344218);
 
   constant IdealGases.Common.DataRecord Dminus(
     name="Dminus",
@@ -7422,7 +7422,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={16423.73393,-0.1010243437},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={16423.73393,-0.1010243437},
-    R_s=4127.004454271128);
+    R_s=4127.023316102554);
 
   constant IdealGases.Common.DataRecord DBr(
     name="DBr",
@@ -7436,7 +7436,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={665400.044,-2594.092228,6.8858794,-0.001103284901,2.894201105e-007,-3.152037514e-011,
         1.011011776e-015},
     bhigh={10378.1314,-19.73703653},
-    R_s=101.4973711182908);
+    R_s=101.4978349962259);
 
   constant IdealGases.Common.DataRecord DCL(
     name="DCL",
@@ -7450,7 +7450,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={411728.4899999999,-1764.535217,5.6688771,-0.000347596417,
         5.88268803e-008,3.76025313e-013,-5.16460056e-016},
     bhigh={-1541.258092,-12.75659404},
-    R_s=221.9139339893436);
+    R_s=221.9149482124345);
 
   constant IdealGases.Common.DataRecord DF(
     name="DF",
@@ -7464,7 +7464,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={800117.2800000001,-2438.386832,5.62066445,-0.0002020416838,
         1.714418979e-008,2.697462563e-012,-2.88829741e-016},
     bhigh={-18574.47029,-14.73004444},
-    R_s=395.6916093945809);
+    R_s=395.6934178414862);
 
   constant IdealGases.Common.DataRecord DOCL(
     name="DOCL",
@@ -7478,7 +7478,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={604306.633,-2646.500381,8.61247421,-0.0005532268239999999,
         1.086845232e-007,-1.13738129e-011,4.90429552e-016},
     bhigh={4845.79518,-25.88861801},
-    R_s=155.5080599811822);
+    R_s=155.5087707065632);
 
   constant IdealGases.Common.DataRecord DO2(
     name="DO2",
@@ -7492,7 +7492,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1267224.927,2799.947016,2.325174609,0.00272632507,-6.31450732e-007,
         6.7292892e-011,-2.765192818e-015},
     bhigh={-19594.11733,17.89922833},
-    R_s=244.4505323303493);
+    R_s=244.4516495534548);
 
   constant IdealGases.Common.DataRecord DO2minus(
     name="DO2minus",
@@ -7506,7 +7506,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={552766.192,-2796.895783,8.772206669999999,-0.0006291116630000001,
         1.272331622e-007,-1.364440687e-011,6.00519944e-016},
     bhigh={2512.066767,-28.90020381},
-    R_s=244.4465896088767);
+    R_s=244.4477068139626);
 
   constant IdealGases.Common.DataRecord D2(
     name="D2",
@@ -7520,7 +7520,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={821516.856,-2365.623159,5.34297451,6.92814599e-005,-8.52367102e-008,
         2.456447415e-011,-1.960597698e-015},
     bhigh={14342.14587,-17.12600356},
-    R_s=2064.064282742384);
+    R_s=2064.073716226885);
 
   constant IdealGases.Common.DataRecord D2plus(
     name="D2plus",
@@ -7534,7 +7534,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={925595.135,-4505.21994,11.03203365,-0.00470608903,1.83806846e-006,-3.135924623e-010,
         1.857684975e-014},
     bhigh={205829.889,-52.8391224},
-    R_s=2064.345425380731);
+    R_s=2064.354860150151);
 
   constant IdealGases.Common.DataRecord D2minus(
     name="D2minus",
@@ -7548,7 +7548,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-57988.05190000001,-312.2959355,4.73038828,5.6959008e-005,
         2.01897543e-008,-2.311492448e-012,1.070266527e-016},
     bhigh={28512.00896,-9.15752792},
-    R_s=2063.783216671086);
+    R_s=2063.792648871018);
 
   constant IdealGases.Common.DataRecord D2O(
     name="D2O",
@@ -7562,7 +7562,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1544193.253,-5474.238899999999,10.17542424,-0.0009619415540000001,
         2.036545675e-007,-2.050566442e-011,8.510770689999999e-016},
     bhigh={2983.24898,-44.6501157},
-    R_s=415.1506091292798);
+    R_s=415.1525065105142);
 
   constant IdealGases.Common.DataRecord D2O2(
     name="D2O2",
@@ -7576,7 +7576,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1147867.936,-5225.76093,13.11088701,-0.001179811896,2.729336904e-007,
         -2.961433535e-011,1.310306129e-015},
     bhigh={12195.80532,-56.905382},
-    R_s=230.7844415816536);
+    R_s=230.7854963460187);
 
   constant IdealGases.Common.DataRecord D2S(
     name="D2S",
@@ -7590,7 +7590,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={423581.463,-2823.776231,8.96282184,-0.000646923123,1.634615644e-007,
         -1.797991376e-011,8.16093957e-016},
     bhigh={12046.03509,-31.91047376},
-    R_s=230.3611505368158);
+    R_s=230.3622033665950);
 
   constant IdealGases.Common.DataRecord eminus(
     name="eminus",
@@ -7602,7 +7602,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={-745.375,-11.72081224},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={-745.375,-11.72081224},
-    R_s=15156355.44527048);
+    R_s=15156424.71503372);
 
   constant IdealGases.Common.DataRecord F(
     name="F",
@@ -7616,7 +7616,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={14735.06226,81.4992736,2.444371819,2.120210026e-005,-4.54691862e-009,
         5.10952873e-013,-2.333894647e-017},
     bhigh={8388.37465,5.47871064},
-    R_s=437.6405697085111);
+    R_s=437.6425698766095);
 
   constant IdealGases.Common.DataRecord Fplus(
     name="Fplus",
@@ -7630,7 +7630,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={16496.35664,133.7351478,2.332522942,0.0001215277877,-4.8010377e-008,
         9.027225149999999e-012,-5.47066494e-016},
     bhigh={211074.5327,6.62581709},
-    R_s=437.653207431117);
+    R_s=437.655207656974);
 
   constant IdealGases.Common.DataRecord Fminus(
     name="Fminus",
@@ -7642,7 +7642,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={-31425.72443,3.26488271},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={-31425.72443,3.26488271},
-    R_s=437.6279327157407);
+    R_s=437.6299328260836);
 
   constant IdealGases.Common.DataRecord FCN(
     name="FCN",
@@ -7656,7 +7656,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={398187.355,-2302.971079,9.027081389999999,-0.000522871026,
         1.191059272e-007,-1.280287231e-011,5.73380719e-016},
     bhigh={15884.49451,-29.84971982},
-    R_s=184.7011806733685);
+    R_s=184.7020248213632);
 
   constant IdealGases.Common.DataRecord FCO(
     name="FCO",
@@ -7670,7 +7670,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-60858.5158,-1022.397533,7.52732256,-0.0001057942328,-1.365311093e-009,
         2.484612871e-012,-9.9979168e-017},
     bhigh={-18050.98416,-16.30331278},
-    R_s=176.8716601042511);
+    R_s=176.8724684686408);
 
   constant IdealGases.Common.DataRecord FO(
     name="FO",
@@ -7684,7 +7684,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1597940.503,4377.376380000001,-0.489750764,0.002682336321,-6.90080485e-007,
         7.24647968e-011,-2.726912632e-015},
     bhigh={-16442.48211,35.5992361},
-    R_s=237.5712541866057);
+    R_s=237.5723399690413);
 
   constant IdealGases.Common.DataRecord FO2_FOO(
     name="FO2_FOO",
@@ -7698,7 +7698,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1213166.895,2493.397189,4.46506574,0.0009416104040000001,-6.426472259999999e-008,
         -1.085643277e-011,1.216995394e-015},
     bhigh={-15968.00286,8.65519318},
-    R_s=163.0378036103753);
+    R_s=163.0385487492773);
 
   constant IdealGases.Common.DataRecord FO2_OFO(
     name="FO2_OFO",
@@ -7712,7 +7712,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-621186.7340000001,936.947459,6.40155875,0.0002136110846,-4.33797765e-008,
         4.66731224e-012,-2.059767432e-016},
     bhigh={36383.5727,-6.15026433},
-    R_s=163.0378036103753);
+    R_s=163.0385487492773);
 
   constant IdealGases.Common.DataRecord F2(
     name="F2",
@@ -7726,7 +7726,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2941167.79,9456.5977,-7.73861615,0.00764471299,-2.241007605e-006,
         2.915845236e-010,-1.425033974e-014},
     bhigh={-60710.0561,84.23835080000001},
-    R_s=218.8202848542556);
+    R_s=218.8212849383047);
 
   constant IdealGases.Common.DataRecord F2O(
     name="F2O",
@@ -7740,7 +7740,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-188537.4518,-210.0729689,7.15123916,0.0001327687906,
         1.804705706e-008,-1.416973671e-012,6.489389390000001e-017},
     bhigh={1449.129965,-12.57858336},
-    R_s=153.9825212609751);
+    R_s=153.9832250141188);
 
   constant IdealGases.Common.DataRecord F2O2(
     name="F2O2",
@@ -7754,7 +7754,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-219056.3532,-391.092081,10.29107144,-0.0001163345202,
         2.570922521e-008,-2.949199983e-012,1.367386916e-016},
     bhigh={827.8020939999999,-27.56752555},
-    R_s=118.7856270933028);
+    R_s=118.7861699845206);
 
   constant IdealGases.Common.DataRecord FS2F(
     name="FS2F",
@@ -7768,7 +7768,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-207709.7921,-109.4539831,10.08136946,-3.23953791e-005,
         7.12522527e-009,-8.13478741e-013,3.75502241e-017},
     bhigh={-43494.4606,-23.46916058},
-    R_s=81.41321845936034);
+    R_s=81.41359054580208);
 
   constant IdealGases.Common.DataRecord Fe(
     name="Fe",
@@ -7782,7 +7782,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1954923.682,6737.161099999999,-5.48641097,0.004378803450000001,-1.116286672e-006,
         1.544348856e-010,-8.023578182e-015},
     bhigh={7137.37006,65.0497986},
-    R_s=148.8848061599069);
+    R_s=148.8854866147372);
 
   constant IdealGases.Common.DataRecord Feplus(
     name="Feplus",
@@ -7796,7 +7796,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-817645.009,1925.359408,1.717387154,0.000338533898,-9.813533120000001e-008,
         2.228179208e-011,-1.483964439e-015},
     bhigh={128635.2466,15.00256262},
-    R_s=148.8862687618774);
+    R_s=148.8869492233923);
 
   constant IdealGases.Common.DataRecord Fe_CO_5(
     name="Fe_CO_5",
@@ -7810,7 +7810,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1116600.852,-8067.07473,36.5294241,-0.0020471903,4.44196775e-007,-4.93250713e-011,
         2.235704865e-015},
     bhigh={-48606.6125,-175.4566113},
-    R_s=42.44340477448436);
+    R_s=42.44359875545891);
 
   constant IdealGases.Common.DataRecord FeCL(
     name="FeCL",
@@ -7824,7 +7824,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={528870.022,-1282.897413,5.79844169,-0.0002896589776,3.34390381e-008,
         -1.469606582e-013,-1.213444602e-016},
     bhigh={37261.9673,-4.075134191},
-    R_s=91.06959626716905);
+    R_s=91.07001248658240);
 
   constant IdealGases.Common.DataRecord FeCL2(
     name="FeCL2",
@@ -7838,7 +7838,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={164412.3697,692.800269,4.63827014,0.002754339782,-8.624218250000001e-007,
         1.170827576e-010,-5.93806195e-015},
     bhigh={-22197.21855,11.16897701},
-    R_s=65.59689469905563);
+    R_s=65.59719449945169);
 
   constant IdealGases.Common.DataRecord FeCL3(
     name="FeCL3",
@@ -7852,7 +7852,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-59157.40590000001,-10.33382228,10.00849967,-3.65765187e-006,
         8.545873639999999e-010,-1.023070527e-013,4.90406364e-018},
     bhigh={-130501.205,-15.98494171},
-    R_s=51.25935242040887);
+    R_s=51.25958669329980);
 
   constant IdealGases.Common.DataRecord FeO(
     name="FeO",
@@ -7866,7 +7866,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-119597.148,-362.486478,5.51888075,-0.0009978856889999999,
         4.37691383e-007,-6.79062946e-011,3.63929268e-015},
     bhigh={30379.85806,-3.63365542},
-    R_s=115.7288807478384);
+    R_s=115.7294096686729);
 
   constant IdealGases.Common.DataRecord Fe_OH_2(
     name="Fe_OH_2",
@@ -7880,7 +7880,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1612519.19,-6533.24199,18.42922816,-0.002073249635,4.26587436e-007,-4.56406313e-011,
         1.990105746e-015},
     bhigh={-2992.568633,-84.45940589999999},
-    R_s=92.52728253650581);
+    R_s=92.52770541804735);
 
   constant IdealGases.Common.DataRecord Fe2CL4(
     name="Fe2CL4",
@@ -7894,7 +7894,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={140245.0973,693.606441,13.1380041,0.00275433307,-8.623996010000001e-007,
         1.170782491e-010,-5.93777808e-015},
     bhigh={-59741.72730000001,-17.52491511},
-    R_s=32.79844734952781);
+    R_s=32.79859724972584);
 
   constant IdealGases.Common.DataRecord Fe2CL6(
     name="Fe2CL6",
@@ -7908,7 +7908,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-99991.17999999999,-14.57716085,22.0120846,-5.22948113e-006,
         1.226831608e-009,-1.473195806e-013,7.07827233e-018},
     bhigh={-85514.9619,-61.43757198},
-    R_s=25.62967621020443);
+    R_s=25.62979334664990);
 
   constant IdealGases.Common.DataRecord Ga(
     name="Ga",
@@ -7922,7 +7922,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-55441.8652,880.8624419999999,1.760717716,0.000299325946,-5.61082731e-008,
         2.682832239e-012,3.132134914e-016},
     bhigh={26843.51822,12.52212023},
-    R_s=119.2500609554953);
+    R_s=119.2506059693358);
 
   constant IdealGases.Common.DataRecord Gaplus(
     name="Gaplus",
@@ -7936,7 +7936,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={35666.0714,-110.8845546,2.635517951,-8.33897352e-005,
         2.734243614e-008,-4.55567374e-012,3.035050101e-016},
     bhigh={102989.743,4.25707541},
-    R_s=119.2509992555999);
+    R_s=119.2515442737287);
 
   constant IdealGases.Common.DataRecord GaBr(
     name="GaBr",
@@ -7950,7 +7950,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={335980.503,-840.683668,5.14508473,-3.265526e-005,-7.67102275e-008,
         3.63512382e-011,-3.35817783e-015},
     bhigh={2035.179445,-0.427789408},
-    R_s=55.56799240778737);
+    R_s=55.56824637264665);
 
   constant IdealGases.Common.DataRecord GaBr2(
     name="GaBr2",
@@ -7964,7 +7964,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-330229.436,476.672265,7.1047254,-0.0005522771210000001,
         3.159876015e-007,-5.51363715e-011,3.17329323e-015},
     bhigh={-23656.8362,-1.162714892},
-    R_s=36.22374319808653);
+    R_s=36.22390875306603);
 
   constant IdealGases.Common.DataRecord GaBr3(
     name="GaBr3",
@@ -7978,7 +7978,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-51030.6375,-9.39520969,10.00768765,-3.2959543e-006,
         7.679838140000001e-010,-9.175147259999999e-014,4.39118694e-018},
     bhigh={-38334.0215,-14.10315914},
-    R_s=26.86984988769855);
+    R_s=26.86997269216475);
 
   constant IdealGases.Common.DataRecord GaCL(
     name="GaCL",
@@ -7992,7 +7992,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-486484.224,1452.870183,2.719542959,0.001144285628,-3.43145286e-007,
         5.47044048e-011,-3.019622103e-015},
     bhigh={-18950.84035,15.70926145},
-    R_s=79.05293983418271);
+    R_s=79.05330113333841);
 
   constant IdealGases.Common.DataRecord GaCL2(
     name="GaCL2",
@@ -8006,7 +8006,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-344540.53,471.443716,7.10877548,-0.000553943356,3.16363824e-007,-5.51802393e-011,
         3.17535303e-015},
     bhigh={-32309.3616,-3.74484074},
-    R_s=59.12345248846255);
+    R_s=59.12372270299867);
 
   constant IdealGases.Common.DataRecord GaCL3(
     name="GaCL3",
@@ -8020,7 +8020,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-94669.1731,-25.61468254,10.02010048,-8.35407307e-006,
         1.901439055e-009,-2.231168493e-013,1.052949609e-017},
     bhigh={-55182.0143,-18.64958383},
-    R_s=47.21931827216866);
+    R_s=47.21953408071240);
 
   constant IdealGases.Common.DataRecord GaF(
     name="GaF",
@@ -8034,7 +8034,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-298339.2279,722.5157870000001,3.63955743,0.000554673676,-1.46490145e-007,
         2.177385396e-011,-1.031058874e-015},
     bhigh={-34085.2871,7.55396},
-    R_s=93.71438796179906);
+    R_s=93.71481626882115);
 
   constant IdealGases.Common.DataRecord GaF2(
     name="GaF2",
@@ -8048,7 +8048,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={410025.1359999999,-1723.259472,8.95132922,-0.001059205682,
         2.745755154e-007,-2.907681311e-011,1.084834142e-015},
     bhigh={-53765.716,-21.13835528},
-    R_s=77.18610233224483);
+    R_s=77.18645509931031);
 
   constant IdealGases.Common.DataRecord GaF3(
     name="GaF3",
@@ -8062,7 +8062,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-209696.176,-143.1211274,10.10568378,-4.18493682e-005,
         9.16475945e-009,-1.042661957e-012,4.79916345e-017},
     bhigh={-113667.8134,-23.9253933},
-    R_s=65.61386896362842);
+    R_s=65.61416884160271);
 
   constant IdealGases.Common.DataRecord GaH(
     name="GaH",
@@ -8076,7 +8076,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3257993.99,-11090.99502,18.01126796,-0.008167719110000001,
         2.601293566e-006,-3.81345935e-010,2.028049649e-014},
     bhigh={93697.78240000001,-98.2090022},
-    R_s=117.5507069466347);
+    R_s=117.5512441938422);
 
   constant IdealGases.Common.DataRecord GaI(
     name="GaI",
@@ -8090,7 +8090,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1498356.654,-4551.96724,9.803005349999999,-0.002943735609,
         8.658040509999999e-007,-1.106638204e-010,5.00783686e-015},
     bhigh={32918.1191,-32.2735977},
-    R_s=42.28540396720764);
+    R_s=42.28559722606409);
 
   constant IdealGases.Common.DataRecord GaI2(
     name="GaI2",
@@ -8104,7 +8104,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-320287.975,479.650233,7.10233396,-0.000551265783,3.157543452e-007,-5.51087194e-011,
         3.17197773e-015},
     bhigh={-9180.919610000001,0.727520488},
-    R_s=25.69907626430948);
+    R_s=25.69919371793709);
 
   constant IdealGases.Common.DataRecord GaI3(
     name="GaI3",
@@ -8118,7 +8118,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-31640.4013,-4.20866283,10.00352001,-1.53265018e-006,3.61153154e-010,
         -4.35097887e-014,2.095704875e-018},
     bhigh={-17000.58453,-10.90291552},
-    R_s=18.45870319408682);
+    R_s=18.45878755671638);
 
   constant IdealGases.Common.DataRecord GaO(
     name="GaO",
@@ -8132,7 +8132,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2937313.804,-11183.14112,18.59366773,-0.00685475345,1.665399251e-006,
         -1.887560878e-010,7.97268692e-015},
     bhigh={85302.48080000001,-99.04040480000001},
-    R_s=96.9929913301541);
+    R_s=96.9934346215225);
 
   constant IdealGases.Common.DataRecord GaOH(
     name="GaOH",
@@ -8146,7 +8146,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={842905.101,-2372.324595,8.009071090000001,8.77723071e-005,-5.94306891e-008,
         9.841943439999999e-012,-5.53155279e-016},
     bhigh={-3751.78825,-21.71053719},
-    R_s=95.86578353088434);
+    R_s=95.86622167052498);
 
   constant IdealGases.Common.DataRecord Ga2Br2(
     name="Ga2Br2",
@@ -8160,7 +8160,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-18853.73131,-1.263621802,10.00108034,-4.774975660000001e-007,
         1.137227648e-010,-1.380820486e-014,6.69024243e-019},
     bhigh={-19510.53843,-11.41667594},
-    R_s=27.78399620389368);
+    R_s=27.78412318632332);
 
   constant IdealGases.Common.DataRecord Ga2Br4(
     name="Ga2Br4",
@@ -8174,7 +8174,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-57421.6721,-7.16013737,16.00598947,-2.60818227e-006,6.14645595e-010,
         -7.40543865e-014,3.56712663e-018},
     bhigh={-54933.8976,-34.79271660000001},
-    R_s=18.11187159904327);
+    R_s=18.11195437653302);
 
   constant IdealGases.Common.DataRecord Ga2Br6(
     name="Ga2Br6",
@@ -8188,7 +8188,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-95261.73,-14.4468188,22.01192546,-5.14500674e-006,1.204348449e-009,
         -1.443806473e-013,6.928270740000001e-018},
     bhigh={-87822.23300000001,-57.6589512},
-    R_s=13.43492494384927);
+    R_s=13.43498634608238);
 
   constant IdealGases.Common.DataRecord Ga2CL2(
     name="Ga2CL2",
@@ -8202,7 +8202,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-36689.542,-4.43458068,10.00373051,-1.630793333e-006,3.85375332e-010,
         -4.65252773e-014,2.244498791e-018},
     bhigh={-29656.33085,-14.69535817},
-    R_s=39.52646991709135);
+    R_s=39.52665056666920);
 
   constant IdealGases.Common.DataRecord Ga2CL4(
     name="Ga2CL4",
@@ -8216,7 +8216,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-112711.0409,-21.38517542,16.01738077,-7.41556464e-006,
         1.721694751e-009,-2.051361953e-013,9.797311499999999e-018},
     bhigh={-77468.53380000001,-41.4728087},
-    R_s=29.56172624423128);
+    R_s=29.56186135149933);
 
   constant IdealGases.Common.DataRecord Ga2CL6(
     name="Ga2CL6",
@@ -8230,7 +8230,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-189844.5426,-44.1365524,22.03505047,-1.470071128e-005,
         3.36951281e-009,-3.9754628e-013,1.884231868e-017},
     bhigh={-122696.9998,-67.45332883},
-    R_s=23.60965913608433);
+    R_s=23.60976704035620);
 
   constant IdealGases.Common.DataRecord Ga2F2(
     name="Ga2F2",
@@ -8244,7 +8244,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-87732.34929999999,-19.8377587,10.0159403,-6.744402830000001e-006,
         1.556129063e-009,-1.845316975e-013,8.780884020000001e-018},
     bhigh={-76073.6863,-19.08325521},
-    R_s=46.85719398089953);
+    R_s=46.85740813441057);
 
   constant IdealGases.Common.DataRecord Ga2F4(
     name="Ga2F4",
@@ -8258,7 +8258,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-270436.609,-104.9957196,16.07903965,-3.17889592e-005,
         7.04958272e-009,-8.10237952e-013,3.76054053e-017},
     bhigh={-164416.9589,-48.9659173},
-    R_s=38.59305116612241);
+    R_s=38.59322754965515);
 
   constant IdealGases.Common.DataRecord Ga2F6(
     name="Ga2F6",
@@ -8272,7 +8272,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-436866.48,-212.8208368,22.15886373,-6.34628791e-005,
         1.399738556e-008,-1.601732039e-012,7.407584420000001e-017},
     bhigh={-249429.8707,-77.87635830000001},
-    R_s=32.80693448181421);
+    R_s=32.80708442080135);
 
   constant IdealGases.Common.DataRecord Ga2I2(
     name="Ga2I2",
@@ -8286,7 +8286,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-12190.56501,-0.528755447,10.00045392,-2.011599344e-007,
         4.79946781e-011,-5.83478108e-015,2.829565069e-019},
     bhigh={-1393.258606,-9.052614910000001},
-    R_s=21.14270198360382);
+    R_s=21.14279861303205);
 
   constant IdealGases.Common.DataRecord Ga2I4(
     name="Ga2I4",
@@ -8300,7 +8300,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-31712.9976,-2.287068836,16.00194812,-8.58896438e-007,
         2.041966602e-010,-2.476145769e-014,1.198551944e-018},
     bhigh={-24019.40505,-30.08672521},
-    R_s=12.84953813215474);
+    R_s=12.84959685896855);
 
   constant IdealGases.Common.DataRecord Ga2I6(
     name="Ga2I6",
@@ -8314,7 +8314,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-60156.9815,-6.32920923,22.0053304,-2.332008629e-006,5.51386848e-010,
         -6.659445350000001e-014,3.21367043e-018},
     bhigh={-44886.9938,-51.6100875},
-    R_s=9.22935159704341);
+    R_s=9.22939377835819);
 
   constant IdealGases.Common.DataRecord Ga2O(
     name="Ga2O",
@@ -8328,7 +8328,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-119387.4986,-87.19341610000001,7.0646782,-2.571524542e-005,
         5.65110849e-009,-6.44819054e-013,2.975374645e-017},
     bhigh={-13936.94796,-6.9428013},
-    R_s=53.4880543264709);
+    R_s=53.4882987852970);
 
   constant IdealGases.Common.DataRecord Ge(
     name="Ge",
@@ -8342,7 +8342,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-856541.384,3917.95866,-1.809888212,0.002276482224,-5.36562755e-007,
         5.984958090000001e-011,-2.541700646e-015},
     bhigh={19565.18798,38.41408752},
-    R_s=114.4613436123348);
+    R_s=114.4618667400881);
 
   constant IdealGases.Common.DataRecord Geplus(
     name="Geplus",
@@ -8356,7 +8356,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2244860.57,5165.53114,-0.386751651,0.000852873094,-1.386040003e-007,
         1.155945775e-011,-3.784413134e-016},
     bhigh={100682.3985,29.65845411},
-    R_s=114.4622080667311);
+    R_s=114.4627311984352);
 
   constant IdealGases.Common.DataRecord Geminus(
     name="Geminus",
@@ -8370,7 +8370,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={13520.40246,-0.504851878,2.500140247,-3.65294416e-009,-6.7167222e-012,
         1.378119925e-015,-8.475212940000001e-020},
     bhigh={28817.39757,7.577953867},
-    R_s=114.4604791709957);
+    R_s=114.4610022947982);
 
   constant IdealGases.Common.DataRecord GeBr(
     name="GeBr",
@@ -8384,7 +8384,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={225675.0476,-731.071546,6.26328381,-0.001198085447,4.00037777e-007,-5.42993788e-011,
         2.510481953e-015},
     bhigh={19428.63606,-6.106507844},
-    R_s=54.50540172015943);
+    R_s=54.50565082861338);
 
   constant IdealGases.Common.DataRecord GeBr2(
     name="GeBr2",
@@ -8398,7 +8398,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-26366.55245,-3.99050902,7.00332744,-1.445749787e-006,
         3.40159136e-010,-4.09345703e-014,1.969987842e-018},
     bhigh={-9484.999249999999,-1.673617098},
-    R_s=35.76916987885463);
+    R_s=35.76933335627754);
 
   constant IdealGases.Common.DataRecord GeBr3(
     name="GeBr3",
@@ -8412,7 +8412,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-54339.267,-9.28032795,10.00765019,-3.29732215e-006,7.71292926e-010,
         -9.24157185e-014,4.43287623e-018},
     bhigh={-17426.97092,-13.66946296},
-    R_s=26.61891711914763);
+    R_s=26.61903877676468);
 
   constant IdealGases.Common.DataRecord GeBr4(
     name="GeBr4",
@@ -8426,7 +8426,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-69777.5791,-11.79873115,13.00953955,-4.02493875e-006,
         9.203567209999999e-010,-1.076853369e-013,5.0409548e-018},
     bhigh={-39041.4816,-26.8943607},
-    R_s=21.19654511339533);
+    R_s=21.19664198890521);
 
   constant IdealGases.Common.DataRecord GeCL(
     name="GeCL",
@@ -8440,7 +8440,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-378419.325,1429.309204,3.19485464,0.0008119939119999999,-2.652459954e-007,
         5.15195788e-011,-3.53421457e-015},
     bhigh={-2087.046335,13.8503382},
-    R_s=76.91961551626839);
+    R_s=76.91996706539740);
 
   constant IdealGases.Common.DataRecord GeCL2(
     name="GeCL2",
@@ -8454,7 +8454,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-48901.28920000001,-11.26210418,7.00906353,-3.83918073e-006,
         8.86563357e-010,-1.05200054e-013,5.00842222e-018},
     bhigh={-22752.54424,-4.656641298},
-    R_s=57.9220040962479);
+    R_s=57.9222688197512);
 
   constant IdealGases.Common.DataRecord GeCL3(
     name="GeCL3",
@@ -8468,7 +8468,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-75744.9982,-15.7921342,10.01278835,-5.44173831e-006,
         1.260936724e-009,-1.500137106e-013,7.15640081e-018},
     bhigh={-35251.3172,-17.19719944},
-    R_s=46.44982374203208);
+    R_s=46.45003603372086);
 
   constant IdealGases.Common.DataRecord GeCL4(
     name="GeCL4",
@@ -8482,7 +8482,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-137626.121,-36.037695,13.0281667,-1.16495696e-005,2.63619338e-009,-3.07292672e-013,
         1.43980875e-017},
     bhigh={-64262.8178,-33.18158305},
-    R_s=38.77078320556581);
+    R_s=38.77096040139519);
 
   constant IdealGases.Common.DataRecord GeF(
     name="GeF",
@@ -8496,7 +8496,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-515048.058,1659.711777,2.999610299,0.0008198511679999999,-2.271982948e-007,
         3.62418386e-011,-2.133840473e-015},
     bhigh={-20515.29487,13.7315423},
-    R_s=90.73130597718665);
+    R_s=90.73172065049690);
 
   constant IdealGases.Common.DataRecord GeF2(
     name="GeF2",
@@ -8510,7 +8510,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-127532.7716,-71.6259135,7.05300237,-2.101910441e-005,4.6078937e-009,
         -5.24639467e-013,2.416218951e-017},
     bhigh={-71126.3763,-8.483841439000001},
-    R_s=75.15104846699552);
+    R_s=75.15139193316412);
 
   constant IdealGases.Common.DataRecord GeF3(
     name="GeF3",
@@ -8524,7 +8524,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-206958.0129,-111.0233803,10.08234122,-3.27167626e-005,
         7.1838967e-009,-8.19038812e-013,3.77632244e-017},
     bhigh={-99997.4909,-23.0346594},
-    R_s=64.13745174366579);
+    R_s=64.13774487390501);
 
   constant IdealGases.Common.DataRecord GeF4(
     name="GeF4",
@@ -8538,7 +8538,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-325303.268,-253.8279448,13.18792173,-7.46005855e-005,
         1.637384721e-008,-1.866482733e-012,8.605530500000001e-017},
     bhigh={-146617.6526,-41.22237561},
-    R_s=55.93937900969867);
+    R_s=55.93963467192260);
 
   constant IdealGases.Common.DataRecord GeH4(
     name="GeH4",
@@ -8552,7 +8552,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3809805.88,10931.67093,-5.14967541,0.009485931369999999,-1.649459859e-006,
         1.419674126e-010,-5.00463975e-015},
     bhigh={-61585.1852,71.68961272999999},
-    R_s=108.4424304333173);
+    R_s=108.4429260525649);
 
   constant IdealGases.Common.DataRecord GeI(
     name="GeI",
@@ -8566,7 +8566,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-213314.8437,-295.3079008,6.87660736,-0.002102579132,8.59629938e-007,
         -1.44769276e-010,8.401042789999999e-015},
     bhigh={24523.26136,-8.549783749},
-    R_s=41.66726344257999);
+    R_s=41.66745387632140);
 
   constant IdealGases.Common.DataRecord GeO(
     name="GeO",
@@ -8580,7 +8580,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1044508.485,2734.866048,1.298071298,0.001832638634,-5.06098635e-007,
         6.37495802e-011,-2.172371872e-015},
     bhigh={-23621.04658,23.50906051},
-    R_s=93.80108619868818);
+    R_s=93.80151490195107);
 
   constant IdealGases.Common.DataRecord GeO2(
     name="GeO2",
@@ -8594,7 +8594,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-172734.7526,-296.1154443,7.72072625,-8.82493339e-005,
         1.949874702e-008,-2.235834829e-012,1.036128507e-016},
     bhigh={-13879.83288,-16.69845695},
-    R_s=79.45878584234529);
+    R_s=79.45914899635699);
 
   constant IdealGases.Common.DataRecord GeS(
     name="GeS",
@@ -8608,7 +8608,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2351367.441,7211.58186,-4.36252631,0.00545173775,-1.721002774e-006,
         2.632908084e-010,-1.39437404e-014},
     bhigh={-35833.1725,65.05566890999999},
-    R_s=79.40854782484124);
+    R_s=79.40891074924788);
 
   constant IdealGases.Common.DataRecord GeS2(
     name="GeS2",
@@ -8622,7 +8622,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-89709.8036,-33.64377,7.52543372,-1.026368137e-005,2.282230718e-009,
         -2.62874877e-013,1.222218614e-017},
     bhigh={11952.32103,-11.35170616},
-    R_s=60.79163559260072);
+    R_s=60.79191343130804);
 
   constant IdealGases.Common.DataRecord Ge2(
     name="Ge2",
@@ -8636,7 +8636,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1969461.258,-5248.6871,10.58277303,-0.00333655151,1.052745838e-006,-1.484534793e-010,
         7.475431760000001e-015},
     bhigh={89256.65990000001,-37.50233948},
-    R_s=57.23067180616741);
+    R_s=57.23093337004406);
 
   constant IdealGases.Common.DataRecord H(
     name="H",
@@ -8649,7 +8649,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={60.78774250000001,-0.1819354417,2.500211817,-1.226512864e-007,
         3.73287633e-011,-5.68774456e-015,3.410210197e-019},
     bhigh={25474.86398,-0.448191777},
-    R_s=8248.975137408972);
+    R_s=8249.012838065759);
 
   constant IdealGases.Common.DataRecord Hplus(
     name="Hplus",
@@ -8661,7 +8661,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={184021.4877,-1.140646644},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={184021.4877,-1.140646644},
-    R_s=8253.46732163884);
+    R_s=8253.50504282645);
 
   constant IdealGases.Common.DataRecord Hminus(
     name="Hminus",
@@ -8673,7 +8673,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={15976.15494,-1.139013868},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={15976.15494,-1.139013868},
-    R_s=8244.487840516989);
+    R_s=8244.525520665280);
 
   constant IdealGases.Common.DataRecord HALO(
     name="HALO",
@@ -8687,7 +8687,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={78474.67049999999,-1515.62885,8.572776230000001,-0.0004142611439999999,
         8.9350817e-008,-1.007036446e-011,4.60801725e-016},
     bhigh={6663.24189,-26.72948642},
-    R_s=189.0130500714294);
+    R_s=189.0139139261520);
 
   constant IdealGases.Common.DataRecord HALO2(
     name="HALO2",
@@ -8701,7 +8701,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={698570.544,-2864.935042,10.86721494,-5.3683127e-005,-2.836877559e-008,
         6.29164119e-012,-3.88903311e-016},
     bhigh={-27643.92495,-37.7588634},
-    R_s=138.6016114681605);
+    R_s=138.6022449252502);
 
   constant IdealGases.Common.DataRecord HBO(
     name="HBO",
@@ -8715,7 +8715,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={886186.0229999999,-3913.06805,9.8886448,-0.0008222269139999999,
         1.621530554e-007,-1.703550237e-011,7.372740020000001e-016},
     bhigh={-3161.852029,-40.3681272},
-    R_s=298.8845488264217);
+    R_s=298.8859148317262);
 
   constant IdealGases.Common.DataRecord HBOplus(
     name="HBOplus",
@@ -8729,7 +8729,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={18360.83606,-1212.975446,6.82290196,0.0009142272500000001,-2.665355457e-007,
         3.29704981e-011,-1.530684082e-015},
     bhigh={146361.7504,-16.99646159},
-    R_s=298.8904431859389);
+    R_s=298.8918092181826);
 
   constant IdealGases.Common.DataRecord HBO2(
     name="HBO2",
@@ -8743,7 +8743,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1049369.185,-4479.145479999999,11.97755861,-0.00047357434,
         6.08020714e-008,-3.64156544e-012,6.15597317e-017},
     bhigh={-42211.4947,-49.11366819999999},
-    R_s=189.7512742555869);
+    R_s=189.7521414842482);
 
   constant IdealGases.Common.DataRecord HBS(
     name="HBS",
@@ -8757,7 +8757,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-202183.6183,-505.202662,6.41521828,0.001049432932,-3.68314669e-007,
         5.34296831e-011,-2.154140451e-015},
     bhigh={6485.47562,-13.31379864},
-    R_s=189.4650298036138);
+    R_s=189.4658957240394);
 
   constant IdealGases.Common.DataRecord HBSplus(
     name="HBSplus",
@@ -8771,7 +8771,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={661065.836,-2791.498527,9.131267640000001,-0.000506379529,
         7.751213140000001e-008,-4.19113293e-012,2.687149095e-017},
     bhigh={151073.4114,-30.81426166},
-    R_s=189.4673983652048);
+    R_s=189.4682642964555);
 
   constant IdealGases.Common.DataRecord HCN(
     name="HCN",
@@ -8785,7 +8785,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1236889.278,-4446.732410000001,9.73887485,-0.000585518264,
         1.07279144e-007,-1.013313244e-011,3.34824798e-016},
     bhigh={42215.1377,-40.05774072000001},
-    R_s=307.6546678043644);
+    R_s=307.6560738921324);
 
   constant IdealGases.Common.DataRecord HCO(
     name="HCO",
@@ -8799,7 +8799,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={694960.6120000001,-3656.22338,9.604731170000001,-0.001117129278,
         2.875328019e-007,-3.62624774e-011,1.808329595e-015},
     bhigh={25437.0444,-35.8247372},
-    R_s=286.5276910501192);
+    R_s=286.5290005803287);
 
   constant IdealGases.Common.DataRecord HCOplus(
     name="HCOplus",
@@ -8813,7 +8813,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1219060.653,-4714.29489,10.21192493,-0.000885451707,1.667408026e-007,
         -1.683285548e-011,7.04005178e-016},
     bhigh={127798.9027,-43.5115846},
-    R_s=286.5331080963119);
+    R_s=286.5344176512791);
 
   constant IdealGases.Common.DataRecord HCCN(
     name="HCCN",
@@ -8827,7 +8827,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={939562.031,-4091.06775,12.72233302,-0.000687440531,1.231169968e-007,
         -1.186956238e-011,4.76061035e-016},
     bhigh={95851.6482,-52.48695794},
-    R_s=212.9947607390504);
+    R_s=212.9957341984484);
 
   constant IdealGases.Common.DataRecord HCCO(
     name="HCCO",
@@ -8841,7 +8841,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1093922.002,-4498.228209999999,12.46446433,-0.00063433174,
         1.108549019e-007,-1.125488678e-011,5.68915194e-016},
     bhigh={46522.803,-50.9907043},
-    R_s=202.6499473296036);
+    R_s=202.6508735096423);
 
   constant IdealGases.Common.DataRecord HCL(
     name="HCL",
@@ -8855,7 +8855,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={915774.951,-2770.550211,5.97353979,-0.000362981006,4.73552919e-008,
         2.810262054e-012,-6.65610422e-016},
     bhigh={5674.95805,-16.42825822},
-    R_s=228.0377850927595);
+    R_s=228.0388273039587);
 
   constant IdealGases.Common.DataRecord HD(
     name="HD",
@@ -8869,7 +8869,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={845583.0000000001,-1956.578537,4.40437387,0.000575168109,-2.131983152e-007,
         4.03612668e-011,-2.727170705e-015},
     bhigh={12272.54163,-10.84742878},
-    R_s=2751.276123892388);
+    R_s=2751.288698171634);
 
   constant IdealGases.Common.DataRecord HDplus(
     name="HDplus",
@@ -8883,7 +8883,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1340083.03,-5730.069570000001,12.13836576,-0.00524333812,
         1.976302344e-006,-3.30657353e-010,1.937902763e-014},
     bhigh={213534.8051,-61.2875839},
-    R_s=2751.775661664527);
+    R_s=2751.788238226832);
 
   constant IdealGases.Common.DataRecord HDO(
     name="HDO",
@@ -8897,7 +8897,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1711376.798,-5322.8723,9.124351519999999,-0.000340066415,
         4.152343519999999e-008,-4.78076857e-014,-1.46803517e-016},
     bhigh={3245.22468,-37.7460068},
-    R_s=437.1104987729112);
+    R_s=437.1124965184028);
 
   constant IdealGases.Common.DataRecord HDO2(
     name="HDO2",
@@ -8911,7 +8911,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1313180.619,-5175.63712,12.16490975,-0.000613669948,1.227560176e-007,
         -1.079624939e-011,3.87401372e-016},
     bhigh={13032.0967,-50.85276870000001},
-    R_s=237.4149656367485);
+    R_s=237.4160507048917);
 
   constant IdealGases.Common.DataRecord HF(
     name="HF",
@@ -8925,7 +8925,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={725708.904,-1484.797741,3.85552747,0.000713898985,-2.106757333e-007,
         3.050092453e-011,-1.639495583e-015},
     bhigh={-23554.5666,-3.20385683},
-    R_s=415.5917909075958);
+    R_s=415.5936903051829);
 
   constant IdealGases.Common.DataRecord HI(
     name="HI",
@@ -8939,7 +8939,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={472492.145,-1923.465741,5.75804897,-0.000406626638,
         9.474332049999999e-008,-1.033534431e-011,4.61161479e-016},
     bhigh={13948.57037,-11.82487652},
-    R_s=65.00129268145288);
+    R_s=65.00158975974263);
 
   constant IdealGases.Common.DataRecord HNC(
     name="HNC",
@@ -8953,7 +8953,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1198791.66,-3918.94186,9.11802009,-0.00034177611,3.31480968e-008,-5.70157474e-013,
         -7.789455389999999e-017},
     bhigh={46588.103,-34.68575882},
-    R_s=307.6546678043644);
+    R_s=307.6560738921324);
 
   constant IdealGases.Common.DataRecord HNCO(
     name="HNCO",
@@ -8967,7 +8967,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1253216.926,-5021.091539999999,12.47789314,-0.000689165525,
         1.097738448e-007,-9.3064038e-012,3.24260695e-016},
     bhigh={14531.55559,-53.06419819},
-    R_s=193.2486285797427);
+    R_s=193.2495117925175);
 
   constant IdealGases.Common.DataRecord HNO(
     name="HNO",
@@ -8981,7 +8981,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-5795614.98,19454.57427,-21.52568374,0.01797428992,-4.97604067e-006,
         6.397924169999999e-010,-3.142619368e-014},
     bhigh={-110419.2372,181.8650338},
-    R_s=268.0873565649622);
+    R_s=268.0885818164934);
 
   constant IdealGases.Common.DataRecord HNO2(
     name="HNO2",
@@ -8995,7 +8995,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={878790.4129999999,-3990.45503,11.87349269,-0.000488190061,
         7.13363679e-008,-5.37630334e-012,1.581778986e-016},
     bhigh={12463.43241,-46.08874688},
-    R_s=176.8530871172158);
+    R_s=176.8538953967206);
 
   constant IdealGases.Common.DataRecord HNO3(
     name="HNO3",
@@ -9009,7 +9009,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-94978.0964,-2733.024468,14.49426995,-0.000782186805,
         1.702693665e-007,-1.930543961e-011,8.870455120000001e-016},
     bhigh={-4882.51778,-59.28392985000001},
-    R_s=131.9488535987269);
+    R_s=131.9494566504223);
 
   constant IdealGases.Common.DataRecord HOCL(
     name="HOCL",
@@ -9023,7 +9023,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={853045.781,-2847.760552,7.94832904,-0.0001048782013,-1.482405043e-008,
         4.59167827e-012,-3.060073987e-016},
     bhigh={7250.964950000001,-22.4983169},
-    R_s=158.4906235834537);
+    R_s=158.4913479401773);
 
   constant IdealGases.Common.DataRecord HOF(
     name="HOF",
@@ -9037,7 +9037,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={881201.823,-3120.013169,8.223710069999999,-0.0002298036315,
         1.459115709e-008,1.095883303e-012,-1.404445608e-016},
     bhigh={6300.54671,-25.90150427},
-    R_s=230.9207160039958);
+    R_s=230.9217713911818);
 
   constant IdealGases.Common.DataRecord HO2(
     name="HO2",
@@ -9051,7 +9051,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1810669.724,4963.19203,-1.039498992,0.004560148530000001,-1.061859447e-006,
         1.144567878e-010,-4.763064160e-015},
     bhigh={-3.200817190e+004,4.066850920e+001},
-    R_s=251.9022478439252);
+    R_s=251.9033991239365);
 
   constant IdealGases.Common.DataRecord HO2minus(
     name="HO2minus",
@@ -9065,7 +9065,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={793330.6,-2503.312417,7.54896233,8.308390149999999e-005,-5.96973091e-008,
         9.955377000000001e-012,-5.606477280e-016},
     bhigh={2.512079084e+003,-2.070065846e+001},
-    R_s=251.8980610846054);
+    R_s=251.8992123454818);
 
   constant IdealGases.Common.DataRecord HPO(
     name="HPO",
@@ -9079,7 +9079,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={384245.945,-2434.951707,8.582173920000001,-0.000405844857,-1.66948874e-008,
         2.253640566e-011,-1.943063011e-015},
     bhigh={5761.63212,-26.49097544},
-    R_s=173.2863945743971);
+    R_s=173.2871865528888);
 
   constant IdealGases.Common.DataRecord HSO3F(
     name="HSO3F",
@@ -9093,7 +9093,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={554404.708,-3974.42432,17.78869264,-0.000440932203,5.94441139e-008,-3.92701581e-012,
         8.891284000000001e-017},
     bhigh={-71534.3827,-76.13127849},
-    R_s=83.08693868405707);
+    R_s=83.08731841997657);
 
   constant IdealGases.Common.DataRecord H2(
     name="H2",
@@ -9107,7 +9107,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={560812.801,-837.150474,2.975364532,0.001252249124,-3.74071619e-007,
         5.936625200000001e-011,-3.6069941e-015},
     bhigh={5339.82441,-2.202774769},
-    R_s=4124.487568704486);
+    R_s=4124.506419032879);
 
   constant IdealGases.Common.DataRecord H2plus(
     name="H2plus",
@@ -9121,7 +9121,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1672225.964,-6595.18499,12.79321925,-0.00550934526,2.030669412e-006,
         -3.35102748e-010,1.946089104e-014},
     bhigh={218999.9548,-67.9271078},
-    R_s=4125.610309053885);
+    R_s=4125.629164513588);
 
   constant IdealGases.Common.DataRecord H2minus(
     name="H2minus",
@@ -9135,7 +9135,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={95992.7562,-914.4682879999999,5.14941881,-0.0001016559478,
         5.446919560000001e-008,-6.155174449999999e-012,2.822451181e-016},
     bhigh={32341.0518,-14.4078098},
-    R_s=4123.365439272186);
+    R_s=4123.384284472061);
 
   constant IdealGases.Common.DataRecord HBOH(
     name="HBOH",
@@ -9149,7 +9149,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1534611.049,-5753.66643,12.70893665,-0.000705962825,1.027679375e-007,
         -7.67092674e-012,2.211854768e-016},
     bhigh={27793.70419,-56.0886008},
-    R_s=288.4337486488024);
+    R_s=288.4350668903514);
 
   constant IdealGases.Common.DataRecord HCOOH(
     name="HCOOH",
@@ -9163,7 +9163,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={487233.645,-7632.238079999999,21.32788153,-0.004402546540000001,
         1.102001695e-006,-1.364343517e-010,6.64842975e-015},
     bhigh={-5781.43191,-111.1790688},
-    R_s=180.6497197850404);
+    R_s=180.6505454164637);
 
   constant IdealGases.Common.DataRecord H2F2(
     name="H2F2",
@@ -9177,7 +9177,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1464995.601,-3335.07492,9.187487040000001,0.001051127249,-3.27860557e-007,
         4.45604623e-011,-2.281370136e-015},
     bhigh={-48254.42090000001,-26.39128168},
-    R_s=207.7958954537979);
+    R_s=207.7968451525914);
 
   constant IdealGases.Common.DataRecord H2O(
     name="H2O",
@@ -9191,7 +9191,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1034972.096,-2412.698562,4.64611078,0.002291998307,-6.836830479999999e-007,
         9.426468930000001e-011,-4.82238053e-015},
     bhigh={-13842.86509,-7.97814851},
-    R_s=461.5233290850878);
+    R_s=461.5254384056201);
 
   constant IdealGases.Common.DataRecord H2Oplus(
     name="H2Oplus",
@@ -9205,7 +9205,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={622871.426,-2864.257487,7.71756556,-0.000902780167,6.17743686e-007,-1.201457479e-010,
         7.407709940000001e-015},
     bhigh={134208.6651,-26.3661792},
-    R_s=461.5373837880259);
+    R_s=461.5394931727930);
 
   constant IdealGases.Common.DataRecord H2O2(
     name="H2O2",
@@ -9219,7 +9219,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1489428.027,-5170.82178,11.2820497,-8.04239779e-005,-1.818383769e-008,
         6.94726559e-012,-4.8278319e-016},
     bhigh={14182.51038,-46.50855660000001},
-    R_s=244.4377545224592);
+    R_s=244.4388716871657);
 
   constant IdealGases.Common.DataRecord H2S(
     name="H2S",
@@ -9233,7 +9233,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1430040.22,-5284.02865,10.16182124,-0.000970384996,2.154003405e-007,
         -2.1696957e-011,9.318163070000001e-016},
     bhigh={29086.96214,-43.49160391},
-    R_s=243.9629493135154);
+    R_s=243.9640643081986);
 
   constant IdealGases.Common.DataRecord H2SO4(
     name="H2SO4",
@@ -9247,7 +9247,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1437877.914,-6614.90253,21.57662058,-0.000480625597,3.010775121e-008,
         2.334842469e-012,-2.946330375e-016},
     bhigh={-52590.92950000001,-102.3603724},
-    R_s=84.77366288710837);
+    R_s=84.77405033193827);
 
   constant IdealGases.Common.DataRecord H2BOH(
     name="H2BOH",
@@ -9261,7 +9261,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2294795.193,-9382.923559999999,17.98228329,-0.001506116214,
         2.635641095e-007,-2.483163637e-011,9.736759120000001e-016},
     bhigh={20397.38953,-94.48201210000001},
-    R_s=278.689102647899);
+    R_s=278.690376353060);
 
   constant IdealGases.Common.DataRecord HB_OH_2(
     name="HB_OH_2",
@@ -9275,7 +9275,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2122674.609,-8615.948939999998,19.6617952,-0.00081484115,
         8.955082040000001e-008,-3.34483051e-012,-6.919578139999999e-017},
     bhigh={-27887.90377,-99.8355961},
-    R_s=181.4055272090662);
+    R_s=181.4063562947897);
 
   constant IdealGases.Common.DataRecord H3BO3(
     name="H3BO3",
@@ -9289,7 +9289,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2297369.132,-8933.57179,21.93496552,-0.000309478349,-5.06405299e-008,
         1.482296684e-011,-9.7644209e-016},
     bhigh={-69702.9847,-112.2292829},
-    R_s=134.4665358412059);
+    R_s=134.4671503995762);
 
   constant IdealGases.Common.DataRecord H3B3O3(
     name="H3B3O3",
@@ -9303,7 +9303,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1286220.713,-10932.58784,32.1351867,-0.002595402269,5.35376647e-007,
         -5.833567379999999e-011,2.600757913e-015},
     bhigh={-87528.5689,-177.0847815},
-    R_s=99.62818294214057);
+    R_s=99.62863827724203);
 
   constant IdealGases.Common.DataRecord H3B3O6(
     name="H3B3O6",
@@ -9317,7 +9317,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1952433.352,-11549.32896,38.9267611,-0.00111385228,1.280317726e-007,
         -5.72846482e-012,-2.214529572e-017},
     bhigh={-212092.7136,-207.5566801},
-    R_s=63.25042475186231);
+    R_s=63.25071382808272);
 
   constant IdealGases.Common.DataRecord H3F3(
     name="H3F3",
@@ -9331,7 +9331,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2515790.373,-8789.42332,20.23933445,-0.001131704646,1.692779921e-007,
         -1.308662105e-011,3.978322e-016},
     bhigh={-54717.1365,-99.07787640000001},
-    R_s=138.5305969691986);
+    R_s=138.5312301017276);
 
   constant IdealGases.Common.DataRecord H3Oplus(
     name="H3Oplus",
@@ -9345,7 +9345,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2955126.2,-9185.669409999999,13.41398696,-0.000559033921,
         1.138387119e-008,7.25992721e-012,-6.13373436e-016},
     bhigh={129053.4257,-70.2182818},
-    R_s=437.0822491314233);
+    R_s=437.0842467478043);
 
   constant IdealGases.Common.DataRecord H4F4(
     name="H4F4",
@@ -9359,7 +9359,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3354037.99,-11719.2204,27.65243565,-0.001508934621,2.257027572e-007,
         -1.744867255e-011,5.304351740000001e-016},
     bhigh={-74202.13160000001,-138.8603332},
-    R_s=103.897947726899);
+    R_s=103.898422576296);
 
   constant IdealGases.Common.DataRecord H5F5(
     name="H5F5",
@@ -9373,7 +9373,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4192290.73,-14649.03043,35.0655492,-0.001886170471,2.821289954e-007,
         -2.181090984e-011,6.63047416e-016},
     bhigh={-93687.042,-178.8592044},
-    R_s=83.11835818151914);
+    R_s=83.11873806103655);
 
   constant IdealGases.Common.DataRecord H6F6(
     name="H6F6",
@@ -9387,7 +9387,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5024520.319999999,-17428.17868,42.148705,-0.002084564791,
         2.930051519e-007,-2.052079159e-011,5.2069373e-016},
     bhigh={-115449.7653,-216.3947001},
-    R_s=69.26529848459929);
+    R_s=69.26561505086380);
 
   constant IdealGases.Common.DataRecord H7F7(
     name="H7F7",
@@ -9401,7 +9401,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5868789.83,-20508.63473,49.8917611,-0.002640634895,3.94979633e-007,-3.053515088e-011,
         9.28260178e-016},
     bhigh={-133017.7809,-259.2385142},
-    R_s=59.37025584394225);
+    R_s=59.37052718645469);
 
   constant IdealGases.Common.DataRecord He(
     name="He",
@@ -9413,7 +9413,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={-745.375,0.9287239740000001},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={-745.375,0.9287239740000001},
-    R_s=2077.26673798694);
+    R_s=2077.27623181121);
 
   constant IdealGases.Common.DataRecord Heplus(
     name="Heplus",
@@ -9425,7 +9425,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={285323.3739,1.621665557},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={285323.3739,1.621665557},
-    R_s=2077.551488943151);
+    R_s=2077.560984068828);
 
   constant IdealGases.Common.DataRecord Hg(
     name="Hg",
@@ -9438,7 +9438,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={51465.7351,-168.1269855,2.718343098,-0.0001445026192,5.15897766e-008,
         -9.47248501e-012,7.034797406e-016},
     bhigh={7688.68493,5.27123609},
-    R_s=41.45008225734085);
+    R_s=41.45027169848946);
 
   constant IdealGases.Common.DataRecord Hgplus(
     name="Hgplus",
@@ -9452,7 +9452,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-12299.84728,27.32269908,2.48418216,-4.42679761e-006,
         7.489685859999999e-009,-2.549887287e-012,2.819873366e-016},
     bhigh={128318.8257,7.62524457},
-    R_s=41.45019562080521);
+    R_s=41.45038506247193);
 
   constant IdealGases.Common.DataRecord HgBr2(
     name="HgBr2",
@@ -9466,7 +9466,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-22436.4929,-3.31265227,7.50276517,-1.202360213e-006,
         2.830526999e-010,-3.4076867e-014,1.640497921e-018},
     bhigh={-13274.83366,-4.3685556},
-    R_s=23.07025011237576);
+    R_s=23.07035555136265);
 
   constant IdealGases.Common.DataRecord I(
     name="I",
@@ -9480,7 +9480,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-778586.0569999999,2303.279568,0.002886686091,0.001180878463,-2.264074866e-007,
         1.963511339e-011,-6.243525940999999e-016},
     bhigh={-2616.792742,25.58922997},
-    R_s=65.51756608730962);
+    R_s=65.51786552514660);
 
   constant IdealGases.Common.DataRecord Iplus(
     name="Iplus",
@@ -9494,7 +9494,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-778838.5329999999,2404.962651,-0.1791751142,0.001227311979,-1.80149403e-007,
         9.923983959999999e-012,-9.775286439000001e-017},
     bhigh={118853.1631,27.10544347},
-    R_s=65.5178493168297);
+    R_s=65.5181487559611);
 
   constant IdealGases.Common.DataRecord Iminus(
     name="Iminus",
@@ -9506,7 +9506,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={-24149.70936,6.11346538},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={-24149.70936,6.11346538},
-    R_s=65.51728286023828);
+    R_s=65.51758229678082);
 
   constant IdealGases.Common.DataRecord IF5(
     name="IF5",
@@ -9520,7 +9520,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-362050.626,-163.9236093,16.12272743,-4.91443155e-005,
         1.086015052e-008,-1.244672691e-012,5.76359362e-017},
     bhigh={-106164.2293,-53.9877336},
-    R_s=37.47004808359156);
+    R_s=37.47021933461353);
 
   constant IdealGases.Common.DataRecord IF7(
     name="IF7",
@@ -9534,7 +9534,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-561442.264,-264.6288326,22.19879891,-7.984221469999999e-005,
         1.768835964e-008,-2.031523755e-012,9.423767390000001e-017},
     bhigh={-122524.5322,-87.74010730000001},
-    R_s=31.99186836728072);
+    R_s=31.99201458113507);
 
   constant IdealGases.Common.DataRecord I2(
     name="I2",
@@ -9548,7 +9548,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-5632594.16,17939.6156,-17.23055169,0.0124421408,-3.33276858e-006,
         4.12547794e-010,-1.960461713e-014},
     bhigh={-106850.5292,160.0531883},
-    R_s=32.75878304365481);
+    R_s=32.75893276257330);
 
   constant IdealGases.Common.DataRecord In(
     name="In",
@@ -9562,7 +9562,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1683608.899,2210.473186,3.47221937,-0.001082267422,3.47969998e-007,
         -5.15809241e-011,3.183043089e-015},
     bhigh={10959.65206,2.557189088},
-    R_s=72.41436011775157);
+    R_s=72.41469107631208);
 
   constant IdealGases.Common.DataRecord Inplus(
     name="Inplus",
@@ -9576,7 +9576,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={45369.9514,-144.5142103,2.681812441,-0.000115748006,3.94771481e-008,
         -6.87924362e-012,4.81920492e-016},
     bhigh={1004.26144,4.68375918},
-    R_s=72.4147061149626);
+    R_s=72.4150370751044);
 
   constant IdealGases.Common.DataRecord InBr(
     name="InBr",
@@ -9590,7 +9590,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={794837.442,-2318.183711,7.03288958,-0.001245920568,3.27669335e-007,-3.003771106e-011,
         5.85319277e-016},
     bhigh={6957.627289999999,-12.7350266},
-    R_s=42.69919166812174);
+    R_s=42.69938681813046);
 
   constant IdealGases.Common.DataRecord InBr2(
     name="InBr2",
@@ -9604,7 +9604,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-321716.203,479.2682100000001,7.10264948,-0.000551401978,
         3.157862421e-007,-5.51125451e-011,3.17216139e-015},
     bhigh={-23709.23659,0.1193263347},
-    R_s=30.27561847749303);
+    R_s=30.27575684749441);
 
   constant IdealGases.Common.DataRecord InBr3(
     name="InBr3",
@@ -9618,7 +9618,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-35057.831,-4.85872132,10.00406131,-1.767620958e-006,4.16401606e-010,
         -5.01552887e-014,2.415414123e-018},
     bhigh={-33931.7924,-12.29069868},
-    R_s=23.45209714269597);
+    R_s=23.45220432685527);
 
   constant IdealGases.Common.DataRecord InCL(
     name="InCL",
@@ -9632,7 +9632,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-274575.1636,894.0986909999999,3.26811839,0.0009180277780000001,-3.083262431e-007,
         5.74545881e-011,-3.64527575e-015},
     bhigh={-15616.0343,12.66880374},
-    R_s=55.32985073633636);
+    R_s=55.33010361280621);
 
   constant IdealGases.Common.DataRecord InCL2(
     name="InCL2",
@@ -9646,7 +9646,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-332871.984,475.769161,7.10544369,-0.000552578696,3.160567738e-007,-5.51445368e-011,
         3.17368038e-015},
     bhigh={-29950.95917,-2.294555511},
-    R_s=44.76789214102647);
+    R_s=44.76809674570869);
 
   constant IdealGases.Common.DataRecord InCL3(
     name="InCL3",
@@ -9660,7 +9660,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-71140.4363,-16.28425068,10.01309622,-5.54452888e-006,
         1.279877732e-009,-1.518261505e-013,7.22656277e-018},
     bhigh={-47589.7417,-16.69761011},
-    R_s=37.59193767887258);
+    R_s=37.59210948697197);
 
   constant IdealGases.Common.DataRecord InF(
     name="InF",
@@ -9674,7 +9674,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-468900.12,1321.019051,2.881329353,0.001041591078,-3.090754867e-007,
         4.92664656e-011,-2.699156425e-015},
     bhigh={-33083.6981,13.96688303},
-    R_s=62.13342909518585);
+    R_s=62.13371306635150);
 
   constant IdealGases.Common.DataRecord InF2(
     name="InF2",
@@ -9688,7 +9688,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={431896.034,-1688.47242,8.925863010000001,-0.001049188835,
         2.72393419e-007,-2.882959902e-011,1.073493779e-015},
     bhigh={-46736.91940000001,-19.32464363},
-    R_s=54.40881152731022);
+    R_s=54.40906019431374);
 
   constant IdealGases.Common.DataRecord InF3(
     name="InF3",
@@ -9702,7 +9702,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-165685.5506,-79.6588929,10.05913347,-2.350816639e-005,
         5.16351293e-009,-5.88804881e-013,2.715090697e-017},
     bhigh={-106868.2627,-21.32968218},
-    R_s=48.39250730113827);
+    R_s=48.39272847155986);
 
   constant IdealGases.Common.DataRecord InH(
     name="InH",
@@ -9716,7 +9716,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={779740.666,-3646.88208,9.54296735,-0.00348128172,1.304805603e-006,-2.182950701e-010,
         1.274009748e-014},
     bhigh={46432.9546,-36.5932923},
-    R_s=71.78419618265131);
+    R_s=71.78452426114565);
 
   constant IdealGases.Common.DataRecord InI(
     name="InI",
@@ -9730,7 +9730,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1529221.772,-4690.373680000001,10.04593462,-0.00314043411,
         9.460834390000001e-007,-1.253862848e-010,5.94980564e-015},
     bhigh={31524.78143,-32.9769749},
-    R_s=34.39676915431156);
+    R_s=34.39692635939059);
 
   constant IdealGases.Common.DataRecord InI2(
     name="InI2",
@@ -9744,7 +9744,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-313067.1665,481.38107,7.10091418,-0.000550655992,3.156120735e-007,-5.50917054e-011,
         3.17116283e-015},
     bhigh={-10430.1275,2.141662307},
-    R_s=22.55524786115741);
+    R_s=22.55535094640668);
 
   constant IdealGases.Common.DataRecord InI3(
     name="InI3",
@@ -9758,7 +9758,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-21967.42567,-2.151167521,10.001822,-8.002214699999999e-007,
         1.897343164e-010,-2.29625246e-014,1.109838196e-018},
     bhigh={-15724.06335,-9.17088869},
-    R_s=16.7789000499484);
+    R_s=16.7789767352992);
 
   constant IdealGases.Common.DataRecord InO(
     name="InO",
@@ -9772,7 +9772,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-805213.0950000001,1693.064203,4.76086358,-0.00073407184,
         3.22959776e-007,-4.58015038e-011,1.954611725e-015},
     bhigh={4005.51981,3.50074246},
-    R_s=63.55784475153917);
+    R_s=63.55813523277484);
 
   constant IdealGases.Common.DataRecord InOH(
     name="InOH",
@@ -9786,7 +9786,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={852512.8929999999,-2350.317172,7.98451514,9.91581562e-005,-6.21238545e-008,
         1.016169575e-011,-5.682557639999999e-016},
     bhigh={-1536.21361,-20.43107643},
-    R_s=63.07187980702344);
+    R_s=63.07216806723198);
 
   constant IdealGases.Common.DataRecord In2Br2(
     name="In2Br2",
@@ -9800,7 +9800,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-12907.81804,-0.607540124,10.00052163,-2.312058331e-007,
         5.51731572e-011,-6.708620190000001e-015,3.25384165e-019},
     bhigh={-26631.36878,-9.149949469999999},
-    R_s=21.34959583406087);
+    R_s=21.34969340906523);
 
   constant IdealGases.Common.DataRecord In2Br4(
     name="In2Br4",
@@ -9814,7 +9814,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-44534.6371,-4.91152398,16.00413764,-1.810579975e-006,
         4.28171574e-010,-5.17199802e-014,2.496142837e-018},
     bhigh={-57391.7541,-31.7490639},
-    R_s=15.13780923874652);
+    R_s=15.13787842374721);
 
   constant IdealGases.Common.DataRecord In2Br6(
     name="In2Br6",
@@ -9828,7 +9828,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-69450.3948,-8.402368170000001,22.00703884,-3.068251799e-006,
         7.23596573e-010,-8.722870580000001e-014,4.20346991e-018},
     bhigh={-82357.59850000001,-53.221928},
-    R_s=11.72604857134799);
+    R_s=11.72610216342764);
 
   constant IdealGases.Common.DataRecord In2CL2(
     name="In2CL2",
@@ -9842,7 +9842,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-26166.06332,-2.401955489,10.00203984,-8.97519003e-007,
         2.130755553e-010,-2.5811409e-014,1.248404822e-018},
     bhigh={-30980.16735,-12.34946505},
-    R_s=27.66492536816818);
+    R_s=27.66505180640310);
 
   constant IdealGases.Common.DataRecord In2CL4(
     name="In2CL4",
@@ -9856,7 +9856,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-85037.7179,-15.52464614,16.01269668,-5.44154987e-006,
         1.267594997e-009,-1.514110365e-013,7.24540454e-018},
     bhigh={-74619.21740000001,-36.91150615},
-    R_s=22.38394607051324);
+    R_s=22.38404837285434);
 
   constant IdealGases.Common.DataRecord In2CL6(
     name="In2CL6",
@@ -9870,7 +9870,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-149940.0484,-29.88680816,22.02425362,-1.033652301e-005,
         2.397911922e-009,-2.855307516e-013,1.363051661e-017},
     bhigh={-113011.0233,-62.93985679999999},
-    R_s=18.79596883943629);
+    R_s=18.79605474348599);
 
   constant IdealGases.Common.DataRecord In2F2(
     name="In2F2",
@@ -9884,7 +9884,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-64097.1544,-11.63740672,10.00956511,-4.11408691e-006,
         9.60882832e-010,-1.150013486e-013,5.511437479999999e-018},
     bhigh={-67142.7785,-16.61718474},
-    R_s=31.06671454759293);
+    R_s=31.06685653317575);
 
   constant IdealGases.Common.DataRecord In2F4(
     name="In2F4",
@@ -9898,7 +9898,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-220597.7486,-78.2208377,16.05923872,-2.39402324e-005,
         5.32958279e-009,-6.14460957e-013,2.859099598e-017},
     bhigh={-159571.6347,-44.6957458},
-    R_s=27.20440576365511);
+    R_s=27.20453009715687);
 
   constant IdealGases.Common.DataRecord In2F6(
     name="In2F6",
@@ -9912,7 +9912,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-317096.638,-116.7440973,22.08847456,-3.57773393e-005,
         7.96895904e-009,-9.191681699999999e-013,4.278494150000001e-017},
     bhigh={-242666.1118,-71.5532856},
-    R_s=24.19625365056914);
+    R_s=24.19636423577993);
 
   constant IdealGases.Common.DataRecord In2I2(
     name="In2I2",
@@ -9926,7 +9926,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-8148.157299999999,-0.2444544443,10.00021086,-9.37678925e-008,
         2.24298818e-011,-2.732299303e-015,1.327135699e-019},
     bhigh={-6352.6515,-6.94772542},
-    R_s=17.19838457715578);
+    R_s=17.19846317969530);
 
   constant IdealGases.Common.DataRecord In2I4(
     name="In2I4",
@@ -9940,7 +9940,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-25056.99251,-1.642155234,16.00140149,-6.18706628e-007,
         1.472308565e-010,-1.786593333e-014,8.652338779999999e-019},
     bhigh={-28796.55333,-27.57790375},
-    R_s=11.2776239305787);
+    R_s=11.2776754732033);
 
   constant IdealGases.Common.DataRecord In2I6(
     name="In2I6",
@@ -9954,7 +9954,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-43119.0585,-3.39035059,22.00288128,-1.268348706e-006,3.0121219e-010,
         -3.64967671e-014,1.765530622e-018},
     bhigh={-45138.2027,-48.0686837},
-    R_s=8.389450024974199);
+    R_s=8.389488367649591);
 
   constant IdealGases.Common.DataRecord In2O(
     name="In2O",
@@ -9968,7 +9968,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-92327.8636,-52.0112728,7.03872362,-1.543821179e-005,3.39970087e-009,
         -3.8854571e-013,1.79512527e-017},
     bhigh={-6270.9268,-4.42182041},
-    R_s=33.84883449209683);
+    R_s=33.84898919292578);
 
   constant IdealGases.Common.DataRecord K(
     name="K",
@@ -9982,7 +9982,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3566422.36,10852.89825,-10.54134898,0.00800980135,-2.696681041e-006,
         4.71529415e-010,-2.97689735e-014},
     bhigh={-58753.3701,97.3855124},
-    R_s=212.6555886061542);
+    R_s=212.6565605154188);
 
   constant IdealGases.Common.DataRecord Kplus(
     name="Kplus",
@@ -9994,7 +9994,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={61075.1686,4.34740444},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={61075.1686,4.34740444},
-    R_s=212.6585724825086);
+    R_s=212.6595444054105);
 
   constant IdealGases.Common.DataRecord Kminus(
     name="Kminus",
@@ -10006,7 +10006,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={3394.15071,4.34744653},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={3394.15071,4.34744653},
-    R_s=212.6526048135341);
+    R_s=212.6535767091617);
 
   constant IdealGases.Common.DataRecord KALF4(
     name="KALF4",
@@ -10020,7 +10020,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-343513.537,-242.0680834,16.1802925,-7.19381768e-005,
         1.585712708e-008,-1.814017733e-012,8.388391179999999e-017},
     bhigh={-233965.8121,-52.338987},
-    R_s=58.5223484977814);
+    R_s=58.5226159650653);
 
   constant IdealGases.Common.DataRecord KBO2(
     name="KBO2",
@@ -10034,7 +10034,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={88907.266,-1671.432436,11.1748393,-0.000451376026,9.69900346e-008,-1.09002769e-011,
         4.9768458e-016},
     bhigh={-73753.36080000001,-32.7474937},
-    R_s=101.5097652124759);
+    R_s=101.5102291470563);
 
   constant IdealGases.Common.DataRecord KBr(
     name="KBr",
@@ -10048,7 +10048,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1562614.367,-4384.89478,9.045464600000001,-0.0020456809,
         4.40192385e-007,-1.448178289e-011,-2.27333876e-015},
     bhigh={5315.34201,-28.64647026},
-    R_s=69.86816221199086);
+    R_s=69.86848153355020);
 
   constant IdealGases.Common.DataRecord KCN(
     name="KCN",
@@ -10062,7 +10062,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={361566.387,-1749.018011,8.680702670000001,-0.000440235004,
         9.249499710000001e-008,-1.021916855e-011,4.604767189999999e-016},
     bhigh={18137.34856,-22.81619241},
-    R_s=127.6876697939207);
+    R_s=127.6882533705389);
 
   constant IdealGases.Common.DataRecord KCL(
     name="KCL",
@@ -10076,7 +10076,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-212294.5722,934.61589,2.866264958,0.001468386693,-5.83426078e-007,
         1.255777709e-010,-9.150147999999999e-015},
     bhigh={-32737.8764,14.01864636},
-    R_s=111.5268546624942);
+    R_s=111.5273643786225);
 
   constant IdealGases.Common.DataRecord KF(
     name="KF",
@@ -10090,7 +10090,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1483743.237,4550.04804,-1.081464319,0.00350396588,-1.093902537e-006,
         1.771028824e-010,-1.029032783e-014},
     bhigh={-69633.2981,40.8863592},
-    R_s=143.1143514525623);
+    R_s=143.1150055344276);
 
   constant IdealGases.Common.DataRecord KH(
     name="KH",
@@ -10104,7 +10104,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3752276.52,11727.78444,-10.14137678,0.008854548899999998,-2.517188074e-006,
         3.34407236e-010,-1.701157835e-014},
     bhigh={-60251.033,101.030459},
-    R_s=207.3111815019309);
+    R_s=207.3121289854147);
 
   constant IdealGases.Common.DataRecord KI(
     name="KI",
@@ -10118,7 +10118,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3293747.78,-10028.24194,16.29302044,-0.00669639675,2.001412089e-006,
         -2.677673023e-010,1.273359646e-014},
     bhigh={46763.4867,-78.5912337},
-    R_s=50.08634494472592);
+    R_s=50.08657385656878);
 
   constant IdealGases.Common.DataRecord KLi(
     name="KLi",
@@ -10132,7 +10132,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={12112968.43,-40810.0487,56.8379212,-0.03128695515,
         8.975062200000001e-006,-1.189303691e-009,5.88012918e-014},
     bhigh={273879.2595,-366.96936},
-    R_s=180.5951002730276);
+    R_s=180.5959256548210);
 
   constant IdealGases.Common.DataRecord KNO2(
     name="KNO2",
@@ -10146,7 +10146,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-168941.4093,-851.5973150000001,10.63209586,-0.000252325481,
         5.57364441e-008,-6.39318592e-012,2.964484049e-016},
     bhigh={-21877.01436,-27.55200432},
-    R_s=97.69801113463794);
+    R_s=97.69845764818962);
 
   constant IdealGases.Common.DataRecord KNO3(
     name="KNO3",
@@ -10160,7 +10160,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-318368.287,-1375.234449,14.01587531,-0.000404066008,8.90084778e-008,
         -1.018771993e-011,4.71598202e-016},
     bhigh={-35138.5322,-48.04256439},
-    R_s=82.23747616297011);
+    R_s=82.23785201655338);
 
   constant IdealGases.Common.DataRecord KNa(
     name="KNa",
@@ -10174,7 +10174,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6260326.62,-25635.93614,43.7333545,-0.0267265511,8.23270579e-006,-1.12850359e-009,
         5.66326489e-014},
     bhigh={169727.4909,-266.4117219},
-    R_s=133.9141641864532);
+    R_s=133.9147762202948);
 
   constant IdealGases.Common.DataRecord KO(
     name="KO",
@@ -10188,7 +10188,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={696010.338,-3304.83529,10.05743444,-0.004331112,1.747281632e-006,-3.012370548e-010,
         1.79082787e-014},
     bhigh={26049.72496,-34.4878152},
-    R_s=150.9041575238168);
+    R_s=150.9048472077781);
 
   constant IdealGases.Common.DataRecord KOH(
     name="KOH",
@@ -10202,7 +10202,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={891727.195,-2334.179072,7.97257871,0.0001038863156,-6.315893469999999e-008,
         1.027938106e-011,-5.73668582e-016},
     bhigh={-14436.96469,-20.76401416},
-    R_s=148.1931584774721);
+    R_s=148.1938357712344);
 
   constant IdealGases.Common.DataRecord K2(
     name="K2",
@@ -10216,7 +10216,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-27344707.45,65621.80009999999,-44.7635044,0.008938859150000001,
         2.984557092e-006,-1.064158914e-009,8.334936929999999e-014},
     bhigh={-422624.383,386.714251},
-    R_s=106.3277943030771);
+    R_s=106.3282802577094);
 
   constant IdealGases.Common.DataRecord K2plus(
     name="K2plus",
@@ -10230,7 +10230,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={11079507.39,-41774.8382,64.48659840000001,-0.0402499803,
         1.360587923e-005,-2.361920107e-009,1.67343061e-013},
     bhigh={317761.205,-410.50631},
-    R_s=106.3285402669322);
+    R_s=106.3290262249738);
 
   constant IdealGases.Common.DataRecord K2Br2(
     name="K2Br2",
@@ -10244,7 +10244,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-15892.29976,-0.810137946,10.00069442,-3.074491521e-007,
         7.33102416e-011,-8.908944780000001e-015,4.319245429999999e-019},
     bhigh={-67825.9544,-11.80425726},
-    R_s=34.93408110599543);
+    R_s=34.93424076677510);
 
   constant IdealGases.Common.DataRecord K2CO3(
     name="K2CO3",
@@ -10258,7 +10258,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-326426.316,-1521.168973,17.12283562,-0.000446458071,9.83337963e-008,
         -1.125478371e-011,5.21006912e-016},
     bhigh={-94882.75099999999,-62.1522063},
-    R_s=60.16021070073188);
+    R_s=60.16048565361002);
 
   constant IdealGases.Common.DataRecord K2C2N2(
     name="K2C2N2",
@@ -10272,7 +10272,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={726959.95,-3492.10868,18.35676822,-0.000878547514,1.845532919e-007,-2.038717568e-011,
         9.18542099e-016},
     bhigh={15826.00773,-67.28484052},
-    R_s=63.84383489696034);
+    R_s=63.84412668526946);
 
   constant IdealGases.Common.DataRecord K2CL2(
     name="K2CL2",
@@ -10286,7 +10286,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-26146.11331,-2.096229095,10.00178456,-7.864803710000001e-007,
         1.869281152e-010,-2.266272348e-014,1.096790704e-018},
     bhigh={-77071.8933,-14.99720802},
-    R_s=55.76342733124707);
+    R_s=55.76368218931125);
 
   constant IdealGases.Common.DataRecord K2F2(
     name="K2F2",
@@ -10300,7 +10300,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-57408.9253,-9.04618211,10.00750685,-3.25076484e-006,7.63006459e-010,
         -9.165649529999999e-014,4.40504844e-018},
     bhigh={-106541.3546,-18.7403762},
-    R_s=71.55717572628115);
+    R_s=71.55750276721382);
 
   constant IdealGases.Common.DataRecord K2I2(
     name="K2I2",
@@ -10314,7 +10314,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-11796.34729,-0.472476155,10.00040695,-1.807689054e-007,
         4.32056097e-011,-5.259699430000001e-015,2.553419144e-019},
     bhigh={-53402.10230000001,-9.6644405},
-    R_s=25.04317247236296);
+    R_s=25.04328692828439);
 
   constant IdealGases.Common.DataRecord K2O(
     name="K2O",
@@ -10328,7 +10328,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-46114.6458,-13.63119524,7.01053044,-4.32365826e-006,
         9.747788419999999e-010,-1.135283694e-013,5.325860600000001e-018},
     bhigh={-11072.22244,-5.76871872},
-    R_s=88.26778207142554);
+    R_s=88.26818548558326);
 
   constant IdealGases.Common.DataRecord K2Oplus(
     name="K2Oplus",
@@ -10342,7 +10342,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-37800.335,-8.84953739,7.00684789,-2.815510856e-006,6.3550015e-010,-7.408551990000001e-014,
         3.478334960000001e-018},
     bhigh={42145.19680000001,-4.41827661},
-    R_s=88.26829614832124);
+    R_s=88.26869956482847);
 
   constant IdealGases.Common.DataRecord K2O2(
     name="K2O2",
@@ -10356,7 +10356,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-147607.3073,-102.193204,10.07664713,-3.076517991e-005,
         6.81525281e-009,-7.82865445e-013,3.6325061e-017},
     bhigh={-25920.56324,-21.62287184},
-    R_s=75.45207876190838);
+    R_s=75.45242360388910);
 
   constant IdealGases.Common.DataRecord K2O2H2(
     name="K2O2H2",
@@ -10370,7 +10370,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1773523.196,-4665.292469999999,16.94308128,0.0002085297143,-1.264714762e-007,
         2.057506565e-011,-1.148042134e-015},
     bhigh={-50512.63310000001,-63.3477392},
-    R_s=74.09657923873607);
+    R_s=74.09691788561720);
 
   constant IdealGases.Common.DataRecord K2SO4(
     name="K2SO4",
@@ -10384,7 +10384,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-544612.564,-959.0667229999999,19.71591285,-0.0002866586009,
         6.342480639999999e-008,-7.281462539999999e-012,3.37788693e-016},
     bhigh={-133787.3384,-73.99103550999999},
-    R_s=47.71324555604525);
+    R_s=47.71346362200676);
 
   constant IdealGases.Common.DataRecord Kr(
     name="Kr",
@@ -10397,7 +10397,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={264.3639057,-0.7910050820000001,2.500920585,-5.32816411e-007,
         1.620730161e-010,-2.467898017e-014,1.47858504e-018},
     bhigh={-740.348894,5.48439815},
-    R_s=99.21804295942721);
+    R_s=99.21849642004774);
 
   constant IdealGases.Common.DataRecord Krplus(
     name="Krplus",
@@ -10411,7 +10411,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-221656.7015,1166.16784,0.486965532,0.001429223599,-3.94962861e-007,
         4.98285351e-011,-2.406719258e-015},
     bhigh={155600.2861,20.59230986},
-    R_s=99.21869249850485);
+    R_s=99.21914596209399);
 
   constant IdealGases.Common.DataRecord Li(
     name="Li",
@@ -10424,7 +10424,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1125610.652,-3463.53673,6.56661192,-0.002260983356,5.92228916e-007,-6.2816351e-011,
         2.884948238e-015},
     bhigh={40346.374,-26.55918195},
-    R_s=1197.878115545311);
+    R_s=1197.883590260769);
 
   constant IdealGases.Common.DataRecord Liplus(
     name="Liplus",
@@ -10436,7 +10436,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={81727.24550000001,1.754357228},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={81727.24550000001,1.754357228},
-    R_s=1197.972800443499);
+    R_s=1197.978275591700);
 
   constant IdealGases.Common.DataRecord Liminus(
     name="Liminus",
@@ -10448,7 +10448,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={10496.98659,1.754594332},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={10496.98659,1.754594332},
-    R_s=1197.783445613274);
+    R_s=1197.788919896059);
 
   constant IdealGases.Common.DataRecord LiALF4(
     name="LiALF4",
@@ -10462,7 +10462,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-402070.0930000001,-278.3355146,16.20791185,-8.316341570000001e-005,
         1.83690569e-008,-2.104932808e-012,9.74725302e-017},
     bhigh={-227869.6416,-55.9730484},
-    R_s=75.64376972342085);
+    R_s=75.64411544149525);
 
   constant IdealGases.Common.DataRecord LiBO2(
     name="LiBO2",
@@ -10476,7 +10476,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={85544.04520000001,-1731.920898,11.2146209,-0.000465916217,
         9.999875689999999e-008,-1.122880592e-011,5.12352946e-016},
     bhigh={-71547.4382,-36.1239729},
-    R_s=167.1223779316112);
+    R_s=167.1231417384243);
 
   constant IdealGases.Common.DataRecord LiBr(
     name="LiBr",
@@ -10490,7 +10490,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={63801.9142,-259.7050764,4.65676887,0.0001022867706,-5.178252340000001e-008,
         2.058203991e-011,-1.942190308e-015},
     bhigh={-17933.63752,-0.2290806613},
-    R_s=95.73921354136679);
+    R_s=95.73965110253900);
 
   constant IdealGases.Common.DataRecord LiCL(
     name="LiCL",
@@ -10504,7 +10504,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-235276.9705,612.004692,3.63429373,0.0006810973320000001,-2.174238799e-007,
         4.22040361e-011,-2.848628426e-015},
     bhigh={-28623.58494,5.618511135},
-    R_s=196.1237911025145);
+    R_s=196.1246874557720);
 
   constant IdealGases.Common.DataRecord LiF(
     name="LiF",
@@ -10518,7 +10518,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-378424.649,766.806246,3.5854734,0.0006031084350000001,-1.588764206e-007,
         2.569397177e-011,-1.406798386e-015},
     bhigh={-47564.6945,4.38516329},
-    R_s=320.5344369680795);
+    R_s=320.5359019208275);
 
   constant IdealGases.Common.DataRecord LiH(
     name="LiH",
@@ -10532,7 +10532,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2633686.357,6996.429169999999,-3.23353306,0.00403393598,-9.09957964e-007,
         8.775909869999999e-011,-2.889490251e-015},
     bhigh={-29900.43016,49.71984499999999},
-    R_s=1045.984999257763);
+    R_s=1045.989779769378);
 
   constant IdealGases.Common.DataRecord LiI(
     name="LiI",
@@ -10546,7 +10546,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1616342.632,-4877.71708,9.987186550000001,-0.002889137815,
         8.03731377e-007,-9.028172610000001e-011,3.078321954e-015},
     bhigh={19377.18764,-37.2927631},
-    R_s=62.11993577369485);
+    R_s=62.12021968319137);
 
   constant IdealGases.Common.DataRecord LiN(
     name="LiN",
@@ -10560,7 +10560,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-59934.8998,-40.3113455,4.52962421,8.744156930000001e-005,
         2.557428364e-009,-2.9057518e-013,1.336125922e-017},
     bhigh={38948.3113,-1.214952896},
-    R_s=396.9157473135476);
+    R_s=396.9175613551846);
 
   constant IdealGases.Common.DataRecord LiNO2(
     name="LiNO2",
@@ -10574,7 +10574,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-219667.116,-861.004271,10.63956465,-0.0002554392587,5.64447854e-008,
         -6.47614005e-012,3.003536591e-016},
     bhigh={-23135.47535,-32.38277103},
-    R_s=157.0353470012182);
+    R_s=157.0360647068267);
 
   constant IdealGases.Common.DataRecord LiNO3(
     name="LiNO3",
@@ -10588,7 +10588,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-355940.245,-1447.644737,14.06684061,-0.000423637128,
         9.320824509999999e-008,-1.065894872e-011,4.93078062e-016},
     bhigh={-34348.2746,-52.75382697000001},
-    R_s=120.5941470051156);
+    R_s=120.5946981618922);
 
   constant IdealGases.Common.DataRecord LiO(
     name="LiO",
@@ -10602,7 +10602,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1612392.133,-5551.31234,11.20573851,-0.00343722688,
         9.133194659999999e-007,-1.027902258e-010,3.822991e-015},
     bhigh={42015.7547,-48.5735458},
-    R_s=362.4379696953846);
+    R_s=362.4396261617060);
 
   constant IdealGases.Common.DataRecord LiOF(
     name="LiOF",
@@ -10616,7 +10616,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-183356.3281,-211.0049301,7.15681817,-6.24946201e-005,
         1.376567002e-008,-1.574099067e-012,7.277167140000001e-017},
     bhigh={-12545.30277,-12.72130479},
-    R_s=198.2524861367527);
+    R_s=198.2533922188796);
 
   constant IdealGases.Common.DataRecord LiOH(
     name="LiOH",
@@ -10630,7 +10630,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={850075.137,-2430.540791,8.055314620000001,6.895680879999999e-005,-5.527207459999999e-008,
         9.368054029999999e-012,-5.31378568e-016},
     bhigh={-13658.94396,-24.57598093},
-    R_s=347.1836461316316);
+    R_s=347.1852328804418);
 
   constant IdealGases.Common.DataRecord LiON(
     name="LiON",
@@ -10644,7 +10644,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-97406.29139999999,-511.1560940000001,7.37849387,-0.0001508777884,
         3.32991498e-008,-3.81751429e-012,1.769558455e-016},
     bhigh={22110.06635,-14.5410504},
-    R_s=225.0372018372214);
+    R_s=225.0382303347218);
 
   constant IdealGases.Common.DataRecord Li2(
     name="Li2",
@@ -10658,7 +10658,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={37676454,-118574.7185,148.2167789,-0.0837853211,2.424919798e-005,-3.27582024e-009,
         1.652000081e-013},
     bhigh={772307.201,-1021.697298},
-    R_s=598.9390577726553);
+    R_s=598.9417951303847);
 
   constant IdealGases.Common.DataRecord Li2plus(
     name="Li2plus",
@@ -10672,7 +10672,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={12799310.73,-34928.6139,38.4478536,-0.01380635397,2.53139425e-006,-2.197815991e-010,
         7.08766925e-015},
     bhigh={311796.445,-250.9543641},
-    R_s=598.9627280617069);
+    R_s=598.9654655276177);
 
   constant IdealGases.Common.DataRecord Li2Br2(
     name="Li2Br2",
@@ -10686,7 +10686,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-89009.8336,-19.88916335,10.01596418,-6.74913405e-006,
         1.556299963e-009,-1.844693069e-013,8.774879919999999e-018},
     bhigh={-62799.8996,-19.43063525},
-    R_s=47.8696067706834);
+    R_s=47.8698255512695);
 
   constant IdealGases.Common.DataRecord Li2F2(
     name="Li2F2",
@@ -10700,7 +10700,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-218893.1683,-92.5981453,10.06970757,-2.803632163e-005,
         6.217549520000001e-009,-7.14626702e-013,3.3168573e-017},
     bhigh={-115661.1527,-27.29853181},
-    R_s=160.2672184840397);
+    R_s=160.2679509604137);
 
   constant IdealGases.Common.DataRecord Li2I2(
     name="Li2I2",
@@ -10714,7 +10714,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-69735.8706,-13.16825508,10.01074855,-4.60020378e-006,
         1.070510527e-009,-1.277717768e-013,6.11061224e-018},
     bhigh={-46774.7005,-17.21894034},
-    R_s=31.05996788684742);
+    R_s=31.06010984159569);
 
   constant IdealGases.Common.DataRecord Li2O(
     name="Li2O",
@@ -10728,7 +10728,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={726148.7039999999,-9543.783720000001,28.87491643,-0.01959494099,
         8.086339840000001e-006,-1.370211764e-009,8.11172719e-014},
     bhigh={29907.26399,-156.4517822},
-    R_s=278.2490780217794);
+    R_s=278.2503497158768);
 
   constant IdealGases.Common.DataRecord Li2Oplus(
     name="Li2Oplus",
@@ -10742,7 +10742,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-130216.6086,-146.6759528,7.61072945,-4.46942669e-005,
         9.947160640000001e-009,-1.147038806e-012,5.33924147e-017},
     bhigh={50987.6231,-15.28011047},
-    R_s=278.2541865590885);
+    R_s=278.2554582765336);
 
   constant IdealGases.Common.DataRecord Li2O2(
     name="Li2O2",
@@ -10756,7 +10756,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-293923.2153,-235.9107937,10.17463402,-6.931624359999999e-005,
         1.521202834e-008,-1.733841909e-012,7.99315462e-017},
     bhigh={-36184.8191,-29.04221044},
-    R_s=181.2189848476923);
+    R_s=181.2198130808530);
 
   constant IdealGases.Common.DataRecord Li2O2H2(
     name="Li2O2H2",
@@ -10770,7 +10770,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1215377.492,-3982.05744,15.85877373,0.000750914568,-2.585218184e-007,
         3.6468417e-011,-1.904139406e-015},
     bhigh={-67387.4838,-66.472084},
-    R_s=173.5918230658158);
+    R_s=173.5926164402209);
 
   constant IdealGases.Common.DataRecord Li2SO4(
     name="Li2SO4",
@@ -10784,7 +10784,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-603875.0870000001,-1064.550976,19.79557349,-0.000318897825,
         7.062411120000001e-008,-8.11443907e-012,3.76683021e-016},
     bhigh={-126890.8595,-80.14316674},
-    R_s=75.62419618607918);
+    R_s=75.62454181469576);
 
   constant IdealGases.Common.DataRecord Li3plus(
     name="Li3plus",
@@ -10798,7 +10798,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-43550.9806,-6.05643275,7.00472289,-1.953320933e-006,
         4.429152229999999e-010,-5.18198319e-014,2.439894871e-018},
     bhigh={88799.02870000001,-10.66880792},
-    R_s=399.303225171653);
+    R_s=399.305050124886);
 
   constant IdealGases.Common.DataRecord Li3Br3(
     name="Li3Br3",
@@ -10812,7 +10812,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-158467.0201,-40.4136094,16.03177633,-1.322713911e-005,
         3.014221791e-009,-3.54029216e-013,1.672030783e-017},
     bhigh={-104247.0448,-44.05478160000001},
-    R_s=31.9130711804556);
+    R_s=31.9132170341797);
 
   constant IdealGases.Common.DataRecord Li3CL3(
     name="Li3CL3",
@@ -10826,7 +10826,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-200593.0356,-59.3940019,16.04590929,-1.885890854e-005,
         4.25351737e-009,-4.95556094e-013,2.325408214e-017},
     bhigh={-122492.7071,-48.44413629},
-    R_s=65.37459703417152);
+    R_s=65.37489581859069);
 
   constant IdealGases.Common.DataRecord Li3F3(
     name="Li3F3",
@@ -10840,7 +10840,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-361866.499,-193.7051395,16.14457133,-5.7756285e-005,
         1.274057038e-008,-1.458168875e-012,6.744850030000001e-017},
     bhigh={-188208.1974,-56.3361288},
-    R_s=106.8448123226932);
+    R_s=106.8453006402758);
 
   constant IdealGases.Common.DataRecord Li3I3(
     name="Li3I3",
@@ -10854,7 +10854,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-126669.6511,-27.83891914,16.02228068,-9.399364930000001e-006,
         2.163919735e-009,-2.561731922e-013,1.217394107e-017},
     bhigh={-78695.5068,-40.9172406},
-    R_s=20.70664525789828);
+    R_s=20.70673989439712);
 
   constant IdealGases.Common.DataRecord Mg(
     name="Mg",
@@ -10867,7 +10867,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-536483.155,1973.709576,-0.36337769,0.002071795561,-7.738051719999999e-007,
         1.359277788e-010,-7.766898397000001e-015},
     bhigh={4829.188109999999,23.39104998},
-    R_s=342.0889528903518);
+    R_s=342.0905163546595);
 
   constant IdealGases.Common.DataRecord Mgplus(
     name="Mgplus",
@@ -10880,7 +10880,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-19147.58821,48.7734792,2.457662661,1.218104674e-005,
         1.897261686e-009,-1.580433756e-012,2.135732238e-016},
     bhigh={106102.2394,4.64644286},
-    R_s=342.0966745211126);
+    R_s=342.0982380207109);
 
   constant IdealGases.Common.DataRecord MgBr(
     name="MgBr",
@@ -10894,7 +10894,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={24776.04216,-641.7687520000001,6.01993209,-0.001391004302,
         6.44333096e-007,-1.197734078e-010,7.421644240000001e-015},
     bhigh={2824.060334,-6.26443992},
-    R_s=79.78650596397624);
+    R_s=79.78687061578175);
 
   constant IdealGases.Common.DataRecord MgBr2(
     name="MgBr2",
@@ -10908,7 +10908,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-43268.9901,-12.83036001,7.5100243,-4.1523324e-006,9.42649918e-010,-1.103873928e-013,
         5.20110431e-018},
     bhigh={-39198.8602,-7.40916803},
-    R_s=45.15961393274782);
+    R_s=45.15982032773351);
 
   constant IdealGases.Common.DataRecord MgCL(
     name="MgCL",
@@ -10922,7 +10922,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1041328.453,-3380.15833,8.637775469999999,-0.002447789643,
         7.84196944e-007,-1.12640938e-010,5.81062073e-015},
     bhigh={13271.88977,-27.03802395},
-    R_s=139.1357140466548);
+    R_s=139.1363499447772);
 
   constant IdealGases.Common.DataRecord MgCLplus(
     name="MgCLplus",
@@ -10936,7 +10936,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-12683919.21,34788.2454,-30.0422295,0.01481739497,-2.470965605e-006,
         1.424433718e-010,2.789613105e-016},
     bhigh={-148701.374,255.2015117},
-    R_s=139.1369913744347);
+    R_s=139.1376272783949);
 
   constant IdealGases.Common.DataRecord MgCL2(
     name="MgCL2",
@@ -10950,7 +10950,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-68352.1701,-24.90899393,7.5187832,-7.56451826e-006,1.67929377e-009,
         -1.931706275e-013,8.971657820000001e-018},
     bhigh={-50326.8691,-10.53268382},
-    R_s=87.32680047473507);
+    R_s=87.32719958828287);
 
   constant IdealGases.Common.DataRecord MgF(
     name="MgF",
@@ -10964,7 +10964,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-169588.3782,358.875763,3.93600165,0.000481304414,-1.658385409e-007,
         3.33605229e-011,-2.270104205e-015},
     bhigh={-31693.2399,4.4105659},
-    R_s=192.0050477695481);
+    R_s=192.0059252987303);
 
   constant IdealGases.Common.DataRecord MgFplus(
     name="MgFplus",
@@ -10978,7 +10978,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-10568523.62,20771.22379,-6.11952356,0.002245834831,-9.51573861e-008,
         -2.263502341e-011,2.284524246e-015},
     bhigh={-83315.4988,87.2710238},
-    R_s=192.0074802643611);
+    R_s=192.0083578046608);
 
   constant IdealGases.Common.DataRecord MgF2(
     name="MgF2",
@@ -10992,7 +10992,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-124441.9584,-86.87343749999999,7.56358123,-2.499267978e-005,
         5.44012914e-009,-6.15824576e-013,2.822792666e-017},
     bhigh={-90600.19439999999,-14.2079699},
-    R_s=133.4547500375527);
+    R_s=133.4553599717134);
 
   constant IdealGases.Common.DataRecord MgF2plus(
     name="MgF2plus",
@@ -11006,7 +11006,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-150231.687,77.2528956,7.27156936,0.000223752977,-1.003070865e-007,
         1.996274309e-011,-1.233278721e-015},
     bhigh={66991.175,-10.94528006},
-    R_s=133.4559251867945);
+    R_s=133.4565351263261);
 
   constant IdealGases.Common.DataRecord MgH(
     name="MgH",
@@ -11020,7 +11020,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-100574.8598,1952.890106,-1.317191549,0.0056036658,-2.13733498e-006,
         3.3248805e-010,-1.824672746e-014},
     bhigh={15985.82755,34.3123316},
-    R_s=328.4672582481529);
+    R_s=328.4687594566258);
 
   constant IdealGases.Common.DataRecord MgI(
     name="MgI",
@@ -11034,7 +11034,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2370562.811,6916.45248,-3.18389449,0.00405155114,-9.774290750000001e-007,
         1.0233294e-010,-3.79030487e-015},
     bhigh={-38185.5111,59.9310438},
-    R_s=54.98645025341336);
+    R_s=54.98670156042475);
 
   constant IdealGases.Common.DataRecord MgI2(
     name="MgI2",
@@ -11048,7 +11048,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-33402.9918,-9.34351178,7.50746854,-3.14770789e-006,
         7.241336470000001e-010,-8.56766495e-014,4.0696917e-018},
     bhigh={-22945.55505,-5.24127259},
-    R_s=29.89591963639075);
+    R_s=29.89605627103769);
 
   constant IdealGases.Common.DataRecord MgN(
     name="MgN",
@@ -11062,7 +11062,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-60185.891,-40.1086478,4.52949895,4.76049091e-005,2.547271298e-009,-2.894058118e-013,
         1.330639131e-017},
     bhigh={33412.857,0.7925250209},
-    R_s=217.0217453153997);
+    R_s=217.0227371795039);
 
   constant IdealGases.Common.DataRecord MgO(
     name="MgO",
@@ -11076,7 +11076,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-15867383.67,34204.681,-17.74087677,0.00700496305,-1.104138249e-006,
         8.957488529999999e-011,-3.052513649e-015},
     bhigh={-230050.4434,173.8984472},
-    R_s=206.2919185002134);
+    R_s=206.2928613253144);
 
   constant IdealGases.Common.DataRecord MgOH(
     name="MgOH",
@@ -11090,7 +11090,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={664866.475,-1770.750355,7.26999927,0.000533684276,-1.980894443e-007,
         3.025677088e-011,-1.554849476e-015},
     bhigh={-6149.11456,-16.71027009},
-    R_s=201.2588006392279);
+    R_s=201.2597204612472);
 
   constant IdealGases.Common.DataRecord MgOHplus(
     name="MgOHplus",
@@ -11104,7 +11104,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={829633.954,-2459.700177,8.11873202,3.5005791e-005,-4.67057475e-008,
         8.312358260000001e-012,-4.80283622e-016},
     bhigh={88016.61709999999,-24.38155217},
-    R_s=201.261473255793);
+    R_s=201.262393090027);
 
   constant IdealGases.Common.DataRecord Mg_OH_2(
     name="Mg_OH_2",
@@ -11118,7 +11118,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1713709.254,-4730.00535,14.48925967,0.0001907819857,-1.226834131e-007,
         2.015343753e-011,-1.128993279e-015},
     bhigh={-38877.2467,-58.4049812},
-    R_s=142.5671745798331);
+    R_s=142.5678261609117);
 
   constant IdealGases.Common.DataRecord MgS(
     name="MgS",
@@ -11132,7 +11132,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={26507943.28,-77113.5586,84.63771680000001,-0.0364425068,
         8.403084420000002e-006,-9.53988217e-010,4.264658029999999e-014},
     bhigh={507893.117,-583.4656096},
-    R_s=147.4981727869434);
+    R_s=147.4988469043818);
 
   constant IdealGases.Common.DataRecord Mg2(
     name="Mg2",
@@ -11146,7 +11146,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={30382.24994,59.4524046,2.352706666,0.0001378537924,-5.89569204e-008,
         1.104045317e-011,-6.558868290000001e-016},
     bhigh={33510.3656,15.88177377},
-    R_s=171.0444764451759);
+    R_s=171.0452581773298);
 
   constant IdealGases.Common.DataRecord Mg2F4(
     name="Mg2F4",
@@ -11160,7 +11160,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-298061.0166,-120.1299868,16.09110864,-3.68745629e-005,
         8.22031705e-009,-9.48886978e-013,4.41979533e-017},
     bhigh={-211734.969,-53.08655469999999},
-    R_s=66.72737501877634);
+    R_s=66.72767998585672);
 
   constant IdealGases.Common.DataRecord Mn(
     name="Mn",
@@ -11174,7 +11174,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5855.15582,883.8588440000001,-0.0364866258,0.002703720687,-1.324971998e-006,
         2.87260329e-010,-1.92363357e-014},
     bhigh={28678.03487,22.92541198},
-    R_s=151.3426878337088);
+    R_s=151.3433795219048);
 
   constant IdealGases.Common.DataRecord Mnplus(
     name="Mnplus",
@@ -11188,7 +11188,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={647131.41,-2403.796253,5.93771575,-0.002341014594,7.46416564e-007,-9.075969730000001e-011,
         4.467879847e-015},
     bhigh={134990.2108,-17.02666341},
-    R_s=151.344199125594);
+    R_s=151.344890820697);
 
   constant IdealGases.Common.DataRecord Mo(
     name="Mo",
@@ -11202,7 +11202,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5573271,-16623.65811,21.35147077,-0.01003069377,2.409784357e-006,-1.811267352e-010,
         1.034189087e-015},
     bhigh={184264.6473,-127.5326434},
-    R_s=86.66324786324788);
+    R_s=86.66364394413175);
 
   constant IdealGases.Common.DataRecord Moplus(
     name="Moplus",
@@ -11216,7 +11216,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={12988911.2,-39482.7623,48.6659978,-0.02605352326,7.21543192e-006,-8.719164960000001e-010,
         3.78842304e-014},
     bhigh={411894.857,-321.679103},
-    R_s=86.66374342015469);
+    R_s=86.66413950330343);
 
   constant IdealGases.Common.DataRecord Mominus(
     name="Mominus",
@@ -11228,7 +11228,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={69051.2369,7.48565954},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={69051.2369,7.48565954},
-    R_s=86.66275231200837);
+    R_s=86.66314839062741);
 
   constant IdealGases.Common.DataRecord MoO(
     name="MoO",
@@ -11242,7 +11242,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1573131.992,-5241.48358,11.02656868,-0.00390299662,1.147334134e-006,
         -1.358975691e-010,5.77526858e-015},
     bhigh={74489.72,-42.5361293},
-    R_s=74.27654605974304);
+    R_s=74.27688552913452);
 
   constant IdealGases.Common.DataRecord MoO2(
     name="MoO2",
@@ -11256,7 +11256,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={309614.3654,-1932.750274,9.428673180000001,-0.001630508855,
         5.752760170000001e-007,-7.59045747e-011,3.46133778e-015},
     bhigh={7327.72518,-25.33315948},
-    R_s=64.98788483243551);
+    R_s=64.98818184944678);
 
   constant IdealGases.Common.DataRecord MoO3(
     name="MoO3",
@@ -11270,7 +11270,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-409759.727,237.9066513,9.3111008,0.000657933891,-2.895307725e-007,
         5.69263726e-011,-3.48965731e-015},
     bhigh={-49237.38720000001,-21.14864892},
-    R_s=57.76417934919292);
+    R_s=57.76444335138275);
 
   constant IdealGases.Common.DataRecord MoO3minus(
     name="MoO3minus",
@@ -11284,7 +11284,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-488109.872,18.48536991,10.42644941,-0.000626555791,3.020554347e-007,
         -4.73319589e-011,2.527517727e-015},
     bhigh={-83378.155,-27.01522825},
-    R_s=57.763959190069);
+    R_s=57.764223191253);
 
   constant IdealGases.Common.DataRecord Mo2O6(
     name="Mo2O6",
@@ -11298,7 +11298,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-631223.816,-664.282755,22.4938357,-0.0001968470329,4.33674061e-008,
         -4.959777990000001e-012,2.293212733e-016},
     bhigh={-143057.325,-86.69628539999999},
-    R_s=28.88208967459646);
+    R_s=28.88222167569138);
 
   constant IdealGases.Common.DataRecord Mo3O9(
     name="Mo3O9",
@@ -11312,7 +11312,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-923029.054,-1076.171759,34.8000726,-0.00031896338,7.02839704e-008,-8.03964264e-012,
         3.71787953e-016},
     bhigh={-235742.2166,-144.8769485},
-    R_s=19.25472644973097);
+    R_s=19.25481445046092);
 
   constant IdealGases.Common.DataRecord Mo4O12(
     name="Mo4O12",
@@ -11326,7 +11326,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1225283.388,-1368.141197,47.0168781,-0.00040529102,
         8.928472389999999e-008,-1.021091158e-011,4.721091689999999e-016},
     bhigh={-325647.777,-204.7486535},
-    R_s=14.44104483729823);
+    R_s=14.44111083784569);
 
   constant IdealGases.Common.DataRecord Mo5O15(
     name="Mo5O15",
@@ -11340,7 +11340,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1535389.516,-1710.367122,59.2712578,-0.0005066836290000001,
         1.116223706e-007,-1.276562233e-011,5.90231891e-016},
     bhigh={-412897.2380000001,-265.1287167},
-    R_s=11.55283586983858);
+    R_s=11.55288867027655);
 
   constant IdealGases.Common.DataRecord N(
     name="N",
@@ -11353,7 +11353,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={88765.0138,-107.12315,2.362188287,0.0002916720081,-1.7295151e-007,
         4.01265788e-011,-2.677227571e-015},
     bhigh={56973.5133,4.865231506},
-    R_s=593.6067739010616);
+    R_s=593.6094868884177);
 
   constant IdealGases.Common.DataRecord Nplus(
     name="Nplus",
@@ -11367,7 +11367,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={290497.0374,-855.7908610000001,3.47738929,-0.000528826719,
         1.352350307e-007,-1.389834122e-011,5.046166279e-016},
     bhigh={231080.9984,-1.994146545},
-    R_s=593.6300245904811);
+    R_s=593.6327376841008);
 
   constant IdealGases.Common.DataRecord Nminus(
     name="Nminus",
@@ -11381,7 +11381,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2404.189576,0.2954965336,2.499789368,8.30756497e-008,-1.82994277e-011,
         2.100136461e-015,-9.754986710000001e-020},
     bhigh={56214.13890000001,5.006484157},
-    R_s=593.583525032889);
+    R_s=593.586237913990);
 
   constant IdealGases.Common.DataRecord NCO(
     name="NCO",
@@ -11395,7 +11395,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={108944.5289,-1735.459316,8.65561033,-0.000405322926,7.59971641e-008,
         -7.25380415e-012,3.24487241e-016},
     bhigh={23657.92776,-26.1953297},
-    R_s=197.8844652615144);
+    R_s=197.8853696616591);
 
   constant IdealGases.Common.DataRecord ND(
     name="ND",
@@ -11409,7 +11409,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={543965.796,-2084.583507,5.83408972,-0.000418939336,
         9.768929529999999e-008,-1.056317654e-011,4.68307921e-016},
     bhigh={54666.3341,-14.80810939},
-    R_s=518.9797614376608);
+    R_s=518.9821333538733);
 
   constant IdealGases.Common.DataRecord ND2(
     name="ND2",
@@ -11423,7 +11423,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1631308.357,-6564.63749,12.80547961,-0.003094456779,
         9.181660230000001e-007,-1.241119284e-010,6.22629986e-015},
     bhigh={61089.2958,-61.24502693},
-    R_s=461.0211398962811);
+    R_s=461.0232469216360);
 
   constant IdealGases.Common.DataRecord ND3(
     name="ND3",
@@ -11437,7 +11437,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2599516.958,-10134.20124,17.98028169,-0.0035826098,1.009922e-006,-1.537638609e-010,
         9.106175650000001e-015},
     bhigh={53972.0566,-98.10988569},
-    R_s=414.7074423540001);
+    R_s=414.7093377098096);
 
   constant IdealGases.Common.DataRecord NF(
     name="NF",
@@ -11451,7 +11451,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={800298.733,-3237.69658,8.703408870000001,-0.002701025798,
         9.15004211e-007,-1.36525663e-010,7.23462441e-015},
     bhigh={46428.19450000001,-30.19933248},
-    R_s=251.9147402635602);
+    R_s=251.9158916006662);
 
   constant IdealGases.Common.DataRecord NF2(
     name="NF2",
@@ -11465,7 +11465,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-194501.0078,-353.603407,7.26349436,-8.4023804e-005,2.326721111e-008,
         -2.667577562e-012,1.236070614e-016},
     bhigh={3435.44059,-13.36102511},
-    R_s=159.8829112799979);
+    R_s=159.8836419999556);
 
   constant IdealGases.Common.DataRecord NF3(
     name="NF3",
@@ -11479,7 +11479,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-349626.876,-497.372867,10.36866128,8.90068765e-005,5.88265436e-008,
         -3.157737664e-012,1.714329953e-016},
     bhigh={-17131.83352,-30.98920858},
-    R_s=117.1020898851994);
+    R_s=117.1026250820724);
 
   constant IdealGases.Common.DataRecord NH(
     name="NH",
@@ -11493,7 +11493,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1958141.991,-5782.861300000001,9.33574202,-0.002292910311,
         6.07609248e-007,-6.647942750000001e-011,2.384234783e-015},
     bhigh={78989.1234,-41.169704},
-    R_s=553.7576658514623);
+    R_s=553.7601967146732);
 
   constant IdealGases.Common.DataRecord NHplus(
     name="NHplus",
@@ -11507,7 +11507,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1405709.438,-4136.21571,7.63201448,-0.001228325778,2.721187746e-007,
         -2.010098289e-011,3.71719018e-017},
     bhigh={225897.596,-27.86785234},
-    R_s=553.7778996070318);
+    R_s=553.7804305627179);
 
   constant IdealGases.Common.DataRecord NHF(
     name="NHF",
@@ -11521,7 +11521,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={901390.2720000001,-3463.39705,8.705804860000001,-0.0004018963409999999,
         2.322774501e-008,6.28048733e-012,-6.28309569e-016},
     bhigh={33370.6534,-29.00483634},
-    R_s=244.4495175309689);
+    R_s=244.4506347494363);
 
   constant IdealGases.Common.DataRecord NHF2(
     name="NHF2",
@@ -11535,7 +11535,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={739427.899,-4004.47177,12.2132232,-0.000697043773,1.271073981e-007,-1.247136898e-011,
         5.08651759e-016},
     bhigh={9134.195979999999,-48.67843963},
-    R_s=156.8429568448825);
+    R_s=156.8436736712017);
 
   constant IdealGases.Common.DataRecord NH2(
     name="NH2",
@@ -11549,7 +11549,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2111053.74,-6880.62723,11.32305924,-0.001829236741,5.64389009e-007,-7.88645248e-011,
         4.078593449999999e-015},
     bhigh={65037.7856,-53.59155744},
-    R_s=518.9221710860547);
+    R_s=518.9245427390595);
 
   constant IdealGases.Common.DataRecord NH2F(
     name="NH2F",
@@ -11563,7 +11563,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1927205.34,-7500.447160000001,13.9558958,-0.00118480442,
         2.05067867e-007,-1.90876131e-011,7.38923621e-016},
     bhigh={35529.2734,-67.31185490999999},
-    R_s=237.4140084108204);
+    R_s=237.4150934745887);
 
   constant IdealGases.Common.DataRecord NH3(
     name="NH3",
@@ -11577,7 +11577,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2452389.535,-8040.89424,12.71346201,-0.000398018658,3.55250275e-008,
         2.53092357e-012,-3.32270053e-016},
     bhigh={43861.91959999999,-64.62330602},
-    R_s=488.2101075011215);
+    R_s=488.2123387894204);
 
   constant IdealGases.Common.DataRecord NH2OH(
     name="NH2OH",
@@ -11591,7 +11591,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4878285.05,-15336.04636,22.2723999,-0.002514583678,3.33958973e-007,-1.881744532e-011,
         1.918174365e-016},
     bhigh={89230.2071,-126.9053624},
-    R_s=251.7254658806319);
+    R_s=251.7266163526888);
 
   constant IdealGases.Common.DataRecord NH4plus(
     name="NH4plus",
@@ -11605,7 +11605,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4141889,-14420.72042,20.11893564,-0.001971492619,3.112721421e-007,-2.602979969e-011,
         8.894342129999999e-016},
     bhigh={166419.6236,-120.1535761},
-    R_s=460.944275399867);
+    R_s=460.946382073925);
 
   constant IdealGases.Common.DataRecord NO(
     name="NO",
@@ -11619,7 +11619,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={223901.8716,-1289.651623,5.43393603,-0.00036560349,
         9.880966450000001e-008,-1.416076856e-011,9.380184619999999e-016},
     bhigh={17503.17656,-8.50166909},
-    R_s=277.0927244793559);
+    R_s=277.0939908885193);
 
   constant IdealGases.Common.DataRecord NOCL(
     name="NOCL",
@@ -11633,7 +11633,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-613341.333,-391.929883,9.13891722,-0.002605664613,1.295687247e-006,
         -2.215378352e-010,1.280394898e-014},
     bhigh={4517.32842,-23.07323335},
-    R_s=127.0178172324398);
+    R_s=127.0183977476012);
 
   constant IdealGases.Common.DataRecord NOF(
     name="NOF",
@@ -11647,7 +11647,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1889069.274,-6731.02266,14.19018767,-0.00369312462,9.93857514e-007,-1.080748188e-010,
         4.21035443e-015},
     bhigh={32099.0078,-63.70266962},
-    R_s=169.667509250456);
+    R_s=169.668284689396);
 
   constant IdealGases.Common.DataRecord NOF3(
     name="NOF3",
@@ -11661,7 +11661,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-278562.5217,-1252.321663,13.90824337,-0.00035666875,7.78501106e-008,
         -8.85041197e-012,4.07598003e-016},
     bhigh={-20256.51446,-51.06881858999999},
-    R_s=95.56720511710552);
+    R_s=95.56764189213999);
 
   constant IdealGases.Common.DataRecord NO2(
     name="NO2",
@@ -11675,7 +11675,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={721300.157,-3832.6152,11.13963285,-0.002238062246,6.54772343e-007,-7.6113359e-011,
         3.32836105e-015},
     bhigh={25024.97403,-43.0513004},
-    R_s=180.7277825477389);
+    R_s=180.7286085359359);
 
   constant IdealGases.Common.DataRecord NO2minus(
     name="NO2minus",
@@ -11689,7 +11689,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={132571.0335,-1557.032129,8.12672192,-0.000272862678,-4.7075418e-008,
         2.826729008e-011,-2.353985481e-015},
     bhigh={-17157.95217,-22.28576043},
-    R_s=180.7256274558646);
+    R_s=180.7264534342121);
 
   constant IdealGases.Common.DataRecord NO2CL(
     name="NO2CL",
@@ -11703,7 +11703,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-108677.3327,-1452.231167,11.05656962,-0.000400009928,
         9.101543039999999e-008,-1.036656913e-011,4.78166481e-016},
     bhigh={6294.26732,-35.21239681},
-    R_s=102.0700356623311);
+    R_s=102.0705021575403);
 
   constant IdealGases.Common.DataRecord NO2F(
     name="NO2F",
@@ -11717,7 +11717,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-100857.7842,-1704.722752,11.22954945,-0.000468521597,
         1.047692566e-007,-1.189150595e-011,5.470307120000001e-016},
     bhigh={-6891.71918,-38.49788492},
-    R_s=127.9072731127937);
+    R_s=127.9078576930747);
 
   constant IdealGases.Common.DataRecord NO3(
     name="NO3",
@@ -11731,7 +11731,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-394387.271,-824.426353,10.61325843,-0.0002448749816,5.40606032e-008,
         -6.19546675e-012,2.870000149e-016},
     bhigh={8982.01173,-34.44666597},
-    R_s=134.0937893618085);
+    R_s=134.0944022165990);
 
   constant IdealGases.Common.DataRecord NO3minus(
     name="NO3minus",
@@ -11745,7 +11745,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-311000.5758,-1369.087552,11.01342913,-0.000403687882,
         8.90208647e-008,-1.01973348e-011,4.72333079e-016},
     bhigh={-33643.2109,-38.78432657},
-    R_s=134.0926029523154);
+    R_s=134.0932158016836);
 
   constant IdealGases.Common.DataRecord NO3F(
     name="NO3F",
@@ -11759,7 +11759,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-341179.33,-2353.908798,16.28114887,-0.001910415273,4.69087356e-007,
         -5.68604014e-011,2.720906921e-015},
     bhigh={9760.583979999999,-65.58153684},
-    R_s=102.6436166371052);
+    R_s=102.6440857537770);
 
   constant IdealGases.Common.DataRecord N2(
     name="N2",
@@ -11773,7 +11773,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={587712.406,-2239.249073,6.06694922,-0.00061396855,1.491806679e-007,-1.923105485e-011,
         1.061954386e-015},
     bhigh={12832.10415,-15.86640027},
-    R_s=296.8033869505308);
+    R_s=296.8047434442088);
 
   constant IdealGases.Common.DataRecord N2plus(
     name="N2plus",
@@ -11787,7 +11787,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2845599.002,7058.89303,-2.884886385,0.003068677059,-4.36165231e-007,
         2.102514545e-011,5.41199647e-016},
     bhigh={134038.8483,50.90897022},
-    R_s=296.809199509051);
+    R_s=296.810556029295);
 
   constant IdealGases.Common.DataRecord N2minus(
     name="N2minus",
@@ -11801,7 +11801,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={216963.7706,-1275.098516,5.3910957,-0.000319890751,
         7.311051349999999e-008,-8.202017370000001e-012,3.7400447e-016},
     bhigh={24249.64308,-9.014934294},
-    R_s=296.7975746196665);
+    R_s=296.7989310867801);
 
   constant IdealGases.Common.DataRecord NCN(
     name="NCN",
@@ -11815,7 +11815,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-164188.0975,-776.784075,7.99998187,-0.0001659081508,
         2.983403318e-008,-3.120157047e-012,1.99269872e-016},
     bhigh={61844.24479999999,-21.4910882},
-    R_s=207.7366386751982);
+    R_s=207.7375881031678);
 
   constant IdealGases.Common.DataRecord N2D2_cis(
     name="N2D2_cis",
@@ -11829,7 +11829,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={879807.471,-5299.36204,13.55007485,-0.001316635227,2.755816197e-007,
         -3.036294387e-011,1.365324117e-015},
     bhigh={53563.11889999999,-62.71215875},
-    R_s=259.4898807188304);
+    R_s=259.4910666769367);
 
   constant IdealGases.Common.DataRecord N2F2(
     name="N2F2",
@@ -11843,7 +11843,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-182488.386,-953.402996,10.6979548,-0.00027599687,6.0554397e-008,-6.91121508e-012,
         3.19258723e-016},
     bhigh={9283.46696,-32.46968772},
-    R_s=125.9573701317801);
+    R_s=125.9579458003331);
 
   constant IdealGases.Common.DataRecord N2F4(
     name="N2F4",
@@ -11857,7 +11857,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-518859.471,-670.225651,16.50109262,-0.0002006404436,4.43675251e-008,
         -5.08980888e-012,2.359374159e-016},
     bhigh={-5281.4889,-60.40513435},
-    R_s=79.94145563999894);
+    R_s=79.94182099997779);
 
   constant IdealGases.Common.DataRecord N2H2(
     name="N2H2",
@@ -11871,7 +11871,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6217567.87,-17539.52096,20.22730509,-0.000975729766,-4.20841674e-007,
         1.117921171e-010,-7.627102210000001e-015},
     bhigh={137415.2574,-119.9559168},
-    R_s=276.8788329257312);
+    R_s=276.8800983573366);
 
   constant IdealGases.Common.DataRecord NH2NO2(
     name="NH2NO2",
@@ -11885,7 +11885,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1654040.575,-8125.220880000001,20.21742772,-0.001244291821,
         2.122804183e-007,-1.948359653e-011,7.43935136e-016},
     bhigh={42308.2258,-101.6190179},
-    R_s=134.0436782824811);
+    R_s=134.0442909082467);
 
   constant IdealGases.Common.DataRecord N2H4(
     name="N2H4",
@@ -11899,7 +11899,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3293486.7,-11998.50628,21.04406814,-0.001399381724,1.933173351e-007,
         -1.318016127e-011,3.16640017e-016},
     bhigh={83484.337,-115.5751024},
-    R_s=259.4610855430274);
+    R_s=259.4622713695297);
 
   constant IdealGases.Common.DataRecord N2O(
     name="N2O",
@@ -11913,7 +11913,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={343844.804,-2404.557558,9.125636220000001,-0.000540166793,
         1.315124031e-007,-1.4142151e-011,6.38106687e-016},
     bhigh={21986.32638,-31.47805016},
-    R_s=188.9103169986913);
+    R_s=188.9111803838883);
 
   constant IdealGases.Common.DataRecord N2Oplus(
     name="N2Oplus",
@@ -11927,7 +11927,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-29835.53254,-1179.455967,8.30018669,-0.0002887267217,
         5.70510501e-008,-5.95888512e-012,2.835725557e-016},
     bhigh={164602.1769,-22.87356617},
-    R_s=188.9126717112227);
+    R_s=188.9135351071816);
 
   constant IdealGases.Common.DataRecord N2O3(
     name="N2O3",
@@ -11941,7 +11941,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={778388.186,-4483.02466,16.66668024,-0.002062143878,
         5.309541710000001e-007,-6.19045122e-011,2.692956658e-015},
     bhigh={33609.1245,-67.39212388},
-    R_s=109.384251877345);
+    R_s=109.384751801041);
 
   constant IdealGases.Common.DataRecord N2O4(
     name="N2O4",
@@ -11955,7 +11955,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-458284.3760000001,-1604.749805,16.74102133,-0.0005091385080000001,
         1.14363467e-007,-1.316288176e-011,5.976316620000001e-016},
     bhigh={4306.90052,-65.69450380000001},
-    R_s=90.36389127386944);
+    R_s=90.36430426796797);
 
   constant IdealGases.Common.DataRecord N2O5(
     name="N2O5",
@@ -11969,7 +11969,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-53255.7896,-3109.277389,20.36088958,-0.000995990114,
         2.401398635e-007,-3.057161911e-011,1.495915511e-015},
     bhigh={13369.57281,-82.98623341000001},
-    R_s=76.97843911327057);
+    R_s=76.97879093124365);
 
   constant IdealGases.Common.DataRecord N3(
     name="N3",
@@ -11983,7 +11983,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={252926.4658,-2362.876591,9.135267130000001,-0.000621287085,
         1.324094351e-007,-1.47898964e-011,6.721230470000001e-016},
     bhigh={64126.95389999999,-31.35825973},
-    R_s=197.8689246336872);
+    R_s=197.8698289628059);
 
   constant IdealGases.Common.DataRecord N3H(
     name="N3H",
@@ -11997,7 +11997,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1170469.241,-5102.45199,12.7828891,-0.000840948716,1.592142834e-007,
         -1.512289051e-011,6.102906629999999e-016},
     bhigh={64283.4447,-55.13119107999999},
-    R_s=193.2338075357372);
+    R_s=193.2346906807747);
 
   constant IdealGases.Common.DataRecord Na(
     name="Na",
@@ -12010,7 +12010,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={952572.3380000001,-2623.807254,5.16259662,-0.001210218586,
         2.306301844e-007,-1.249597843e-011,7.226771190000001e-016},
     bhigh={29129.63564,-15.19717061},
-    R_s=361.6596425279592);
+    R_s=361.6612954370574);
 
   constant IdealGases.Common.DataRecord Naplus(
     name="Naplus",
@@ -12022,7 +12022,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={72565.3707,3.55084508},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={72565.3707,3.55084508},
-    R_s=361.6682729411619);
+    R_s=361.6699258897041);
 
   constant IdealGases.Common.DataRecord Naminus(
     name="Naminus",
@@ -12034,7 +12034,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={5082.19967,3.55091679},
     ahigh={0,0,2.500000001,0,0,0,0},
     bhigh={5082.19967,3.55091679},
-    R_s=361.6510125266381);
+    R_s=361.6526653962943);
 
   constant IdealGases.Common.DataRecord NaALF4(
     name="NaALF4",
@@ -12048,7 +12048,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-357117.793,-249.6543879,16.18634511,-7.449049300000001e-005,
         1.644510872e-008,-1.883696066e-012,8.719877450000001e-017},
     bhigh={-227953.3538,-53.7066514},
-    R_s=66.00624957484196);
+    R_s=66.00655124613074);
 
   constant IdealGases.Common.DataRecord NaBO2(
     name="NaBO2",
@@ -12062,7 +12062,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={85958.14049999999,-1691.902222,11.18847517,-0.000456420231,
         9.80450516e-008,-1.101655008e-011,5.02917276e-016},
     bhigh={-69492.9206,-34.1635313},
-    R_s=126.360582599552);
+    R_s=126.361160110925);
 
   constant IdealGases.Common.DataRecord NaBr(
     name="NaBr",
@@ -12076,7 +12076,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={897851.3019999999,-2697.899721,7.54537716,-0.001566692184,
         4.47039274e-007,-4.83281021e-011,1.4239613e-015},
     bhigh={-1750.862247,-18.56478949},
-    R_s=80.80636952072025);
+    R_s=80.80673883365340);
 
   constant IdealGases.Common.DataRecord NaCN(
     name="NaCN",
@@ -12090,7 +12090,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={366557.029,-1782.094358,8.69962263,-0.0004463297,9.36222931e-008,-1.03307132e-011,
         4.650466810000001e-016},
     bhigh={20109.26347,-24.19276094},
-    R_s=169.6582765338215);
+    R_s=169.6590519305644);
 
   constant IdealGases.Common.DataRecord NaCL(
     name="NaCL",
@@ -12104,7 +12104,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={331449.8760000001,-896.831565,5.27728738,-0.0001475674008,-1.491128988e-008,
         2.465673596e-011,-2.730355213e-015},
     bhigh={-17362.77667,-3.99828856},
-    R_s=142.2669048712099);
+    R_s=142.2675550799526);
 
   constant IdealGases.Common.DataRecord NaF(
     name="NaF",
@@ -12118,7 +12118,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1092926.912,3293.30364,0.413591984,0.00263499447,-8.384295630000001e-007,
         1.417053025e-010,-8.600270160000001e-015},
     bhigh={-57728.8463,29.09489906},
-    R_s=198.0193794189646);
+    R_s=198.0202844357134);
 
   constant IdealGases.Common.DataRecord NaH(
     name="NaH",
@@ -12132,7 +12132,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4756184.75,14520.47626,-13.27563485,0.01055828277,-2.990041189e-006,
         3.90532288e-010,-1.923931194e-014},
     bhigh={-76329.2227,122.207006},
-    R_s=346.4693922878474);
+    R_s=346.4709757722716);
 
   constant IdealGases.Common.DataRecord NaI(
     name="NaI",
@@ -12146,7 +12146,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2281549.408,-7093.15663,13.04994968,-0.00501349233,1.581735155e-006,
         -2.285837754e-010,1.19588995e-014},
     bhigh={32538.9362,-56.4002332},
-    R_s=55.46892262170982);
+    R_s=55.46917613378606);
 
   constant IdealGases.Common.DataRecord NaLi(
     name="NaLi",
@@ -12160,7 +12160,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={10916648.6,-34800.1064,46.14311919999999,-0.02260951051,
         5.68532437e-006,-6.458143299999999e-010,2.696508992e-014},
     bhigh={239443.1755,-296.1780126},
-    R_s=277.7901136522716);
+    R_s=277.7913832487437);
 
   constant IdealGases.Common.DataRecord NaNO2(
     name="NaNO2",
@@ -12174,7 +12174,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-176555.7495,-863.521295,10.6410594,-0.0002559465044,5.65446563e-008,
         -6.48671032e-012,3.008171243e-016},
     bhigh={-18684.35672,-29.21304474},
-    R_s=120.5078551036904);
+    R_s=120.5084058660833);
 
   constant IdealGases.Common.DataRecord NaNO3(
     name="NaNO3",
@@ -12188,7 +12188,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-322559.219,-1396.782195,14.03092409,-0.000409816177,
         9.023845720000001e-008,-1.032543966e-011,4.77867155e-016},
     bhigh={-31388.89875,-49.59121431},
-    R_s=97.82345175291582);
+    R_s=97.82389883977432);
 
   constant IdealGases.Common.DataRecord NaO(
     name="NaO",
@@ -12202,7 +12202,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={256974.4011,-2269.334161,9.22439762,-0.0036512691,1.446811119e-006,-2.443068386e-010,
         1.428508328e-014},
     bhigh={24132.39357,-29.89159486},
-    R_s=213.2508078525396);
+    R_s=213.2517824821611);
 
   constant IdealGases.Common.DataRecord NaOH(
     name="NaOH",
@@ -12216,7 +12216,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={875378.776,-2342.514649,7.97846989,0.0001016451512,-6.26853195e-008,
         1.022715136e-011,-5.71328641e-016},
     bhigh={-9509.90171,-22.02310401},
-    R_s=207.87681910018);
+    R_s=207.87776916882);
 
   constant IdealGases.Common.DataRecord NaOHplus(
     name="NaOHplus",
@@ -12230,7 +12230,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={881541.365,-2363.159755,8.053203930000001,7.27127974e-005,-5.89741789e-008,
         1.007487881e-011,-5.47440621e-016},
     bhigh={95844.41650000001,-20.79484012},
-    R_s=207.8796703758639);
+    R_s=207.8806204575376);
 
   constant IdealGases.Common.DataRecord Na2(
     name="Na2",
@@ -12244,7 +12244,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={19299407.58,-62692.8012,82.67682110000001,-0.0456513781,
         1.259515667e-005,-1.560445735e-009,7.02467717e-014},
     bhigh={409082.08,-550.997089},
-    R_s=180.8298212639796);
+    R_s=180.8306477185287);
 
   constant IdealGases.Common.DataRecord Na2Br2(
     name="Na2Br2",
@@ -12258,7 +12258,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-30217.30975,-2.65923278,10.00225819,-9.935490630000001e-007,
         2.358676253e-010,-2.857194816e-014,1.381909879e-018},
     bhigh={-60900.3992,-14.94517863},
-    R_s=40.40318476036013);
+    R_s=40.40336941682670);
 
   constant IdealGases.Common.DataRecord Na2CL2(
     name="Na2CL2",
@@ -12272,7 +12272,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-44121.0523,-5.39349128,10.00453407,-1.981155641e-006,4.6801882e-010,
         -5.64894068e-014,2.724721177e-018},
     bhigh={-70980.6341,-17.87230397},
-    R_s=71.13345243560495);
+    R_s=71.13377753997629);
 
   constant IdealGases.Common.DataRecord Na2F2(
     name="Na2F2",
@@ -12286,7 +12286,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-90307.50689999999,-18.93938035,10.01535518,-6.53967545e-006,
         1.516333603e-009,-1.804877459e-013,8.61347492e-018},
     bhigh={-103489.6664,-21.78860202},
-    R_s=99.00968970948229);
+    R_s=99.01014221785672);
 
   constant IdealGases.Common.DataRecord Na2I2(
     name="Na2I2",
@@ -12300,7 +12300,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-22312.36397,-1.515570558,10.00129413,-5.71503538e-007,
         1.360287207e-010,-1.650916036e-014,7.996149680000001e-019},
     bhigh={-45969.2175,-12.76523965},
-    R_s=27.73446131085491);
+    R_s=27.73458806689303);
 
   constant IdealGases.Common.DataRecord Na2O(
     name="Na2O",
@@ -12314,7 +12314,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-66005.2516,-25.69021634,7.51938542,-7.81163524e-006,1.73501589e-009,
         -1.996634558e-013,9.27643355e-018},
     bhigh={-4297.33965,-10.63530214},
-    R_s=134.1499548072297);
+    R_s=134.1505679187156);
 
   constant IdealGases.Common.DataRecord Na2Oplus(
     name="Na2Oplus",
@@ -12328,7 +12328,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-57409.0933,-19.89178143,7.51529526,-6.25833323e-006,
         1.407321045e-009,-1.635833952e-013,7.66244513e-018},
     bhigh={60329.77469999999,-9.42652674},
-    R_s=134.1511422318069);
+    R_s=134.1517553487198);
 
   constant IdealGases.Common.DataRecord Na2O2(
     name="Na2O2",
@@ -12342,7 +12342,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-173229.5239,-113.7561118,10.08529143,-3.42209894e-005,
         7.577721890000001e-009,-8.70125673e-013,4.03606139e-017},
     bhigh={-17803.00574,-23.8678919},
-    R_s=106.6254039262698);
+    R_s=106.6258912410805);
 
   constant IdealGases.Common.DataRecord Na2O2H2(
     name="Na2O2H2",
@@ -12356,7 +12356,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1675713.839,-4704.921170000001,16.97343934,0.0001961487616,-1.236951748e-007,
         2.025311778e-011,-1.132991623e-015},
     bhigh={-48562.4557,-68.1348098},
-    R_s=103.93840955009);
+    R_s=103.93888458441);
 
   constant IdealGases.Common.DataRecord Na2SO4(
     name="Na2SO4",
@@ -12370,7 +12370,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-575448.311,-981.7060339999999,19.73310397,-0.000293639552,
         6.498708169999999e-008,-7.462479400000001e-012,3.46249166e-016},
     bhigh={-127059.7762,-76.67871596000001},
-    R_s=58.53524876490879);
+    R_s=58.53551629115134);
 
   constant IdealGases.Common.DataRecord Na3CL3(
     name="Na3CL3",
@@ -12384,7 +12384,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-71602.9797,-9.57349381,16.00799614,-3.47835697e-006,
         8.190943689999999e-010,-9.86321003e-014,4.74900535e-018},
     bhigh={-114725.2948,-40.31342160000001},
-    R_s=47.42230162373664);
+    R_s=47.42251835998420);
 
   constant IdealGases.Common.DataRecord Na3F3(
     name="Na3F3",
@@ -12398,7 +12398,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-155399.5698,-35.5197019,16.02841159,-1.198056094e-005,
         2.75724873e-009,-3.26330097e-013,1.550483212e-017},
     bhigh={-167214.1773,-47.5378068},
-    R_s=66.00645980632153);
+    R_s=66.00676147857115);
 
   constant IdealGases.Common.DataRecord Nb(
     name="Nb",
@@ -12412,7 +12412,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1096553.196,2546.650713,2.236054882,-0.001280029198,
         8.464237990000001e-007,-1.486269508e-010,8.714309406000001e-015},
     bhigh={68791.24550000001,13.9816903},
-    R_s=89.49301436564421);
+    R_s=89.49342337953540);
 
   constant IdealGases.Common.DataRecord Nbplus(
     name="Nbplus",
@@ -12426,7 +12426,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1077639.646,2159.046421,2.310604767,-0.0005363991760000001,
         5.05791509e-007,-1.032401533e-010,6.629241279999999e-015},
     bhigh={151794.5546,12.10678502},
-    R_s=89.49354281328783);
+    R_s=89.49395182959420);
 
   constant IdealGases.Common.DataRecord Nbminus(
     name="Nbminus",
@@ -12440,7 +12440,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={111745.8019,134.0072834,2.391474129,4.52481343e-005,-1.025345e-008,
         1.195577988e-012,-5.606330449999999e-017},
     bhigh={74739.9675,9.67531561},
-    R_s=89.49248592424141);
+    R_s=89.49289493571743);
 
   constant IdealGases.Common.DataRecord NbCL5(
     name="NbCL5",
@@ -12454,7 +12454,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-156381.6638,-44.5052128,16.0354463,-1.489949737e-005,
         3.42077792e-009,-4.04112442e-013,1.917266128e-017},
     bhigh={-89628.15120000001,-43.74582607},
-    R_s=30.77480671712896);
+    R_s=30.77494736859248);
 
   constant IdealGases.Common.DataRecord NbO(
     name="NbO",
@@ -12468,7 +12468,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={553225.878,-1287.669306,4.98006604,0.0001116014163,4.03183868e-008,
         1.04877371e-011,-1.893595022e-015},
     bhigh={32684.5779,-1.868958549},
-    R_s=76.34555300921586);
+    R_s=76.34590193468152);
 
   constant IdealGases.Common.DataRecord NbOCL3(
     name="NbOCL3",
@@ -12482,7 +12482,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-151555.1427,53.0554523,12.28915282,-0.0001527366571,
         6.778576440000001e-008,-9.36517065e-012,4.67003693e-016},
     bhigh={-94907.68120000001,-27.45263834},
-    R_s=38.62439550027646);
+    R_s=38.62457202706361);
 
   constant IdealGases.Common.DataRecord NbO2(
     name="NbO2",
@@ -12496,7 +12496,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-685185.99,911.224932,6.33919984,-8.2300803e-005,1.984439605e-007,-3.26117149e-011,
         1.602430854e-015},
     bhigh={-33250.2732,-3.55955655},
-    R_s=66.56627051015819);
+    R_s=66.56657474093548);
 
   constant IdealGases.Common.DataRecord Ne(
     name="Ne",
@@ -12508,7 +12508,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={-745.375,3.35532272},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={-745.375,3.35532272},
-    R_s=412.0215860493466);
+    R_s=412.0234691298682);
 
   constant IdealGases.Common.DataRecord Neplus(
     name="Neplus",
@@ -12522,7 +12522,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-111274.2658,476.569797,2.196650531,0.0001102593151,-2.287564425e-008,
         2.510218183e-012,-1.126646096e-016},
     bhigh={247253.6944,7.46614054},
-    R_s=412.0327874639962);
+    R_s=412.0346705957119);
 
   constant IdealGases.Common.DataRecord Ni(
     name="Ni",
@@ -12536,7 +12536,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-493826.221,1092.909991,2.410485014,-1.599071827e-005,-1.047414069e-008,
         4.62479521e-012,-4.448865218e-017},
     bhigh={43360.7217,9.677195599999999},
-    R_s=141.6594029311643);
+    R_s=141.6600503634139);
 
   constant IdealGases.Common.DataRecord Niplus(
     name="Niplus",
@@ -12550,7 +12550,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3961999.32,10170.84853,-6.02933129,0.002770858029,-8.9020777e-008,-5.54100058e-011,
         5.235342833e-015},
     bhigh={73403.9512,71.37503100000001},
-    R_s=141.6607270165784);
+    R_s=141.6613744548795);
 
   constant IdealGases.Common.DataRecord Niminus(
     name="Niminus",
@@ -12564,7 +12564,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-543342.48,1182.64533,2.12644124,3.73045594e-005,6.95360843e-009,-1.945719381e-012,
         1.271571579e-016},
     bhigh={28547.59122,10.43462235},
-    R_s=141.6580788705022);
+    R_s=141.6587262967004);
 
   constant IdealGases.Common.DataRecord NiCL(
     name="NiCL",
@@ -12578,7 +12578,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3905769.19,9961.53399,-3.83943234,0.002767979391,-7.00595938e-008,-5.74140366e-011,
         5.3076358e-015},
     bhigh={-45053.9705,67.69402548000001},
-    R_s=88.31428498593679);
+    R_s=88.31468861262884);
 
   constant IdealGases.Common.DataRecord NiCL2(
     name="NiCL2",
@@ -12592,7 +12592,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={158588.9817,-1161.488738,9.608015379999999,-0.0009461224509999999,
         2.608172043e-007,-3.26463725e-011,1.525950893e-015},
     bhigh={-4578.98554,-22.12397347},
-    R_s=64.15517355790227);
+    R_s=64.15546676913628);
 
   constant IdealGases.Common.DataRecord NiO(
     name="NiO",
@@ -12606,7 +12606,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-72340.9194,-80.3555427,4.55922102,2.30515451e-005,
         5.139832819999999e-009,-5.85347491e-013,2.697077329e-017},
     bhigh={34611.4385,1.209414814},
-    R_s=111.3155752629437);
+    R_s=111.3160840134524);
 
   constant IdealGases.Common.DataRecord NiS(
     name="NiS",
@@ -12620,7 +12620,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-735812.898,1178.231095,4.83786558,-0.000393120139,1.341974852e-007,
         -1.569591708e-011,6.67704506e-016},
     bhigh={32755.6594,3.690652283},
-    R_s=91.61104647062973);
+    R_s=91.61146516465695);
 
   constant IdealGases.Common.DataRecord O(
     name="O",
@@ -12634,7 +12634,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={261902.0262,-729.872203,3.31717727,-0.000428133436,1.036104594e-007,
         -9.438304329999999e-012,2.725038297e-016},
     bhigh={33924.2806,-0.667958535},
-    R_s=519.6739877745415);
+    R_s=519.6763628636074);
 
   constant IdealGases.Common.DataRecord Oplus(
     name="Oplus",
@@ -12647,7 +12647,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-216651.3208,666.545615,1.702064364,0.000471499281,-1.427131823e-007,
         2.016595903e-011,-9.107157761999999e-016},
     bhigh={183719.1966,10.05690382},
-    R_s=519.691807375622);
+    R_s=519.694182546130);
 
   constant IdealGases.Common.DataRecord Ominus(
     name="Ominus",
@@ -12661,7 +12661,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={9769.363179999999,7.15960478,2.494961726,1.968240938e-006,-4.30417485e-010,
         4.912083080000001e-014,-2.271600083e-018},
     bhigh={11495.54438,4.83703644},
-    R_s=519.6561693954442);
+    R_s=519.6585444030738);
 
   constant IdealGases.Common.DataRecord OD(
     name="OD",
@@ -12675,7 +12675,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7.832473160e+005,-2.532992554e+003,5.952124650e+000,-3.743595280e-004,4.959527620e-008,
         3.454454730e-012,-7.380626800e-016},
     bhigh={1.930492973e+004,-1.568898441e+001},
-    R_s=461.5688831633072);
+    R_s=461.5709926920374);
 
   constant IdealGases.Common.DataRecord ODminus(
     name="ODminus",
@@ -12689,7 +12689,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3.029467029e+005,-1.079684654e+003,4.211417380e+000,6.260830070e-004,-2.411665054e-007,
         4.248425540e-011,-2.387099102e-015},
     bhigh={-1.188935343e+004,-4.724898790e+000},
-    R_s=461.5548265418994);
+    R_s=461.5569360063860);
 
   constant IdealGases.Common.DataRecord OH(
     name="OH",
@@ -12703,7 +12703,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1017393.379,-2509.957276,5.11654786,0.000130529993,-8.284322259999999e-008,
         2.006475941e-011,-1.556993656e-015},
     bhigh={20196.40206,-11.01282337},
-    R_s=488.8755090449183);
+    R_s=488.8777433743314);
 
   constant IdealGases.Common.DataRecord OHplus(
     name="OHplus",
@@ -12717,7 +12717,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={504072.91,-1380.052958,4.1254622,0.000833194884,-3.44285629e-007,
         6.792853949999999e-011,-4.36387213e-015},
     bhigh={164383.9235,-3.99705849},
-    R_s=488.8912790451466);
+    R_s=488.8935134466341);
 
   constant IdealGases.Common.DataRecord OHminus(
     name="OHminus",
@@ -12731,7 +12731,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={471133.117,-857.233669,3.16618121,0.001233581296,-3.99924458e-007,
         6.23908167e-011,-3.35434322e-015},
     bhigh={-12248.49139,1.48773626},
-    R_s=488.8597400620322);
+    R_s=488.8619743193756);
 
   constant IdealGases.Common.DataRecord O2(
     name="O2",
@@ -12745,7 +12745,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1037939.022,2344.830282,1.819732036,0.001267847582,-2.188067988e-007,
         2.053719572e-011,-8.193467050000001e-016},
     bhigh={-16890.10929,17.38716506},
-    R_s=259.8369938872708);
+    R_s=259.8381814318037);
 
   constant IdealGases.Common.DataRecord O2plus(
     name="O2plus",
@@ -12759,7 +12759,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={73846.5488,-845.955954,4.98516416,-0.000161101089,6.42708399e-008,-1.504939874e-011,
         1.578465409e-015},
     bhigh={144632.1044,-5.81123065},
-    R_s=259.841448711163);
+    R_s=259.842636276056);
 
   constant IdealGases.Common.DataRecord O2minus(
     name="O2minus",
@@ -12773,7 +12773,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-56552.0805,-236.7815862,4.67583367,-2.1972453e-005,1.71150928e-008,
         -1.757645062e-012,8.24817279e-017},
     bhigh={-5960.17775,-2.436885556},
-    R_s=259.8325392161265);
+    R_s=259.8337267403000);
 
   constant IdealGases.Common.DataRecord O3(
     name="O3",
@@ -12787,7 +12787,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-38696624.8,102334.4994,-89.615516,0.0370614497,-4.13763874e-006,-2.725018591e-010,
         5.24818811e-014},
     bhigh={-651791.818,702.9109520000001},
-    R_s=173.2246625915139);
+    R_s=173.2254542878692);
 
   constant IdealGases.Common.DataRecord P(
     name="P",
@@ -12801,7 +12801,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1261794.642,-4559.83819,8.91807931,-0.00438140146,1.454286224e-006,-2.030782763e-010,
         1.021022887e-014},
     bhigh={65417.23959999999,-39.15974795},
-    R_s=268.4359836056074);
+    R_s=268.4372104504842);
 
   constant IdealGases.Common.DataRecord Pplus(
     name="Pplus",
@@ -12815,7 +12815,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-559424.936,1722.576545,0.8430381089999999,0.0006287368940000001,-6.317195459999999e-008,
         -1.810842484e-012,4.31811257e-016},
     bhigh={149049.3431,18.45275207},
-    R_s=268.4407381650862);
+    R_s=268.4419650316930);
 
   constant IdealGases.Common.DataRecord Pminus(
     name="Pminus",
@@ -12829,7 +12829,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={15434.88016,9.495009339999999,2.493170861,2.700167711e-006,-5.94921039e-010,
         6.82376629e-014,-3.16695991e-018},
     bhigh={27975.72693,6.246793872},
-    R_s=268.4312292145488);
+    R_s=268.4324560376965);
 
   constant IdealGases.Common.DataRecord PCL(
     name="PCL",
@@ -12843,7 +12843,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-347168.151,993.555793,3.39943027,0.00040197117,
         8.295588390000001e-008,-3.090212484e-011,2.106384858e-015},
     bhigh={8433.59115,10.64902238},
-    R_s=125.1675059092525);
+    R_s=125.1680779678539);
 
   constant IdealGases.Common.DataRecord PCL2(
     name="PCL2",
@@ -12857,7 +12857,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-83498.33970000001,-26.2524947,7.02036181,-8.388768680000001e-006,
         1.89678474e-009,-2.21487992e-013,1.04165355e-017},
     bhigh={-8742.99368,-6.23402319},
-    R_s=81.61063510936191);
+    R_s=81.61100809806572);
 
   constant IdealGases.Common.DataRecord PCL2minus(
     name="PCL2minus",
@@ -12871,7 +12871,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-85649.8676,-31.8555594,7.02449496,-1.002251172e-005,
         2.253747944e-009,-2.619657192e-013,1.227059658e-017},
     bhigh={-45038.1143,-6.721522361},
-    R_s=81.6101956564922);
+    R_s=81.6105686431876);
 
   constant IdealGases.Common.DataRecord PCL3(
     name="PCL3",
@@ -12885,7 +12885,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-133307.693,-41.4588321,10.0318606,-1.30194616e-005,2.92291689e-009,
         -3.39186924e-013,1.58642553e-017},
     bhigh={-38003.3668,-20.50737678},
-    R_s=60.54252415416013);
+    R_s=60.54280085434240);
 
   constant IdealGases.Common.DataRecord PCL5(
     name="PCL5",
@@ -12899,7 +12899,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-225590.689,-69.38542820000001,16.0535963,-2.20215696e-005,
         4.97139229e-009,-5.79986005e-013,2.72597077e-017},
     bhigh={-50342.3422,-48.7245487},
-    R_s=39.92759061796377);
+    R_s=39.92777310080135);
 
   constant IdealGases.Common.DataRecord PF(
     name="PF",
@@ -12913,7 +12913,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1132572.282,3200.03855,0.778050237,0.001969518902,-4.36581897e-007,
         5.243648570000001e-011,-2.618755712e-015},
     bhigh={-27667.73009,27.59312302},
-    R_s=166.3820675591232);
+    R_s=166.3828279824631);
 
   constant IdealGases.Common.DataRecord PFplus(
     name="PFplus",
@@ -12927,7 +12927,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-40115.2518,-159.7504413,4.62139748,-2.378072183e-005,
         1.431831329e-008,-2.300109157e-012,1.694069882e-016},
     bhigh={107863.3756,-0.04072343949999999},
-    R_s=166.3838941400966);
+    R_s=166.3846545717846);
 
   constant IdealGases.Common.DataRecord PFminus(
     name="PFminus",
@@ -12941,7 +12941,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-130379.3388,271.5526386,4.13761981,0.0002728610614,-7.64441625e-008,
         1.182073001e-011,-6.083906640000001e-016},
     bhigh={-22907.99827,3.7485261},
-    R_s=166.3802410182543);
+    R_s=166.3810014332462);
 
   constant IdealGases.Common.DataRecord PFCL(
     name="PFCL",
@@ -12955,7 +12955,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-128214.3211,-97.3904355,7.07266166,-2.903614134e-005,
         6.408504490000001e-009,-7.33899377e-013,3.39672317e-017},
     bhigh={-36006.4926,-7.626493035},
-    R_s=97.33047724127172);
+    R_s=97.33092207506697);
 
   constant IdealGases.Common.DataRecord PFCLminus(
     name="PFCLminus",
@@ -12969,7 +12969,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-123156.515,-97.6586111,7.07402957,-2.997070692e-005,
         6.685280620000001e-009,-7.7222622e-013,3.5993823e-017},
     bhigh={-65588.1722,-8.208878059},
-    R_s=97.32985218942183);
+    R_s=97.33029702036036);
 
   constant IdealGases.Common.DataRecord PFCL2(
     name="PFCL2",
@@ -12983,7 +12983,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-186458.9813,-114.8004379,10.08599754,-3.44745652e-005,
         7.62797201e-009,-8.75309743e-013,4.05778835e-017},
     bhigh={-64504.7219,-21.74054563},
-    R_s=68.7839036523025);
+    R_s=68.7842180184269);
 
   constant IdealGases.Common.DataRecord PFCL4(
     name="PFCL4",
@@ -12997,7 +12997,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-295437.588,-132.5154294,16.1000538,-4.03535917e-005,
         8.971130739999999e-009,-1.03328881e-012,4.80446835e-017},
     bhigh={-81357.19399999999,-50.62403920000001},
-    R_s=43.35327702723852);
+    R_s=43.35347516664257);
 
   constant IdealGases.Common.DataRecord PF2(
     name="PF2",
@@ -13011,7 +13011,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-170846.712,-169.205154,7.1254916,-4.990852849999999e-005,
         1.09733523e-008,-1.25287026e-012,5.78479114e-017},
     bhigh={-63382.9584,-10.41715673},
-    R_s=120.5510163745587);
+    R_s=120.5515673342134);
 
   constant IdealGases.Common.DataRecord PF2minus(
     name="PF2minus",
@@ -13025,7 +13025,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-165397.6056,-164.0604822,7.12409152,-5.0154314e-005,
         1.117302152e-008,-1.289308601e-012,6.00470667e-017},
     bhigh={-87002.23319999999,-11.09074866},
-    R_s=120.5500575052316);
+    R_s=120.5506084605040);
 
   constant IdealGases.Common.DataRecord PF2CL(
     name="PF2CL",
@@ -13039,7 +13039,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-240928.1185,-203.348467,10.15150769,-6.04836731e-005,
         1.333942001e-008,-1.526772528e-012,7.063339179999999e-017},
     bhigh={-91011.1059,-24.17825549},
-    R_s=79.62256229143155);
+    R_s=79.62292619395801);
 
   constant IdealGases.Common.DataRecord PF2CL3(
     name="PF2CL3",
@@ -13053,7 +13053,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-365527.254,-202.969416,16.15238015,-6.11879657e-005,
         1.355610375e-008,-1.55712964e-012,7.22435997e-017},
     bhigh={-110494.1533,-53.87308191},
-    R_s=47.42196152820714);
+    R_s=47.42217826290034);
 
   constant IdealGases.Common.DataRecord PF3(
     name="PF3",
@@ -13067,7 +13067,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-295704.0675,-299.7689931,10.22297023,-8.890263450000001e-005,
         1.958901359e-008,-2.240491075e-012,1.035952523e-016},
     bhigh={-117374.3464,-27.77419177},
-    R_s=94.51596333673592);
+    R_s=94.51639530723348);
 
   constant IdealGases.Common.DataRecord PF3CL2(
     name="PF3CL2",
@@ -13081,7 +13081,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-422383.8050000001,-320.796522,16.24013,-9.62365531e-005,
         2.129279712e-008,-2.443515401e-012,1.13290435e-016},
     bhigh={-139264.2151,-55.31285745},
-    R_s=52.33342903919946);
+    R_s=52.33366822099038);
 
   constant IdealGases.Common.DataRecord PF4CL(
     name="PF4CL",
@@ -13095,7 +13095,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-478114.004,-426.481283,16.31812121,-0.0001271374903,
         2.806715254e-008,-3.2151663e-012,1.488512118e-016},
     bhigh={-168048.8362,-57.35844805},
-    R_s=58.37979341127105);
+    R_s=58.38006022702912);
 
   constant IdealGases.Common.DataRecord PF5(
     name="PF5",
@@ -13109,7 +13109,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-566872.784,-667.791791,16.49789569,-0.000199009944,4.3950071e-008,-5.03684954e-012,
         2.332945909e-016},
     bhigh={-194432.1623,-62.61721040000001},
-    R_s=66.00580092480199);
+    R_s=66.00610259404029);
 
   constant IdealGases.Common.DataRecord PH(
     name="PH",
@@ -13123,7 +13123,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={781473.0649999999,-3038.451204,7.46748102,-0.001837522255,
         7.1659477e-007,-1.142128853e-010,6.175410560000001e-015},
     bhigh={45362.6018,-24.6729814},
-    R_s=259.9759156024878);
+    R_s=259.9771037819408);
 
   constant IdealGases.Common.DataRecord PH2(
     name="PH2",
@@ -13137,7 +13137,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1127884.913,-4715.238249999999,10.214983,-0.00116757382,
         2.150542671e-007,-1.624213739e-011,3.76622524e-016},
     bhigh={41830.7463,-42.3162325},
-    R_s=252.0328123607044);
+    R_s=252.0339642374405);
 
   constant IdealGases.Common.DataRecord PH2minus(
     name="PH2minus",
@@ -13151,7 +13151,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1382525.815,-5213.40067,10.21694832,-0.001116316349,2.215004171e-007,
         -2.338005187e-011,1.015580932e-015},
     bhigh={29906.83733,-43.78711584999999},
-    R_s=252.0286212601821);
+    R_s=252.0297731177635);
 
   constant IdealGases.Common.DataRecord PH3(
     name="PH3",
@@ -13165,7 +13165,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1334801.106,-6725.46352,14.45857073,-0.001639736883,3.40921857e-007,
         -3.73627208e-011,1.672947506e-015},
     bhigh={39103.2571,-71.9878119},
-    R_s=244.5606938917213);
+    R_s=244.5618116183031);
 
   constant IdealGases.Common.DataRecord PN(
     name="PN",
@@ -13179,7 +13179,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-249562.5593,176.043883,4.14412196,0.0002478018097,-5.674896300000001e-008,
         4.263645119999999e-012,3.063920924e-016},
     bhigh={17703.17267,1.325517397},
-    R_s=184.8463047099495);
+    R_s=184.8471495212110);
 
   constant IdealGases.Common.DataRecord PO(
     name="PO",
@@ -13193,7 +13193,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-336666.744,622.9355840000001,3.56560546,0.0006516620719999999,-2.061770841e-007,
         3.18441323e-011,-1.573691908e-015},
     bhigh={-8939.79039,6.954859188},
-    R_s=177.0047368113038);
+    R_s=177.0055457838999);
 
   constant IdealGases.Common.DataRecord POminus(
     name="POminus",
@@ -13207,7 +13207,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-848.0294779999999,347.054487,2.877890167,0.001622182445,-4.87019099e-007,
         6.64575227e-011,-3.39570376e-015},
     bhigh={-19872.0954,10.75444355},
-    R_s=177.0026695954198);
+    R_s=177.0034785585680);
 
   constant IdealGases.Common.DataRecord POCL3(
     name="POCL3",
@@ -13221,7 +13221,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-218593.797,-508.026968,13.3778465,-0.000151073105,3.34098678e-008,-3.83532976e-012,
         1.77932988e-016},
     bhigh={-70093.15090000001,-39.84746301},
-    R_s=54.2252319785671);
+    R_s=54.2254798065489);
 
   constant IdealGases.Common.DataRecord POFCL2(
     name="POFCL2",
@@ -13235,7 +13235,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-270764.7503,-655.650227,13.48668421,-0.0001942765035,
         4.29118449e-008,-4.9218448e-012,2.282079808e-016},
     bhigh={-96543.92140000001,-41.64963494},
-    R_s=60.74386294492521);
+    R_s=60.74414056529507);
 
   constant IdealGases.Common.DataRecord POF2CL(
     name="POF2CL",
@@ -13249,7 +13249,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-334708.659,-817.6104810000001,13.6066432,-0.0002420426112,
         5.34371272e-008,-6.126461349999999e-012,2.839570116e-016},
     bhigh={-123340.1194,-44.96103437000001},
-    R_s=69.04390565615641);
+    R_s=69.04422121057948);
 
   constant IdealGases.Common.DataRecord POF3(
     name="POF3",
@@ -13263,7 +13263,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-369060.242,-1005.55254,13.7452994,-0.000297103711,6.55452664e-008,-7.50998733e-012,
         3.47896991e-016},
     bhigh={-149976.173,-48.82214181000001},
-    R_s=79.97116769280214);
+    R_s=79.97153318857534);
 
   constant IdealGases.Common.DataRecord PO2(
     name="PO2",
@@ -13277,7 +13277,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={492621.0990000001,-2605.465745,9.51760561,-0.001180371565,
         2.532912819e-007,-1.789964539e-011,1.800381054e-016},
     bhigh={-20288.84763,-29.69743125},
-    R_s=132.0332517522989);
+    R_s=132.0338551897230);
 
   constant IdealGases.Common.DataRecord PO2minus(
     name="PO2minus",
@@ -13291,7 +13291,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1628679.152,-5989.19998,13.69318836,-0.00362384379,
         9.488198340000001e-007,-1.040308759e-010,4.01903366e-015},
     bhigh={-36859.595,-59.5679622},
-    R_s=132.0321015241718);
+    R_s=132.0327049563390);
 
   constant IdealGases.Common.DataRecord PS(
     name="PS",
@@ -13305,7 +13305,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-270272.9081,888.354822,3.16919012,0.001022480817,-3.80374048e-007,
         7.019861879999999e-011,-4.26912231e-015},
     bhigh={11215.10462,11.47334049},
-    R_s=131.8945973573307);
+    R_s=131.8952001610565);
 
   constant IdealGases.Common.DataRecord P2(
     name="P2",
@@ -13319,7 +13319,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-780693.649,2307.91087,1.41174313,0.00210823742,-7.36085662e-007,
         1.25936012e-010,-7.07975249e-015},
     bhigh={1329.82474,21.69741365},
-    R_s=134.2179918028037);
+    R_s=134.2186052252421);
 
   constant IdealGases.Common.DataRecord P2O3(
     name="P2O3",
@@ -13333,7 +13333,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-217534.411,-1369.902,14.0114296,-0.000402385696,8.86834578e-008,-1.01565728e-011,
         4.70435606e-016},
     bhigh={-79227.56999999999,-47.39487232000001},
-    R_s=75.62342443846974);
+    R_s=75.62377006355919);
 
   constant IdealGases.Common.DataRecord P2O4(
     name="P2O4",
@@ -13347,7 +13347,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-367011.486,-1638.42373,17.2118861,-0.000482658015,1.0644619e-007,-1.21961007e-011,
         5.65065458e-016},
     bhigh={-109043.593,-67.14276593},
-    R_s=66.01662587614946);
+    R_s=66.01692759486151);
 
   constant IdealGases.Common.DataRecord P2O5(
     name="P2O5",
@@ -13361,7 +13361,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-324708.016,-2016.97508,20.4869934,-0.000591064115,1.30199302e-007,-1.49068294e-011,
         6.90357341e-016},
     bhigh={-130629.016,-80.31642952},
-    R_s=58.57550459044837);
+    R_s=58.57577230067393);
 
   constant IdealGases.Common.DataRecord P3(
     name="P3",
@@ -13375,7 +13375,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-125351.306,-83.0673462,7.56195677,-2.47440395e-005,5.45727693e-009,
         -6.24466057e-013,2.88772422e-017},
     bhigh={23087.2228,-12.28310621},
-    R_s=89.47866120186912);
+    R_s=89.47907015016139);
 
   constant IdealGases.Common.DataRecord P3O6(
     name="P3O6",
@@ -13389,7 +13389,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-878796.8100000001,-1651.988071,27.72258397,-0.00048593267,
         1.067867708e-007,-1.218015776e-011,5.61491196e-016},
     bhigh={-190916.5548,-122.0665277},
-    R_s=44.01108391743297);
+    R_s=44.01128506324101);
 
   constant IdealGases.Common.DataRecord P4(
     name="P4",
@@ -13403,7 +13403,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-185870.586,-62.8454689,10.0484488,-1.98766885e-005,
         4.482408440000001e-009,-5.22610367e-013,2.45579129e-017},
     bhigh={3848.21092,-24.77297797},
-    R_s=67.10899590140184);
+    R_s=67.10930261262105);
 
   constant IdealGases.Common.DataRecord P4O6(
     name="P4O6",
@@ -13417,7 +13417,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1008997.24,-887.275399,28.6606483,-0.000263601894,5.81094072e-008,-6.64808696e-012,
         3.07439193e-016},
     bhigh={-199713.89,-128.1853821},
-    R_s=37.81171221923487);
+    R_s=37.81188503177960);
 
   constant IdealGases.Common.DataRecord P4O7(
     name="P4O7",
@@ -13431,7 +13431,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1102947.375,-1511.077128,32.109795,-0.000437180376,
         9.516639610000001e-008,-1.075204176e-011,4.91102568e-016},
     bhigh={-242909.654,-147.3140859},
-    R_s=35.24711624669926);
+    R_s=35.24727733815731);
 
   constant IdealGases.Common.DataRecord P4O8(
     name="P4O8",
@@ -13445,7 +13445,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1173177.311,-2200.632995,35.6301013,-0.000648984974,
         1.429623989e-007,-1.635821725e-011,7.571070759999999e-016},
     bhigh={-278384.3144,-167.963696},
-    R_s=33.00831293807473);
+    R_s=33.00846379743076);
 
   constant IdealGases.Common.DataRecord P4O9(
     name="P4O9",
@@ -13459,7 +13459,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1233696.783,-2917.032808,39.1775711,-0.000873640298,
         1.937914895e-007,-2.230510118e-011,1.037248818e-015},
     bhigh={-312963.7516,-189.717642},
-    R_s=31.03692952012733);
+    R_s=31.03707136958232);
 
   constant IdealGases.Common.DataRecord P4O10(
     name="P4O10",
@@ -13473,7 +13473,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1337201.132,-3516.38233,42.6040331,-0.001037406404,2.287613089e-007,
         -2.620219946e-011,1.213529528e-015},
     bhigh={-345951.505,-211.5498906},
-    R_s=29.28775229522418);
+    R_s=29.28788615033696);
 
   constant IdealGases.Common.DataRecord Pb(
     name="Pb",
@@ -13487,7 +13487,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-9084313.07,26726.7318,-26.26244039,0.01358282305,-2.685523566e-006,
         2.3524328e-010,-7.324114532e-015},
     bhigh={-148165.0666,215.4011624},
-    R_s=40.12776061776062);
+    R_s=40.12794401544402);
 
   constant IdealGases.Common.DataRecord Pbplus(
     name="Pbplus",
@@ -13501,7 +13501,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1320690.183,-4096.04801,7.38910151,-0.002807751909,7.83099165e-007,-9.31060091e-011,
         4.016371727e-015},
     bhigh={135434.7306,-27.22020908},
-    R_s=40.12786686364751);
+    R_s=40.12805026181648);
 
   constant IdealGases.Common.DataRecord Pbminus(
     name="Pbminus",
@@ -13513,7 +13513,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={17762.2614,8.2351321},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={17762.2614,8.2351321},
-    R_s=40.12765437243635);
+    R_s=40.12783776963417);
 
   constant IdealGases.Common.DataRecord PbBr(
     name="PbBr",
@@ -13527,7 +13527,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2581831.67,7143.49076,-2.65819364,0.00310772226,-4.63138154e-007,
         1.095529211e-011,1.508555088e-015},
     bhigh={-39704.4098,59.5923865},
-    R_s=28.95979157378512);
+    R_s=28.95992393000446);
 
   constant IdealGases.Common.DataRecord PbBr2(
     name="PbBr2",
@@ -13541,7 +13541,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-13204.21479,-1.143074947,7.00097254,-4.28447161e-007,
         1.018044861e-010,-1.234016791e-014,5.97133765e-019},
     bhigh={-14622.1375,0.8868582650000001},
-    R_s=22.65474322085622);
+    R_s=22.65484676083355);
 
   constant IdealGases.Common.DataRecord PbBr3(
     name="PbBr3",
@@ -13555,7 +13555,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-27879.30766,-2.633265111,10.00223199,-9.80776141e-007,
         2.326232632e-010,-2.81599446e-014,1.361283735e-018},
     bhigh={-15569.81182,-10.81765474},
-    R_s=18.60427108692539);
+    R_s=18.60435611485035);
 
   constant IdealGases.Common.DataRecord PbBr4(
     name="PbBr4",
@@ -13569,7 +13569,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-38802.1603,-4.38293377,13.00369823,-1.620061335e-006,
         3.83413088e-010,-4.63396718e-014,2.237427066e-018},
     bhigh={-25923.27065,-22.87710636},
-    R_s=15.78249711474215);
+    R_s=15.78256924618842);
 
   constant IdealGases.Common.DataRecord PbCL(
     name="PbCL",
@@ -13583,7 +13583,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-385428.553,692.21975,4.50997124,-0.0006853421299999999,
         5.0873955e-007,-9.772753809999999e-011,5.807471579999999e-015},
     bhigh={-5269.68472,6.646491015},
-    R_s=34.26486381787986);
+    R_s=34.26502042010608);
 
   constant IdealGases.Common.DataRecord PbCL2(
     name="PbCL2",
@@ -13597,7 +13597,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-31491.92744,-5.56547758,7.00459954,-1.986025455e-006,
         4.65171959e-010,-5.57913701e-014,2.67814357e-018},
     bhigh={-23274.39309,-2.140739285},
-    R_s=29.896773172819);
+    R_s=29.896909811367);
 
   constant IdealGases.Common.DataRecord PbCL3(
     name="PbCL3",
@@ -13611,7 +13611,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-56644.1279,-9.329514789999999,10.00771099,-3.32972757e-006,
         7.79933081e-010,-9.3546061e-014,4.4905897e-018},
     bhigh={-24485.08643,-15.0749087},
-    R_s=26.51645144932851);
+    R_s=26.51657263864217);
 
   constant IdealGases.Common.DataRecord PbCL4(
     name="PbCL4",
@@ -13625,7 +13625,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-82666.7956,-16.39486405,13.01336711,-5.7161414e-006,1.32936839e-009,
         -1.585922492e-013,7.58176361e-018},
     bhigh={-43439.84220000001,-28.74559263},
-    R_s=23.82288288081785);
+    R_s=23.82299175959566);
 
   constant IdealGases.Common.DataRecord PbF(
     name="PbF",
@@ -13639,7 +13639,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-473420.275,1027.785283,3.88865873,-0.0001649813448,2.93116326e-007,
         -5.76645965e-011,3.24748619e-015},
     bhigh={-20261.65076,9.319483890000001},
-    R_s=36.75743012495325);
+    R_s=36.75759811906577);
 
   constant IdealGases.Common.DataRecord PbF2(
     name="PbF2",
@@ -13653,7 +13653,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-85058.99769999999,-30.74244334,7.02334604,-9.455183590000001e-006,
         2.108489027e-009,-2.434212002e-013,1.133872429e-017},
     bhigh={-55522.3677,-5.49607322},
-    R_s=33.90938129282258);
+    R_s=33.90953627037126);
 
   constant IdealGases.Common.DataRecord PbF3(
     name="PbF3",
@@ -13667,7 +13667,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-145970.4258,-48.2039643,10.03685845,-1.501095764e-005,
         3.36247499e-009,-3.89602071e-013,1.820152103e-017},
     bhigh={-62068.6959,-20.06978661},
-    R_s=31.47094155336267);
+    R_s=31.47108538640211);
 
   constant IdealGases.Common.DataRecord PbF4(
     name="PbF4",
@@ -13681,7 +13681,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-213261.6322,-85.7862195,13.06428551,-2.575563598e-005,
         5.69332459e-009,-6.526219550000001e-013,3.02234196e-017},
     bhigh={-100290.8979,-35.9024028},
-    R_s=29.35967346788974);
+    R_s=29.35980765170704);
 
   constant IdealGases.Common.DataRecord PbI(
     name="PbI",
@@ -13695,7 +13695,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3901070.25,11479.76718,-8.17610902,0.0065234547,-1.522611682e-006,
         1.626692202e-010,-6.55332888e-015},
     bhigh={-61544.3369,99.38404970000001},
-    R_s=24.88584483769403);
+    R_s=24.88595857457400);
 
   constant IdealGases.Common.DataRecord PbI2(
     name="PbI2",
@@ -13709,7 +13709,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-10883.39477,-0.816441837,7.0006973,-3.079876763e-007,
         7.331718140000001e-011,-8.89919388e-015,4.3107125e-019},
     bhigh={-3352.09638,2.458605463},
-    R_s=18.03538126614204);
+    R_s=18.03546369404463);
 
   constant IdealGases.Common.DataRecord PbI3(
     name="PbI3",
@@ -13723,7 +13723,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-16242.29573,-1.002945584,10.00085839,-3.79667974e-007,
         9.04675172e-011,-1.098840054e-014,5.325388290000001e-019},
     bhigh={-413.825893,-7.57941711},
-    R_s=14.14234113149418);
+    R_s=14.14240576686285);
 
   constant IdealGases.Common.DataRecord PbI4(
     name="PbI4",
@@ -13737,7 +13737,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-19584.77744,-1.223385179,13.00104732,-4.63329569e-007,
         1.104213978e-010,-1.341397771e-014,6.50170611e-019},
     bhigh={-8893.193200000002,-18.40570345},
-    R_s=11.63159488959622);
+    R_s=11.63164804999002);
 
   constant IdealGases.Common.DataRecord PbO(
     name="PbO",
@@ -13751,7 +13751,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={242699.685,-110.7731354,3.18068449,0.001991815065,-1.079782025e-006,
         2.540990941e-010,-1.834652493e-014},
     bhigh={8339.391539999999,10.50920926},
-    R_s=37.25131877594653);
+    R_s=37.25148902730025);
 
   constant IdealGases.Common.DataRecord PbO2(
     name="PbO2",
@@ -13765,7 +13765,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-130779.667,-73.1436145,7.55408341,-2.143421561e-005,
         4.696463999999999e-009,-5.34497218e-013,2.460760535e-017},
     bhigh={14133.86101,-12.52684909},
-    R_s=34.75967270738816);
+    R_s=34.75983157106140);
 
   constant IdealGases.Common.DataRecord PbS(
     name="PbS",
@@ -13779,7 +13779,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2105441.649,-5520.41358,9.36924926,-0.001410262019,-1.642683362e-007,
         1.451447577e-010,-1.393564925e-014},
     bhigh={50093.3453,-32.17417657},
-    R_s=34.75005537792824);
+    R_s=34.75021419764696);
 
   constant IdealGases.Common.DataRecord PbS2(
     name="PbS2",
@@ -13793,7 +13793,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-54167.003,-13.43600342,7.51070036,-4.497318629999999e-006,
         1.032444494e-009,-1.219580043e-013,5.78580465e-018},
     bhigh={27012.29533,-8.714618097000001},
-    R_s=30.64339365348469);
+    R_s=30.64353370434526);
 
   constant IdealGases.Common.DataRecord Rb(
     name="Rb",
@@ -13807,7 +13807,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1138274.064,3804.04194,-2.750899258,0.0038914607,-1.632296823e-006,
         3.51189314e-010,-2.521064422e-014},
     bhigh={-14664.54849,42.53442370000001},
-    R_s=97.28192371864024);
+    R_s=97.28236833052917);
 
   constant IdealGases.Common.DataRecord Rbplus(
     name="Rbplus",
@@ -13819,7 +13819,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={58203.2736,5.52050692},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={58203.2736,5.52050692},
-    R_s=97.28254815504691);
+    R_s=97.28299276978971);
 
   constant IdealGases.Common.DataRecord Rbminus(
     name="Rbminus",
@@ -13831,7 +13831,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={2600.405796,5.52052617},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={2600.405796,5.52052617},
-    R_s=97.28129929024978);
+    R_s=97.28174389928485);
 
   constant IdealGases.Common.DataRecord RbBO2(
     name="RbBO2",
@@ -13845,7 +13845,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={91544.63399999999,-1668.328341,11.17268757,-0.000450553353,
         9.68133059e-008,-1.088037652e-011,4.96773366e-016},
     bhigh={-75079.0325,-31.31951149},
-    R_s=64.81624227456703);
+    R_s=64.81653850711271);
 
   constant IdealGases.Common.DataRecord RbBr(
     name="RbBr",
@@ -13859,7 +13859,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1609092.474,-4466.77459,9.06409206,-0.001995333358,4.01663352e-007,-4.1630914e-012,
         -3.092443341e-015},
     bhigh={4427.46769,-27.57714089},
-    R_s=50.27744754547027);
+    R_s=50.27767733071781);
 
   constant IdealGases.Common.DataRecord RbCL(
     name="RbCL",
@@ -13873,7 +13873,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1143043.004,4003.86188,-1.096156782,0.00403358128,-1.454151464e-006,
         2.719263762e-010,-1.81046398e-014},
     bhigh={-52976.86040000001,43.11317822},
-    R_s=68.75965094508142);
+    R_s=68.75996520036256);
 
   constant IdealGases.Common.DataRecord RbF(
     name="RbF",
@@ -13887,7 +13887,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-854481.1149999999,2633.756505,1.216216506,0.002136494067,-6.72842608e-007,
         1.134905135e-010,-6.825624440000001e-015},
     bhigh={-58101.7911,25.88118896},
-    R_s=79.59006592861414);
+    R_s=79.59042968262104);
 
   constant IdealGases.Common.DataRecord RbH(
     name="RbH",
@@ -13901,7 +13901,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2937703.53,9379.81726,-7.54256346,0.007493226800000001,-2.159228887e-006,
         2.871300173e-010,-1.459981256e-014},
     bhigh={-45955.18829999999,83.65664320000001},
-    R_s=96.14802949358978);
+    R_s=96.14846892319164);
 
   constant IdealGases.Common.DataRecord RbI(
     name="RbI",
@@ -13915,7 +13915,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4297424.85,-12969.11161,19.58730402,-0.008458425589999999,
         2.463480035e-006,-3.19157573e-010,1.458455589e-014},
     bhigh={64329.4804,-100.9499336},
-    R_s=39.15045970926431);
+    R_s=39.15063864034603);
 
   constant IdealGases.Common.DataRecord RbK(
     name="RbK",
@@ -13929,7 +13929,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4175391.07,5918.588510000001,9.20264942,-0.010609336,
         4.96482606e-006,-8.716698790000001e-010,5.22188796e-014},
     bhigh={-32727.6904,-13.72401997},
-    R_s=66.74746981722957);
+    R_s=66.74777487615009);
 
   constant IdealGases.Common.DataRecord RbLi(
     name="RbLi",
@@ -13943,7 +13943,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={10855151.94,-38051.0697,55.1655504,-0.03128845612,9.26165025e-006,-1.264671408e-009,
         6.43166205e-014},
     bhigh={254396.4131,-352.075871},
-    R_s=89.9748941659236);
+    R_s=89.9753053821714);
 
   constant IdealGases.Common.DataRecord RbNO2(
     name="RbNO2",
@@ -13957,7 +13957,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-164499.4453,-849.944344,10.63080575,-0.0002517893988,
         5.56142012e-008,-6.378805599999999e-012,2.957679896e-016},
     bhigh={-21285.90982,-25.68367325},
-    R_s=63.24076447461196);
+    R_s=63.24105350668160);
 
   constant IdealGases.Common.DataRecord RbNO3(
     name="RbNO3",
@@ -13971,7 +13971,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-314741.3867,-1371.457846,14.01319759,-0.000403027502,
         8.878332289999999e-008,-1.016221214e-011,4.704254090000001e-016},
     bhigh={-35043.3994,-46.19379241},
-    R_s=56.37973672415301);
+    R_s=56.37999439896333);
 
   constant IdealGases.Common.DataRecord RbNa(
     name="RbNa",
@@ -13985,7 +13985,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4297114.27,-18310.13588,34.543942,-0.02230134993,7.33987453e-006,-1.064784996e-009,
         5.61759846e-014},
     bhigh={124261.0951,-199.366198},
-    R_s=76.6610574070579);
+    R_s=76.6614077744873);
 
   constant IdealGases.Common.DataRecord RbO(
     name="RbO",
@@ -13999,7 +13999,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={617075.688,-2175.08962,8.29041221,-0.002996487663,1.233144275e-006,-2.115810631e-010,
         1.24260743e-014},
     bhigh={18281.64827,-21.17386042},
-    R_s=81.94246022359934);
+    R_s=81.94283472885820);
 
   constant IdealGases.Common.DataRecord RbOH(
     name="RbOH",
@@ -14013,7 +14013,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={895858.313,-2332.339,7.97119248,0.0001044439355,-6.32825775e-008,
         1.029358824e-011,-5.74327779e-016},
     bhigh={-15155.68947,-19.50051629},
-    R_s=81.13647856445964);
+    R_s=81.13684938610477);
 
   constant IdealGases.Common.DataRecord Rb2Br2(
     name="Rb2Br2",
@@ -14027,7 +14027,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-10145.35336,-0.360155032,10.00031058,-1.380745805e-007,
         3.30206795e-011,-4.02158182e-015,1.953006729e-019},
     bhigh={-69379.6088,-9.12256236},
-    R_s=25.13872377273513);
+    R_s=25.13883866535890);
 
   constant IdealGases.Common.DataRecord Rb2CL2(
     name="Rb2CL2",
@@ -14041,7 +14041,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-18188.75133,-1.13790358,10.00097318,-4.3021564e-007,
         1.024725787e-010,-1.244291058e-014,6.02891239e-019},
     bhigh={-77408.9767,-12.04843385},
-    R_s=34.37982547254071);
+    R_s=34.37998260018128);
 
   constant IdealGases.Common.DataRecord Rb2F2(
     name="Rb2F2",
@@ -14055,7 +14055,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-43765.7439,-5.76145204,10.00482691,-2.104159548e-006,
         4.96241627e-010,-5.98217497e-014,2.882751742e-018},
     bhigh={-105917.6154,-16.03254014},
-    R_s=39.79503296430707);
+    R_s=39.79521484131052);
 
   constant IdealGases.Common.DataRecord Rb2I2(
     name="Rb2I2",
@@ -14069,7 +14069,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-6799.83464,-0.1642527699,10.000142,-6.321420729999999e-008,
         1.51281117e-011,-1.843027189e-015,8.951244179999999e-020},
     bhigh={-55075.7962,-6.94804539},
-    R_s=19.57522985463216);
+    R_s=19.57531932017302);
 
   constant IdealGases.Common.DataRecord Rb2O(
     name="Rb2O",
@@ -14083,7 +14083,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-38463.6009,-10.82831019,7.00842189,-3.47622812e-006,7.86978506e-010,
         -9.195683850000001e-014,4.325201520000001e-018},
     bhigh={-15253.73768,-3.23038878},
-    R_s=44.47787733704229);
+    R_s=44.47808061625699);
 
   constant IdealGases.Common.DataRecord Rb2O2(
     name="Rb2O2",
@@ -14097,7 +14097,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-131856.7396,-96.47737790000001,10.07222726,-2.894921706e-005,
         6.4056391e-009,-7.35141939e-013,3.40856171e-017},
     bhigh={-28821.79733,-19.10948823},
-    R_s=40.97123011179967);
+    R_s=40.97141736442910);
 
   constant IdealGases.Common.DataRecord Rb2O2H2(
     name="Rb2O2H2",
@@ -14111,7 +14111,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1792711.652,-4659.406599999999,16.93822422,0.0002106246492,-1.26961747e-007,
         2.063382927e-011,-1.150861507e-015},
     bhigh={-50241.1763,-60.27054920000001},
-    R_s=40.56823928222982);
+    R_s=40.56842469305239);
 
   constant IdealGases.Common.DataRecord Rb2SO4(
     name="Rb2SO4",
@@ -14125,7 +14125,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-530289.831,-951.543545,19.71013517,-0.0002842916301,
         6.289142939999999e-008,-7.2193243e-012,3.34871819e-016},
     bhigh={-133871.3151,-70.56246881999999},
-    R_s=31.1405545056109);
+    R_s=31.1406968286678);
 
   constant IdealGases.Common.DataRecord Rn(
     name="Rn",
@@ -14139,7 +14139,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={27301.90029,-82.84672620000001,2.598178483,-5.81372985e-005,
         1.819136527e-008,-2.866656182e-012,1.789322176e-016},
     bhigh={-220.280934,6.25500571},
-    R_s=37.44960759867686);
+    R_s=37.44977875627878);
 
   constant IdealGases.Common.DataRecord Rnplus(
     name="Rnplus",
@@ -14153,7 +14153,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-19982.85319,59.3067566,2.432476003,3.71602592e-005,-1.012057848e-008,
         1.192256661e-012,-3.18452198e-017},
     bhigh={124352.8478,8.821997789999999},
-    R_s=37.44970013595992);
+    R_s=37.44987129398476);
 
   constant IdealGases.Common.DataRecord S(
     name="S",
@@ -14167,7 +14167,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-485424.479,1438.830408,1.258504116,0.000379799043,1.630685864e-009,
         -9.547095849999999e-012,8.041466646e-016},
     bhigh={23349.9527,15.59554855},
-    R_s=259.300545766412);
+    R_s=259.301730859192);
 
   constant IdealGases.Common.DataRecord Splus(
     name="Splus",
@@ -14180,7 +14180,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1346218.684,-4056.87151,7.15343655,-0.002523562352,6.42953961e-007,-6.43167216e-011,
         2.141387919e-015},
     bhigh={179282.3835,-27.86935079},
-    R_s=259.3049822146652);
+    R_s=259.3061673277216);
 
   constant IdealGases.Common.DataRecord Sminus(
     name="Sminus",
@@ -14194,7 +14194,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2730.311692,141.4072078,2.403340775,3.69357753e-005,-7.94408044e-009,
         8.95220838e-013,-4.09966282e-017},
     bhigh={6931.1957,6.574986902},
-    R_s=259.2961094699624);
+    R_s=259.2972945424673);
 
   constant IdealGases.Common.DataRecord SCL(
     name="SCL",
@@ -14208,7 +14208,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-94051.23449999999,362.976085,4.06995936,0.0003034029742,-8.24830139e-008,
         1.252700734e-011,-6.41746365e-016},
     bhigh={15231.11069,6.014528409},
-    R_s=123.1445244231168);
+    R_s=123.1450872359963);
 
   constant IdealGases.Common.DataRecord SCL2(
     name="SCL2",
@@ -14222,7 +14222,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-234103.9963,428.7569580000001,6.47141539,0.000317947674,-9.74748308e-008,
         1.39331857e-011,-6.39479517e-016},
     bhigh={-7210.4737,-2.774273151},
-    R_s=80.7457633702693);
+    R_s=80.7461324062115);
 
   constant IdealGases.Common.DataRecord SCL2plus(
     name="SCL2plus",
@@ -14236,7 +14236,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-233940.3605,551.628326,6.12521216,0.000677105632,-2.674382769e-007,
         4.93593888e-011,-2.955831247e-015},
     bhigh={102678.7381,0.1365611954},
-    R_s=80.74619356286517);
+    R_s=80.74656260077346);
 
   constant IdealGases.Common.DataRecord SD(
     name="SD",
@@ -14250,7 +14250,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={245673.249,-1180.034105,5.28469005,-0.0002384319882,
         6.009960290000001e-008,-7.13116364e-012,4.0358587e-016},
     bhigh={22655.45124,-8.350483655},
-    R_s=243.9756775281227);
+    R_s=243.9767925809782);
 
   constant IdealGases.Common.DataRecord SF(
     name="SF",
@@ -14264,7 +14264,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={763458.075,-2423.63843,7.35219871,-0.001598026079,4.86851502e-007,-6.47800053e-011,
         2.98029731e-015},
     bhigh={15774.61591,-19.02584835},
-    R_s=162.8264369187207);
+    R_s=162.8271810916042);
 
   constant IdealGases.Common.DataRecord SFplus(
     name="SFplus",
@@ -14278,7 +14278,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-937494.39,2377.21424,2.052929113,0.001081609837,-1.535468024e-007,
         8.2226919e-012,3.25974688e-017},
     bhigh={102684.9122,18.87705768},
-    R_s=162.8281862643848);
+    R_s=162.8289304452634);
 
   constant IdealGases.Common.DataRecord SFminus(
     name="SFminus",
@@ -14292,7 +14292,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={206892.3125,-1324.372811,6.64621124,-0.001641781588,6.78388312e-007,
         -1.198331099e-010,7.12173954e-015},
     bhigh={-21509.94816,-14.70239183},
-    R_s=162.8246876106444);
+    R_s=162.8254317755329);
 
   constant IdealGases.Common.DataRecord SF2(
     name="SF2",
@@ -14306,7 +14306,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-170261.2287,-149.7038204,7.11093414,-4.4077416e-005,9.68220831e-009,
         -1.104468959e-012,5.09530878e-017},
     bhigh={-37042.8949,-10.9525396},
-    R_s=118.6733889293497);
+    R_s=118.6739313076004);
 
   constant IdealGases.Common.DataRecord SF2plus(
     name="SF2plus",
@@ -14320,7 +14320,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-384753.102,532.789302,6.2819089,0.000452279012,-1.426421096e-007,
         2.079708115e-011,-9.69170989e-016},
     bhigh={78842.1381,-4.21611053},
-    R_s=118.6743181764573);
+    R_s=118.6748605589550);
 
   constant IdealGases.Common.DataRecord SF2minus(
     name="SF2minus",
@@ -14334,7 +14334,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-93766.18949999999,-36.3899527,7.02794282,-1.142143365e-005,
         2.566295898e-009,-2.981125977e-013,1.395700722e-017},
     bhigh={-49670.5033,-8.483087898999999},
-    R_s=118.6724596967944);
+    R_s=118.6730020707982);
 
   constant IdealGases.Common.DataRecord SF3(
     name="SF3",
@@ -14348,7 +14348,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-241128.346,-141.8950375,10.10590548,-4.231526910000001e-005,
         9.336120599999999e-009,-1.068727665e-012,4.9443426e-017},
     bhigh={-63584.4586,-24.89561796},
-    R_s=93.35787595092299);
+    R_s=93.35830262856243);
 
   constant IdealGases.Common.DataRecord SF3plus(
     name="SF3plus",
@@ -14362,7 +14362,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-377826.075,-162.1770252,9.96026597,0.0001237729568,-6.442207889999999e-008,
         1.300856025e-011,-7.915106980000001e-016},
     bhigh={44154.26809999999,-26.7390077},
-    R_s=93.35845102756454);
+    R_s=93.35887770783228);
 
   constant IdealGases.Common.DataRecord SF3minus(
     name="SF3minus",
@@ -14376,7 +14376,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-225386.0964,-130.8890242,10.0997238,-4.05234553e-005,
         9.064565220000001e-009,-1.049320641e-012,4.89920126e-017},
     bhigh={-98002.272,-25.24368023},
-    R_s=93.35730088136619);
+    R_s=93.35772755637736);
 
   constant IdealGases.Common.DataRecord SF4(
     name="SF4",
@@ -14390,7 +14390,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-377712.516,-293.7595659,13.21902007,-8.74766945e-005,
         1.929905265e-008,-2.209423506e-012,1.022335559e-016},
     bhigh={-94831.7534,-42.43061278},
-    R_s=76.944093437409);
+    R_s=76.944445098411);
 
   constant IdealGases.Common.DataRecord SF4plus(
     name="SF4plus",
@@ -14404,7 +14404,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-418917.275,40.0288964,12.83873264,0.0001340235036,-4.81813518e-008,
         7.574595959999999e-012,-3.69667078e-016},
     bhigh={44699.4423,-37.60378598},
-    R_s=76.94448407488684);
+    R_s=76.94483573767371);
 
   constant IdealGases.Common.DataRecord SF4minus(
     name="SF4minus",
@@ -14418,7 +14418,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={320882.208,-1710.416599,14.94425485,-0.001057207329,2.74284692e-007,
         -2.905761211e-011,1.084482543e-015},
     bhigh={-100523.1225,-51.64256578},
-    R_s=76.94370280389758);
+    R_s=76.94405446311376);
 
   constant IdealGases.Common.DataRecord SF5(
     name="SF5",
@@ -14432,7 +14432,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-389242.637,-182.5826536,16.13765057,-5.54483423e-005,
         1.231433706e-008,-1.417173409e-012,6.5848894e-017},
     bhigh={-113567.1054,-55.77524201},
-    R_s=65.43890500308933);
+    R_s=65.43920408141807);
 
   constant IdealGases.Common.DataRecord SF5plus(
     name="SF5plus",
@@ -14446,7 +14446,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-981434.232,720.881739,15.64386818,-0.0002452519972,2.241690996e-007,
         -3.99003589e-011,2.279087545e-015},
     bhigh={9090.95319,-55.31460631},
-    R_s=65.43918755291948);
+    R_s=65.43948663253957);
 
   constant IdealGases.Common.DataRecord SF5minus(
     name="SF5minus",
@@ -14460,7 +14460,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-373321.92,-179.3729521,16.13699748,-5.57753997e-005,
         1.249477046e-008,-1.448104799e-012,6.7674623e-017},
     bhigh={-149855.4401,-56.31439391},
-    R_s=65.4386224556991);
+    R_s=65.4389215327365);
 
   constant IdealGases.Common.DataRecord SF6(
     name="SF6",
@@ -14474,7 +14474,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-730672.65,-636.705655,19.47442853,-0.0001894325671,4.17872283e-008,
         -4.78374495e-012,2.213516129e-016},
     bhigh={-151060.9837,-81.47574587},
-    R_s=56.92682986733026);
+    R_s=56.92709004254462);
 
   constant IdealGases.Common.DataRecord SF6minus(
     name="SF6minus",
@@ -14488,7 +14488,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-681807.3509999999,-594.742996,19.45009842,-0.0001820212649,
         4.05707957e-008,-4.683820930000001e-012,2.182263999e-016},
     bhigh={-165890.2452,-79.65845887},
-    R_s=56.92661604478445);
+    R_s=56.92687621902157);
 
   constant IdealGases.Common.DataRecord SH(
     name="SH",
@@ -14502,7 +14502,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1682631.601,-5177.15221,9.198168519999999,-0.002323550224,
         6.543914779999999e-007,-8.468470419999999e-011,3.86474155e-015},
     bhigh={48992.14490000001,-37.70400275},
-    R_s=251.3980311396568);
+    R_s=251.3991801152241);
 
   constant IdealGases.Common.DataRecord SHminus(
     name="SHminus",
@@ -14516,7 +14516,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1198715.402,-3894.84682,7.66042233,-0.00135523759,3.34237024e-007,-3.35072231e-011,
         9.05508478e-016},
     bhigh={13174.77387,-28.18370616},
-    R_s=251.3938611241634);
+    R_s=251.3950100806723);
 
   constant IdealGases.Common.DataRecord SN(
     name="SN",
@@ -14530,7 +14530,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-483728.446,1058.07559,3.086198804,0.000911136078,-2.764061722e-007,
         4.157370109999999e-011,-2.128351755e-015},
     bhigh={23793.45477,10.33222139},
-    R_s=180.4680964670286);
+    R_s=180.4689212683708);
 
   constant IdealGases.Common.DataRecord SO(
     name="SO",
@@ -14544,7 +14544,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1443410.557,4113.87436,-0.538369578,0.002794153269,-6.63335226e-007,
         7.838221189999999e-011,-3.56050907e-015},
     bhigh={-27088.38059,36.15358329},
-    R_s=172.9860770133404);
+    R_s=172.9868676192775);
 
   constant IdealGases.Common.DataRecord SOminus(
     name="SOminus",
@@ -14558,7 +14558,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={176715.6147,-663.398736,5.17727981,-0.0002853461125,7.21442153e-008,
         -3.67646949e-012,-2.910092894e-016},
     bhigh={-9984.43801,-3.951456757},
-    R_s=172.9841025982081);
+    R_s=172.9848931951214);
 
   constant IdealGases.Common.DataRecord SOF2(
     name="SOF2",
@@ -14572,7 +14572,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-251055.5779,-607.4439609999999,10.45046709,-0.0001796384979,
         3.96416973e-008,-4.54305524e-012,2.104969923e-016},
     bhigh={-70720.71710000001,-29.04334504},
-    R_s=96.61114859761017);
+    R_s=96.61159014382582);
 
   constant IdealGases.Common.DataRecord SO2(
     name="SO2",
@@ -14586,7 +14586,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-112764.0116,-825.226138,7.61617863,-0.000199932761,5.65563143e-008,
         -5.45431661e-012,2.918294102e-016},
     bhigh={-33513.0869,-16.55776085},
-    R_s=129.7842463294403);
+    R_s=129.7848394881352);
 
   constant IdealGases.Common.DataRecord SO2minus(
     name="SO2minus",
@@ -14600,7 +14600,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-179340.0005,-366.316876,7.27444105,-0.0001101944663,
         2.443328132e-008,-2.809735019e-012,1.305160431e-016},
     bhigh={-49730.7261,-12.61421156},
-    R_s=129.7831349525343);
+    R_s=129.7837281061498);
 
   constant IdealGases.Common.DataRecord SO2CL2(
     name="SO2CL2",
@@ -14614,7 +14614,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-237663.9109,-964.7740410000001,13.71469904,-0.0002850327057,
         6.29350962e-008,-7.21784426e-012,3.34684022e-016},
     bhigh={-41900.7299,-44.81942574999999},
-    R_s=61.60246218042851);
+    R_s=61.60274372489253);
 
   constant IdealGases.Common.DataRecord SO2FCL(
     name="SO2FCL",
@@ -14628,7 +14628,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-291540.2438,-1107.134423,13.81845158,-0.000325851446,7.184741e-008,
         -8.230625200000001e-012,3.81292562e-016},
     bhigh={-65524.7269,-47.09166446},
-    R_s=70.15531995476509);
+    R_s=70.15564058873419);
 
   constant IdealGases.Common.DataRecord SO2F2(
     name="SO2F2",
@@ -14642,7 +14642,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-340390.445,-1309.288764,13.96601541,-0.000384008815,
         8.456688780000001e-008,-9.678246870000001e-012,4.48001428e-016},
     bhigh={-89019.9414,-51.0927005},
-    R_s=81.46602585735764);
+    R_s=81.46639818514737);
 
   constant IdealGases.Common.DataRecord SO3(
     name="SO3",
@@ -14656,7 +14656,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-216692.3781,-1301.022399,10.96287985,-0.000383710002,
         8.466889039999999e-008,-9.70539929e-012,4.49839754e-016},
     bhigh={-43982.83990000001,-36.55217314},
-    R_s=103.8488594010732);
+    R_s=103.8493340261194);
 
   constant IdealGases.Common.DataRecord S2(
     name="S2",
@@ -14670,7 +14670,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-15881.28788,631.548088,2.449628069,0.001986240565,-6.50792724e-007,
         1.002813651e-010,-5.59699005e-015},
     bhigh={10855.08427,14.58544515},
-    R_s=129.650272883206);
+    R_s=129.650865429596);
 
   constant IdealGases.Common.DataRecord S2minus(
     name="S2minus",
@@ -14684,7 +14684,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={483020.403,-1319.171302,6.03177848,-0.0007965560690000001,
         2.28224169e-007,-2.504364698e-011,7.28055078e-016},
     bhigh={2660.25849,-9.010480318999999},
-    R_s=129.6491637996061);
+    R_s=129.6497563409274);
 
   constant IdealGases.Common.DataRecord S2CL2(
     name="S2CL2",
@@ -14698,7 +14698,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={632881.6,-3442.7058,15.1963735,-0.002960877176,6.88828437e-007,-7.990692529999999e-011,
         3.69246606e-015},
     bhigh={15266.72656,-54.53315445000001},
-    R_s=61.5722622115584);
+    R_s=61.5725436179982);
 
   constant IdealGases.Common.DataRecord S2F2(
     name="S2F2",
@@ -14712,7 +14712,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-259175.7719,-105.9653069,10.06588551,-2.274618148e-005,
         5.41234314e-009,-9.91138714e-013,9.621861440000001e-017},
     bhigh={-51476.75180000001,-23.7566614},
-    R_s=81.41321845936034);
+    R_s=81.41359054580208);
 
   constant IdealGases.Common.DataRecord S2O(
     name="S2O",
@@ -14726,7 +14726,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-144213.979,-327.643013,7.24428611,-9.7765383e-005,2.1627127e-008,-2.48278222e-012,
         1.15177875e-016},
     bhigh={-7438.55393,-10.85180744},
-    R_s=103.7630632452009);
+    R_s=103.7635374781291);
 
   constant IdealGases.Common.DataRecord S3(
     name="S3",
@@ -14740,7 +14740,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-111780.5401,-51.97908390000001,7.03876084,-1.546804022e-005,
         3.40834041e-009,-3.89686236e-013,1.800860389e-017},
     bhigh={15254.06485,-7.610045099},
-    R_s=86.43351525547067);
+    R_s=86.43391028639743);
 
   constant IdealGases.Common.DataRecord S4(
     name="S4",
@@ -14754,7 +14754,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-206833.3537,-96.96151430000001,10.0724321,-2.895047053e-005,
         6.38780619e-009,-7.31176743e-013,3.38226529e-017},
     bhigh={13211.0953,-23.44872237},
-    R_s=64.82513644160301);
+    R_s=64.82543271479807);
 
   constant IdealGases.Common.DataRecord S5(
     name="S5",
@@ -14768,7 +14768,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4038495.16,8601.80388,7.4437809,0.001533393812,-2.532718676e-007,
         2.145210795e-011,-7.213102680000001e-016},
     bhigh={-46869.2542,11.04229196},
-    R_s=51.8601091532824);
+    R_s=51.8603461718385);
 
   constant IdealGases.Common.DataRecord S6(
     name="S6",
@@ -14782,7 +14782,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3686845.06,-7695.0179,18.60721995,0.002290382548,-1.219834021e-006,
         2.060780798e-010,-1.190354318e-014},
     bhigh={60324.8648,-74.90245718},
-    R_s=43.21675762773533);
+    R_s=43.21695514319871);
 
   constant IdealGases.Common.DataRecord S7(
     name="S7",
@@ -14796,7 +14796,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-272639.6041,-73.7321522,19.05771987,-2.394575885e-005,
         5.4426713e-009,-6.379663479999999e-013,3.008212993e-017},
     bhigh={7308.458830000001,-61.59112428},
-    R_s=37.04293510948742);
+    R_s=37.04310440845604);
 
   constant IdealGases.Common.DataRecord S8(
     name="S8",
@@ -14810,7 +14810,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-8727921.130000001,12216.27968,22.09959617,-0.00349406483,
         1.397604162e-006,-2.169815281e-010,1.212304364e-014},
     bhigh={-86581.10819999999,-64.35742508},
-    R_s=32.4125682208015);
+    R_s=32.4127163573990);
 
   constant IdealGases.Common.DataRecord Sc(
     name="Sc",
@@ -14824,7 +14824,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={8810382.649999999,-27112.32975,34.7658866,-0.01861104581,
         5.290283900000001e-006,-6.58540806e-010,2.997850429e-014},
     bhigh={216246.0097,-222.5618519},
-    R_s=184.9472516516738);
+    R_s=184.9480969242976);
 
   constant IdealGases.Common.DataRecord Scplus(
     name="Scplus",
@@ -14838,7 +14838,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1973658.531,-4954.3841,6.36062735,-0.000716878592,2.464991123e-008,
         9.632373790000001e-012,-8.544709642000001e-016},
     bhigh={154342.3764,-22.61925782},
-    R_s=184.9495086029939);
+    R_s=184.9503538859327);
 
   constant IdealGases.Common.DataRecord Scminus(
     name="Scminus",
@@ -14850,7 +14850,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={41657.4639,8.270420720000001},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={41657.4639,8.270420720000001},
-    R_s=184.9449947554365);
+    R_s=184.9458400177455);
 
   constant IdealGases.Common.DataRecord ScO(
     name="ScO",
@@ -14864,7 +14864,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1224192.443,-3918.91572,8.679848809999999,-0.001995893306,
         4.06698985e-007,-1.504459913e-011,-8.4729989e-016},
     bhigh={16773.22594,-29.51656272},
-    R_s=136.4027514584045);
+    R_s=136.4033748659469);
 
   constant IdealGases.Common.DataRecord ScOplus(
     name="ScOplus",
@@ -14878,7 +14878,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1814357.141,5853.42532,-3.65710121,0.00573436451,-2.092878161e-006,
         3.69564502e-010,-2.214038347e-014},
     bhigh={29553.64078,56.6088941},
-    R_s=136.4039790991619);
+    R_s=136.4046025123150);
 
   constant IdealGases.Common.DataRecord ScO2(
     name="ScO2",
@@ -14892,7 +14892,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-190390.2542,-231.558882,7.17210491,-6.85920964e-005,
         1.510998557e-008,-1.727951588e-012,7.9889805e-017},
     bhigh={-51129.74750000001,-10.90764597},
-    R_s=108.0437051871159);
+    R_s=108.0441989840518);
 
   constant IdealGases.Common.DataRecord Sc2O(
     name="Sc2O",
@@ -14906,7 +14906,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-135088.0396,-185.4540692,7.13829408,-5.52943214e-005,
         1.221589315e-008,-1.400490463e-012,6.48885811e-017},
     bhigh={-4240.235140000001,-9.37271095},
-    R_s=78.50416603642182);
+    R_s=78.50452482749232);
 
   constant IdealGases.Common.DataRecord Sc2O2(
     name="Sc2O2",
@@ -14920,7 +14920,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-297734.8677,-580.367792,10.43318377,-0.0001734165462,
         3.83608979e-008,-4.403078029999999e-012,2.042208922e-016},
     bhigh={-59648.6628,-28.55828369},
-    R_s=68.20137572920227);
+    R_s=68.20168743297344);
 
   constant IdealGases.Common.DataRecord Si(
     name="Si",
@@ -14934,7 +14934,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-616929.885,2240.683927,-0.444861932,0.001710056321,-4.10771416e-007,
         4.55888478e-011,-1.889515353e-015},
     bhigh={39535.5876,26.79668061},
-    R_s=296.0414448736893);
+    R_s=296.0427978850296);
 
   constant IdealGases.Common.DataRecord Siplus(
     name="Siplus",
@@ -14948,7 +14948,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={59193.9023,-48.5673095,2.556312024,-3.50339716e-005,1.190298787e-008,
         -2.082923821e-012,1.471452049e-016},
     bhigh={149143.1392,5.24426714},
-    R_s=296.0472276266784);
+    R_s=296.0485806644480);
 
   constant IdealGases.Common.DataRecord Siminus(
     name="Siminus",
@@ -14962,7 +14962,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-6162070.100000001,18833.10402,-18.9930245,0.01111021657,-2.535790208e-006,
         2.699962923e-010,-1.105062911e-014},
     bhigh={-83140.8931,159.5298253},
-    R_s=296.0356623466072);
+    R_s=296.0370153315195);
 
   constant IdealGases.Common.DataRecord SiBr(
     name="SiBr",
@@ -14976,7 +14976,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1317799.94,-3669.79502,8.51168612,-0.001987602041,5.03541489e-007,-4.49012019e-011,
         8.23567007e-016},
     bhigh={43328.5155,-24.67075472},
-    R_s=76.99333731520194);
+    R_s=76.99368920126494);
 
   constant IdealGases.Common.DataRecord SiBr2(
     name="SiBr2",
@@ -14990,7 +14990,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-51473.4394,-12.77719997,7.01020224,-4.29633186e-006,
         9.877651970000001e-010,-1.168133105e-013,5.54668138e-018},
     bhigh={-8319.54225,-3.61182661},
-    R_s=44.25098260450734);
+    R_s=44.25118484673499);
 
   constant IdealGases.Common.DataRecord SiBr3(
     name="SiBr3",
@@ -15004,7 +15004,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-88880.24740000001,-22.67879074,10.01791167,-7.48115075e-006,
         1.70924269e-009,-2.011596627e-013,9.51553415e-018},
     bhigh={-22030.26938,-15.37574366},
-    R_s=31.04760873421148);
+    R_s=31.04775063247416);
 
   constant IdealGases.Common.DataRecord SiBr4(
     name="SiBr4",
@@ -15018,7 +15018,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-127140.9281,-37.6808795,13.02910642,-1.194958251e-005,
         2.693843051e-009,-3.137193207e-013,1.471642663e-017},
     bhigh={-54089.9883,-29.4038433},
-    R_s=23.9126722202809);
+    R_s=23.9127815094269);
 
   constant IdealGases.Common.DataRecord SiC(
     name="SiC",
@@ -15032,7 +15032,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-62688.06030000001,720.983692,2.162879732,0.002201299585,-6.569466590000001e-007,
         9.177110259999999e-011,-4.96916674e-015},
     bhigh={83212.2585,16.01675317},
-    R_s=207.3630917643068);
+    R_s=207.3640394850384);
 
   constant IdealGases.Common.DataRecord SiC2(
     name="SiC2",
@@ -15046,7 +15046,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7026893.09,-24661.48437,39.15453030000001,-0.02002884068,
         6.30735369e-006,-8.84838351e-010,4.53054985e-014},
     bhigh={226732.5155,-236.6622024},
-    R_s=159.5656621291998);
+    R_s=159.5663913992196);
 
   constant IdealGases.Common.DataRecord SiCL(
     name="SiCL",
@@ -15060,7 +15060,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={376729.456,-1147.956509,5.73540843,-0.0005784890810000001,
         1.517304648e-007,-1.291391394e-011,1.55462842e-016},
     bhigh={23062.78401,-6.098515228},
-    R_s=130.857228294656);
+    R_s=130.857826357248);
 
   constant IdealGases.Common.DataRecord SiCL2(
     name="SiCL2",
@@ -15074,7 +15074,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-80508.7157,-26.61025523,7.02041472,-8.335824719999999e-006,
         1.871092411e-009,-2.171552767e-013,1.015849895e-017},
     bhigh={-21812.94885,-6.638764238},
-    R_s=83.99177707176879);
+    R_s=83.99216094311129);
 
   constant IdealGases.Common.DataRecord SiCL3(
     name="SiCL3",
@@ -15088,7 +15088,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-147718.0114,-53.3520098,10.04043521,-1.63512106e-005,
         3.64194011e-009,-4.20060059e-013,1.955201587e-017},
     bhigh={-43605.7165,-20.06632444},
-    R_s=61.84315461026669);
+    R_s=61.84343725477800);
 
   constant IdealGases.Common.DataRecord SiCL4(
     name="SiCL4",
@@ -15102,7 +15102,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-210033.0761,-84.76107710000001,13.06364027,-2.55402042e-005,
         5.65381847e-009,-6.48875267e-013,3.008025543e-017},
     bhigh={-83722.6813,-35.92584781},
-    R_s=48.93816565870598);
+    R_s=48.93838932297415);
 
   constant IdealGases.Common.DataRecord SiF(
     name="SiF",
@@ -15116,7 +15116,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-365363.788,872.2860040000001,3.37721827,0.000750815243,-2.308898619e-007,
         3.7667818e-011,-2.143080403e-015},
     bhigh={-10116.97664,8.968132819999999},
-    R_s=176.5884184385121);
+    R_s=176.5892255083899);
 
   constant IdealGases.Common.DataRecord SiFCL(
     name="SiFCL",
@@ -15130,7 +15130,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-128469.8945,-124.7550173,7.09289385,-3.70731177e-005,
         8.175173009999999e-009,-9.35643521e-013,4.32854434e-017},
     bhigh={-47233.0972,-8.337392707999999},
-    R_s=100.7364182280103);
+    R_s=100.7368786281286);
 
   constant IdealGases.Common.DataRecord SiF2(
     name="SiF2",
@@ -15144,7 +15144,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-167520.0202,-184.621209,7.13698635,-5.45076986e-005,
         1.199012961e-008,-1.369470187e-012,6.32488999e-017},
     bhigh={-72874.0102,-11.17933348},
-    R_s=125.8199426283947);
+    R_s=125.8205176688567);
 
   constant IdealGases.Common.DataRecord SiF3(
     name="SiF3",
@@ -15158,7 +15158,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-290328.3702,-342.787694,10.25536335,-0.000101979669,
         2.250326132e-008,-2.577117181e-012,1.192923177e-016},
     bhigh={-121808.8967,-27.25261142},
-    R_s=97.7245257954454);
+    R_s=97.7249724301782);
 
   constant IdealGases.Common.DataRecord SiF4(
     name="SiF4",
@@ -15172,7 +15172,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-384589.232,-656.997991,13.4892572,-5.10047136e-005,5.34632958e-008,
         -4.95959811e-012,2.299314375e-016},
     bhigh={-195728.4479,-46.7389465},
-    R_s=79.88607681521283);
+    R_s=79.88644192209141);
 
   constant IdealGases.Common.DataRecord SiH(
     name="SiH",
@@ -15186,7 +15186,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={404208.649,-2364.796524,7.62749914,-0.002496591233,1.10843641e-006,-1.943991955e-010,
         1.136251507e-014},
     bhigh={57047.3768,-24.48054429},
-    R_s=285.7851116952825);
+    R_s=285.7864178316486);
 
   constant IdealGases.Common.DataRecord SiHplus(
     name="SiHplus",
@@ -15200,7 +15200,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={171169.2033,-1045.807287,4.83864824,0.0001277940891,-6.883872450000001e-008,
         1.41884348e-011,-7.85531696e-016},
     bhigh={143172.145,-7.55329914},
-    R_s=285.7905006994252);
+    R_s=285.7918068604209);
 
   constant IdealGases.Common.DataRecord SiHBr3(
     name="SiHBr3",
@@ -15214,7 +15214,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={219997.3526,-2024.458552,14.35781007,-0.000503701584,
         1.054049755e-007,-1.160828765e-011,5.21725768e-016},
     bhigh={-28420.86214,-45.3643717},
-    R_s=30.9311894878318);
+    R_s=30.9313308540184);
 
   constant IdealGases.Common.DataRecord SiHCL(
     name="SiHCL",
@@ -15228,7 +15228,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={101215.289,-1163.239598,7.37636655,0.0001874151313,-1.661351093e-007,
         3.96441404e-011,-2.64058008e-015},
     bhigh={11410.64087,-15.07678798},
-    R_s=128.8137967020334);
+    R_s=128.8143854254394);
 
   constant IdealGases.Common.DataRecord SiHCL3(
     name="SiHCL3",
@@ -15242,7 +15242,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={172864.4072,-2116.727327,14.41802307,-0.000525524962,
         1.098826178e-007,-1.209327059e-011,5.432187049999999e-016},
     bhigh={-51303.5194,-50.36360893000001},
-    R_s=61.3829621673851);
+    R_s=61.3832427086585);
 
   constant IdealGases.Common.DataRecord SiHF(
     name="SiHF",
@@ -15256,7 +15256,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4049752.24,-9295.526819999999,10.71754366,0.00186812422,-1.129820372e-006,
         1.9602501e-010,-1.144682011e-014},
     bhigh={41332.252,-47.363176},
-    R_s=172.8873639844189);
+    R_s=172.8881541392034);
 
   constant IdealGases.Common.DataRecord SiHF3(
     name="SiHF3",
@@ -15270,7 +15270,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={78201.008,-2592.742261,14.75104214,-0.00065310472,1.372428937e-007,-1.516371051e-011,
         6.83249715e-016},
     bhigh={-133661.1887,-58.5145095},
-    R_s=96.58035105245745);
+    R_s=96.58079245791771);
 
   constant IdealGases.Common.DataRecord SiHI3(
     name="SiHI3",
@@ -15284,7 +15284,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={227942.4252,-1898.603142,14.28134804,-0.000477602695,
         1.003097496e-007,-1.107859145e-011,4.990338200000001e-016},
     bhigh={-1614.547674,-41.2294307},
-    R_s=20.28875798440168);
+    R_s=20.28885071101179);
 
   constant IdealGases.Common.DataRecord SiH2(
     name="SiH2",
@@ -15298,7 +15298,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4624039.37,-11434.3611,12.6488087,0.00091148995,-8.766611539999999e-007,
         1.646297357e-010,-9.965090370000001e-015},
     bhigh={107247.5101,-66.0607807},
-    R_s=276.2156419406685);
+    R_s=276.2169043412628);
 
   constant IdealGases.Common.DataRecord SiH2Br2(
     name="SiH2Br2",
@@ -15312,7 +15312,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={566585.144,-3973.91962,15.67387912,-0.0009943802290000002,
         2.084856022e-007,-2.299521351e-011,1.034736283e-015},
     bhigh={-2990.69018,-61.9047652},
-    R_s=43.7812603042567);
+    R_s=43.7814603996917);
 
   constant IdealGases.Common.DataRecord SiH2CL2(
     name="SiH2CL2",
@@ -15326,7 +15326,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={540020.458,-4062.33729,15.73118788,-0.001015038389,2.127060243e-007,
         -2.345079226e-011,1.054871984e-015},
     bhigh={-18230.98225,-65.44540499},
-    R_s=82.31549021467541);
+    R_s=82.31586642480976);
 
   constant IdealGases.Common.DataRecord SiH2F2(
     name="SiH2F2",
@@ -15340,7 +15340,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={472653.4080000001,-4388.51769,15.96032597,-0.001102993658,
         2.315838331e-007,-2.556974559e-011,1.151499711e-015},
     bhigh={-73161.8446,-70.9898927},
-    R_s=122.0953514262753);
+    R_s=122.0959094440730);
 
   constant IdealGases.Common.DataRecord SiH2I2(
     name="SiH2I2",
@@ -15354,7 +15354,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={594239.083,-3924.81448,15.63850289,-0.0009805706340000001,
         2.054871384e-007,-2.265587199e-011,1.019168663e-015},
     bhigh={15136.27352,-59.4081252},
-    R_s=29.28555749576134);
+    R_s=29.28569134084312);
 
   constant IdealGases.Common.DataRecord SiH3(
     name="SiH3",
@@ -15368,7 +15368,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={605632.122,-4721.254059999999,13.29129523,-0.001256824868,
         2.68828594e-007,-3.010741582e-011,1.370945857e-015},
     bhigh={49744.2064,-61.405031},
-    R_s=267.2662726154092);
+    R_s=267.2674941143040);
 
   constant IdealGases.Common.DataRecord SiH3Br(
     name="SiH3Br",
@@ -15382,7 +15382,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={927928.578,-5917.93579,16.99209298,-0.001487507364,3.123451161e-007,
         -3.44907147e-011,1.553431675e-015},
     bhigh={22415.60128,-79.4861159},
-    R_s=74.89616561327956);
+    R_s=74.89650791454575);
 
   constant IdealGases.Common.DataRecord SiH3CL(
     name="SiH3CL",
@@ -15396,7 +15396,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={908778.094,-5958.94956,17.02076016,-0.001498450667,3.146813781e-007,
         -3.47516846e-011,1.565281681e-015},
     bhigh={14937.93206,-81.27277864},
-    R_s=124.9125931908624);
+    R_s=124.9131640844250);
 
   constant IdealGases.Common.DataRecord SiH3F(
     name="SiH3F",
@@ -15410,7 +15410,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={862431.317,-6103.37057,17.12733597,-0.001540724131,3.23962872e-007,-3.58105689e-011,
         1.61415138e-015},
     bhigh={-12614.87616,-83.99227209999999},
-    R_s=165.9319455967618);
+    R_s=165.9327039628893);
 
   constant IdealGases.Common.DataRecord SiH3I(
     name="SiH3I",
@@ -15424,7 +15424,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={936114.918,-5859.72029,16.95376698,-0.00147349713,3.094475885e-007,-3.41746247e-011,
         1.539334807e-015},
     bhigh={31274.99231,-78.01700080000001},
-    R_s=52.61864803065607);
+    R_s=52.61888851599598);
 
   constant IdealGases.Common.DataRecord SiH4(
     name="SiH4",
@@ -15438,7 +15438,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1290378.74,-7813.39978,18.28851664,-0.001975620946,4.15650215e-007,-4.59674561e-011,
         2.072777131e-015},
     bhigh={47668.8795,-98.0169746},
-    R_s=258.8786216507884);
+    R_s=258.8798048152302);
 
   constant IdealGases.Common.DataRecord SiI(
     name="SiI",
@@ -15452,7 +15452,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={852940.2790000001,-2442.039471,7.72297752,-0.001985601243,
         6.542866629999999e-007,-9.49415829e-011,4.89004137e-015},
     bhigh={45781.6094,-17.33975081},
-    R_s=53.64522620399243);
+    R_s=53.64547138114808);
 
   constant IdealGases.Common.DataRecord SiI2(
     name="SiI2",
@@ -15466,7 +15466,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={10021.68907,14.33017148,6.70133055,0.00039607699,-2.073866165e-007,
         4.5534571e-011,-3.01679828e-015},
     bhigh={9007.368100000002,0.2887336913},
-    R_s=29.49498400890774);
+    R_s=29.49511881114079);
 
   constant IdealGases.Common.DataRecord SiN(
     name="SiN",
@@ -15480,7 +15480,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2932685.132,5853.68859,1.321451677,0.001258329284,-3.77388636e-007,
         6.88776104e-011,-4.18984259e-015},
     bhigh={6527.14881,25.53145732},
-    R_s=197.5299936805394);
+    R_s=197.5308964606269);
 
   constant IdealGases.Common.DataRecord SiO(
     name="SiO",
@@ -15494,7 +15494,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-176513.4162,-31.9917709,4.47744193,4.59176471e-006,3.55814315e-008,
         -1.327012559e-011,1.613253297e-015},
     bhigh={-13508.4236,-0.838695733},
-    R_s=188.601357834542);
+    R_s=188.602219807689);
 
   constant IdealGases.Common.DataRecord SiO2(
     name="SiO2",
@@ -15508,7 +15508,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-146403.1193,-626.144106,7.96456371,-0.0001854119096,4.09521467e-008,
         -4.69720676e-012,2.17805428e-016},
     bhigh={-37918.3477,-20.45285414},
-    R_s=138.3801092797952);
+    R_s=138.3807417245437);
 
   constant IdealGases.Common.DataRecord SiS(
     name="SiS",
@@ -15522,7 +15522,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2102323.897,6228.83618,-3.004120882,0.004495499930000001,-1.368821364e-006,
         1.998097253e-010,-9.882035800000001e-015},
     bhigh={-27955.38166,54.05828786},
-    R_s=138.2278119051379);
+    R_s=138.2284436538350);
 
   constant IdealGases.Common.DataRecord SiS2(
     name="SiS2",
@@ -15536,7 +15536,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-126648.9071,-97.7423522,7.57280368,-2.905413928e-005,
         6.40558784e-009,-7.329273340000001e-013,3.38981978e-017},
     bhigh={-1244.672263,-13.52710463},
-    R_s=90.1634974597546);
+    R_s=90.1639095379844);
 
   constant IdealGases.Common.DataRecord Si2(
     name="Si2",
@@ -15550,7 +15550,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1370060.657,-4207.06004,9.337432890000001,-0.002749217168,
         9.586345959999999e-007,-1.372449748e-010,6.765028100000001e-015},
     bhigh={95108.84539999999,-31.6838519},
-    R_s=148.0207224368446);
+    R_s=148.0213989425148);
 
   constant IdealGases.Common.DataRecord Si2C(
     name="Si2C",
@@ -15564,7 +15564,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-125382.9442,-341.427779,7.25436533,-0.0001017635503,
         2.250902158e-008,-2.584074852e-012,1.198884876e-016},
     bhigh={66080.0938,-11.46216579},
-    R_s=121.9458007060545);
+    R_s=121.9463580403539);
 
   constant IdealGases.Common.DataRecord Si2F6(
     name="Si2F6",
@@ -15578,7 +15578,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-918630.314,157.3948683,21.41256129,-0.0002681898667,7.21228011e-008,
         -9.18425266e-012,4.53723836e-016},
     bhigh={-296617.6753,-78.4902247},
-    R_s=48.8622628977227);
+    R_s=48.8624862150891);
 
   constant IdealGases.Common.DataRecord Si2N(
     name="Si2N",
@@ -15592,7 +15592,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-280502.6986,250.2366876,7.0924561,0.0002853120795,-9.79210181e-008,
         1.552154244e-011,-8.03626045e-016},
     bhigh={43420.1479,-10.0957091},
-    R_s=118.4774080655251);
+    R_s=118.4779495480758);
 
   constant IdealGases.Common.DataRecord Si3(
     name="Si3",
@@ -15606,7 +15606,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1699395.561,4697.81538,2.618198124,0.001959082075,-2.581160603e-007,
         6.10344486e-012,6.08630924e-016},
     bhigh={42779.1681,25.86540384},
-    R_s=98.6804816245631);
+    R_s=98.6809326283432);
 
   constant IdealGases.Common.DataRecord Sn(
     name="Sn",
@@ -15620,7 +15620,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-5145695.64,11405.75108,-4.17963206,0.002236390679,-3.60321977e-007,
         2.440237836e-011,-2.937628285e-016},
     bhigh={-42150.1357,59.81450930000001},
-    R_s=70.0401988038076);
+    R_s=70.0405189116334);
 
   constant IdealGases.Common.DataRecord Snplus(
     name="Snplus",
@@ -15634,7 +15634,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4622916.850000001,-11859.58712,12.37026473,-0.002773624217,
         3.09851349e-007,-5.362951439999999e-012,-8.663474691e-016},
     bhigh={199432.2977,-68.3710828},
-    R_s=70.04052248530566);
+    R_s=70.04084259461079);
 
   constant IdealGases.Common.DataRecord Snminus(
     name="Snminus",
@@ -15648,7 +15648,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-64477.1322,743.05551,1.921380256,0.0002361623997,-5.28066836e-008,
         6.10233938e-012,-2.843422486e-016},
     bhigh={16457.39414,12.65436865},
-    R_s=70.03987512530121);
+    R_s=70.04019523164769);
 
   constant IdealGases.Common.DataRecord SnBr(
     name="SnBr",
@@ -15662,7 +15662,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1815578.541,-6728.26458,13.32464516,-0.0046081023,1.236439537e-006,-1.528863587e-010,
         6.971513500000001e-015},
     bhigh={49255.8309,-56.4096278},
-    R_s=41.86246689558642);
+    R_s=41.86265822147482);
 
   constant IdealGases.Common.DataRecord SnBr2(
     name="SnBr2",
@@ -15676,7 +15676,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-19408.94091,-2.335607932,7.00196926,-8.622241869999999e-007,
         2.039869794e-010,-2.464780359e-014,1.189850894e-018},
     bhigh={-16448.28122,-0.434935475},
-    R_s=29.85254812974386);
+    R_s=29.85268456616808);
 
   constant IdealGases.Common.DataRecord SnBr3(
     name="SnBr3",
@@ -15690,7 +15690,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-38930.0453,-4.99084417,10.00418437,-1.82499691e-006,4.30564666e-010,
         -5.19188793e-014,2.502455595e-018},
     bhigh={-22172.99473,-12.29854098},
-    R_s=23.19743765728666);
+    R_s=23.19754367756444);
 
   constant IdealGases.Common.DataRecord SnBr4(
     name="SnBr4",
@@ -15704,7 +15704,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-51768.1292,-7.42612695,13.00619502,-2.692587978e-006,6.3367598e-010,
         -7.62708719e-014,3.671112e-018},
     bhigh={-43001.6634,-24.71455118},
-    R_s=18.96869453329257);
+    R_s=18.96878122675816);
 
   constant IdealGases.Common.DataRecord SnCL(
     name="SnCL",
@@ -15718,7 +15718,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={774160.568,-3602.04848,9.749059819999999,-0.002596198909,
         6.36771216e-007,-6.75429557e-011,2.484167602e-015},
     bhigh={24424.47662,-32.25454098},
-    R_s=53.93299300091461);
+    R_s=53.93323949326363);
 
   constant IdealGases.Common.DataRecord SnCL2(
     name="SnCL2",
@@ -15732,7 +15732,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-39035.88490000001,-7.94796268,7.00648762,-2.776594714e-006,
         6.461341420000001e-010,-7.1190674e-015,3.68813118e-018},
     bhigh={-26545.29653,-3.368081174},
-    R_s=43.84900008438107);
+    R_s=43.84920048941018);
 
   constant IdealGases.Common.DataRecord SnCL3(
     name="SnCL3",
@@ -15746,7 +15746,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-74829.66399999999,-15.28523914,10.01240305,-5.28558124e-006,
         1.226095111e-009,-1.459895108e-013,6.96887978e-018},
     bhigh={-38308.7827,-16.63063137},
-    R_s=36.94188004567489);
+    R_s=36.94204888278706);
 
   constant IdealGases.Common.DataRecord SnCL4(
     name="SnCL4",
@@ -15760,7 +15760,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-107833.6862,-25.54305872,13.02040391,-8.5951259e-006,
         1.976570888e-009,-2.337929994e-013,1.110287624e-017},
     bhigh={-61635.6203,-30.72702622},
-    R_s=31.91466363685217);
+    R_s=31.91480949785431);
 
   constant IdealGases.Common.DataRecord SnF(
     name="SnF",
@@ -15774,7 +15774,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={25897.15476,-1484.478214,7.37851893,-0.00132424444,2.847634043e-007,
         -2.360371345e-011,6.11678371e-016},
     bhigh={-4776.68897,-16.81202516},
-    R_s=60.3773757213968);
+    R_s=60.3776516667939);
 
   constant IdealGases.Common.DataRecord SnF2(
     name="SnF2",
@@ -15788,7 +15788,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-102775.8772,-44.5175162,7.03326876,-1.329882797e-005,
         2.934271938e-009,-3.35841592e-013,1.553358669e-017},
     bhigh={-63621.2588,-6.81008452},
-    R_s=53.05750395280852);
+    R_s=53.05774644387112);
 
   constant IdealGases.Common.DataRecord SnF3(
     name="SnF3",
@@ -15802,7 +15802,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-182931.9689,-75.5735868,10.05671455,-2.275132668e-005,
         5.03469582e-009,-5.77653096e-013,2.67721417e-017},
     bhigh={-80918.97590000001,-21.91673972},
-    R_s=47.32057756812237);
+    R_s=47.32079383945597);
 
   constant IdealGases.Common.DataRecord SnF4(
     name="SnF4",
@@ -15816,7 +15816,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-263569.2764,-144.5469969,13.10690681,-4.23775579e-005,
         9.28687195e-009,-1.057062694e-012,4.86710868e-017},
     bhigh={-127153.9967,-38.039219},
-    R_s=42.70322404618472);
+    R_s=42.70341921462281);
 
   constant IdealGases.Common.DataRecord SnI(
     name="SnI",
@@ -15830,7 +15830,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-55549.91850000001,-1530.457453,7.93260139,-0.002108885464,
         7.8098036e-007,-1.348104887e-010,8.207184700000001e-015},
     bhigh={27448.64953,-16.26822892},
-    R_s=33.85171891542058);
+    R_s=33.85187362943234);
 
   constant IdealGases.Common.DataRecord SnI2(
     name="SnI2",
@@ -15844,7 +15844,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-15594.5339,-1.594789414,7.00135116,-5.93532424e-007,
         1.407432564e-010,-1.703457321e-014,8.23361171e-019},
     bhigh={-3100.608319,1.235038509},
-    R_s=22.31959534728624);
+    R_s=22.31969735552238);
 
   constant IdealGases.Common.DataRecord SnI3(
     name="SnI3",
@@ -15858,7 +15858,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-25175.3487,-2.34828289,10.0019913,-8.752764839999999e-007,
         2.07646498e-010,-2.514060336e-014,1.215482266e-018},
     bhigh={-4017.05561,-9.26390846},
-    R_s=16.64814230474298);
+    R_s=16.64821839248585);
 
   constant IdealGases.Common.DataRecord SnI4(
     name="SnI4",
@@ -15872,7 +15872,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-28018.40706,-2.474699366,13.00210215,-9.250962339999999e-007,
         2.196515817e-010,-2.661071614e-014,1.287167546e-018},
     bhigh={-18250.83832,-20.27484281},
-    R_s=13.27495113262402);
+    R_s=13.27501180372172);
 
   constant IdealGases.Common.DataRecord SnO(
     name="SnO",
@@ -15886,7 +15886,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2555955.548,7870.0535,-5.43976873,0.00630781918,-2.06887137e-006,
         3.30707488e-010,-1.848169716e-014},
     bhigh={-48416.6391,71.75952460000001},
-    R_s=61.72154281735352);
+    R_s=61.72182490605704);
 
   constant IdealGases.Common.DataRecord SnO2(
     name="SnO2",
@@ -15900,7 +15900,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-157355.8926,-142.7316788,7.60570076,-4.19800853e-005,
         9.218742430000002e-009,-1.051372983e-012,4.84957927e-017},
     bhigh={-523.453187,-14.28360169},
-    R_s=55.16912084762137);
+    R_s=55.16937298950028);
 
   constant IdealGases.Common.DataRecord SnS(
     name="SnS",
@@ -15914,7 +15914,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1797985.129,6141.73632,-4.01950488,0.005993829179999999,-2.188735204e-006,
         3.899542e-010,-2.40656363e-014},
     bhigh={-26113.49815,62.56820705},
-    R_s=55.14489802686122);
+    R_s=55.14515005803350);
 
   constant IdealGases.Common.DataRecord SnS2(
     name="SnS2",
@@ -15928,7 +15928,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-67640.84050000001,-19.70189679,7.51533387,-6.33255918e-006,
         1.434207625e-009,-1.676383081e-013,7.886911900000001e-018},
     bhigh={15650.53629,-9.922744838},
-    R_s=45.47403194049442);
+    R_s=45.47423977247867);
 
   constant IdealGases.Common.DataRecord Sn2(
     name="Sn2",
@@ -15942,7 +15942,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4275783.04,12364.21656,-8.43833617,0.00708805629,-1.712012737e-006,
         1.805262952e-010,-7.058656809999999e-015},
     bhigh={-30014.1872,100.5138538},
-    R_s=35.0200994019038);
+    R_s=35.0202594558167);
 
   constant IdealGases.Common.DataRecord Sr(
     name="Sr",
@@ -15956,7 +15956,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={14894144.1,-43753.3505,51.3726628,-0.02592566025,6.58299e-006,-6.949611799999999e-010,
         2.417779662e-014},
     bhigh={297754.5522,-345.489077},
-    R_s=94.89239899566309);
+    R_s=94.89283268660124);
 
   constant IdealGases.Common.DataRecord Srplus(
     name="Srplus",
@@ -15970,7 +15970,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3145095.058,-9514.756889999999,13.50086948,-0.00605971712,
         1.594068746e-006,-1.718800946e-010,6.322256169e-015},
     bhigh={145799.1907,-72.3641693},
-    R_s=94.8929931328011);
+    R_s=94.8934268264547);
 
   constant IdealGases.Common.DataRecord SrBr(
     name="SrBr",
@@ -15984,7 +15984,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3009976.114,-9193.19224,15.26033745,-0.00600925395,1.692611858e-006,
         -2.039438429e-010,8.807775840000001e-015},
     bhigh={49228.06129999999,-70.6825383},
-    R_s=49.63152742293642);
+    R_s=49.63175425610659);
 
   constant IdealGases.Common.DataRecord SrBr2(
     name="SrBr2",
@@ -15998,7 +15998,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-11861.73059,-1.404383013,7.50121557,-5.415983190000001e-007,
         1.296969275e-010,-1.580911652e-014,7.68158227e-019},
     bhigh={-51185.75210000001,-3.55203711},
-    R_s=33.60360185589343);
+    R_s=33.60375543592480);
 
   constant IdealGases.Common.DataRecord SrCL(
     name="SrCL",
@@ -16012,7 +16012,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2070217.324,-6199.89173,11.50315072,-0.00367568546,9.46173235e-007,-9.203765750000001e-011,
         2.707242192e-015},
     bhigh={22714.71632,-45.61058514},
-    R_s=67.55723838697359);
+    R_s=67.55754714681531);
 
   constant IdealGases.Common.DataRecord SrCLplus(
     name="SrCLplus",
@@ -16026,7 +16026,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-21324.75783,-4.05794827,4.50314939,3.82620238e-005,2.67695151e-009,
         5.667610500000001e-014,1.613288103e-018},
     bhigh={47693.2603,3.637722496},
-    R_s=67.55753952586014);
+    R_s=67.55784828707816);
 
   constant IdealGases.Common.DataRecord SrCL2(
     name="SrCL2",
@@ -16040,7 +16040,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-25927.16099,-5.26378585,7.00447524,-1.970397814e-006,4.6796712e-010,
         -5.67021588e-014,2.742892387e-018},
     bhigh={-60453.9953,-2.192202775},
-    R_s=52.44863303180551);
+    R_s=52.44887274011834);
 
   constant IdealGases.Common.DataRecord SrF(
     name="SrF",
@@ -16054,7 +16054,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={870234.0489999999,-2589.81877,7.20026422,-0.001173446296,
         1.996165066e-007,1.103842667e-011,-2.343183859e-015},
     bhigh={-21336.71699,-16.67390309},
-    R_s=77.98346017622593);
+    R_s=77.98381658749135);
 
   constant IdealGases.Common.DataRecord SrFplus(
     name="SrFplus",
@@ -16068,7 +16068,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-47520.8206,-25.26802345,4.51929528,2.55642675e-005,3.38254183e-009,
         -1.511394636e-013,9.53749118e-018},
     bhigh={23838.61417,1.892197325},
-    R_s=77.98386143853246);
+    R_s=77.98421785163177);
 
   constant IdealGases.Common.DataRecord SrF2(
     name="SrF2",
@@ -16082,7 +16082,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-61262.6543,-19.64060822,7.01555775,-6.51252678e-006,
         1.490473613e-009,-1.75643704e-013,8.317093849999999e-018},
     bhigh={-96567.0125,-5.40230876},
-    R_s=66.1891687767028);
+    R_s=66.1894712839953);
 
   constant IdealGases.Common.DataRecord SrH(
     name="SrH",
@@ -16096,7 +16096,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-226982.5428,1345.209458,1.152194421,0.003109555289,-1.188080968e-006,
         2.073091147e-010,-1.300839287e-014},
     bhigh={17355.47062,21.12916944},
-    R_s=93.81321511026886);
+    R_s=93.81364386896504);
 
   constant IdealGases.Common.DataRecord SrI(
     name="SrI",
@@ -16110,7 +16110,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2201136.857,-7082.2307,13.32597928,-0.00530586442,1.63607115e-006,-2.205540591e-010,
         1.078496824e-014},
     bhigh={42190.77170000001,-55.308332},
-    R_s=38.75768577822381);
+    R_s=38.75786291419342);
 
   constant IdealGases.Common.DataRecord SrI2(
     name="SrI2",
@@ -16124,7 +16124,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-8090.381920000001,-0.734826323,7.50064006,-2.863515042e-007,
         6.87655697e-011,-8.398807359999999e-015,4.08696816e-019},
     bhigh={-35721.0642,-1.693119087},
-    R_s=24.35198375392549);
+    R_s=24.35209505087647);
 
   constant IdealGases.Common.DataRecord SrO(
     name="SrO",
@@ -16138,7 +16138,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-51729330.5,151082.1,-161.4513515,0.08516051790000001,-2.091669402e-005,
         2.452307103e-009,-1.108841292e-013},
     bhigh={-968782.9519999999,1197.846971},
-    R_s=80.24049550566787);
+    R_s=80.24086223236189);
 
   constant IdealGases.Common.DataRecord SrOH(
     name="SrOH",
@@ -16152,7 +16152,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2545648.379,-7416.19598,13.81956204,-0.003096481934,7.72389421e-007,
         -7.921280320000001e-011,2.740829111e-015},
     bhigh={22313.02058,-61.4878113},
-    R_s=79.46748909032763);
+    R_s=79.46785228411618);
 
   constant IdealGases.Common.DataRecord SrOHplus(
     name="SrOHplus",
@@ -16166,7 +16166,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={867969.566,-2340.609538,7.97682975,0.0001023752569,-6.28603233e-008,
         1.024851502e-011,-5.72368392e-016},
     bhigh={50731.5772,-20.27046917},
-    R_s=79.46790577007029);
+    R_s=79.46826896576320);
 
   constant IdealGases.Common.DataRecord Sr_OH_2(
     name="Sr_OH_2",
@@ -16180,7 +16180,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1750013.518,-4681.6015,13.95548402,0.000203501956,-1.253496115e-007,
         2.044549432e-011,-1.142004855e-015},
     bhigh={-44271.7024,-50.5145685},
-    R_s=68.35609712624722);
+    R_s=68.35640953714845);
 
   constant IdealGases.Common.DataRecord SrS(
     name="SrS",
@@ -16194,7 +16194,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-13794329.47,39213.3158,-36.0286638,0.01818513386,-3.27585816e-006,
         2.324312746e-010,-3.6145557e-015},
     bhigh={-241024.6179,299.1679642},
-    R_s=69.46962443079751);
+    R_s=69.46994193090195);
 
   constant IdealGases.Common.DataRecord Sr2(
     name="Sr2",
@@ -16208,7 +16208,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={209844.5682,103.865013,2.30933233,0.0001330517507,-4.42643339e-008,
         6.71141915e-012,-3.374128e-016},
     bhigh={36366.4269,21.68088517},
-    R_s=47.44619949783154);
+    R_s=47.44641634330062);
 
   constant IdealGases.Common.DataRecord Ta(
     name="Ta",
@@ -16222,7 +16222,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1689726.898,-5986.85466,9.565039670000001,-0.002511649459,
         6.44303117e-007,-7.189237249999999e-011,3.11335207e-015},
     bhigh={130671.0983,-43.3509627},
-    R_s=45.94953575034582);
+    R_s=45.94974575554621);
 
   constant IdealGases.Common.DataRecord Taplus(
     name="Taplus",
@@ -16236,7 +16236,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3656142.13,-12540.73524,18.65022579,-0.007943274660000001,
         2.151786937e-006,-2.816764844e-010,1.413722944e-014},
     bhigh={263687.6455,-106.5864286},
-    R_s=45.94967506111836);
+    R_s=45.94988506695545);
 
   constant IdealGases.Common.DataRecord Taminus(
     name="Taminus",
@@ -16250,7 +16250,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4235467.48,11010.56361,-4.73691107,0.002503562129,-4.82185169e-007,
         4.88640803e-011,-2.030547835e-015},
     bhigh={15746.99408,64.918027},
-    R_s=45.94939644041801);
+    R_s=45.94960644498170);
 
   constant IdealGases.Common.DataRecord TaCL5(
     name="TaCL5",
@@ -16264,7 +16264,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-142644.4545,-38.9434032,16.0314237,-1.333676355e-005,
         3.084307611e-009,-3.66393006e-013,1.745841795e-017},
     bhigh={-97012.9717,-42.56986372},
-    R_s=23.21097872243015);
+    R_s=23.21108480459526);
 
   constant IdealGases.Common.DataRecord TaO(
     name="TaO",
@@ -16278,7 +16278,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6106591.12,-19841.35246,28.15797433,-0.01330045882,3.87680749e-006,-5.068872769999999e-010,
         2.443666035e-014},
     bhigh={152581.4433,-165.8307106},
-    R_s=42.21673513675993);
+    R_s=42.21692808177620);
 
   constant IdealGases.Common.DataRecord TaO2(
     name="TaO2",
@@ -16292,7 +16292,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1297565.964,-4149.217430000001,10.41680373,-0.001045478838,
         2.754904271e-007,-3.29704313e-011,1.356249074e-015},
     bhigh={3418.98567,-33.9264279},
-    R_s=39.04485019021192);
+    R_s=39.04502863862178);
 
   constant IdealGases.Common.DataRecord Ti(
     name="Ti",
@@ -16306,7 +16306,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-170478.6714,1073.852803,1.181955014,0.0002245246352,
         3.091697848e-007,-5.74002728e-011,2.927371014e-015},
     bhigh={49780.69910000001,17.40431368},
-    R_s=173.699458917417);
+    R_s=173.700252783755);
 
   constant IdealGases.Common.DataRecord Tiplus(
     name="Tiplus",
@@ -16320,7 +16320,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-768546.308,2545.8681,0.342386278,0.000709990136,2.706231875e-008,-2.3716601e-011,
         1.895443077e-015},
     bhigh={119882.1489,24.8479915},
-    R_s=173.7014496963525);
+    R_s=173.7022435717890);
 
   constant IdealGases.Common.DataRecord Timinus(
     name="Timinus",
@@ -16334,7 +16334,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={23411.1764,2.580413872,2.497754577,9.76907204e-007,-2.280024955e-010,
         2.717202291e-014,-1.295670294e-018},
     bhigh={54546.62179999999,7.99982395},
-    R_s=173.6974681841134);
+    R_s=173.6982620413530);
 
   constant IdealGases.Common.DataRecord TiCL(
     name="TiCL",
@@ -16348,7 +16348,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-963322.542,2868.829781,1.973820676,0.001752668011,-4.25543436e-007,
         5.0491034e-011,-2.304720715e-015},
     bhigh={-1811.011561,23.19450287},
-    R_s=99.78963034085456);
+    R_s=99.79008641382623);
 
   constant IdealGases.Common.DataRecord TiCL2(
     name="TiCL2",
@@ -16362,7 +16362,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3190012.95,10157.63826,-4.84079477,0.00682200634,-1.70075327e-006,
         2.118106588e-010,-1.041245457e-014},
     bhigh={-94809.82980000001,78.23195948},
-    R_s=70.00304783073595);
+    R_s=70.00336776876900);
 
   constant IdealGases.Common.DataRecord TiCL3(
     name="TiCL3",
@@ -16376,7 +16376,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-94087.92310000002,-125.5351109,10.66923972,-0.0002637456897,
         7.95916935e-008,-1.176740054e-011,6.41622348e-016},
     bhigh={-67691.1468,-23.69164216},
-    R_s=53.91096183522882);
+    R_s=53.91120822688782);
 
   constant IdealGases.Common.DataRecord TiCL4(
     name="TiCL4",
@@ -16390,7 +16390,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-143256.2278,-43.1677485,13.03337752,-1.371365738e-005,
         3.093403483e-009,-3.60424516e-013,1.691384523e-017},
     bhigh={-95889.46999999999,-32.47541011},
-    R_s=43.83443607357694);
+    R_s=43.83463641204351);
 
   constant IdealGases.Common.DataRecord TiO(
     name="TiO",
@@ -16404,7 +16404,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2330644.03,-7415.79386,12.81799311,-0.004344555950000001,
         1.186303111e-006,-1.367644275e-010,5.70321225e-015},
     bhigh={51448.4136,-57.9399424},
-    R_s=130.1853869953528);
+    R_s=130.1859819873987);
 
   constant IdealGases.Common.DataRecord TiOplus(
     name="TiOplus",
@@ -16418,7 +16418,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={342132.953,-2161.85106,8.02517566,-0.002708700692,1.004583805e-006,-1.50576685e-010,
         8.04565811e-015},
     bhigh={93626.4699,-22.61587887},
-    R_s=130.1865052722056);
+    R_s=130.1871002693624);
 
   constant IdealGases.Common.DataRecord TiOCL(
     name="TiOCL",
@@ -16432,7 +16432,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-127305.9873,-111.111885,7.58288808,-3.3128718e-005,7.31401409e-009,
         -8.37882226e-013,3.87927506e-017},
     bhigh={-31393.56857,-12.47104274},
-    R_s=83.71448075602551);
+    R_s=83.71486336002836);
 
   constant IdealGases.Common.DataRecord TiOCL2(
     name="TiOCL2",
@@ -16446,7 +16446,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-132295.1633,-96.91212050000002,10.07240769,-2.897248531e-005,
         6.40177504e-009,-7.3384526e-013,3.39928267e-017},
     bhigh={-68474.09640000001,-19.75043469},
-    R_s=61.69269078832164);
+    R_s=61.69297274516148);
 
   constant IdealGases.Common.DataRecord TiO2(
     name="TiO2",
@@ -16460,7 +16460,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={154629.9764,-1046.25688,7.78898583,-0.0001546805714,-7.05993595e-008,
         3.100244802e-011,-2.49472543e-015},
     bhigh={-32663.3675,-15.9153466},
-    R_s=104.1055370383819);
+    R_s=104.1060128365333);
 
   constant IdealGases.Common.DataRecord U(
     name="U",
@@ -16474,7 +16474,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4092498.96,12748.88349,-12.18707506,0.00725810568,-7.78777507e-007,
         -3.84435385e-011,7.066508567e-015},
     bhigh={-16993.72664,115.5026301},
-    R_s=34.93051327252644);
+    R_s=34.93067291699987);
 
   constant IdealGases.Common.DataRecord UF(
     name="UF",
@@ -16488,7 +16488,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-5325439.37,15339.67086,-11.75044398,0.00964721093,-2.49877819e-006,
         3.155572896e-010,-1.544694839e-014},
     bhigh={-105719.6525,122.0828149},
-    R_s=32.34859321557893);
+    R_s=32.34874105978867);
 
   constant IdealGases.Common.DataRecord UFplus(
     name="UFplus",
@@ -16502,7 +16502,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={539509.184,-2923.962095,10.08511948,-0.002425945123,5.92872548e-007,
         -6.79584554e-011,3.152666445e-015},
     bhigh={82672.91220000001,-33.07089704},
-    R_s=32.34866226067727);
+    R_s=32.34881010520256);
 
   constant IdealGases.Common.DataRecord UFminus(
     name="UFminus",
@@ -16516,7 +16516,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4311143.56,19748.17938,-27.60304763,0.02276806261,-6.88874172e-006,
         9.483511059999999e-010,-4.9106881e-014},
     bhigh={-138080.129,224.0758537},
-    R_s=32.34852417077533);
+    R_s=32.34867201466950);
 
   constant IdealGases.Common.DataRecord UF2(
     name="UF2",
@@ -16530,7 +16530,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-471677.682,322.423686,8.214090629999999,-0.000140741378,
         6.54117805e-009,1.818915497e-012,-2.287963719e-016},
     bhigh={-69952.3505,-9.648963156000001},
-    R_s=30.12209191389676);
+    R_s=30.12222958222888);
 
   constant IdealGases.Common.DataRecord UF2plus(
     name="UF2plus",
@@ -16544,7 +16544,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3779149.61,12987.37504,-10.27930641,0.01048838051,-2.651047812e-006,
         3.116973593e-010,-1.417216291e-014},
     bhigh={-74334.402,118.9131079},
-    R_s=30.12215178155214);
+    R_s=30.12228945015788);
 
   constant IdealGases.Common.DataRecord UF2minus(
     name="UF2minus",
@@ -16558,7 +16558,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={10382318.55,-28401.13518,34.9853337,-0.01053216396,1.92462047e-006,-1.69874957e-010,
         5.70985889e-015},
     bhigh={100157.2794,-209.4039075},
-    R_s=30.12203204647934);
+    R_s=30.12216971453784);
 
   constant IdealGases.Common.DataRecord UF3(
     name="UF3",
@@ -16572,7 +16572,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3828876.42,12968.91783,-7.26555429,0.01048289752,-2.649840687e-006,
         3.115594509e-010,-1.4165794e-014},
     bhigh={-211361.5913,105.4464687},
-    R_s=28.18234662058458);
+    R_s=28.18247542361279);
 
   constant IdealGases.Common.DataRecord UF3plus(
     name="UF3plus",
@@ -16586,7 +16586,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1196316.388,3972.78507,4.53590711,0.00413341615,-1.097960689e-006,
         1.319641252e-010,-6.10112918e-015},
     bhigh={-61995.4174,21.37623045},
-    R_s=28.18239902600868);
+    R_s=28.18252782927640);
 
   constant IdealGases.Common.DataRecord UF3minus(
     name="UF3minus",
@@ -16600,7 +16600,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-191005.3149,-506.918131,11.81482258,-0.0001711879404,-9.38483918e-008,
         2.242009537e-011,-1.42819528e-015},
     bhigh={-143862.8681,-27.74680411},
-    R_s=28.18229421535538);
+    R_s=28.18242301814408);
 
   constant IdealGases.Common.DataRecord UF4(
     name="UF4",
@@ -16614,7 +16614,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1230291.173,3876.46379,7.62162591,0.004094525220000001,-1.088530094e-006,
         1.308042117e-010,-6.04439087e-015},
     bhigh={-221414.292,6.270300658},
-    R_s=26.47731100897964);
+    R_s=26.47743201940801);
 
   constant IdealGases.Common.DataRecord UF4plus(
     name="UF4plus",
@@ -16628,7 +16628,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1617630.159,3765.93477,9.16613853,0.002426641067,-5.695320299999999e-007,
         6.021096599999999e-011,-2.438874329e-015},
     bhigh={-106191.0645,-4.162641042},
-    R_s=26.47735726514645);
+    R_s=26.47747827578622);
 
   constant IdealGases.Common.DataRecord UF4minus(
     name="UF4minus",
@@ -16642,7 +16642,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4639200.11,16268.24426,-9.59529105,0.01441556535,-4.008173850000001e-006,
         5.140230790000001e-010,-2.511687821e-014},
     bhigh={-312514.0933,127.4038784},
-    R_s=26.47726475297446);
+    R_s=26.47738576319141);
 
   constant IdealGases.Common.DataRecord UF5(
     name="UF5",
@@ -16656,7 +16656,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1695373.88,3735.42535,12.1874804,0.002418608203,-5.67852616e-007,
         6.00276561e-011,-2.430740809e-015},
     bhigh={-264510.7342,-18.83137475},
-    R_s=24.96681544870847);
+    R_s=24.96692955565201);
 
   constant IdealGases.Common.DataRecord UF5plus(
     name="UF5plus",
@@ -16670,7 +16670,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-262847.8263,-117.4047323,16.08988291,-3.66551671e-005,
         8.221494970000001e-009,-9.53716052e-013,4.46014508e-017},
     bhigh={-107629.3931,-47.63374165000001},
-    R_s=24.96685657770803);
+    R_s=24.96697068483954);
 
   constant IdealGases.Common.DataRecord UF5minus(
     name="UF5minus",
@@ -16684,7 +16684,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1331518.187,3905.51686,10.58727667,0.00411250727,-1.09327793e-006,
         1.314215436e-010,-6.07577827e-015},
     bhigh={-304950.6955,-7.977511665},
-    R_s=24.96677431984442);
+    R_s=24.96688842659999);
 
   constant IdealGases.Common.DataRecord UF6(
     name="UF6",
@@ -16698,7 +16698,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-340902.792,-145.8950046,19.10902533,-4.358451129999999e-005,
         9.617604659999999e-009,-1.100915551e-012,5.09264508e-017},
     bhigh={-264364.5561,-65.79130395999999},
-    R_s=23.61936209268818);
+    R_s=23.61947004130590);
 
   constant IdealGases.Common.DataRecord UF6minus(
     name="UF6minus",
@@ -16712,7 +16712,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2699676.848,-6574.45967,22.41731997,0.000605779971,-4.51749171e-007,
         7.821820469999999e-011,-4.56033472e-015},
     bhigh={-285566.7984,-91.82896336},
-    R_s=23.61932528345421);
+    R_s=23.61943323190370);
 
   constant IdealGases.Common.DataRecord UO(
     name="UO",
@@ -16726,7 +16726,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2458660.003,3942.65216,5.01603072,-0.0005450639469999999,
         2.096321351e-007,-2.654652526e-011,1.361108472e-015},
     bhigh={-26651.49645,5.580598689},
-    R_s=32.73049369969828);
+    R_s=32.73064328932472);
 
   constant IdealGases.Common.DataRecord UOplus(
     name="UOplus",
@@ -16740,7 +16740,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-106371.4748,-1793.716133,8.024449049999999,-0.001565116442,
         5.06603391e-007,-7.37397747e-011,4.07476643e-015},
     bhigh={77890.8584,-21.1528425},
-    R_s=32.73056438468461);
+    R_s=32.73071397463411);
 
   constant IdealGases.Common.DataRecord UOF(
     name="UOF",
@@ -16754,7 +16754,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3805936.01,12952.07909,-10.25373631,0.01047841671,-2.648894949e-006,
         3.114551623e-010,-1.416111895e-014},
     bhigh={-147897.6701,118.4570601},
-    R_s=30.45296155292104);
+    R_s=30.45310073344135);
 
   constant IdealGases.Common.DataRecord UOF2(
     name="UOF2",
@@ -16768,7 +16768,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1198944.06,3852.17341,4.63910975,0.00408773844,-1.087067018e-006,
         1.306398384e-010,-6.03690152e-015},
     bhigh={-161263.7583,20.18237189},
-    R_s=28.47177017682031);
+    R_s=28.47190030261383);
 
   constant IdealGases.Common.DataRecord UOF3(
     name="UOF3",
@@ -16782,7 +16782,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1658296.049,3714.43468,9.20242554,0.002412862293,-5.66624172e-007,
         5.98906211e-011,-2.42453481e-015},
     bhigh={-210549.1714,-5.670532802},
-    R_s=26.73261498260018);
+    R_s=26.73273715985561);
 
   constant IdealGases.Common.DataRecord UOF4(
     name="UOF4",
@@ -16796,7 +16796,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-299619.0288,-167.7276501,16.12494871,-4.98441446e-005,
         1.098253497e-008,-1.255803231e-012,5.80448098e-017},
     bhigh={-219545.926,-50.24484645},
-    R_s=25.1936960110336);
+    R_s=25.1938111548994);
 
   constant IdealGases.Common.DataRecord UO2(
     name="UO2",
@@ -16810,7 +16810,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1190542.635,3832.18635,2.153236312,0.00408235191,-1.085924847e-006,
         1.305134065e-010,-6.03121575e-015},
     bhigh={-83676.1801,25.90742388},
-    R_s=30.79118065327443);
+    R_s=30.79132137957249);
 
   constant IdealGases.Common.DataRecord UO2plus(
     name="UO2plus",
@@ -16824,7 +16824,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1589957.42,3657.74607,3.74678542,0.002394401448,-5.62410144e-007,
         5.93945164e-011,-2.401047056e-015},
     bhigh={-20485.58817,14.64015614},
-    R_s=30.79124321009879);
+    R_s=30.79138393668275);
 
   constant IdealGases.Common.DataRecord UO2minus(
     name="UO2minus",
@@ -16838,7 +16838,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-273825.164,3228.53442,-0.2805114576,0.006607310710000001,-2.070291015e-006,
         2.851708013e-010,-1.466578192e-014},
     bhigh={-88934.3618,41.45760316},
-    R_s=30.79111809670427);
+    R_s=30.79125882271642);
 
   constant IdealGases.Common.DataRecord UO2F(
     name="UO2F",
@@ -16852,7 +16852,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1614277.202,3712.77186,6.20330882,0.002412618055,-5.665888019999999e-007,
         5.98882352e-011,-2.424485602e-015},
     bhigh={-147835.7384,8.736139132},
-    R_s=28.76719998738163);
+    R_s=28.76733146339111);
 
   constant IdealGases.Common.DataRecord UO2F2(
     name="UO2F2",
@@ -16866,7 +16866,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-263655.2036,-203.2835065,13.15092994,-6.00648683e-005,
         1.321137913e-008,-1.508668985e-012,6.96618275e-017},
     bhigh={-166444.4818,-35.66258175},
-    R_s=26.99289036202185);
+    R_s=26.99301372882539);
 
   constant IdealGases.Common.DataRecord UO3(
     name="UO3",
@@ -16880,7 +16880,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1097362.721,2808.784061,5.96612147,0.002861871152,-1.05284381e-006,
         1.849985929e-010,-1.102849619e-014},
     bhigh={-117336.0017,6.672828312},
-    R_s=29.06882497956226);
+    R_s=29.06895783410181);
 
   constant IdealGases.Common.DataRecord UO3minus(
     name="UO3minus",
@@ -16894,7 +16894,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1632938.634,3667.49541,6.24003065,0.002396952522,-5.62949023e-007,
         5.94541313e-011,-2.403730982e-015},
     bhigh={-184592.7385,7.032059012},
-    R_s=29.06876922566257);
+    R_s=29.06890207994731);
 
   constant IdealGases.Common.DataRecord V(
     name="V",
@@ -16908,7 +16908,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1200390.3,-5027.0053,10.58830594,-0.005044326100000001,
         1.488547375e-006,-1.785922508e-010,8.113013866e-015},
     bhigh={91707.40909999999,-47.6833632},
-    R_s=163.2160811911703);
+    R_s=163.2168271448622);
 
   constant IdealGases.Common.DataRecord Vplus(
     name="Vplus",
@@ -16922,7 +16922,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2347072.054,-9021.197190000001,14.77349798,-0.00689189688,
         1.968884877e-006,-2.539798544e-010,1.226783122e-014},
     bhigh={195835.1444,-78.5559293},
-    R_s=163.2178389192786);
+    R_s=163.2185848810040);
 
   constant IdealGases.Common.DataRecord Vminus(
     name="Vminus",
@@ -16936,7 +16936,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={26001.0043,2.096334097,2.498006548,8.991278839999999e-007,-2.139749508e-010,
         2.581021334e-014,-1.240812796e-018},
     bhigh={54700.0708,7.97790024},
-    R_s=163.2143235009202);
+    R_s=163.2150694465790);
 
   constant IdealGases.Common.DataRecord VCL4(
     name="VCL4",
@@ -16950,7 +16950,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1717776.251,4550.441049999999,8.164464799999999,0.002224875998,-4.094111780000001e-007,
         3.2717875e-011,-8.8586908e-016},
     bhigh={-96906.20060000001,4.348293098},
-    R_s=43.13525824433798);
+    R_s=43.13545538732112);
 
   constant IdealGases.Common.DataRecord VN(
     name="VN",
@@ -16964,7 +16964,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1018619.667,-3932.30557,9.856823609999999,-0.00328922171,
         1.005181767e-006,-1.243211436e-010,5.48677656e-015},
     bhigh={85573.18339999999,-35.52830762},
-    R_s=128.0169735265951);
+    R_s=128.0175586082447);
 
   constant IdealGases.Common.DataRecord VO(
     name="VO",
@@ -16978,7 +16978,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2986190.283,-10113.44974,17.18161749,-0.00787670503,2.562279547e-006,
         -3.54740035e-010,1.770268056e-014},
     bhigh={79612.5488,-87.89993010000001},
-    R_s=124.2061579691937);
+    R_s=124.2067256341041);
 
   constant IdealGases.Common.DataRecord VO2(
     name="VO2",
@@ -16992,7 +16992,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={121063.2401,-1627.832993,9.252713099999999,-0.001572703139,
         5.23143016e-007,-6.476071140000001e-011,2.847226026e-015},
     bhigh={-20973.06345,-25.47380687},
-    R_s=100.2464664342907);
+    R_s=100.2469245951606);
 
   constant IdealGases.Common.DataRecord V4O10(
     name="V4O10",
@@ -17006,7 +17006,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1360273.27,-1341.69286,40.9913859,-0.000393226553,8.62849412e-008,-9.83594409e-012,
         4.53563729e-016},
     bhigh={-348461.612,-190.7911348},
-    R_s=22.85702661095228);
+    R_s=22.85713107543436);
 
   constant IdealGases.Common.DataRecord W(
     name="W",
@@ -17020,7 +17020,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-8048745.96,14657.00424,-0.2508531501,-0.002596486992,
         1.409225475e-006,-2.233011706e-010,1.262640862e-014},
     bhigh={-3091.130919,39.5582219},
-    R_s=45.22667536988686);
+    R_s=45.22688207136640);
 
   constant IdealGases.Common.DataRecord Wplus(
     name="Wplus",
@@ -17034,7 +17034,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6387743.399999999,-20618.11463,27.59291576,-0.01244535845,
         3.27120049e-006,-4.065463720000001e-010,1.912595872e-014},
     bhigh={324517.443,-171.6919194},
-    R_s=45.22681033196339);
+    R_s=45.22701703405976);
 
   constant IdealGases.Common.DataRecord Wminus(
     name="Wminus",
@@ -17046,7 +17046,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={91429.8137,8.46116967},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={91429.8137,8.46116967},
-    R_s=45.22654040861582);
+    R_s=45.22674710947855);
 
   constant IdealGases.Common.DataRecord WCL6(
     name="WCL6",
@@ -17060,7 +17060,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-151673.5473,-34.5137925,19.02867176,-1.242486969e-005,
         2.917675103e-009,-3.50598144e-013,1.685355887e-017},
     bhigh={-65357.79790000001,-58.94914959000001},
-    R_s=20.96659757210799);
+    R_s=20.96669339667842);
 
   constant IdealGases.Common.DataRecord WO(
     name="WO",
@@ -17074,7 +17074,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1262156.956,-4177.263120000001,9.35828647,-0.00288761222,
         8.89393396e-007,-8.955318699999999e-011,2.504359614e-015},
     bhigh={73133.8064,-31.4488229},
-    R_s=41.60576943285459);
+    R_s=41.60595958554720);
 
   constant IdealGases.Common.DataRecord WOCL4(
     name="WOCL4",
@@ -17088,7 +17088,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-304902.8285,-353.942586,16.26432703,-0.0001058245461,
         2.340548846e-008,-2.685852021e-012,1.245412684e-016},
     bhigh={-72725.46739999999,-49.91761253},
-    R_s=24.33612740940034);
+    R_s=24.33623863388237);
 
   constant IdealGases.Common.DataRecord WO2(
     name="WO2",
@@ -17102,7 +17102,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-753740.6680000001,3204.64305,0.6701965600000001,0.00448823887,-8.858328459999999e-007,
         6.24517175e-011,-9.046613900000001e-016},
     bhigh={-17694.2023,34.0572401},
-    R_s=38.52167450893908);
+    R_s=38.52185056625593);
 
   constant IdealGases.Common.DataRecord WO2CL2(
     name="WO2CL2",
@@ -17116,7 +17116,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-240479.173,-306.8379644,13.22814502,-9.10022071e-005,
         2.00658102e-008,-2.296837607e-012,1.062829386e-016},
     bhigh={-83674.93059999999,-34.91556626},
-    R_s=28.99606897840868);
+    R_s=28.99620150042825);
 
   constant IdealGases.Common.DataRecord WO3(
     name="WO3",
@@ -17130,7 +17130,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1732203.64,-6284.719779999999,16.81358864,-0.00347208936,
         8.079935799999999e-007,-6.589378720000001e-011,1.142928957e-015},
     bhigh={-2473.075565,-74.0747409},
-    R_s=35.86325290655294);
+    R_s=35.86341681396767);
 
   constant IdealGases.Common.DataRecord WO3minus(
     name="WO3minus",
@@ -17144,7 +17144,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={463783.251,-1347.089334,9.773637559999999,0.001071395459,-3.84240366e-007,
         5.7375319e-011,-3.157605982e-015},
     bhigh={-72395.1557,-23.91116343},
-    R_s=35.86316804334235);
+    R_s=35.86333195036923);
 
   constant IdealGases.Common.DataRecord Xe(
     name="Xe",
@@ -17157,7 +17157,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4025.22668,-12.09507521,2.514153347,-8.248102080000001e-006,
         2.530232618e-009,-3.89233323e-013,2.360439138e-017},
     bhigh={-668.5800730000001,6.063710715},
-    R_s=63.3276107637117);
+    R_s=63.3279001926988);
 
   constant IdealGases.Common.DataRecord Xeplus(
     name="Xeplus",
@@ -17171,7 +17171,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-12416.83887,-150.0654643,2.964678293,-0.000469339666,
         1.959138719e-007,-3.037761925e-011,1.637361082e-015},
     bhigh={141496.6808,4.565685735},
-    R_s=63.32787537547646);
+    R_s=63.32816480567290);
 
   constant IdealGases.Common.DataRecord Zn(
     name="Zn",
@@ -17184,7 +17184,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-175559.1489,498.413924,1.969386292,0.0002608808787,-5.62719508e-008,
         2.723336049e-012,4.266685808e-016},
     bhigh={11737.73458,8.961085649999999},
-    R_s=127.1520415965744);
+    R_s=127.1526227251873);
 
   constant IdealGases.Common.DataRecord Znplus(
     name="Znplus",
@@ -17198,7 +17198,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-343617.946,956.7355239999999,1.511478952,0.000461346796,-8.786800980000001e-008,
         7.558567779999999e-013,1.168827311e-015},
     bhigh={118532.1933,13.0074267},
-    R_s=127.1531083681794);
+    R_s=127.1536895016679);
 
   constant IdealGases.Common.DataRecord Zr(
     name="Zr",
@@ -17212,7 +17212,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6006771.84,-15669.60605,17.9698235,-0.00676340965,1.733678968e-006,-2.064699786e-010,
         9.334092610000001e-015},
     bhigh={173463.6249,-105.1117377},
-    R_s=91.1434710163992);
+    R_s=91.1438875734456);
 
   constant IdealGases.Common.DataRecord Zrplus(
     name="Zrplus",
@@ -17226,7 +17226,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={729813.716,-2017.117556,5.0374983,-0.000550337195,1.023753499e-007,-1.261537793e-011,
         7.092401041999999e-016},
     bhigh={162088.4945,-9.820640859999999},
-    R_s=91.14401913541281);
+    R_s=91.14443569496429);
 
   constant IdealGases.Common.DataRecord Zrminus(
     name="Zrminus",
@@ -17240,7 +17240,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={84718.61159999999,317.543934,2.251491246,0.0001018645389,-2.285208242e-008,
         2.647293502e-012,-1.235813604e-016},
     bhigh={64223.376,10.81261057},
-    R_s=91.14292290397806);
+    R_s=91.14333945851938);
 
   constant IdealGases.Common.DataRecord ZrN(
     name="ZrN",
@@ -17254,7 +17254,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-72557.9089,-81.267966,4.5599244,1.29116165e-005,
         5.203830769999999e-009,-5.92743667e-013,2.731548854e-017},
     bhigh={84686.48390000001,1.493633264},
-    R_s=79.01184730311593);
+    R_s=79.01220841446461);
 
   constant IdealGases.Common.DataRecord ZrO(
     name="ZrO",
@@ -17268,7 +17268,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={464809.831,344.231447,4.81577918,-0.000466063314,2.140489079e-007,-2.054364483e-011,
         4.08466776e-016},
     bhigh={7317.3407,1.502933548},
-    R_s=77.54344667302101);
+    R_s=77.54380107327319);
 
   constant IdealGases.Common.DataRecord ZrOplus(
     name="ZrOplus",
@@ -17282,7 +17282,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-493716.656,669.990076,4.57535347,-0.00069232379,4.28060094e-007,-7.54766022e-011,
         4.41427986e-015},
     bhigh={80188.80660000001,2.928943704},
-    R_s=77.5438434199298);
+    R_s=77.5441978219953);
 
   constant IdealGases.Common.DataRecord ZrO2(
     name="ZrO2",
@@ -17296,7 +17296,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2854363.887,-8738.589889999999,16.21315114,-0.004417922830000001,
         8.959096920000001e-007,-4.054667109999999e-011,-2.147732083e-015},
     bhigh={15275.10023,-74.8199549},
-    R_s=67.47511012572349);
+    R_s=67.47541851021077);
 
   annotation (Documentation(info="<html>
 <p>This package contains ideal gas models for the 1241 ideal gases from</p>

--- a/Modelica/Media/IdealGases/Common/SingleGasesData.mo
+++ b/Modelica/Media/IdealGases/Common/SingleGasesData.mo
@@ -2,6 +2,9 @@ within Modelica.Media.IdealGases.Common;
 package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
   extends Modelica.Icons.Package;
 
+  final constant Real R_NASA_2002(final unit="J/(mol.K)")=8.314510
+    "Universal gas constant as used by McBride B.J., Zehe M.J., and Gordon S. (2002)";
+
   constant IdealGases.Common.DataRecord Ag(
     name="Ag",
     MM=0.1078682,
@@ -13,7 +16,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-330992.637,982.0086420000001,1.381179917,0.0006170899989999999,-1.6881146e-007,
         2.008826848e-011,-5.627285655e-016},
     bhigh={27267.19171,14.56862733},
-    R_s=77.08027018157344);
+    R_s=R_NASA_2002/Ag.MM);
 
   constant IdealGases.Common.DataRecord Agplus(
     name="Agplus",
@@ -27,7 +30,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-53274323.49999999,131071.0631,-109.8820208,0.0482600276,-1.093661557e-005,
         1.26383591e-009,-5.852542535e-014},
     bhigh={-743912.2509999999,844.6266189999999},
-    R_s=77.08066220119817);
+    R_s=R_NASA_2002/Agplus.MM);
 
   constant IdealGases.Common.DataRecord Agminus(
     name="Agminus",
@@ -39,7 +42,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={17665.65919,5.8696798},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={17665.65919,5.8696798},
-    R_s=77.07987816593619);
+    R_s=R_NASA_2002/Agminus.MM);
 
   constant IdealGases.Common.DataRecord Air(
     name="Air",
@@ -53,7 +56,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={241521.443,-1257.8746,5.14455867,-0.000213854179,7.06522784e-008,-1.07148349e-011,
         6.57780015e-016},
     bhigh={6462.26319,-8.147411905},
-    R_s=287.0525368759184);
+    R_s=R_NASA_2002/Air.MM);
 
   constant IdealGases.Common.DataRecord AL(
     name="AL",
@@ -67,7 +70,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-29208.20938,116.7751876,2.356906505,7.73723152e-005,-1.529455262e-008,
         -9.97167026e-013,5.053278264e-016},
     bhigh={38232.8865,6.600920155},
-    R_s=308.1555247147142);
+    R_s=R_NASA_2002/AL.MM);
 
   constant IdealGases.Common.DataRecord ALplus(
     name="ALplus",
@@ -80,7 +83,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4181.18325,-9.94855727,2.548615878,-5.878760040000001e-005,
         3.132291294e-008,-7.74889463e-012,7.27444769e-016},
     bhigh={109101.1485,3.48866729},
-    R_s=308.1617903900885);
+    R_s=R_NASA_2002/ALplus.MM);
 
   constant IdealGases.Common.DataRecord ALminus(
     name="ALminus",
@@ -94,7 +97,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={633981.432,-2383.438463,5.46997113,-0.001299840355,2.88830547e-007,-3.25324051e-011,
         1.472436088e-015},
     bhigh={47803.0654,-15.36906816},
-    R_s=308.1492592941274);
+    R_s=R_NASA_2002/ALminus.MM);
 
   constant IdealGases.Common.DataRecord ALBr(
     name="ALBr",
@@ -108,7 +111,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-610339.5599999999,2010.066834,1.769617961,0.001929888914,-6.64104783e-007,
         1.172854627e-010,-7.17874276e-015},
     bhigh={-12178.12867,22.04450764},
-    R_s=77.7889147173493);
+    R_s=R_NASA_2002/ALBr.MM);
 
   constant IdealGases.Common.DataRecord ALBr2(
     name="ALBr2",
@@ -122,7 +125,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-352378.29,467.154417,7.11190819,-0.00055517092,3.16630113e-007,-5.52102833e-011,
         3.17672595e-015},
     bhigh={-22650.04078,-2.69561036},
-    R_s=44.51271783754827);
+    R_s=R_NASA_2002/ALBr2.MM);
 
   constant IdealGases.Common.DataRecord ALBr3(
     name="ALBr3",
@@ -136,7 +139,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-89355.2744,-26.78035134,10.02063997,-8.458764399999999e-006,
         1.904243317e-009,-2.215195785e-013,1.038219389e-017},
     bhigh={-52492.4764,-15.79666403},
-    R_s=31.17627094511754);
+    R_s=R_NASA_2002/ALBr3.MM);
 
   constant IdealGases.Common.DataRecord ALC(
     name="ALC",
@@ -150,7 +153,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1937001.487,-6749.117789999999,13.47525643,-0.00585080265,
         1.926461091e-006,-2.585922351e-010,1.222659806e-014},
     bhigh={122536.3649,-61.52244872},
-    R_s=213.2350033357921);
+    R_s=R_NASA_2002/ALC.MM);
 
   constant IdealGases.Common.DataRecord ALC2(
     name="ALC2",
@@ -164,7 +167,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={146601.7895,-1362.764489,8.457759149999999,-0.000367890168,
         7.9031745e-008,-8.880023720000001e-012,4.05363395e-016},
     bhigh={87059.24230000001,-21.27956728},
-    R_s=163.020216600071);
+    R_s=R_NASA_2002/ALC2.MM);
 
   constant IdealGases.Common.DataRecord ALCL(
     name="ALCL",
@@ -178,7 +181,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-899346.1220000001,2765.942061,1.003500696,0.002267806833,-7.2805416e-007,
         1.182380673e-010,-6.66049813e-015},
     bhigh={-24961.64448,26.1692548},
-    R_s=133.1716429134144);
+    R_s=R_NASA_2002/ALCL.MM);
 
   constant IdealGases.Common.DataRecord ALCLplus(
     name="ALCLplus",
@@ -192,7 +195,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-754724.0819999999,1251.545253,4.44242491,-0.0009786116429999999,
         6.347511329999999e-007,-1.158320344e-010,6.870022460000001e-015},
     bhigh={93183.32699999999,4.047521108},
-    R_s=133.1728130767181);
+    R_s=R_NASA_2002/ALCLplus.MM);
 
   constant IdealGases.Common.DataRecord ALCL2(
     name="ALCL2",
@@ -206,7 +209,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={430345.306,-1552.370585,8.760657419999999,-0.0009467450059999999,
         2.40184488e-007,-2.427836709e-011,8.390123470000001e-016},
     bhigh={-21458.84709,-18.03641668},
-    R_s=84.93941281882071);
+    R_s=R_NASA_2002/ALCL2.MM);
 
   constant IdealGases.Common.DataRecord ALCL3(
     name="ALCL3",
@@ -220,7 +223,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-137863.0916,-55.7920729,10.04190387,-1.682165339e-005,
         3.72466466e-009,-4.27552678e-013,1.982341329e-017},
     bhigh={-73434.0747,-20.45130429},
-    R_s=62.35545562295541);
+    R_s=R_NASA_2002/ALCL3.MM);
 
   constant IdealGases.Common.DataRecord ALF(
     name="ALF",
@@ -234,7 +237,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-711122.905,1903.013316,2.191607179,0.001421471467,-4.17963477e-007,
         6.1538044e-011,-2.945403999e-015},
     bhigh={-45407.2896,16.13163743},
-    R_s=180.8290698727558);
+    R_s=R_NASA_2002/ALF.MM);
 
   constant IdealGases.Common.DataRecord ALFplus(
     name="ALFplus",
@@ -248,7 +251,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1505101.126,-2236.668821,3.098216724,0.00311541393,-1.168427068e-006,
         1.773587168e-010,-9.665841379999999e-015},
     bhigh={98850.8385,5.99189459},
-    R_s=180.8312274225215);
+    R_s=R_NASA_2002/ALFplus.MM);
 
   constant IdealGases.Common.DataRecord ALFCL(
     name="ALFCL",
@@ -262,7 +265,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={69706.36350000001,-622.4485910000001,7.57347541,-0.0002236155999,
         2.382317949e-008,4.44378576e-012,-5.486977849999999e-016},
     bhigh={-51009.43199999999,-10.91164505},
-    R_s=102.1025383275730);
+    R_s=R_NASA_2002/ALFCL.MM);
 
   constant IdealGases.Common.DataRecord ALFCL2(
     name="ALFCL2",
@@ -276,7 +279,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-172036.0526,-119.3340759,10.08894431,-3.55099381e-005,
         7.83095261e-009,-8.961734229999999e-013,4.14533026e-017},
     bhigh={-98041.8547,-21.27046859},
-    R_s=71.13353337997505);
+    R_s=R_NASA_2002/ALFCL2.MM);
 
   constant IdealGases.Common.DataRecord ALF2(
     name="ALF2",
@@ -290,7 +293,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-214689.6245,30.9684015,6.81639962,0.0001820129379,-7.79367744e-008,
         1.472534201e-011,-8.803695299999999e-016},
     bhigh={-78840.02680000001,-7.915370474},
-    R_s=127.9581693989729);
+    R_s=R_NASA_2002/ALF2.MM);
 
   constant IdealGases.Common.DataRecord ALF2minus(
     name="ALF2minus",
@@ -304,7 +307,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-159007.6965,-206.0486516,7.15528938,-6.260167690000001e-005,
         1.391935746e-008,-1.603901265e-012,7.461508519999999e-017},
     bhigh={-104047.9429,-11.22696648},
-    R_s=127.9570890812191);
+    R_s=R_NASA_2002/ALF2minus.MM);
 
   constant IdealGases.Common.DataRecord ALF2CL(
     name="ALF2CL",
@@ -318,7 +321,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-211542.2988,-195.9188681,10.1457685,-5.81321935e-005,
         1.281071982e-008,-1.465366277e-012,6.77600245e-017},
     bhigh={-122715.311,-23.59853398},
-    R_s=82.78799860414892);
+    R_s=R_NASA_2002/ALF2CL.MM);
 
   constant IdealGases.Common.DataRecord ALF3(
     name="ALF3",
@@ -332,7 +335,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-249397.216,-291.1202519,10.21662932,-8.64298597e-005,
         1.905713108e-008,-2.181058411e-012,1.009055287e-016},
     bhigh={-147569.4276,-27.03983244},
-    R_s=99.00966919561910);
+    R_s=R_NASA_2002/ALF3.MM);
 
   constant IdealGases.Common.DataRecord ALF4minus(
     name="ALF4minus",
@@ -346,7 +349,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-321741.161,-261.2097043,13.19792654,-8.01013541e-005,
         1.786204421e-008,-2.062751964e-012,9.61258177e-017},
     bhigh={-238157.7915,-42.31634321999999},
-    R_s=80.74244747494282);
+    R_s=R_NASA_2002/ALF4minus.MM);
 
   constant IdealGases.Common.DataRecord ALH(
     name="ALH",
@@ -360,7 +363,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6802018.430000001,-21784.16933,30.32713047,-0.01503343597,
         4.49214236e-006,-6.17845037e-010,3.11520526e-014},
     bhigh={165830.1221,-187.6766425},
-    R_s=297.0584160233356);
+    R_s=R_NASA_2002/ALH.MM);
 
   constant IdealGases.Common.DataRecord ALHCL(
     name="ALHCL",
@@ -374,7 +377,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-168391.533,-886.230179,8.062379399999999,-0.0009200551470000001,
         3.94981722e-007,-6.40108676e-011,3.5783541e-015},
     bhigh={3641.50485,-18.00686894},
-    R_s=131.0558834098504);
+    R_s=R_NASA_2002/ALHCL.MM);
 
   constant IdealGases.Common.DataRecord ALHCL2(
     name="ALHCL2",
@@ -388,7 +391,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={96080.63939999999,-1485.540161,11.03592709,-0.00039569552,
         8.46584373e-008,-9.48333652e-012,4.31903353e-016},
     bhigh={-36692.1639,-32.36862171},
-    R_s=84.07371265246324);
+    R_s=R_NASA_2002/ALHCL2.MM);
 
   constant IdealGases.Common.DataRecord ALHF(
     name="ALHF",
@@ -402,7 +405,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={734216.9250000001,-3462.16413,10.39714588,-0.001750737965,
         4.615687860000001e-007,-5.39041474e-011,2.340478515e-015},
     bhigh={-2965.279722,-37.13172313},
-    R_s=176.9500941021363);
+    R_s=R_NASA_2002/ALHF.MM);
 
   constant IdealGases.Common.DataRecord ALHFCL(
     name="ALHFCL",
@@ -416,7 +419,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={40689.8713,-1502.129854,11.05214126,-0.000403158773,8.64525222e-008,
         -9.70065952e-012,4.423629509999999e-016},
     bhigh={-61298.8811,-34.03564016},
-    R_s=100.8542106655696);
+    R_s=R_NASA_2002/ALHFCL.MM);
 
   constant IdealGases.Common.DataRecord ALHF2(
     name="ALHF2",
@@ -430,7 +433,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4419.9473,-1612.826324,11.13336052,-0.000435181266,9.34439616e-008,
         -1.049431425e-011,4.78833398e-016},
     bhigh={-86069.16189999999,-36.76383785},
-    R_s=126.0036093197574);
+    R_s=R_NASA_2002/ALHF2.MM);
 
   constant IdealGases.Common.DataRecord ALH2(
     name="ALH2",
@@ -444,7 +447,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={143291.0601,-2365.907684,9.085667190000001,-0.001308536612,
         4.77719136e-007,-7.32472189e-011,3.99790094e-015},
     bhigh={44859.5185,-32.20814285},
-    R_s=286.7327704832203);
+    R_s=R_NASA_2002/ALH2.MM);
 
   constant IdealGases.Common.DataRecord ALH2CL(
     name="ALH2CL",
@@ -458,7 +461,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={316692.993,-3094.037914,12.1587202,-0.0008248269589999999,
         1.765027123e-007,-1.977372723e-011,9.00617628e-016},
     bhigh={2411.845642,-47.18390855},
-    R_s=129.0063006263202);
+    R_s=R_NASA_2002/ALH2CL.MM);
 
   constant IdealGases.Common.DataRecord ALH2F(
     name="ALH2F",
@@ -472,7 +475,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={271151.4962,-3169.62348,12.21401118,-0.000846560026,1.812341995e-007,
         -2.030947985e-011,9.251825820000001e-016},
     bhigh={-22592.17746,-49.41337333},
-    R_s=173.2340398001149);
+    R_s=R_NASA_2002/ALH2F.MM);
 
   constant IdealGases.Common.DataRecord ALH3(
     name="ALH3",
@@ -486,7 +489,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={588545.855,-4595.78566,13.20893344,-0.001226849004,2.626580824e-007,
         -2.943725869e-011,1.341177648e-015},
     bhigh={39917.1695,-61.81829295},
-    R_s=277.1008431227516);
+    R_s=R_NASA_2002/ALH3.MM);
 
   constant IdealGases.Common.DataRecord ALI(
     name="ALI",
@@ -500,7 +503,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={475281.792,-1198.028588,5.43368536,-0.0001004479306,-1.005928846e-007,
         4.568173190000001e-011,-3.960201360000001e-015},
     bhigh={14646.27816,-3.141199746},
-    R_s=54.03031833797392);
+    R_s=R_NASA_2002/ALI.MM);
 
   constant IdealGases.Common.DataRecord ALI2(
     name="ALI2",
@@ -514,7 +517,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-335599.902,474.334794,7.10650139,-0.0005529965340000001,
         3.161480314e-007,-5.51548916e-011,3.17415582e-015},
     bhigh={-9785.48885,-0.5602275943999999},
-    R_s=29.61108246697739);
+    R_s=R_NASA_2002/ALI2.MM);
 
   constant IdealGases.Common.DataRecord ALI3(
     name="ALI3",
@@ -528,7 +531,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-63574.2747,-15.7877228,10.01249733,-5.22867312e-006,1.19617352e-009,
         -1.40919449e-013,6.67127639e-018},
     bhigh={-26114.55525,-12.47999813},
-    R_s=20.39394905624389);
+    R_s=R_NASA_2002/ALI3.MM);
 
   constant IdealGases.Common.DataRecord ALN(
     name="ALN",
@@ -542,7 +545,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3821214.22,-10677.76595,14.49174222,-0.00372722713,
         7.922770960000001e-007,-8.086892210000001e-011,2.893539736e-015},
     bhigh={120523.634,-72.88585119000001},
-    R_s=202.8511203628709);
+    R_s=R_NASA_2002/ALN.MM);
 
   constant IdealGases.Common.DataRecord ALO(
     name="ALO",
@@ -556,7 +559,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={15657.21161,3855.74101,-5.92607978,0.009050960419999999,-2.930661549e-006,
         4.238529070000001e-010,-2.280655341e-014},
     bhigh={-13316.94655,68.30663436},
-    R_s=193.4464529368810);
+    R_s=R_NASA_2002/ALO.MM);
 
   constant IdealGases.Common.DataRecord ALOplus(
     name="ALOplus",
@@ -570,7 +573,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={27108.46446,-699.8653420000001,5.78781584,-0.000687189546,
         2.075047303e-007,-2.655281004e-011,1.28312966e-015},
     bhigh={121868.2226,-7.05103588},
-    R_s=193.4489220797986);
+    R_s=R_NASA_2002/ALOplus.MM);
 
   constant IdealGases.Common.DataRecord ALOminus(
     name="ALOminus",
@@ -584,7 +587,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-69719.4829,-232.0553036,4.67278433,-4.26644704e-005,
         1.632506336e-008,-1.727134051e-012,8.136840640000001e-017},
     bhigh={-33077.1893,-2.155922595},
-    R_s=193.4439838569940);
+    R_s=R_NASA_2002/ALOminus.MM);
 
   constant IdealGases.Common.DataRecord ALOCL(
     name="ALOCL",
@@ -598,7 +601,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-125802.7706,-242.0565961,7.68113002,-7.268741699999999e-005,
         1.611337534e-008,1.852889749e-012,8.60727822e-017},
     bhigh={-37543.2605,-14.7581832},
-    R_s=106.0065350792408);
+    R_s=R_NASA_2002/ALOCL.MM);
 
   constant IdealGases.Common.DataRecord ALOCL2(
     name="ALOCL2",
@@ -612,7 +615,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-170771.3922,-118.0013804,10.08798517,-3.51385804e-005,
         7.751187029999999e-009,-8.8724706e-013,4.10481544e-017},
     bhigh={-51249.4414,-20.5925296},
-    R_s=73.00670424557380);
+    R_s=R_NASA_2002/ALOCL2.MM);
 
   constant IdealGases.Common.DataRecord ALOF(
     name="ALOF",
@@ -626,7 +629,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-164102.0297,-327.777029,7.74451974,-9.78864944e-005,
         2.165743208e-008,-2.486541919e-012,1.153633944e-016},
     bhigh={-69740.85090000001,-17.17253748},
-    R_s=134.1496995453705);
+    R_s=R_NASA_2002/ALOF.MM);
 
   constant IdealGases.Common.DataRecord ALOF2(
     name="ALOF2",
@@ -640,7 +643,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-249668.1413,-283.7821503,10.21108125,-8.418303430000001e-005,
         1.855520828e-008,-2.122974022e-012,9.8193191e-017},
     bhigh={-95218.0419,-25.22534812},
-    R_s=102.6764830461244);
+    R_s=R_NASA_2002/ALOF2.MM);
 
   constant IdealGases.Common.DataRecord ALOF2minus(
     name="ALOF2minus",
@@ -654,7 +657,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-238988.1459,-288.0143725,10.2170024,-8.747061999999999e-005,
         1.944846334e-008,-2.241045051e-012,1.042591053e-016},
     bhigh={-119057.6566,-26.00779629},
-    R_s=102.6757874483721);
+    R_s=R_NASA_2002/ALOF2minus.MM);
 
   constant IdealGases.Common.DataRecord ALOH(
     name="ALOH",
@@ -668,7 +671,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={788206.811,-2263.671626,7.82395488,0.0001821171456,-8.26372932e-008,
         1.265414876e-011,-6.87597253e-016},
     bhigh={-10398.08093,-22.09032458},
-    R_s=189.0139139261520);
+    R_s=R_NASA_2002/ALOH.MM);
 
   constant IdealGases.Common.DataRecord ALOHCL(
     name="ALOHCL",
@@ -682,7 +685,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={796711.551,-2843.470502,10.9555997,-0.0001099328162,-1.344506283e-008,
         4.41589377e-012,-2.973546112e-016},
     bhigh={-29698.61461,-32.96113996},
-    R_s=104.661548912527);
+    R_s=R_NASA_2002/ALOHCL.MM);
 
   constant IdealGases.Common.DataRecord ALOHCL2(
     name="ALOHCL2",
@@ -696,7 +699,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={738592.976,-2863.204228,13.97062327,-0.0001160311527,-1.208248796e-008,
         4.25832763e-012,-2.900049181e-016},
     bhigh={-72930.48,-46.81834857},
-    R_s=72.36623724862652);
+    R_s=R_NASA_2002/ALOHCL2.MM);
 
   constant IdealGases.Common.DataRecord ALOHF(
     name="ALOHF",
@@ -710,7 +713,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={755711.3130000001,-2936.702803,11.02455104,-0.000137307803,-7.432816159999999e-009,
         3.72998122e-012,-2.657027781e-016},
     bhigh={-53401.309,-35.27397302},
-    R_s=132.0029987260349);
+    R_s=R_NASA_2002/ALOHF.MM);
 
   constant IdealGases.Common.DataRecord ALOHF2(
     name="ALOHF2",
@@ -724,7 +727,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={653011.992,-3034.017232,14.09719788,-0.0001663681799,-1.011564183e-009,
         2.993805003e-012,-2.315956955e-016},
     bhigh={-122305.2213,-51.5121069},
-    R_s=101.4141683496150);
+    R_s=R_NASA_2002/ALOHF2.MM);
 
   constant IdealGases.Common.DataRecord ALO2(
     name="ALO2",
@@ -738,7 +741,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={118721.6642,-833.56254,8.309301189999999,-0.000353866722,
         5.96706946e-008,4.0148977e-014,-3.51570252e-016},
     bhigh={-2033.107586,-17.15063884},
-    R_s=140.9708774473283);
+    R_s=R_NASA_2002/ALO2.MM);
 
   constant IdealGases.Common.DataRecord ALO2minus(
     name="ALO2minus",
@@ -752,7 +755,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-187241.0758,-233.8853263,7.67607002,-7.093570299999999e-005,
         1.576717569e-008,-1.816494162e-012,8.449707959999999e-017},
     bhigh={-55946.40560000001,-17.73751567},
-    R_s=140.9695662323259);
+    R_s=R_NASA_2002/ALO2minus.MM);
 
   constant IdealGases.Common.DataRecord AL_OH_2(
     name="AL_OH_2",
@@ -766,7 +769,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1669643.735,-5924.73828,15.49480264,-0.000538348808,
         5.413044529999999e-008,-1.196022328e-012,-1.082001733e-016},
     bhigh={-26975.25061,-66.17911543},
-    R_s=136.3118939603764);
+    R_s=R_NASA_2002/AL_OH_2.MM);
 
   constant IdealGases.Common.DataRecord AL_OH_2CL(
     name="AL_OH_2CL",
@@ -780,7 +783,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1603911.487,-5767.23224,18.17772266,-0.000369181615,1.137918702e-008,
         4.0830794e-012,-3.64132343e-016},
     bhigh={-71186.9985,-77.57541774000001},
-    R_s=86.20609033864847);
+    R_s=R_NASA_2002/AL_OH_2CL.MM);
 
   constant IdealGases.Common.DataRecord AL_OH_2F(
     name="AL_OH_2F",
@@ -794,7 +797,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1559238.236,-5841.27303,18.23229919,-0.000390780542,1.610928938e-008,
         3.54478406e-012,-3.39345388e-016},
     bhigh={-96231.0089,-79.71351802},
-    R_s=103.9383632958562);
+    R_s=R_NASA_2002/AL_OH_2F.MM);
 
   constant IdealGases.Common.DataRecord AL_OH_3(
     name="AL_OH_3",
@@ -808,7 +811,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2477063.616,-8968.617249999999,22.80320998,-0.0008320292249999999,
         8.66349443e-008,-2.420287082e-012,-1.331746442e-016},
     bhigh={-70152.7864,-112.1899198},
-    R_s=106.5914198426692);
+    R_s=R_NASA_2002/AL_OH_3.MM);
 
   constant IdealGases.Common.DataRecord ALS(
     name="ALS",
@@ -822,7 +825,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={8909844.290000001,-25076.77454,28.93456134,-0.00983976682,
         2.045319809e-006,-2.08797089e-010,8.152792520000001e-015},
     bhigh={188576.1615,-178.6036457},
-    R_s=140.8128280103399);
+    R_s=R_NASA_2002/ALS.MM);
 
   constant IdealGases.Common.DataRecord ALS2(
     name="ALS2",
@@ -836,7 +839,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-68525.6354,-26.71667739,7.52019386,-8.148565100000001e-006,
         1.811865152e-009,-2.086958125e-013,9.703246379999999e-018},
     bhigh={27583.62737,-7.873490263},
-    R_s=91.25638950359944);
+    R_s=R_NASA_2002/ALS2.MM);
 
   constant IdealGases.Common.DataRecord AL2(
     name="AL2",
@@ -850,7 +853,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2320724.102,9218.70789,-9.44695187,0.00999992001,-3.154798085e-006,
         4.36154481e-010,-2.24115724e-014},
     bhigh={2904.589544,99.60320745000001},
-    R_s=154.0777623573571);
+    R_s=R_NASA_2002/AL2.MM);
 
   constant IdealGases.Common.DataRecord AL2Br6(
     name="AL2Br6",
@@ -864,7 +867,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-173182.949,-43.42299780000001,22.0341421,-1.421187503e-005,
         3.23863134e-009,-3.80387976e-013,1.796525455e-017},
     bhigh={-120233.8355,-62.0105495},
-    R_s=15.58813547255877);
+    R_s=R_NASA_2002/AL2Br6.MM);
 
   constant IdealGases.Common.DataRecord AL2C2(
     name="AL2C2",
@@ -878,7 +881,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={159765.1967,-1644.007203,11.64643675,-0.000437921543,9.36964011e-008,
         -1.049615854e-011,4.78046893e-016},
     bhigh={72048.89810000001,-36.48164252},
-    R_s=106.6175016678961);
+    R_s=R_NASA_2002/AL2C2.MM);
 
   constant IdealGases.Common.DataRecord AL2CL6(
     name="AL2CL6",
@@ -892,7 +895,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-275297.5554,-92.48235969999999,22.07058224,-2.870537915e-005,
         6.42332569e-009,-7.4365852e-013,3.47206467e-017},
     bhigh={-162915.7014,-70.91602129},
-    R_s=31.17772781147771);
+    R_s=R_NASA_2002/AL2CL6.MM);
 
   constant IdealGases.Common.DataRecord AL2F6(
     name="AL2F6",
@@ -906,7 +909,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-585298.2609999999,-545.0571990000001,22.4068632,-0.0001627323704,
         3.59522504e-008,-4.12120144e-012,1.909095384e-016},
     bhigh={-321968.391,-85.89867941},
-    R_s=49.50483459780955);
+    R_s=R_NASA_2002/AL2F6.MM);
 
   constant IdealGases.Common.DataRecord AL2I6(
     name="AL2I6",
@@ -920,7 +923,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-121011.2399,-24.67542774,22.0199265,-8.46202259e-006,
         1.957831901e-009,-2.326573151e-013,1.108910373e-017},
     bhigh={-65485.2375,-55.28536481},
-    R_s=10.19697452812194);
+    R_s=R_NASA_2002/AL2I6.MM);
 
   constant IdealGases.Common.DataRecord AL2O(
     name="AL2O",
@@ -934,7 +937,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-117107.4351,-178.3009166,7.63321536,-5.33593177e-005,
         1.180702791e-008,-1.355444579e-012,6.28732389e-017},
     bhigh={-19475.80149,-14.15764167},
-    R_s=118.8424206141590);
+    R_s=R_NASA_2002/AL2O.MM);
 
   constant IdealGases.Common.DataRecord AL2Oplus(
     name="AL2Oplus",
@@ -948,7 +951,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-110222.5105,-121.4571732,7.59159595,-3.69453916e-005,
         8.21852032e-009,-9.473649719999999e-013,4.40862135e-017},
     bhigh={76149.43580000001,-12.82233856},
-    R_s=118.843352506037);
+    R_s=R_NASA_2002/AL2Oplus.MM);
 
   constant IdealGases.Common.DataRecord AL2O2(
     name="AL2O2",
@@ -962,7 +965,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-194061.1656,-460.975243,10.84375637,-0.0001376042893,
         3.044733119e-008,-3.49619392e-012,1.622305079e-016},
     bhigh={-49630.5578,-29.4653809},
-    R_s=96.72322646844050);
+    R_s=R_NASA_2002/AL2O2.MM);
 
   constant IdealGases.Common.DataRecord AL2O2plus(
     name="AL2O2plus",
@@ -976,7 +979,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-165200.5184,-60.2160697,10.04626917,-1.892194088e-005,
         4.2533012e-009,-4.942390419999999e-013,2.314507373e-017},
     bhigh={63862.19,-23.45753361},
-    R_s=96.72384375023042);
+    R_s=R_NASA_2002/AL2O2plus.MM);
 
   constant IdealGases.Common.DataRecord AL2O3(
     name="AL2O3",
@@ -990,7 +993,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-277778.4969,-491.746593,13.86703888,-0.000146938194,3.25040649e-008,
         -3.73086735e-012,1.730444284e-016},
     bhigh={-67907.5785,-43.75559873},
-    R_s=81.54576253047284);
+    R_s=R_NASA_2002/AL2O3.MM);
 
   constant IdealGases.Common.DataRecord AL2S(
     name="AL2S",
@@ -1004,7 +1007,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-70434.3737,-26.76376869,7.52023382,-8.16612306e-006,1.81602604e-009,
         -2.091989298e-013,9.727537699999999e-018},
     bhigh={24227.18377,-10.66580982},
-    R_s=96.64879637666198);
+    R_s=R_NASA_2002/AL2S.MM);
 
   constant IdealGases.Common.DataRecord AL2S2(
     name="AL2S2",
@@ -1018,7 +1021,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-137780.6456,-77.050325,10.55723566,-2.277554487e-005,
         5.00768285e-009,-5.715862119999999e-013,2.63799924e-017},
     bhigh={13133.36091,-22.56851594},
-    R_s=70.40641400516995);
+    R_s=R_NASA_2002/AL2S2.MM);
 
   constant IdealGases.Common.DataRecord Ar(
     name="Ar",
@@ -1031,7 +1034,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={20.10538475,-0.05992661069999999,2.500069401,-3.99214116e-008,
         1.20527214e-011,-1.819015576e-015,1.078576636e-019},
     bhigh={-744.993961,4.37918011},
-    R_s=208.1333233203164);
+    R_s=R_NASA_2002/Ar.MM);
 
   constant IdealGases.Common.DataRecord Arplus(
     name="Arplus",
@@ -1045,7 +1048,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-383596.54,816.20197,2.301342628,-4.95298377e-006,1.205108477e-008,-2.185050286e-012,
         1.265493898e-016},
     bhigh={177181.1455,7.94750748},
-    R_s=208.136181623842);
+    R_s=R_NASA_2002/Arplus.MM);
 
   constant IdealGases.Common.DataRecord B(
     name="B",
@@ -1059,7 +1062,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-107265.961,322.530716,2.126407232,0.0002106579339,-5.93712916e-008,
         7.37742799e-012,-2.282443381e-016},
     bhigh={66434.13099999999,6.87706967},
-    R_s=769.0787161224679);
+    R_s=R_NASA_2002/B.MM);
 
   constant IdealGases.Common.DataRecord Bplus(
     name="Bplus",
@@ -1073,7 +1076,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-8911.54803,4.58779009,2.531500086,-4.9039491e-005,2.853326582e-008,
         -7.38217591e-012,7.12072156e-016},
     bhigh={165452.6303,2.23866978},
-    R_s=769.1177447039815);
+    R_s=R_NASA_2002/Bplus.MM);
 
   constant IdealGases.Common.DataRecord Bminus(
     name="Bminus",
@@ -1087,7 +1090,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={21.18018248,0.0002070697496,2.499999729,1.456693631e-010,-3.88857176e-014,
         5.09059863e-018,-2.601566168e-022},
     bhigh={64517.8914,4.61645583},
-    R_s=769.0396915017336);
+    R_s=R_NASA_2002/Bminus.MM);
 
   constant IdealGases.Common.DataRecord BBr(
     name="BBr",
@@ -1101,7 +1104,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={253685.8027,-640.59095,4.66682347,0.000417548639,-2.963714868e-007,
         7.51911954e-011,-4.83536832e-015},
     bhigh={31890.8434,-0.8255870910000001},
-    R_s=91.65529405280273);
+    R_s=R_NASA_2002/BBr.MM);
 
   constant IdealGases.Common.DataRecord BBr2(
     name="BBr2",
@@ -1115,7 +1118,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-419163.337,415.768847,7.14816983,-0.000568959075,3.19544177e-007,-5.55317699e-011,
         3.19113676e-015},
     bhigh={6118.98205,-5.50275962},
-    R_s=48.73144257087429);
+    R_s=R_NASA_2002/BBr2.MM);
 
   constant IdealGases.Common.DataRecord BBr3(
     name="BBr3",
@@ -1129,7 +1132,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-190104.6795,-150.3627687,10.10999896,-4.32309511e-005,
         9.409696190000001e-009,-1.06521847e-012,4.883048770000001e-017},
     bhigh={-27425.53062,-19.97496003},
-    R_s=33.18860942907438);
+    R_s=R_NASA_2002/BBr3.MM);
 
   constant IdealGases.Common.DataRecord BC(
     name="BC",
@@ -1143,7 +1146,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2346280.674,6450.7513,-2.619532384,0.0033391605,-4.50802214e-007,
         1.351919576e-011,8.265104270000001e-016},
     bhigh={57866.8507,50.37884876},
-    R_s=364.324743555476);
+    R_s=R_NASA_2002/BC.MM);
 
   constant IdealGases.Common.DataRecord BC2(
     name="BC2",
@@ -1157,7 +1160,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1525485.889,-5987.862380000001,14.08384855,-0.0037474998,
         1.081927223e-006,-1.378744645e-010,6.473822e-015},
     bhigh={131120.4013,-63.37215498},
-    R_s=238.7004627875197);
+    R_s=R_NASA_2002/BC2.MM);
 
   constant IdealGases.Common.DataRecord BCL(
     name="BCL",
@@ -1171,7 +1174,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-74212.6254,263.8090127,3.60022765,0.001018866266,-4.666184119999999e-007,
         9.849002029999999e-011,-6.46881817e-015},
     bhigh={19127.2648,5.235317877},
-    R_s=179.7187878263877);
+    R_s=R_NASA_2002/BCL.MM);
 
   constant IdealGases.Common.DataRecord BCLplus(
     name="BCLplus",
@@ -1185,7 +1188,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-216942.3542,358.997516,4.03520837,0.000327445243,-8.63457845e-008,
         1.207061044e-011,-5.262253270000001e-016},
     bhigh={144547.7224,3.488222017},
-    R_s=179.7209189628252);
+    R_s=R_NASA_2002/BCLplus.MM);
 
   constant IdealGases.Common.DataRecord BCLOH(
     name="BCLOH",
@@ -1199,7 +1202,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={702773.844,-2857.391274,10.9117584,-8.10770934e-005,-2.124440337e-008,
         5.40991244e-012,-3.46415384e-016},
     bhigh={-13072.21888,-35.85168799},
-    R_s=131.4103668422385);
+    R_s=R_NASA_2002/BCLOH.MM);
 
   constant IdealGases.Common.DataRecord BCL_OH_2(
     name="BCL_OH_2",
@@ -1213,7 +1216,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1423878.191,-5849.70407,17.92165219,-0.0002009909087,-3.39343578e-008,
         9.838560759999999e-012,-6.47267882e-016},
     bhigh={-64742.6176,-81.00399519},
-    R_s=103.5705868606709);
+    R_s=R_NASA_2002/BCL_OH_2.MM);
 
   constant IdealGases.Common.DataRecord BCL2(
     name="BCL2",
@@ -1227,7 +1230,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={350140.313,-1662.20359,8.83953472,-0.000977254411,2.467356248e-007,-2.501151018e-011,
         8.722954559999999e-016},
     bhigh={568.2909440000001,-21.48348344},
-    R_s=101.7476167749673);
+    R_s=R_NASA_2002/BCL2.MM);
 
   constant IdealGases.Common.DataRecord BCL2plus(
     name="BCL2plus",
@@ -1241,7 +1244,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={302929.3331,-1305.533159,8.920390060000001,-0.000728991964,
         1.727833266e-007,-1.523567337e-011,4.22691144e-016},
     bhigh={86534.15770000001,-22.67466616},
-    R_s=101.748299853363);
+    R_s=R_NASA_2002/BCL2plus.MM);
 
   constant IdealGases.Common.DataRecord BCL2OH(
     name="BCL2OH",
@@ -1255,7 +1258,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={587811.379,-2982.969317,14.00662004,-0.0001194189832,-1.269775742e-008,
         4.42289219e-012,-3.004089365e-016},
     bhigh={-58241.6807,-51.50858228},
-    R_s=84.2194538854349);
+    R_s=R_NASA_2002/BCL2OH.MM);
 
   constant IdealGases.Common.DataRecord BF(
     name="BF",
@@ -1269,7 +1272,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-374638.978,560.449391,3.60918611,0.000618721693,-1.77893877e-007,
         2.426601527e-011,-9.394651579999999e-016},
     bhigh={-18191.79292,3.71660929},
-    R_s=278.9223905026049);
+    R_s=R_NASA_2002/BF.MM);
 
   constant IdealGases.Common.DataRecord BFCL(
     name="BFCL",
@@ -1283,7 +1286,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-108630.9561,-523.343848,7.29750474,-3.054410701e-005,-3.154598306e-008,
         1.052290533e-011,-7.615432260000001e-016},
     bhigh={-33058.9121,-11.86586595},
-    R_s=127.4012232513068);
+    R_s=R_NASA_2002/BFCL.MM);
 
   constant IdealGases.Common.DataRecord BFCL2(
     name="BFCL2",
@@ -1297,7 +1300,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-223361.3309,-644.060296,10.47861848,-0.0001911892367,
         4.22488779e-008,-4.84726692e-012,2.247974725e-016},
     bhigh={-77406.2648,-28.14630564},
-    R_s=82.5545024477448);
+    R_s=R_NASA_2002/BFCL2.MM);
 
   constant IdealGases.Common.DataRecord BFOH(
     name="BFOH",
@@ -1311,7 +1314,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={725131.809,-3215.62085,11.17909777,-0.0001883881929,2.57970808e-009,
         2.6651581e-012,-2.186647438e-016},
     bhigh={-37168.0808,-39.7846349},
-    R_s=177.5969328853272);
+    R_s=R_NASA_2002/BFOH.MM);
 
   constant IdealGases.Common.DataRecord BF_OH_2(
     name="BF_OH_2",
@@ -1325,7 +1328,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1422037.64,-6257.297570000001,18.22460686,-0.000322139645,-7.1267399e-009,
         6.75869977e-012,-5.04255454e-016},
     bhigh={-91862.5419,-85.27895049999999},
-    R_s=130.2722982161066);
+    R_s=R_NASA_2002/BF_OH_2.MM);
 
   constant IdealGases.Common.DataRecord BF2(
     name="BF2",
@@ -1339,7 +1342,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-115309.1296,-810.9800119999999,7.60270923,-0.0002409209242,
         5.32847186e-008,-6.11879794e-012,2.839984178e-016},
     bhigh={-57962.2217,-16.55644047},
-    R_s=170.3520525355961);
+    R_s=R_NASA_2002/BF2.MM);
 
   constant IdealGases.Common.DataRecord BF2plus(
     name="BF2plus",
@@ -1353,7 +1356,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-176940.9966,-534.368518,7.72805291,-1.958622052e-006,-2.419680893e-008,
         5.73253381e-012,-3.21635423e-016},
     bhigh={39087.4505,-19.36560315},
-    R_s=170.3539673150824);
+    R_s=R_NASA_2002/BF2plus.MM);
 
   constant IdealGases.Common.DataRecord BF2minus(
     name="BF2minus",
@@ -1367,7 +1370,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-170992.0627,-615.621979,7.45887137,-0.0001836703248,
         4.064363959999999e-008,-4.66770095e-012,2.16626484e-016},
     bhigh={-87414.0453,-16.20604664},
-    R_s=170.3501377991535);
+    R_s=R_NASA_2002/BF2minus.MM);
 
   constant IdealGases.Common.DataRecord BF2CL(
     name="BF2CL",
@@ -1381,7 +1384,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-206681.7398,-1024.447292,10.75843981,-0.0003023235319,
         6.67252147e-008,-7.6499419e-012,3.5462245e-016},
     bhigh={-104693.6725,-32.29995036},
-    R_s=98.67588924475329);
+    R_s=R_NASA_2002/BF2CL.MM);
 
   constant IdealGases.Common.DataRecord BF2OH(
     name="BF2OH",
@@ -1395,7 +1398,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={576075.9250000001,-3611.90019,14.4689764,-0.0003028293733,
         2.764337508e-008,-1.90549317e-013,-8.69497194e-017},
     bhigh={-113358.9041,-58.9698151},
-    R_s=126.3312543508982);
+    R_s=R_NASA_2002/BF2OH.MM);
 
   constant IdealGases.Common.DataRecord BF3(
     name="BF3",
@@ -1409,7 +1412,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-181976.7014,-1405.347931,11.03412258,-0.000410459105,
         9.031277570000001e-008,-1.03305736e-011,4.780551830000001e-016},
     bhigh={-132313.6863,-37.3838608},
-    R_s=122.6216603029231);
+    R_s=R_NASA_2002/BF3.MM);
 
   constant IdealGases.Common.DataRecord BF4minus(
     name="BF4minus",
@@ -1423,7 +1426,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-437324.171,-775.928941,13.58222575,-0.0002341024178,5.19691594e-008,
         -5.982245780000001e-012,2.781163206e-016},
     bhigh={-212725.1877,-49.533697},
-    R_s=95.783590121866);
+    R_s=R_NASA_2002/BF4minus.MM);
 
   constant IdealGases.Common.DataRecord BH(
     name="BH",
@@ -1437,7 +1440,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1098531.663,-174.5890126,8.442426810000001,-0.00544019667,
         2.718307052e-006,-4.83981221e-010,2.868523222e-014},
     bhigh={50167.3567,-29.71030686},
-    R_s=703.4903299280646);
+    R_s=R_NASA_2002/BH.MM);
 
   constant IdealGases.Common.DataRecord BHCL(
     name="BHCL",
@@ -1451,7 +1454,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={349999.172,-2238.404757,8.71110605,-0.001088882906,4.18930109e-007,-6.56871126e-011,
         3.6200676e-015},
     bhigh={28412.40364,-25.89566225},
-    R_s=175.8867945762328);
+    R_s=R_NASA_2002/BHCL.MM);
 
   constant IdealGases.Common.DataRecord BHCL2(
     name="BHCL2",
@@ -1465,7 +1468,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={411099.606,-2858.027441,11.79547506,-0.000632281797,1.269551549e-007,
         -1.352862344e-011,5.92165351e-016},
     bhigh={-16172.8876,-42.17900972},
-    R_s=100.5079000359505);
+    R_s=R_NASA_2002/BHCL2.MM);
 
   constant IdealGases.Common.DataRecord BHF(
     name="BHF",
@@ -1479,7 +1482,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1184821.3,-4677.43518,10.67328148,-0.001606366598,3.7045347e-007,-3.79788275e-011,
         1.432441145e-015},
     bhigh={18026.40937,-42.85931169999999},
-    R_s=269.799701617367);
+    R_s=R_NASA_2002/BHF.MM);
 
   constant IdealGases.Common.DataRecord BHFCL(
     name="BHFCL",
@@ -1493,7 +1496,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={439077.892,-3137.181709,12.00286161,-0.000715366934,1.453878608e-007,
         -1.56519707e-011,6.910075059999999e-016},
     bhigh={-42323.6834,-44.66542881},
-    R_s=125.4635120103015);
+    R_s=R_NASA_2002/BHFCL.MM);
 
   constant IdealGases.Common.DataRecord BHF2(
     name="BHF2",
@@ -1507,7 +1510,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={466087.6960000001,-3728.10049,12.44152658,-0.000890684319,
         1.841732568e-007,-2.010774349e-011,8.979196590000001e-016},
     bhigh={-69781.4293,-51.0321804},
-    R_s=166.905257892512);
+    R_s=R_NASA_2002/BHF2.MM);
 
   constant IdealGases.Common.DataRecord BH2(
     name="BH2",
@@ -1521,7 +1524,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1360117.365,-4917.70449,9.75897103,-0.000741587064,1.269760019e-007,
         -1.187742442e-011,4.68255251e-016},
     bhigh={68902.92660000001,-41.9049012},
-    R_s=648.2098530585770);
+    R_s=R_NASA_2002/BH2.MM);
 
   constant IdealGases.Common.DataRecord BH2CL(
     name="BH2CL",
@@ -1535,7 +1538,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1427215.437,-6265.56434,13.82183005,-0.001313843556,2.587131606e-007,
         -2.71384527e-011,1.172827257e-015},
     bhigh={26393.87516,-63.99725308},
-    R_s=172.2148025222930);
+    R_s=R_NASA_2002/BH2CL.MM);
 
   constant IdealGases.Common.DataRecord BH2F(
     name="BH2F",
@@ -1549,7 +1552,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1435082.111,-6625.32017,14.09165008,-0.00142246906,2.828724718e-007,
         -2.992498948e-011,1.302618926e-015},
     bhigh={-793.719267,-68.013564},
-    R_s=261.2548629260902);
+    R_s=R_NASA_2002/BH2F.MM);
 
   constant IdealGases.Common.DataRecord BH3(
     name="BH3",
@@ -1563,7 +1566,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1855778.95,-8002.492370000001,15.05692199,-0.001790456689,
         3.6125111e-007,-3.86603591e-011,1.698508879e-015},
     bhigh={59675.3707,-79.94046159999999},
-    R_s=600.9843279493336);
+    R_s=R_NASA_2002/BH3.MM);
 
   constant IdealGases.Common.DataRecord BH3NH3(
     name="BH3NH3",
@@ -1577,7 +1580,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4354925.96,-18242.35232,31.6299983,-0.00320824361,5.88507545e-007,-5.80853553e-011,
         2.3825786e-015},
     bhigh={94381.18030000001,-189.7865799},
-    R_s=269.3801526242705);
+    R_s=R_NASA_2002/BH3NH3.MM);
 
   constant IdealGases.Common.DataRecord BH4(
     name="BH4",
@@ -1591,7 +1594,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1354714.146,-7870.76275,18.2617061,-0.001948275329,4.07270689e-007,-4.4827109e-011,
         2.014115885e-015},
     bhigh={74702.49489999999,-96.8608689},
-    R_s=560.1727711018706);
+    R_s=R_NASA_2002/BH4.MM);
 
   constant IdealGases.Common.DataRecord BI(
     name="BI",
@@ -1605,7 +1608,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2132872.626,-6283.684960000001,11.23964343,-0.00325885675,
         7.06428215e-007,-4.23006893e-011,-4.20807847e-016},
     bhigh={77976.3481,-46.6404261},
-    R_s=60.37455341800017);
+    R_s=R_NASA_2002/BI.MM);
 
   constant IdealGases.Common.DataRecord BI2(
     name="BI2",
@@ -1619,7 +1622,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-392402.223,442.290235,7.12962358,-0.000561963406,3.18076052e-007,-5.537079720000001e-011,
         3.1839597e-015},
     bhigh={22919.72638,-3.20179324},
-    R_s=31.42057246328451);
+    R_s=R_NASA_2002/BI2.MM);
 
   constant IdealGases.Common.DataRecord BI3(
     name="BI3",
@@ -1633,7 +1636,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-150617.6506,-81.67210609999999,10.05937867,-2.319396215e-005,
         5.01996673e-009,-5.65434963e-013,2.580651348e-017},
     bhigh={-426.168791,-16.17962779},
-    R_s=21.23624935671316);
+    R_s=R_NASA_2002/BI3.MM);
 
   constant IdealGases.Common.DataRecord BN(
     name="BN",
@@ -1647,7 +1650,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-227693.2705,-102.5649298,4.41458681,0.0002561670989,-1.612994942e-008,
         -6.526052929999999e-013,5.74946612e-017},
     bhigh={67844.6513,-0.6778568656},
-    R_s=335.0233905639926);
+    R_s=R_NASA_2002/BN.MM);
 
   constant IdealGases.Common.DataRecord BO(
     name="BO",
@@ -1661,7 +1664,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={17886.00589,-630.901963,4.5745284,0.0001988001643,-9.70296348e-008,
         1.870854291e-011,-1.030218131e-015},
     bhigh={4841.311089999999,-3.39889058},
-    R_s=310.1225643780026);
+    R_s=R_NASA_2002/BO.MM);
 
   constant IdealGases.Common.DataRecord BOminus(
     name="BOminus",
@@ -1676,7 +1679,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={212280.4369,-1262.124688,5.38316731,-0.00031810491,7.28898825e-008,-8.141708919999999e-012,
         3.71536439e-016},
     bhigh={-27068.92261,-9.77375367},
-    R_s=310.1162187152155);
+    R_s=R_NASA_2002/BOminus.MM);
 
   constant IdealGases.Common.DataRecord BOCL(
     name="BOCL",
@@ -1690,7 +1693,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={155714.8487,-1446.254968,8.50944805,-0.000385900738,8.26226882e-008,
         -9.261027459999999e-012,4.21999801e-016},
     bhigh={-32035.8904,-23.72713292},
-    R_s=133.5376802423253);
+    R_s=R_NASA_2002/BOCL.MM);
 
   constant IdealGases.Common.DataRecord BOCL2(
     name="BOCL2",
@@ -1704,7 +1707,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-229752.7041,-619.456793,10.46075518,-0.0001841620739,
         4.07121543e-008,-4.67224655e-012,2.167237536e-016},
     bhigh={-43715.3842,-27.43570215},
-    R_s=85.08817353074818);
+    R_s=R_NASA_2002/BOCL2.MM);
 
   constant IdealGases.Common.DataRecord BOF(
     name="BOF",
@@ -1718,7 +1721,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={193702.0297,-1739.112297,8.695650860000001,-0.000451889557,
         9.59101908e-008,-1.067806769e-011,4.840007660000001e-016},
     bhigh={-63301.5239,-27.02458617},
-    R_s=181.5046327165343);
+    R_s=R_NASA_2002/BOF.MM);
 
   constant IdealGases.Common.DataRecord BOF2(
     name="BOF2",
@@ -1732,7 +1735,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-220502.8861,-1254.23869,10.9255138,-0.0003680144,8.10716494e-008,-9.28127506e-012,
         4.2975493e-016},
     bhigh={-96804.47579999999,-34.8285333},
-    R_s=128.2960717158763);
+    R_s=R_NASA_2002/BOF2.MM);
 
   constant IdealGases.Common.DataRecord BOH(
     name="BOH",
@@ -1746,7 +1749,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={844749.8570000001,-3016.982887,8.0838647,-0.0001609855388,-2.191830959e-009,
         3.127133119e-012,-2.376665451e-016},
     bhigh={16476.98495,-26.03227947},
-    R_s=298.8859148317262);
+    R_s=R_NASA_2002/BOH.MM);
 
   constant IdealGases.Common.DataRecord BO2(
     name="BO2",
@@ -1760,7 +1763,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-38344.5234,-956.326114,8.200962779999999,-0.0002062130802,
         9.87228899e-009,8.15836676e-012,-7.52751966e-016},
     bhigh={-34235.6402,-22.24772278},
-    R_s=194.2197814519105);
+    R_s=R_NASA_2002/BO2.MM);
 
   constant IdealGases.Common.DataRecord BO2minus(
     name="BO2minus",
@@ -1774,7 +1777,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={119922.6372,-1715.766982,8.701038219999999,-0.000460124212,
         9.867011870000001e-008,-1.107288516e-011,5.05018324e-016},
     bhigh={-78257.89689999999,-28.39356505},
-    R_s=194.2172925917263);
+    R_s=R_NASA_2002/BO2minus.MM);
 
   constant IdealGases.Common.DataRecord B_OH_2(
     name="B_OH_2",
@@ -1788,7 +1791,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1557023.406,-5784.71076,14.87391235,-0.0001821804765,-3.80354164e-008,
         1.030332746e-011,-6.68588983e-016},
     bhigh={-18068.10301,-65.902689},
-    R_s=185.4854181799361);
+    R_s=R_NASA_2002/B_OH_2.MM);
 
   constant IdealGases.Common.DataRecord BS(
     name="BS",
@@ -1802,7 +1805,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1358760.165,-4364.03596,9.034307589999999,-0.002114548699,
         4.18927531e-007,-1.354787322e-011,-1.360684605e-015},
     bhigh={59130.6545,-33.36696868},
-    R_s=193.9199085735610);
+    R_s=R_NASA_2002/BS.MM);
 
   constant IdealGases.Common.DataRecord BS2(
     name="BS2",
@@ -1816,7 +1819,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={512040.251,-1938.581076,9.814873459999999,-0.001339731606,
         3.75430116e-007,-4.40038378e-011,1.887662968e-015},
     bhigh={17365.35,-27.57546712},
-    R_s=110.9474119640784);
+    R_s=R_NASA_2002/BS2.MM);
 
   constant IdealGases.Common.DataRecord B2(
     name="B2",
@@ -1830,7 +1833,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1094594.495,-2602.735739,6.90945621,-0.0006405949889999999,
         1.951732355e-007,-2.555902119e-011,1.053557323e-015},
     bhigh={118780.7611,-19.49045025},
-    R_s=384.5393580612339);
+    R_s=R_NASA_2002/B2.MM);
 
   constant IdealGases.Common.DataRecord B2C(
     name="B2C",
@@ -1844,7 +1847,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1159241.019,-4567.79881,12.28672097,-0.002500830701,6.40997985e-007,
         -6.932935770000001e-011,2.672933741e-015},
     bhigh={122244.2137,-51.99066186},
-    R_s=247.2150615323777);
+    R_s=R_NASA_2002/B2C.MM);
 
   constant IdealGases.Common.DataRecord B2CL4(
     name="B2CL4",
@@ -1858,7 +1861,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-642798.703,507.856299,14.86725022,2.026983515e-006,6.27271881e-009,
         -1.218822573e-012,7.241208409999999e-017},
     bhigh={-68200.66,-41.39110669},
-    R_s=50.87380838748363);
+    R_s=R_NASA_2002/B2CL4.MM);
 
   constant IdealGases.Common.DataRecord B2F4(
     name="B2F4",
@@ -1872,7 +1875,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={38558.6589,-2928.842655,17.92063736,-0.000952399827,1.614708845e-007,
         -1.428613504e-011,5.21873967e-016},
     bhigh={-161305.1924,-71.8480325},
-    R_s=85.17602626779802);
+    R_s=R_NASA_2002/B2F4.MM);
 
   constant IdealGases.Common.DataRecord B2H(
     name="B2H",
@@ -1886,7 +1889,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={617554.5750000001,-2627.897466,9.08490507,-0.000538941833,
         1.0507147e-007,-1.092459556e-011,4.68485466e-016},
     bhigh={109953.7555,-31.6402991},
-    R_s=367.4119330409184);
+    R_s=R_NASA_2002/B2H.MM);
 
   constant IdealGases.Common.DataRecord B2H2(
     name="B2H2",
@@ -1900,7 +1903,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1240614.592,-5368.96502,13.79292454,-0.001136749748,2.245617156e-007,
         -2.361530467e-011,1.022604572e-015},
     bhigh={85065.1149,-64.354613},
-    R_s=351.7451649640323);
+    R_s=R_NASA_2002/B2H2.MM);
 
   constant IdealGases.Common.DataRecord B2H3(
     name="B2H3",
@@ -1914,7 +1917,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1771506.902,-7872.26093,17.89447015,-0.001709304785,3.40957543e-007,
         -3.61454368e-011,1.575671409e-015},
     bhigh={87377.1189,-90.5462946},
-    R_s=337.3598443874053);
+    R_s=R_NASA_2002/B2H3.MM);
 
   constant IdealGases.Common.DataRecord B2H3_db(
     name="B2H3_db",
@@ -1928,7 +1931,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1497731.017,-7219.31414,17.50463766,-0.0015796988,3.16410347e-007,-3.36722515e-011,
         1.472919654e-015},
     bhigh={83243.4967,-87.79549259999999},
-    R_s=337.3598443874053);
+    R_s=R_NASA_2002/B2H3_db.MM);
 
   constant IdealGases.Common.DataRecord B2H4(
     name="B2H4",
@@ -1942,7 +1945,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2292078.842,-10598.32517,22.68612155,-0.002363586598,4.76217307e-007,
         -5.0901004e-011,2.23391159e-015},
     bhigh={86385.91979999999,-124.6794566},
-    R_s=324.1049265292885);
+    R_s=R_NASA_2002/B2H4.MM);
 
   constant IdealGases.Common.DataRecord B2H4_db(
     name="B2H4_db",
@@ -1956,7 +1959,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1886854.256,-10100.45614,22.47110812,-0.002319968667,4.73187996e-007,
         -5.11067303e-011,2.262693782e-015},
     bhigh={82334.87,-123.7455797},
-    R_s=324.1049265292885);
+    R_s=R_NASA_2002/B2H4_db.MM);
 
   constant IdealGases.Common.DataRecord B2H5(
     name="B2H5",
@@ -1970,7 +1973,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2696691.012,-13200.19835,27.35260413,-0.002961879012,5.98499943e-007,
         -6.41374855e-011,2.821187823e-015},
     bhigh={106452.4901,-155.9654379},
-    R_s=311.8522074736420);
+    R_s=R_NASA_2002/B2H5.MM);
 
   constant IdealGases.Common.DataRecord B2H5_db(
     name="B2H5_db",
@@ -1984,7 +1987,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2571729.448,-13568.29858,27.81376038,-0.00319236503,6.56116526e-007,
         -7.12733394e-011,3.16949265e-015},
     bhigh={110637.0527,-159.7214457},
-    R_s=311.8522074736420);
+    R_s=R_NASA_2002/B2H5_db.MM);
 
   constant IdealGases.Common.DataRecord B2H6(
     name="B2H6",
@@ -1998,7 +2001,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2835765.414,-15676.00163,32.2612233,-0.00373860973,7.71880646e-007,-8.41445454e-011,
         3.75222338e-015},
     bhigh={93583.7855,-192.0223395},
-    R_s=300.4921639746668);
+    R_s=R_NASA_2002/B2H6.MM);
 
   constant IdealGases.Common.DataRecord B2O(
     name="B2O",
@@ -2012,7 +2015,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-162872.322,-387.628981,7.78772352,-0.0001146822108,2.528097612e-008,
         -2.893783941e-012,1.339210475e-016},
     bhigh={22630.35354,-19.08513011},
-    R_s=221.0048004593131);
+    R_s=R_NASA_2002/B2O.MM);
 
   constant IdealGases.Common.DataRecord B2O2(
     name="B2O2",
@@ -2026,7 +2029,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={460578.966,-2990.079203,12.56764079,-0.000785097495,1.672537624e-007,
         -1.86769478e-011,8.486190669999999e-016},
     bhigh={-40157.4815,-48.7441371},
-    R_s=155.0612821890013);
+    R_s=R_NASA_2002/B2O2.MM);
 
   constant IdealGases.Common.DataRecord B2O3(
     name="B2O3",
@@ -2040,7 +2043,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={390503.53,-3691.34821,15.55502598,-0.0009707645510000001,
         2.068887872e-007,-2.310858356e-011,1.050136734e-015},
     bhigh={-82630.5441,-63.9086344},
-    R_s=119.4266893803810);
+    R_s=R_NASA_2002/B2O3.MM);
 
   constant IdealGases.Common.DataRecord B2_OH_4(
     name="B2_OH_4",
@@ -2054,7 +2057,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2983925.656,-12074.69577,31.6261057,-0.000516368244,-4.23209397e-008,
         1.67197728e-011,-1.156366726e-015},
     bhigh={-82809.76969999999,-165.3010498},
-    R_s=92.74270908996807);
+    R_s=R_NASA_2002/B2_OH_4.MM);
 
   constant IdealGases.Common.DataRecord B2S(
     name="B2S",
@@ -2068,7 +2071,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-121150.1483,-64.73398450000001,7.54682561,-1.82054145e-005,
         3.92395117e-009,-4.40386238e-013,2.003651718e-017},
     bhigh={72585.3187,-13.94971229},
-    R_s=154.8700802801423);
+    R_s=R_NASA_2002/B2S.MM);
 
   constant IdealGases.Common.DataRecord B2S2(
     name="B2S2",
@@ -2082,7 +2085,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-164153.5014,-774.286564,11.07731737,-0.0002313278554,
         5.12561429e-008,-5.89408123e-012,2.738673834e-016},
     bhigh={17330.03515,-33.59766998},
-    R_s=96.95995428678049);
+    R_s=R_NASA_2002/B2S2.MM);
 
   constant IdealGases.Common.DataRecord B2S3(
     name="B2S3",
@@ -2096,7 +2099,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-190585.5086,-934.8342479999999,13.69333613,-0.000276664725,
         6.1101558e-008,-7.00804857e-012,3.24952462e-016},
     bhigh={2906.43376,-39.46870479},
-    R_s=70.57139462047073);
+    R_s=R_NASA_2002/B2S3.MM);
 
   constant IdealGases.Common.DataRecord B3H7_C2v(
     name="B3H7_C2v",
@@ -2110,7 +2113,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3598592.14,-18637.01968,39.9399883,-0.00427541016,
         8.705358820000001e-007,-9.38510502e-011,4.14786531e-015},
     bhigh={127215.4092,-237.9769856},
-    R_s=210.5547983746187);
+    R_s=R_NASA_2002/B3H7_C2v.MM);
 
   constant IdealGases.Common.DataRecord B3H7_Cs(
     name="B3H7_Cs",
@@ -2124,7 +2127,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3281576.45,-18110.96595,39.6383246,-0.00417842411,8.52682906e-007,-9.20960024e-011,
         4.076496770000001e-015},
     bhigh={121362.2564,-235.7090217},
-    R_s=210.5547983746187);
+    R_s=R_NASA_2002/B3H7_Cs.MM);
 
   constant IdealGases.Common.DataRecord B3H9(
     name="B3H9",
@@ -2138,7 +2141,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3863999.5,-22294.33407,48.7504615,-0.00541844926,1.125767651e-006,-1.233226406e-010,
         5.52034818e-015},
     bhigh={142218.7123,-295.8240102},
-    R_s=200.3281093164445);
+    R_s=R_NASA_2002/B3H9.MM);
 
   constant IdealGases.Common.DataRecord B3N3H6(
     name="B3N3H6",
@@ -2152,7 +2155,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3739245.17,-19412.38951,44.4507003,-0.00321030805,5.71746542e-007,-5.48669214e-011,
         2.191943197e-015},
     bhigh={47584.2616,-264.1156625},
-    R_s=103.2848890581627);
+    R_s=R_NASA_2002/B3N3H6.MM);
 
   constant IdealGases.Common.DataRecord B3O3CL3(
     name="B3O3CL3",
@@ -2166,7 +2169,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-741405.981,-2527.447455,26.87263667,-0.000746338936,1.64633411e-007,
         -1.886231553e-011,8.737926310000001e-016},
     bhigh={-192350.9858,-118.5636255},
-    R_s=44.51256008077512);
+    R_s=R_NASA_2002/B3O3CL3.MM);
 
   constant IdealGases.Common.DataRecord B3O3FCL2(
     name="B3O3FCL2",
@@ -2180,7 +2183,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-716236.083,-2851.210308,27.10953133,-0.000840091964,
         1.852318684e-007,-2.121694694e-011,9.827291560000002e-016},
     bhigh={-220272.9252,-121.0679365},
-    R_s=48.81251977742726);
+    R_s=R_NASA_2002/B3O3FCL2.MM);
 
   constant IdealGases.Common.DataRecord B3O3F2CL(
     name="B3O3F2CL",
@@ -2194,7 +2197,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-681078.749,-3370.00902,27.48953579,-0.000990544256,2.18290844e-007,
         -2.49957348e-011,1.157532106e-015},
     bhigh={-247211.4785,-126.1501548},
-    R_s=54.03207448739431);
+    R_s=R_NASA_2002/B3O3F2CL.MM);
 
   constant IdealGases.Common.DataRecord B3O3F3(
     name="B3O3F3",
@@ -2208,7 +2211,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-662982.291,-3784.94687,27.79526578,-0.001112096232,2.450806704e-007,
         -2.80648498e-011,1.299750466e-015},
     bhigh={-274886.5475,-131.5605015},
-    R_s=60.50154423884477);
+    R_s=R_NASA_2002/B3O3F3.MM);
 
   constant IdealGases.Common.DataRecord B4H4(
     name="B4H4",
@@ -2222,7 +2225,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1937200.886,-10781.85932,28.79625241,-0.002401547707,4.83775678e-007,
         -5.17049023e-011,2.269138182e-015},
     bhigh={98365.95389999999,-156.1814117},
-    R_s=175.8725824820162);
+    R_s=R_NASA_2002/B4H4.MM);
 
   constant IdealGases.Common.DataRecord B4H10(
     name="B4H10",
@@ -2236,7 +2239,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4030474.13,-25606.29762,56.8723366,-0.00617856786,1.280621032e-006,-1.400254585e-010,
         6.258866560000001e-015},
     bhigh={150600.9087,-352.07142},
-    R_s=155.9261037368210);
+    R_s=R_NASA_2002/B4H10.MM);
 
   constant IdealGases.Common.DataRecord B4H12(
     name="B4H12",
@@ -2250,7 +2253,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6158360.8,-32020.8673,66.60443599999999,-0.00740636928,
         1.512993908e-006,-1.635619071e-010,7.24538514e-015},
     bhigh={205458.6275,-414.210686},
-    R_s=150.2460819873334);
+    R_s=R_NASA_2002/B4H12.MM);
 
   constant IdealGases.Common.DataRecord B5H9(
     name="B5H9",
@@ -2264,7 +2267,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3169017.62,-22825.03203,55.1200898,-0.005563411420000001,
         1.157837073e-006,-1.270332301e-010,5.69426203e-015},
     bhigh={133445.2571,-337.106046},
-    R_s=131.7119635728029);
+    R_s=R_NASA_2002/B5H9.MM);
 
   constant IdealGases.Common.DataRecord Ba(
     name="Ba",
@@ -2278,7 +2281,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-19265792.28,60065.0104,-66.3396413,0.0350756593,-7.80760183e-006,
         8.0851268e-010,-3.199486918e-014},
     bhigh={-358966.372,500.75834},
-    R_s=60.54534068318684);
+    R_s=R_NASA_2002/Ba.MM);
 
   constant IdealGases.Common.DataRecord Baplus(
     name="Baplus",
@@ -2292,7 +2295,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={8794971.85,-19518.17883,14.85542861,-0.00094042335,-7.03125779e-007,
         1.667412753e-010,-1.07011731e-014},
     bhigh={214680.0732,-92.28264190000002},
-    R_s=60.54558255336962);
+    R_s=R_NASA_2002/Baplus.MM);
 
   constant IdealGases.Common.DataRecord BaBr(
     name="BaBr",
@@ -2306,7 +2309,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1056014.042,1034.740207,6.73572938,-0.0037840263,1.952196896e-006,-3.34783188e-010,
         1.893189803e-014},
     bhigh={-19502.33645,-5.06927964},
-    R_s=38.27496996285061);
+    R_s=R_NASA_2002/BaBr.MM);
 
   constant IdealGases.Common.DataRecord BaBr2(
     name="BaBr2",
@@ -2320,7 +2323,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-8928.25121,-0.753655889,7.00065821,-2.94982171e-007,
         7.092392109999999e-011,-8.670038099999999e-015,4.22174231e-019},
     bhigh={-51726.6949,1.910185706},
-    R_s=27.98226395409494);
+    R_s=R_NASA_2002/BaBr2.MM);
 
   constant IdealGases.Common.DataRecord BaCL(
     name="BaCL",
@@ -2334,7 +2337,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1075410.089,1209.303069,6.2725586,-0.00328811031,1.717751087e-006,-2.910607065e-010,
         1.632658438e-014},
     bhigh={-27791.73737,-3.574185216},
-    R_s=48.12194698460470);
+    R_s=R_NASA_2002/BaCL.MM);
 
   constant IdealGases.Common.DataRecord BaCLplus(
     name="BaCLplus",
@@ -2348,7 +2351,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-18291.98157,-2.931616688,4.50228071,3.67178849e-005,
         2.396147871e-009,5.4794586e-014,1.174342316e-018},
     bhigh={40551.00150000001,4.503765564},
-    R_s=48.12209977881664);
+    R_s=R_NASA_2002/BaCLplus.MM);
 
   constant IdealGases.Common.DataRecord BaCL2(
     name="BaCL2",
@@ -2362,7 +2365,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-22165.98768,-4.00248381,7.00342674,-1.515820808e-006,
         3.61184921e-010,-4.38675906e-014,2.125803293e-018},
     bhigh={-62190.9527,-1.132439694},
-    R_s=39.92887774752321);
+    R_s=R_NASA_2002/BaCL2.MM);
 
   constant IdealGases.Common.DataRecord BaF(
     name="BaF",
@@ -2376,7 +2379,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1868380.434,-7071.099600000001,14.66959284,-0.0069959502,
         2.366313845e-006,-3.2877343e-010,1.647896238e-014},
     bhigh={3571.78068,-66.6239092},
-    R_s=53.18719689699160);
+    R_s=R_NASA_2002/BaF.MM);
 
   constant IdealGases.Common.DataRecord BaFplus(
     name="BaFplus",
@@ -2390,7 +2393,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-40544.2367,-17.01997704,4.51305534,2.632753508e-005,
         2.612088236e-009,-9.502197929999999e-014,6.515176160000001e-018},
     bhigh={14744.8657,2.783167711},
-    R_s=53.18738354994766);
+    R_s=R_NASA_2002/BaFplus.MM);
 
   constant IdealGases.Common.DataRecord BaF2(
     name="BaF2",
@@ -2404,7 +2407,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-55086.3366,-16.91114228,7.01356488,-5.73190977e-006,
         1.321203959e-009,-1.565528167e-013,7.444983019999999e-018},
     bhigh={-99835.29700000001,-4.38958149},
-    R_s=47.42373651773511);
+    R_s=R_NASA_2002/BaF2.MM);
 
   constant IdealGases.Common.DataRecord BaH(
     name="BaH",
@@ -2418,7 +2421,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-6755466.57,17307.00212,-11.36812458,0.00561774474,-3.18078885e-007,
         -1.052342502e-010,1.111101879e-014},
     bhigh={-89540.70379999999,118.2377538},
-    R_s=60.10419348864431);
+    R_s=R_NASA_2002/BaH.MM);
 
   constant IdealGases.Common.DataRecord BaI(
     name="BaI",
@@ -2432,7 +2435,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3533859.66,7394.258,1.285151488,-0.002303429302,2.214839289e-006,-4.68109681e-010,
         3.011371472e-014},
     bhigh={-53402.2959,37.1044387},
-    R_s=31.46676661943409);
+    R_s=R_NASA_2002/BaI.MM);
 
   constant IdealGases.Common.DataRecord BaI2(
     name="BaI2",
@@ -2446,7 +2449,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-6048.2248,-0.362272945,7.00031745,-1.425793502e-007,3.43334942e-011,
         -4.201754979999999e-015,2.047703474e-019},
     bhigh={-36796.5075,3.61547532},
-    R_s=21.25734086210538);
+    R_s=R_NASA_2002/BaI2.MM);
 
   constant IdealGases.Common.DataRecord BaO(
     name="BaO",
@@ -2460,7 +2463,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={13184816.98,-38542.5325,46.8674161,-0.02188646633,
         5.335677450000001e-006,-5.1523043e-010,1.4330834e-014},
     bhigh={230690.2396,-302.8332772},
-    R_s=54.22751724425800);
+    R_s=R_NASA_2002/BaO.MM);
 
   constant IdealGases.Common.DataRecord BaOplus(
     name="BaOplus",
@@ -2474,7 +2477,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-331767.923,1594.253495,3.22724781,0.00057226415,-1.147415658e-007,
         1.382873231e-011,-6.38443703e-016},
     bhigh={50252.4761,14.09092365},
-    R_s=54.22771127035138);
+    R_s=R_NASA_2002/BaOplus.MM);
 
   constant IdealGases.Common.DataRecord BaOH(
     name="BaOH",
@@ -2488,7 +2491,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2637336.694,-8365.410400000001,15.99803975,-0.005098446049999999,
         1.594657431e-006,-2.180478542e-010,1.084610688e-014},
     bhigh={23935.50647,-74.9070579},
-    R_s=53.87336350419486);
+    R_s=R_NASA_2002/BaOH.MM);
 
   constant IdealGases.Common.DataRecord BaOHplus(
     name="BaOHplus",
@@ -2502,7 +2505,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={876673.843,-2335.8196,7.97316606,0.0001038679898,-6.31948578e-008,
         1.028729445e-011,-5.74180857e-016},
     bhigh={37725.1747,-19.30805001},
-    R_s=53.87355500423480);
+    R_s=R_NASA_2002/BaOHplus.MM);
 
   constant IdealGases.Common.DataRecord Ba_OH_2(
     name="Ba_OH_2",
@@ -2516,7 +2519,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1762908.112,-4676.205419999999,13.95135494,0.0002051842928,-1.25726553e-007,
         2.048917625e-011,-1.144045777e-015},
     bhigh={-45459.6441,-49.2945719},
-    R_s=48.52590449679261);
+    R_s=R_NASA_2002/Ba_OH_2.MM);
 
   constant IdealGases.Common.DataRecord BaS(
     name="BaS",
@@ -2530,7 +2533,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6104262.07,-22276.17479,35.9751351,-0.0215779374,7.31987235e-006,-1.089038636e-009,
         5.88410195e-014},
     bhigh={140413.8006,-214.1776331},
-    R_s=49.08443137810523);
+    R_s=R_NASA_2002/BaS.MM);
 
   constant IdealGases.Common.DataRecord Ba2(
     name="Ba2",
@@ -2544,7 +2547,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={216011.4547,195.0676877,2.253699771,0.0001507750613,-4.742515e-008,
         7.04895196e-012,-3.54744017e-016},
     bhigh={41677.6297,23.75906459},
-    R_s=30.27267034159342);
+    R_s=R_NASA_2002/Ba2.MM);
 
   constant IdealGases.Common.DataRecord Be(
     name="Be",
@@ -2558,7 +2561,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-692628.584,2466.773005,-0.9776613340000001,0.002458939515,-9.047950419999999e-007,
         1.587880407e-010,-9.415600603e-015},
     bhigh={23002.12917,26.23234754},
-    R_s=922.585673480629);
+    R_s=R_NASA_2002/Be.MM);
 
   constant IdealGases.Common.DataRecord Beplus(
     name="Beplus",
@@ -2571,7 +2574,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-94781.35979999999,276.8325398,2.191388413,0.0001648824289,-4.28016682e-008,
         4.54235047e-012,-6.270417825e-017},
     bhigh={145385.0986,5.05550384},
-    R_s=922.6418376051561);
+    R_s=R_NASA_2002/Beplus.MM);
 
   constant IdealGases.Common.DataRecord Beplusplus(
     name="Beplusplus",
@@ -2583,7 +2586,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={359227.916,2.145990203},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={359227.916,2.145990203},
-    R_s=922.6980085682912);
+    R_s=R_NASA_2002/Beplusplus.MM);
 
   constant IdealGases.Common.DataRecord BeBr(
     name="BeBr",
@@ -2597,7 +2600,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={821723.8139999999,-2850.509348,8.017266019999999,-0.002105663212,
         6.84913634e-007,-9.98912932e-011,5.192456840000001e-015},
     bhigh={32293.7287,-23.26810811},
-    R_s=93.50952563392791);
+    R_s=R_NASA_2002/BeBr.MM);
 
   constant IdealGases.Common.DataRecord BeBr2(
     name="BeBr2",
@@ -2611,7 +2614,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-104133.1811,-154.3443092,7.61446541,-4.55670063e-005,
         1.003180548e-008,-1.146879501e-012,5.30179538e-017},
     bhigh={-29845.27608,-11.4936098},
-    R_s=49.25068733784448);
+    R_s=R_NASA_2002/BeBr2.MM);
 
   constant IdealGases.Common.DataRecord BeCL(
     name="BeCL",
@@ -2625,7 +2628,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={280884.5146,-1103.100122,5.67118983,-0.0005443000450000001,
         1.459036606e-007,-1.230971735e-011,9.90080476e-017},
     bhigh={12246.49804,-8.38237137},
-    R_s=186.9892267617391);
+    R_s=R_NASA_2002/BeCL.MM);
 
   constant IdealGases.Common.DataRecord BeCL2(
     name="BeCL2",
@@ -2639,7 +2642,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-115408.746,-248.4300053,7.68567214,-7.44496037e-005,
         1.649479787e-008,-1.895997075e-012,8.804973950000001e-017},
     bhigh={-44687.4728,-15.00337407},
-    R_s=104.0377770355186);
+    R_s=R_NASA_2002/BeCL2.MM);
 
   constant IdealGases.Common.DataRecord BeF(
     name="BeF",
@@ -2653,7 +2656,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-185794.1543,47.76082770000001,4.26998602,0.0002310668473,-6.657214920000001e-008,
         1.152149888e-011,-6.33558644e-016},
     bhigh={-22579.5096,-0.218478727},
-    R_s=296.8345695255235);
+    R_s=R_NASA_2002/BeF.MM);
 
   constant IdealGases.Common.DataRecord BeF2(
     name="BeF2",
@@ -2667,7 +2670,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-64820.1807,-768.455606,8.062860840000001,-0.0002227502549,
         4.89159866e-008,-5.58788672e-012,2.583409761e-016},
     bhigh={-93954.9549,-21.25660266},
-    R_s=176.8706428917751);
+    R_s=R_NASA_2002/BeF2.MM);
 
   constant IdealGases.Common.DataRecord BeH(
     name="BeH",
@@ -2681,7 +2684,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2424081.636,6597.39846,-3.62631648,0.00457963435,-1.163329056e-006,
         1.297785691e-010,-5.29188581e-015},
     bhigh={-2489.846221,52.1601869},
-    R_s=829.7813140398890);
+    R_s=R_NASA_2002/BeH.MM);
 
   constant IdealGases.Common.DataRecord BeHplus(
     name="BeHplus",
@@ -2695,7 +2698,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={462234.1589999999,-1760.169629,5.37990555,2.742462444e-005,-1.16720817e-007,
         3.55717791e-011,-2.569695765e-015},
     bhigh={151585.9734,-13.69222641},
-    R_s=829.826746915193);
+    R_s=R_NASA_2002/BeHplus.MM);
 
   constant IdealGases.Common.DataRecord BeH2(
     name="BeH2",
@@ -2709,7 +2712,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={607426.201,-3407.53425,9.79237036,-0.000825461482,1.915656246e-007,-1.962774813e-011,
         8.929908660000001e-016},
     bhigh={37931.052,-42.5465358},
-    R_s=753.9411729821613);
+    R_s=R_NASA_2002/BeH2.MM);
 
   constant IdealGases.Common.DataRecord BeI(
     name="BeI",
@@ -2723,7 +2726,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-532820.662,1139.497861,3.62917166,0.0001704033769,1.067048688e-007,
         -3.58945788e-011,2.72276956e-015},
     bhigh={15854.74307,9.370951270000001},
-    R_s=61.17359335778813);
+    R_s=R_NASA_2002/BeI.MM);
 
   constant IdealGases.Common.DataRecord BeI2(
     name="BeI2",
@@ -2737,7 +2740,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-93923.72840000001,-89.5921438,7.56555479,-2.577727326e-005,
         5.61426533e-009,-6.35966385e-013,2.917080336e-017},
     bhigh={-9814.768620000001,-9.03204281},
-    R_s=31.63562325862074);
+    R_s=R_NASA_2002/BeI2.MM);
 
   constant IdealGases.Common.DataRecord BeN(
     name="BeN",
@@ -2751,7 +2754,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-59096.9616,-307.8649431,4.72795915,-3.92815883e-005,
         2.006201069e-008,-2.300018068e-012,1.066101831e-016},
     bhigh={51560.9571,-3.031380625},
-    R_s=361.2039020835156);
+    R_s=R_NASA_2002/BeN.MM);
 
   constant IdealGases.Common.DataRecord BeO(
     name="BeO",
@@ -2765,7 +2768,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-35034724.5,105585.9473,-116.5011722,0.0647736948,-1.649656058e-005,
         2.0055584e-009,-9.426891790000001e-014},
     bhigh={-657001.8000000001,864.0898030000001},
-    R_s=332.4263935004191);
+    R_s=R_NASA_2002/BeO.MM);
 
   constant IdealGases.Common.DataRecord BeOH(
     name="BeOH",
@@ -2779,7 +2782,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={855033.031,-2646.537838,8.204784630000001,1.110814513e-005,-4.265364e-008,
         7.926511920000001e-012,-4.64541952e-016},
     bhigh={3121.216271,-25.71641308},
-    R_s=319.5489140807429);
+    R_s=R_NASA_2002/BeOH.MM);
 
   constant IdealGases.Common.DataRecord BeOHplus(
     name="BeOHplus",
@@ -2793,7 +2796,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={813487.439,-2814.653683,8.381145009999999,-6.94207328e-005,-2.369535806e-008,
         5.67810638e-012,-3.58325356e-016},
     bhigh={107312.9932,-29.01093335},
-    R_s=319.5556516461176);
+    R_s=R_NASA_2002/BeOHplus.MM);
 
   constant IdealGases.Common.DataRecord Be_OH_2(
     name="Be_OH_2",
@@ -2807,7 +2810,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1722889.403,-5242.47719,14.86877785,3.93149836e-005,-8.92027631e-008,
         1.630912925e-011,-9.505371139999999e-016},
     bhigh={-46428.2384,-64.7680402},
-    R_s=193.2399811076160);
+    R_s=R_NASA_2002/Be_OH_2.MM);
 
   constant IdealGases.Common.DataRecord BeS(
     name="BeS",
@@ -2821,7 +2824,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-16557083.61,54314.6612,-63.5185925,0.0396409199,-1.078978696e-005,
         1.394030343e-009,-6.93695504e-014},
     bhigh={-312155.9628,480.3454935},
-    R_s=202.4118889168201);
+    R_s=R_NASA_2002/BeS.MM);
 
   constant IdealGases.Common.DataRecord Be2(
     name="Be2",
@@ -2835,7 +2838,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={101003.4484,141.4207488,2.292070182,0.0001543331824,-5.801043e-008,
         1.003129697e-011,-5.68281834e-016},
     bhigh={75501.3973,12.38758616},
-    R_s=461.292836740314);
+    R_s=R_NASA_2002/Be2.MM);
 
   constant IdealGases.Common.DataRecord Be2CL4(
     name="Be2CL4",
@@ -2849,7 +2852,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-335492.008,-231.6199283,16.17047912,-6.73440595e-005,
         1.472073032e-008,-1.672352806e-012,7.68877397e-017},
     bhigh={-103107.5197,-50.47009374},
-    R_s=52.01888851775932);
+    R_s=R_NASA_2002/Be2CL4.MM);
 
   constant IdealGases.Common.DataRecord Be2F4(
     name="Be2F4",
@@ -2863,7 +2866,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-368183.495,-943.919148,16.70099855,-0.0002797974015,
         6.178061719999999e-008,-7.08308019e-012,3.28279104e-016},
     bhigh={-208904.5725,-60.9266576},
-    R_s=88.43532144588757);
+    R_s=R_NASA_2002/Be2F4.MM);
 
   constant IdealGases.Common.DataRecord Be2O(
     name="Be2O",
@@ -2877,7 +2880,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-141264.6378,-349.864459,7.76093268,-0.0001044953518,
         2.313342334e-008,-2.657722263e-012,1.233820439e-016},
     bhigh={-5172.38549,-18.54887619},
-    R_s=244.3736089869422);
+    R_s=R_NASA_2002/Be2O.MM);
 
   constant IdealGases.Common.DataRecord Be2OF2(
     name="Be2OF2",
@@ -2891,7 +2894,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-228182.6506,-1130.355396,13.83400563,-0.000331608064,
         7.30492101e-008,-8.36270438e-012,3.87218498e-016},
     bhigh={-143139.0587,-47.3915023},
-    R_s=115.4463225412055);
+    R_s=R_NASA_2002/Be2OF2.MM);
 
   constant IdealGases.Common.DataRecord Be2O2(
     name="Be2O2",
@@ -2905,7 +2908,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-396057.6640000001,-907.4948830000001,10.67160422,-0.0002670905218,
         5.87762999e-008,-6.71866409e-012,3.105949075e-016},
     bhigh={-48611.1433,-36.1654689},
-    R_s=166.2131967502096);
+    R_s=R_NASA_2002/Be2O2.MM);
 
   constant IdealGases.Common.DataRecord Be3O3(
     name="Be3O3",
@@ -2919,7 +2922,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-589080.936,-1392.823588,17.03450699,-0.000412733074,9.10752915e-008,
         -1.043465231e-011,4.83305377e-016},
     bhigh={-121904.5534,-70.0061451},
-    R_s=110.8087978334731);
+    R_s=R_NASA_2002/Be3O3.MM);
 
   constant IdealGases.Common.DataRecord Be4O4(
     name="Be4O4",
@@ -2933,7 +2936,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-884133.8459999999,-2726.394165,24.02941774,-0.0008114675460000001,
         1.794255972e-007,-2.059359498e-011,9.552905330000001e-016},
     bhigh={-192371.0587,-113.662075},
-    R_s=83.10659837510478);
+    R_s=R_NASA_2002/Be4O4.MM);
 
   constant IdealGases.Common.DataRecord Br(
     name="Br",
@@ -2947,7 +2950,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4789717.399999999,16920.51999,-20.24085357,0.01395620355,-3.65623056e-006,
         4.489781e-010,-2.122507526e-014},
     bhigh={-92070.54960000001,166.1695929},
-    R_s=104.0562424909892);
+    R_s=R_NASA_2002/Br.MM);
 
   constant IdealGases.Common.DataRecord Brplus(
     name="Brplus",
@@ -2961,7 +2964,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1741149.829,-5455.46567,8.470663350000001,-0.002683465574,
         6.59045456e-007,-7.9537703e-011,3.735898818e-015},
     bhigh={185178.1643,-36.3790903},
-    R_s=104.0569569188848);
+    R_s=R_NASA_2002/Brplus.MM);
 
   constant IdealGases.Common.DataRecord Brminus(
     name="Brminus",
@@ -2973,7 +2976,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={-27084.92743,5.41955617},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={-27084.92743,5.41955617},
-    R_s=104.055528072904);
+    R_s=R_NASA_2002/Brminus.MM);
 
   constant IdealGases.Common.DataRecord BrCL(
     name="BrCL",
@@ -2987,7 +2990,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-128486.3067,-1138.379626,7.9640408,-0.00343805667,1.524999514e-006,
         -2.761469114e-010,1.694450407e-014},
     bhigh={5938.264260000001,-19.25044389},
-    R_s=72.07633693664017);
+    R_s=R_NASA_2002/BrCL.MM);
 
   constant IdealGases.Common.DataRecord BrF(
     name="BrF",
@@ -3001,7 +3004,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3771388.47,-12674.9343,20.8055593,-0.0102635936,3.30820359e-006,-4.90319225e-010,
         2.64827508e-014},
     bhigh={70626.0972,-113.02536},
-    R_s=84.06782576543095);
+    R_s=R_NASA_2002/BrF.MM);
 
   constant IdealGases.Common.DataRecord BrF3(
     name="BrF3",
@@ -3015,7 +3018,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-188653.224,-82.45232970000001,10.06180694,-2.477319092e-005,
         5.47857686e-009,-6.28265526e-013,2.910628214e-017},
     bhigh={-33868.0037,-22.98937369},
-    R_s=60.73453619121553);
+    R_s=R_NASA_2002/BrF3.MM);
 
   constant IdealGases.Common.DataRecord BrF5(
     name="BrF5",
@@ -3029,7 +3032,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-375764.764,-157.5896472,16.11869838,-4.776497799999999e-005,
         1.059755365e-008,-1.218527723e-012,5.65753545e-017},
     bhigh={-56672.66800000001,-55.4083931},
-    R_s=47.53973355230688);
+    R_s=R_NASA_2002/BrF5.MM);
 
   constant IdealGases.Common.DataRecord BrO(
     name="BrO",
@@ -3043,7 +3046,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2392612.795,6932.79313,-2.513183892,0.00344654456,-7.569536839999999e-007,
         6.51429134e-011,-1.715768736e-015},
     bhigh={-30844.99064,53.6104836},
-    R_s=86.6967177388914);
+    R_s=R_NASA_2002/BrO.MM);
 
   constant IdealGases.Common.DataRecord OBrO(
     name="OBrO",
@@ -3057,7 +3060,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-162450.466,-145.3689372,7.10582213,-4.14136207e-005,
         8.981833259999999e-009,-1.013712869e-012,4.63513314e-017},
     bhigh={16500.75386,-9.11181792},
-    R_s=74.301179237696);
+    R_s=R_NASA_2002/OBrO.MM);
 
   constant IdealGases.Common.DataRecord BrOO(
     name="BrOO",
@@ -3071,7 +3074,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6172.483480000001,-658.504966,7.48395533,-0.0001920530746,
         4.22694617e-008,-4.83739261e-012,2.23974132e-016},
     bhigh={14603.5347,-9.85038024},
-    R_s=74.301179237696);
+    R_s=R_NASA_2002/BrOO.MM);
 
   constant IdealGases.Common.DataRecord BrO3(
     name="BrO3",
@@ -3085,7 +3088,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-282285.1113,-235.8973461,10.17525279,-6.97845105e-005,
         1.535701661e-008,-1.75445495e-012,8.10410015e-017},
     bhigh={24011.4014,-25.88197197},
-    R_s=65.00677861678689);
+    R_s=R_NASA_2002/BrO3.MM);
 
   constant IdealGases.Common.DataRecord Br2(
     name="Br2",
@@ -3099,7 +3102,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4311698.57,11112.68634,-5.55577561,0.00363051659,-2.754164226e-007,
         -6.21750676e-011,7.37534162e-015},
     bhigh={-70365.8416,78.7847802},
-    R_s=52.02812124549460);
+    R_s=R_NASA_2002/Br2.MM);
 
   constant IdealGases.Common.DataRecord BrBrO(
     name="BrBrO",
@@ -3113,7 +3116,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-85371.0175,-64.8704607,7.04715935,-1.843088186e-005,3.99226786e-009,
         -4.50068795e-013,2.055867395e-017},
     bhigh={18215.66655,-3.162186125},
-    R_s=47.29328799584091);
+    R_s=R_NASA_2002/BrBrO.MM);
 
   constant IdealGases.Common.DataRecord BrOBr(
     name="BrOBr",
@@ -3127,7 +3130,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-96866.60249999999,-39.5739527,7.02943438,-1.171881908e-005,
         2.576958549e-009,-2.941186078e-013,1.357198784e-017},
     bhigh={10769.42321,-5.69777938},
-    R_s=47.29328799584091);
+    R_s=R_NASA_2002/BrOBr.MM);
 
   constant IdealGases.Common.DataRecord C(
     name="C",
@@ -3141,7 +3144,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-128913.6472,171.9528572,2.646044387,-0.000335306895,1.74209274e-007,
         -2.902817829e-011,1.642182385e-015},
     bhigh={84105.9785,4.130047418},
-    R_s=692.2585694422474);
+    R_s=R_NASA_2002/C.MM);
 
   constant IdealGases.Common.DataRecord Cplus(
     name="Cplus",
@@ -3155,7 +3158,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={12551.12551,-34.1187467,2.543383218,-2.805120849e-005,
         9.751641969999999e-009,-1.736855394e-012,1.246191931e-016},
     bhigh={217100.1786,4.063913515},
-    R_s=692.2901904467250);
+    R_s=R_NASA_2002/Cplus.MM);
 
   constant IdealGases.Common.DataRecord Cminus(
     name="Cminus",
@@ -3169,7 +3172,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4.25317572,0.0005778186479999999,2.499999424,2.836136231e-010,-7.32725342e-014,
         9.478507810000001e-018,-4.830487319999999e-022},
     bhigh={70012.17170000001,4.879624211},
-    R_s=692.22695132628);
+    R_s=R_NASA_2002/Cminus.MM);
 
   constant IdealGases.Common.DataRecord CBr(
     name="CBr",
@@ -3183,7 +3186,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1021862.102,-3243.48436,8.38822656,-0.002242155508,
         6.988355369999999e-007,-9.719134370000001e-011,4.71697624e-015},
     bhigh={78059.24059999999,-25.18386915},
-    R_s=90.45897990201784);
+    R_s=R_NASA_2002/CBr.MM);
 
   constant IdealGases.Common.DataRecord CBr2(
     name="CBr2",
@@ -3197,7 +3200,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-744143.141,421.542783,8.796797740000001,-0.002726562507,
         1.336438546e-006,-2.304854483e-010,1.337493953e-014},
     bhigh={33646.1814,-15.99565135},
-    R_s=48.39118210066774);
+    R_s=R_NASA_2002/CBr2.MM);
 
   constant IdealGases.Common.DataRecord CBr3(
     name="CBr3",
@@ -3211,7 +3214,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-192649.8949,-132.4072178,10.09808665,-3.89504082e-005,
         8.55044501e-009,-9.747493679999999e-013,4.49424559e-017},
     bhigh={25415.76129,-18.66868947},
-    R_s=33.03043388617713);
+    R_s=R_NASA_2002/CBr3.MM);
 
   constant IdealGases.Common.DataRecord CBr4(
     name="CBr4",
@@ -3225,7 +3228,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-205978.5072,-104.8517002,13.0777255,-3.086857556e-005,
         6.77530981e-009,-7.72183754e-013,3.55921824e-017},
     bhigh={5615.89394,-32.8378763},
-    R_s=25.0718955982736);
+    R_s=R_NASA_2002/CBr4.MM);
 
   constant IdealGases.Common.DataRecord CCL(
     name="CCL",
@@ -3239,7 +3242,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={590050.763,-2075.31146,6.88001723,-0.001294796228,3.88313798e-007,-5.00698163e-011,
         2.218229619e-015},
     bhigh={63589.2205,-16.10664472},
-    R_s=175.1761872757497);
+    R_s=R_NASA_2002/CCL.MM);
 
   constant IdealGases.Common.DataRecord CCL2(
     name="CCL2",
@@ -3253,7 +3256,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-6437455.17,19584.13353,-16.04038625,0.01238833906,-3.013367274e-006,
         3.47346892e-010,-1.553272793e-014},
     bhigh={-99612.42159999999,155.6949315},
-    R_s=100.2754571756956);
+    R_s=R_NASA_2002/CCL2.MM);
 
   constant IdealGases.Common.DataRecord CCL2Br2(
     name="CCL2Br2",
@@ -3267,7 +3270,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-255334.7012,-159.8005477,13.1186093,-4.717443870000001e-005,
         1.036912808e-008,-1.183321687e-012,5.46061269e-017},
     bhigh={-2588.63698,-34.61705319},
-    R_s=34.25489865679101);
+    R_s=R_NASA_2002/CCL2Br2.MM);
 
   constant IdealGases.Common.DataRecord CCL3(
     name="CCL3",
@@ -3281,7 +3284,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-542757.254,680.902062,9.047723619999999,0.0001324277766,
         6.30126304e-008,-2.6566392e-011,2.105668053e-015},
     bhigh={386.621615,-15.28745849},
-    R_s=70.24187777784348);
+    R_s=R_NASA_2002/CCL3.MM);
 
   constant IdealGases.Common.DataRecord CCL3Br(
     name="CCL3Br",
@@ -3295,7 +3298,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-277232.4186,-184.0310333,13.13673812,-5.44391001e-005,
         1.197658923e-008,-1.367818632e-012,6.316164790000001e-017},
     bhigh={-8895.857689999999,-36.69528209},
-    R_s=41.93450770324052);
+    R_s=R_NASA_2002/CCL3Br.MM);
 
   constant IdealGases.Common.DataRecord CCL4(
     name="CCL4",
@@ -3309,7 +3312,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-304307.8255,-216.8170491,13.16132386,-6.43112489e-005,
         1.416482497e-008,-1.61934332e-012,7.48397435e-017},
     bhigh={-15123.2007,-39.968443},
-    R_s=54.05255531205732);
+    R_s=R_NASA_2002/CCL4.MM);
 
   constant IdealGases.Common.DataRecord CF(
     name="CF",
@@ -3323,7 +3326,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-132980.71,-121.4340891,4.45241362,0.0001293786948,-3.67055059e-008,
         6.590212389999999e-012,-3.73126161e-016},
     bhigh={28159.34108,-0.664046873},
-    R_s=268.1312628222025);
+    R_s=R_NASA_2002/CF.MM);
 
   constant IdealGases.Common.DataRecord CFplus(
     name="CFplus",
@@ -3337,7 +3340,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-80537.6278,-339.027509,4.7083735,-3.96314831e-005,2.497996218e-008,
         -5.23679043e-012,5.31394913e-016},
     bhigh={138133.7068,-3.92051473},
-    R_s=268.1360065715543);
+    R_s=R_NASA_2002/CFplus.MM);
 
   constant IdealGases.Common.DataRecord CFBr3(
     name="CFBr3",
@@ -3351,7 +3354,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-272915.8956,-332.816465,13.24822519,-9.92707754e-005,
         2.193640054e-008,-2.515424945e-012,1.165680878e-016},
     bhigh={-17301.85479,-36.2681843},
-    R_s=30.71245610970161);
+    R_s=R_NASA_2002/CFBr3.MM);
 
   constant IdealGases.Common.DataRecord CFCL(
     name="CFCL",
@@ -3365,7 +3368,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-268163.0077,-2.328091539,6.83463383,0.0001565270633,-5.967755160000001e-008,
         9.82092446e-012,-5.05889721e-016},
     bhigh={301.7669604,-9.005085128999999},
-    R_s=125.1015180031197);
+    R_s=R_NASA_2002/CFCL.MM);
 
   constant IdealGases.Common.DataRecord CFCLBr2(
     name="CFCLBr2",
@@ -3379,7 +3382,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-296081.1596,-353.12762,13.26346169,-0.0001053860298,2.32908508e-008,
         -2.670979639e-012,1.237844667e-016},
     bhigh={-23875.94306,-36.84977271},
-    R_s=36.74595044777440);
+    R_s=R_NASA_2002/CFCLBr2.MM);
 
   constant IdealGases.Common.DataRecord CFCL2(
     name="CFCL2",
@@ -3393,7 +3396,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-265311.8323,-446.972417,10.33334881,-0.0001333673368,
         2.948755634e-008,-3.3833062e-012,1.568746348e-016},
     bhigh={-13931.60489,-25.56817972},
-    R_s=81.58270696820529);
+    R_s=R_NASA_2002/CFCL2.MM);
 
   constant IdealGases.Common.DataRecord CFCL2Br(
     name="CFCL2Br",
@@ -3407,7 +3410,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-321545.505,-388.412962,13.28990796,-0.0001160048581,
         2.564498787e-008,-2.941639768e-012,1.363542881e-016},
     bhigh={-30974.21144,-38.71356695},
-    R_s=45.72957326081455);
+    R_s=R_NASA_2002/CFCL2Br.MM);
 
   constant IdealGases.Common.DataRecord CFCL3(
     name="CFCL3",
@@ -3421,7 +3424,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-345046.478,-417.782145,13.31196736,-0.0001248759531,
         2.761391353e-008,-3.16820764e-012,1.468834601e-016},
     bhigh={-36740.6719,-41.56886057000001},
-    R_s=60.52722434330010);
+    R_s=R_NASA_2002/CFCL3.MM);
 
   constant IdealGases.Common.DataRecord CF2(
     name="CF2",
@@ -3435,7 +3438,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-108642.8547,-585.498914,7.01864895,0.000392918615,-2.603822675e-007,
         6.142196389999999e-011,-4.17283326e-015},
     bhigh={-21529.45157,-13.56143285},
-    R_s=166.2652389322096);
+    R_s=R_NASA_2002/CF2.MM);
 
   constant IdealGases.Common.DataRecord CF2plus(
     name="CF2plus",
@@ -3449,7 +3452,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-64889.6607,-1064.283593,7.7857021,-0.0003158347626,
         7.130804079999999e-008,-8.53318359e-012,4.25163882e-016},
     bhigh={117844.6465,-18.19424707},
-    R_s=166.2670629405895);
+    R_s=R_NASA_2002/CF2plus.MM);
 
   constant IdealGases.Common.DataRecord CF2Br2(
     name="CF2Br2",
@@ -3463,7 +3466,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-332766.93,-618.435249,13.46170049,-0.0001849172548,4.09259134e-008,
         -4.69981043e-012,2.180811799e-016},
     bhigh={-47151.8661,-41.0536924},
-    R_s=39.62771933619107);
+    R_s=R_NASA_2002/CF2Br2.MM);
 
   constant IdealGases.Common.DataRecord CF2CL(
     name="CF2CL",
@@ -3477,7 +3480,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-280234.6654,-686.031485,10.51143635,-0.0002046954963,
         4.52889718e-008,-5.20022903e-012,2.41297145e-016},
     bhigh={-33081.7948,-28.74899785},
-    R_s=97.29067086361192);
+    R_s=R_NASA_2002/CF2CL.MM);
 
   constant IdealGases.Common.DataRecord CF2CLBr(
     name="CF2CLBr",
@@ -3491,7 +3494,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-359282.884,-653.928359,13.48831524,-0.0001956099469,4.32977597e-008,
         -4.97264437e-012,2.30757505e-016},
     bhigh={-53651.4117,-42.24913908000001},
-    R_s=50.27989488801207);
+    R_s=R_NASA_2002/CF2CLBr.MM);
 
   constant IdealGases.Common.DataRecord CF2CL2(
     name="CF2CL2",
@@ -3505,7 +3508,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-382744.855,-693.37748,13.51791274,-0.0002075114435,4.59402161e-008,
         -5.276874600000001e-012,2.449037044e-016},
     bhigh={-60215.2777,-44.79580046},
-    R_s=68.76411285679166);
+    R_s=R_NASA_2002/CF2CL2.MM);
 
   constant IdealGases.Common.DataRecord CF3(
     name="CF3",
@@ -3519,7 +3522,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-299730.5557,-1046.989457,10.77923191,-0.0003116087076,
         6.89135143e-008,-7.91122564e-012,3.67059302e-016},
     bhigh={-54253.044,-34.1703879},
-    R_s=120.489825410547);
+    R_s=R_NASA_2002/CF3.MM);
 
   constant IdealGases.Common.DataRecord CF3plus(
     name="CF3plus",
@@ -3533,7 +3536,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-29109.19531,-1996.658183,11.44279678,-0.000565339304,
         1.232297113e-007,-1.399758046e-011,6.44301795e-016},
     bhigh={59023.458,-40.80349990000001},
-    R_s=120.4907833175454);
+    R_s=R_NASA_2002/CF3plus.MM);
 
   constant IdealGases.Common.DataRecord CF3Br(
     name="CF3Br",
@@ -3547,7 +3550,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-383408.851,-971.9093300000001,13.72477396,-0.0002901710612,
         6.421892200000001e-008,-7.37568877e-012,3.42315425e-016},
     bhigh={-77653.0631,-47.1736721},
-    R_s=55.83584075992214);
+    R_s=R_NASA_2002/CF3Br.MM);
 
   constant IdealGases.Common.DataRecord CF3CL(
     name="CF3CL",
@@ -3561,7 +3564,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-406604.2119999999,-1022.626507,13.76252628,-0.0003052722979,
         6.75596604e-008,-7.75931525e-012,3.60119229e-016},
     bhigh={-84105.5937,-49.13411939},
-    R_s=79.59598689894807);
+    R_s=R_NASA_2002/CF3CL.MM);
 
   constant IdealGases.Common.DataRecord CF4(
     name="CF4",
@@ -3575,7 +3578,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-416445.678,-1414.797167,14.05124837,-0.000419909386,9.27892161e-008,
         -1.06457583e-011,4.937099680000001e-016},
     bhigh={-109469.1149,-54.87105},
-    R_s=94.47843787946721);
+    R_s=R_NASA_2002/CF4.MM);
 
   constant IdealGases.Common.DataRecord CHplus(
     name="CHplus",
@@ -3589,7 +3592,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-7102094.67,18283.54883,-13.12691402,0.006191717360000001,-2.909421253e-007,
         -1.134243575e-010,1.105962085e-014},
     bhigh={75412.9604,124.3984829},
-    R_s=638.6888634074271);
+    R_s=R_NASA_2002/CHplus.MM);
 
   constant IdealGases.Common.DataRecord CHBr3(
     name="CHBr3",
@@ -3603,7 +3606,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={627423.495,-3378.7111,14.87852612,-0.000593274527,1.082421577e-007,-1.061012665e-011,
         4.31915245e-016},
     bhigh={18772.34659,-53.1190965},
-    R_s=32.89870195398548);
+    R_s=R_NASA_2002/CHBr3.MM);
 
   constant IdealGases.Common.DataRecord CHCL(
     name="CHCL",
@@ -3617,7 +3620,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-954806.1900000001,2174.413794,4.86764537,0.0008321641859999999,-1.536948638e-007,
         1.529236537e-011,-6.596159359999999e-016},
     bhigh={18801.2181,2.674761385},
-    R_s=171.5334987634006);
+    R_s=R_NASA_2002/CHCL.MM);
 
   constant IdealGases.Common.DataRecord CHCLBr2(
     name="CHCLBr2",
@@ -3631,7 +3634,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={604286.53,-3438.24101,14.94162631,-0.000622842797,1.153724426e-007,-1.147291377e-011,
         4.733482859999999e-016},
     bhigh={18224.60958,-54.07258924},
-    R_s=39.91993648539051);
+    R_s=R_NASA_2002/CHCLBr2.MM);
 
   constant IdealGases.Common.DataRecord CHCL2(
     name="CHCL2",
@@ -3645,7 +3648,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={884939.3709999999,-3526.96973,11.86372153,-0.000500237612,
         6.1338604e-008,-1.885433405e-012,-1.234221421e-016},
     bhigh={30711.36475,-40.88905858},
-    R_s=99.0711428729393);
+    R_s=R_NASA_2002/CHCL2.MM);
 
   constant IdealGases.Common.DataRecord CHCL2Br(
     name="CHCL2Br",
@@ -3659,7 +3662,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={592487.644,-3509.47561,14.99349593,-0.000643306257,1.198581809e-007,
         -1.198476716e-011,4.96994807e-016},
     bhigh={11972.51405,-56.02687781},
-    R_s=50.75126058545075);
+    R_s=R_NASA_2002/CHCL2Br.MM);
 
   constant IdealGases.Common.DataRecord CHCL3(
     name="CHCL3",
@@ -3673,7 +3676,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={613605.274,-3715.08717,15.10777247,0.0002362584336,1.297140438e-007,
         -1.267494791e-011,5.259022309999999e-016},
     bhigh={6203.31345,-59.92576539},
-    R_s=69.64880525364717);
+    R_s=R_NASA_2002/CHCL3.MM);
 
   constant IdealGases.Common.DataRecord CHF(
     name="CHF",
@@ -3687,7 +3690,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3994085.42,-7962.756200000001,6.75559509,0.00494983657,-2.101763812e-006,
         3.34823295e-010,-1.88682505e-014},
     bhigh={67061.34940000001,-23.81240379},
-    R_s=259.6901265386055);
+    R_s=R_NASA_2002/CHF.MM);
 
   constant IdealGases.Common.DataRecord CHFBr2(
     name="CHFBr2",
@@ -3701,7 +3704,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={593575.1630000001,-3742.65658,15.17184031,-0.0007158039030000001,
         1.360636972e-007,-1.385897355e-011,5.844209110000001e-016},
     bhigh={-2347.676027,-57.6578343},
-    R_s=43.34423629625436);
+    R_s=R_NASA_2002/CHFBr2.MM);
 
   constant IdealGases.Common.DataRecord CHFCL(
     name="CHFCL",
@@ -3715,7 +3718,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={662216.358,-3809.00798,12.23880469,-0.000746718275,1.43476785e-007,-1.475406631e-011,
         6.27378068e-016},
     bhigh={10189.87746,-46.58365563},
-    R_s=123.2326171090995);
+    R_s=R_NASA_2002/CHFCL.MM);
 
   constant IdealGases.Common.DataRecord CHFCLBr(
     name="CHFCLBr",
@@ -3729,7 +3732,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={580011.7509999999,-3823.33785,15.22809062,-0.000737390631,
         1.407097155e-007,-1.438245319e-011,6.08386715e-016},
     bhigh={-8552.249899999999,-59.03677705},
-    R_s=56.41773693293094);
+    R_s=R_NASA_2002/CHFCLBr.MM);
 
   constant IdealGases.Common.DataRecord CHFCL2(
     name="CHFCL2",
@@ -3743,7 +3746,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={564011.302,-3887.0833,15.27760246,-0.0007576487420000001,
         1.452498792e-007,-1.490796515e-011,6.3289985e-016},
     bhigh={-14847.36185,-61.67535516},
-    R_s=80.78375591599298);
+    R_s=R_NASA_2002/CHFCL2.MM);
 
   constant IdealGases.Common.DataRecord CHF2(
     name="CHF2",
@@ -3757,7 +3760,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={552680.655,-3696.00917,12.08610573,-0.00064985881,1.12084622e-007,-9.814147009999999e-012,
         3.34919239e-016},
     bhigh={-9437.06842,-47.044162},
-    R_s=162.9802459201847);
+    R_s=R_NASA_2002/CHF2.MM);
 
   constant IdealGases.Common.DataRecord CHF2Br(
     name="CHF2Br",
@@ -3771,7 +3774,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={576770.684,-4177.71608,15.50150581,-0.000849014729,1.657177491e-007,
         -1.727828054e-011,7.43562723e-016},
     bhigh={-29661.47348,-63.4938014},
-    R_s=63.50859424349048);
+    R_s=R_NASA_2002/CHF2Br.MM);
 
   constant IdealGases.Common.DataRecord CHF2CL(
     name="CHF2CL",
@@ -3785,7 +3788,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={562949.373,-4298.673049999999,15.58191398,-0.000878927848,
         1.720248689e-007,-1.797910869e-011,7.753391699999999e-016},
     bhigh={-36340.6716,-66.11261479999999},
-    R_s=96.15657903158532);
+    R_s=R_NASA_2002/CHF2CL.MM);
 
   constant IdealGases.Common.DataRecord CHF3(
     name="CHF3",
@@ -3799,7 +3802,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={568523.2020000001,-4728.3617,15.86728516,-0.000738234865,
         1.970841706e-007,-2.062115571e-011,8.970599639999999e-016},
     bhigh={-59231.9637,-71.6127322},
-    R_s=118.7552183961043);
+    R_s=R_NASA_2002/CHF3.MM);
 
   constant IdealGases.Common.DataRecord CHI3(
     name="CHI3",
@@ -3813,7 +3816,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={629420.543,-3184.06157,14.79622178,-0.00057495555,1.062025541e-007,-1.052804696e-011,
         4.32972002e-016},
     bhigh={41036.098,-49.0135739},
-    R_s=21.11717854820303);
+    R_s=R_NASA_2002/CHI3.MM);
 
   constant IdealGases.Common.DataRecord CH2(
     name="CH2",
@@ -3827,7 +3830,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2550418.031,-7971.62539,12.28924487,-0.001699122922,2.991728605e-007,
         -2.767007492e-011,1.051341740e-015},
     bhigh={9.642216890e+004,-6.094739910e+001},
-    R_s=592.7681587386234);
+    R_s=R_NASA_2002/CH2.MM);
 
   constant IdealGases.Common.DataRecord CH2Br2(
     name="CH2Br2",
@@ -3841,7 +3844,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1528284.441,-6673.414949999999,16.70213316,-0.001166351237,
         2.122634493e-007,-2.07547224e-011,8.4285777e-016},
     bhigh={36007.0664,-74.48065490000001},
-    R_s=47.83001172724092);
+    R_s=R_NASA_2002/CH2Br2.MM);
 
   constant IdealGases.Common.DataRecord CH2CL(
     name="CH2CL",
@@ -3855,7 +3858,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1662438.334,-6441.12572,13.59753722,-0.00114053681,2.087760159e-007,
         -2.052347186e-011,8.37577227e-016},
     bhigh={52129.0612,-61.48586271},
-    R_s=168.0392194113208);
+    R_s=R_NASA_2002/CH2CL.MM);
 
   constant IdealGases.Common.DataRecord CH2CLBr(
     name="CH2CLBr",
@@ -3869,7 +3872,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1525016.309,-6823.33416,16.82769102,-0.001219735119,2.244964495e-007,
         -2.219063248e-011,9.104705129999999e-016},
     bhigh={33202.3992,-76.37571062000001},
-    R_s=64.26248214804383);
+    R_s=R_NASA_2002/CH2CLBr.MM);
 
   constant IdealGases.Common.DataRecord CH2CL2(
     name="CH2CL2",
@@ -3883,7 +3886,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1529279.337,-6976.95476,16.94154931,-0.001265053995,2.344766734e-007,
         -2.333227421e-011,9.632834730000001e-016},
     bhigh={28063.18171,-79.49453509999999},
-    R_s=97.89541304408743);
+    R_s=R_NASA_2002/CH2CL2.MM);
 
   constant IdealGases.Common.DataRecord CH2F(
     name="CH2F",
@@ -3897,7 +3900,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2535399.502,-9358.43902,17.00366206,-0.003062919929,
         7.612869080000001e-007,-9.664554980000001e-011,4.8447681e-015},
     bhigh={52283.9131,-87.0755157},
-    R_s=251.7642461662176);
+    R_s=R_NASA_2002/CH2F.MM);
 
   constant IdealGases.Common.DataRecord CH2FBr(
     name="CH2FBr",
@@ -3911,7 +3914,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1539975.462,-7231.55136,17.14566439,-0.001350184394,2.538022824e-007,
         -2.558977386e-011,1.069310946e-015},
     bhigh={15096.04224,-80.62053710000001},
-    R_s=73.62600604731205);
+    R_s=R_NASA_2002/CH2FBr.MM);
 
   constant IdealGases.Common.DataRecord CH2FCL(
     name="CH2FCL",
@@ -3925,7 +3928,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1536120.418,-7378.93973,17.25797178,-0.001395645457,2.639247747e-007,
         -2.675653563e-011,1.123582778e-015},
     bhigh={9813.71046,-83.13642553},
-    R_s=121.4187336054605);
+    R_s=R_NASA_2002/CH2FCL.MM);
 
   constant IdealGases.Common.DataRecord CH2F2(
     name="CH2F2",
@@ -3939,7 +3942,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1546609.496,-7876.88333,17.68770469,-0.001581298721,3.068917255e-007,
         -3.18340546e-011,1.363827177e-015},
     bhigh={-9800.13596,-89.0742036},
-    R_s=159.8225447315363);
+    R_s=R_NASA_2002/CH2F2.MM);
 
   constant IdealGases.Common.DataRecord CH2I2(
     name="CH2I2",
@@ -3953,7 +3956,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1512892.716,-6442.9124,16.59026137,-0.00113555152,2.07375025e-007,-2.033902231e-011,
         8.282283700000001e-016},
     bhigh={50582.1903,-71.2523514},
-    R_s=31.0433433175704);
+    R_s=R_NASA_2002/CH2I2.MM);
 
   constant IdealGases.Common.DataRecord CH3(
     name="CH3",
@@ -3967,7 +3970,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2760802.663,-9336.53117,14.87729606,-0.001439429774,2.444477951e-007,
         -2.224555778e-011,8.395065760e-016},
     bhigh={7.481809480e+004,-7.919682400e+001},
-    R_s=553.0279649766005);
+    R_s=R_NASA_2002/CH3.MM);
 
   constant IdealGases.Common.DataRecord CH3Br(
     name="CH3Br",
@@ -3981,7 +3984,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2524874.348,-10118.76098,18.65902163,-0.00179767369,3.29852011e-007,
         -3.25091203e-011,1.330179925e-015},
     bhigh={55405.7639,-97.7866446},
-    R_s=87.57783458179041);
+    R_s=R_NASA_2002/CH3Br.MM);
 
   constant IdealGases.Common.DataRecord CH3CL(
     name="CH3CL",
@@ -3995,7 +3998,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2522463.305,-10301.15447,18.82725852,-0.001872291294,3.47337286e-007,
         -3.45888722e-011,1.428941079e-015},
     bhigh={51114.1741,-100.6571389},
-    R_s=164.6844606350243);
+    R_s=R_NASA_2002/CH3CL.MM);
 
   constant IdealGases.Common.DataRecord CH3F(
     name="CH3F",
@@ -4009,7 +4012,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2561903.188,-10860.52758,19.2944692,-0.002070973131,3.92912453e-007,
         -3.99450342e-011,1.681447081e-015},
     bhigh={35635.0851,-106.1158456},
-    R_s=244.3078412964538);
+    R_s=R_NASA_2002/CH3F.MM);
 
   constant IdealGases.Common.DataRecord CH3I(
     name="CH3I",
@@ -4023,7 +4026,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2511915.982,-9960.289989999999,18.56907132,-0.001768191331,
         3.24220626e-007,-3.19294201e-011,1.305407821e-015},
     bhigh={60669.29949999999,-95.9077704},
-    R_s=58.57805526163038);
+    R_s=R_NASA_2002/CH3I.MM);
 
   constant IdealGases.Common.DataRecord CH2OH(
     name="CH2OH",
@@ -4037,7 +4040,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2250349.506,-8173.186060000001,15.99639179,-0.0008704133719999999,
         6.06918395e-008,4.40834946e-012,-5.7023095e-016},
     bhigh={46453.1343,-78.3515845},
-    R_s=267.9168471143832);
+    R_s=R_NASA_2002/CH2OH.MM);
 
   constant IdealGases.Common.DataRecord CH2OHplus(
     name="CH2OHplus",
@@ -4051,7 +4054,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2603333.487,-10099.5381,17.30843898,-0.000694639032,3.009715083e-008,
         5.22148598e-012,-5.09018379e-016},
     bhigh={146540.2426,-92.2395528},
-    R_s=267.9215832798624);
+    R_s=R_NASA_2002/CH2OHplus.MM);
 
   constant IdealGases.Common.DataRecord CH3O(
     name="CH3O",
@@ -4065,7 +4068,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2101188.243,-8841.968800000001,18.22645731,-0.001743485034,
         3.34043427e-007,-3.43067316e-011,1.473897771e-015},
     bhigh={53095.82060000001,-94.2250059},
-    R_s=267.9168471143832);
+    R_s=R_NASA_2002/CH3O.MM);
 
   constant IdealGases.Common.DataRecord CH4(
     name="CH4",
@@ -4079,7 +4082,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3730042.76,-13835.01485,20.49107091,-0.001961974759,4.72731304e-007,
         -3.72881469e-011,1.623737207e-015},
     bhigh={75320.6691,-121.9124889},
-    R_s=518.2814855078335);
+    R_s=R_NASA_2002/CH4.MM);
 
   constant IdealGases.Common.DataRecord CH3OH(
     name="CH3OH",
@@ -4093,7 +4096,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3411570.76,-13455.00201,22.61407623,-0.002141029179,3.73005054e-007,
         -3.49884639e-011,1.366073444e-015},
     bhigh={56360.8156,-127.7814279},
-    R_s=259.4889934604296);
+    R_s=R_NASA_2002/CH3OH.MM);
 
   constant IdealGases.Common.DataRecord CH3OOH(
     name="CH3OOH",
@@ -4107,7 +4110,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3060740.61,-12829.59627,25.41021168,-0.002394481095,4.44342991e-007,
         -4.4166595e-011,1.819673372e-015},
     bhigh={5.837492360e+004,-1.387713096e+002},
-    R_s=173.070190082442);
+    R_s=R_NASA_2002/CH3OOH.MM);
 
   constant IdealGases.Common.DataRecord CI(
     name="CI",
@@ -4121,7 +4124,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-240822.9894,344.738704,4.9769687,-0.000844481539,
         5.061239719999999e-007,-1.047700525e-010,6.74084314e-015},
     bhigh={64513.4202,1.090913159},
-    R_s=59.85314634823540);
+    R_s=R_NASA_2002/CI.MM);
 
   constant IdealGases.Common.DataRecord CI2(
     name="CI2",
@@ -4135,7 +4138,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-702865.553,308.2750393,9.04642705,-0.002946736644,1.424347233e-006,
         -2.45318341e-010,1.425270291e-014},
     bhigh={50211.34209999999,-15.60349377},
-    R_s=31.27876480458705);
+    R_s=R_NASA_2002/CI2.MM);
 
   constant IdealGases.Common.DataRecord CI3(
     name="CI3",
@@ -4149,7 +4152,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-153651.1918,-83.5704437,10.06203125,-2.466447336e-005,
         5.41905475e-009,-6.181417e-013,2.851262022e-017},
     bhigh={45825.8953,-14.94825345},
-    R_s=21.17137651671042);
+    R_s=R_NASA_2002/CI3.MM);
 
   constant IdealGases.Common.DataRecord CI4(
     name="CI4",
@@ -4163,7 +4166,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-144676.277,-52.8036517,13.03985589,-1.606214814e-005,
         3.56755047e-009,-4.10536698e-013,1.907272766e-017},
     bhigh={28177.46618,-28.10414436},
-    R_s=16.0008712376829);
+    R_s=R_NASA_2002/CI4.MM);
 
   constant IdealGases.Common.DataRecord CN(
     name="CN",
@@ -4177,7 +4180,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2228006.27,5040.733389999999,-0.2121897722,0.001354901134,
         1.325929798e-007,-6.93700637e-011,5.49495227e-015},
     bhigh={17844.96132,32.82563919},
-    R_s=319.5749767463313);
+    R_s=R_NASA_2002/CN.MM);
 
   constant IdealGases.Common.DataRecord CNplus(
     name="CNplus",
@@ -4191,7 +4194,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-7153463.08,18572.50421,-10.84534159,0.00610668143,-1.191208566e-006,
         1.184848778e-010,-4.799838730000001e-015},
     bhigh={92426.44959999999,113.5340573},
-    R_s=319.5817154108049);
+    R_s=R_NASA_2002/CNplus.MM);
 
   constant IdealGases.Common.DataRecord CNminus(
     name="CNminus",
@@ -4205,7 +4208,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={351796.472,-1630.477359,5.60987575,-0.000397560597,
         8.856147079999999e-008,-9.722872320000001e-012,4.43420569e-016},
     bhigh={16479.76581,-11.75502699},
-    R_s=319.5682383660332);
+    R_s=R_NASA_2002/CNminus.MM);
 
   constant IdealGases.Common.DataRecord CNN(
     name="CNN",
@@ -4219,7 +4222,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-181714.8765,-672.986349,7.85794834,-6.13688072e-005,-1.088178985e-008,
         4.45665581e-012,-2.836496278e-016},
     bhigh={77234.8898,-19.66012324},
-    R_s=207.7375881031678);
+    R_s=R_NASA_2002/CNN.MM);
 
   constant IdealGases.Common.DataRecord CO(
     name="CO",
@@ -4233,7 +4236,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={461919.725,-1944.704863,5.91671418,-0.0005664282830000001,
         1.39881454e-007,-1.787680361e-011,9.62093557e-016},
     bhigh={-2466.261084,-13.87413108},
-    R_s=296.8397113898201);
+    R_s=R_NASA_2002/CO.MM);
 
   constant IdealGases.Common.DataRecord COplus(
     name="COplus",
@@ -4247,7 +4250,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={231684.7506,-1057.646148,4.55425778,0.000449552032,-2.489507047e-007,
         5.26756642e-011,-3.28951027e-015},
     bhigh={155505.0724,-3.87346264},
-    R_s=296.8455253446152);
+    R_s=R_NASA_2002/COplus.MM);
 
   constant IdealGases.Common.DataRecord COCL(
     name="COCL",
@@ -4261,7 +4264,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={344372.024,-1793.14347,8.392755899999999,-0.000537476959,
         9.113555710000001e-008,-3.111441728e-012,-2.040435218e-016},
     bhigh={6914.470149999999,-19.98919104},
-    R_s=131.0132974909830);
+    R_s=R_NASA_2002/COCL.MM);
 
   constant IdealGases.Common.DataRecord COCL2(
     name="COCL2",
@@ -4275,7 +4278,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-25458.81891,-1305.958516,10.92922584,-0.000360121016,
         7.78701765e-008,-8.79245203e-012,4.02869661e-016},
     bhigh={-22198.4734,-32.3330345},
-    R_s=84.05618498909682);
+    R_s=R_NASA_2002/COCL2.MM);
 
   constant IdealGases.Common.DataRecord COFCL(
     name="COFCL",
@@ -4289,7 +4292,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-53168.8791,-1581.009678,11.12696501,-0.00043730008,
         9.464190710000001e-008,-1.069291346e-011,4.901756640000001e-016},
     bhigh={-45996.6723,-35.25879824},
-    R_s=100.8289890112020);
+    R_s=R_NASA_2002/COFCL.MM);
 
   constant IdealGases.Common.DataRecord COF2(
     name="COF2",
@@ -4303,7 +4306,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-40738.0685,-1974.009812,11.40363654,-0.000543711147,
         1.175232744e-007,-1.326564192e-011,6.07677213e-016},
     bhigh={-69077.9541,-40.09695},
-    R_s=125.9642430386648);
+    R_s=R_NASA_2002/COF2.MM);
 
   constant IdealGases.Common.DataRecord COHCL(
     name="COHCL",
@@ -4317,7 +4320,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={831895.285,-4416.87084,12.70661114,-0.0009361408629999999,
         1.855335611e-007,-1.958378539e-011,8.512046829999999e-016},
     bhigh={4330.49644,-51.45071542},
-    R_s=128.9650360844187);
+    R_s=R_NASA_2002/COHCL.MM);
 
   constant IdealGases.Common.DataRecord COHF(
     name="COHF",
@@ -4331,7 +4334,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={857885.316,-4791.95912,12.93975218,-0.001018285299,2.021278474e-007,
         -2.136698091e-011,9.299588910000002e-016},
     bhigh={-18789.33107,-55.2744914},
-    R_s=173.1596396127900);
+    R_s=R_NASA_2002/COHF.MM);
 
   constant IdealGases.Common.DataRecord COS(
     name="COS",
@@ -4345,7 +4348,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={195909.8567,-1756.167688,8.71043034,-0.000413942496,1.015243648e-007,
         -1.159609663e-011,5.691053860000001e-016},
     bhigh={-8927.09669,-26.36328016},
-    R_s=138.4019335798026);
+    R_s=R_NASA_2002/COS.MM);
 
   constant IdealGases.Common.DataRecord CO2(
     name="CO2",
@@ -4359,7 +4362,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={117696.2419,-1788.791477,8.29152319,-9.22315678e-005,4.86367688e-009,
         -1.891053312e-012,6.330036589999999e-016},
     bhigh={-39083.5059,-26.52669281},
-    R_s=188.9253456640044);
+    R_s=R_NASA_2002/CO2.MM);
 
   constant IdealGases.Common.DataRecord CO2plus(
     name="CO2plus",
@@ -4373,7 +4376,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-169505.1682,-806.646973,8.00282846,-0.0001577214041,
         2.566759314e-008,-2.404195965e-012,1.6774468e-016},
     bhigh={115438.9478,-21.33567772},
-    R_s=188.9277007404453);
+    R_s=R_NASA_2002/CO2plus.MM);
 
   constant IdealGases.Common.DataRecord COOH(
     name="COOH",
@@ -4387,7 +4390,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={929318.873,-4483.030570000001,12.42199567,-0.0007463139639999999,
         1.332996131e-007,-1.28271055e-011,5.1379979e-016},
     bhigh={-851.8232680000001,-50.6806551},
-    R_s=184.695309195725);
+    R_s=R_NASA_2002/COOH.MM);
 
   constant IdealGases.Common.DataRecord CP(
     name="CP",
@@ -4401,7 +4404,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-5449937.15,16883.45926,-15.956922,0.01136028761,-2.84654133e-006,
         3.37936404e-010,-1.554457397e-014},
     bhigh={-45545.17739999999,145.1324059},
-    R_s=193.430598094507);
+    R_s=R_NASA_2002/CP.MM);
 
   constant IdealGases.Common.DataRecord CS(
     name="CS",
@@ -4415,7 +4418,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-971957.476,2339.201284,1.709390402,0.001577178949,-4.146335910000001e-007,
         4.50475708e-011,-5.94545773e-016},
     bhigh={16810.20727,18.7404822},
-    R_s=188.6415870876696);
+    R_s=R_NASA_2002/CS.MM);
 
   constant IdealGases.Common.DataRecord CS2(
     name="CS2",
@@ -4429,7 +4432,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1390419.724,3354.9755,3.019247723,0.002876437543,-9.076812719999999e-007,
         1.374091042e-010,-6.99957557e-015},
     bhigh={-10138.98046,15.65113703},
-    R_s=109.1992850078867);
+    R_s=R_NASA_2002/CS2.MM);
 
   constant IdealGases.Common.DataRecord C2(
     name="C2",
@@ -4443,7 +4446,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-968926.793,3561.09299,-0.5064138930000001,0.002945154879,-7.13944119e-007,
         8.67065725e-011,-4.07690681e-015},
     bhigh={76817.96829999999,33.3998524},
-    R_s=346.1292847211237);
+    R_s=R_NASA_2002/C2.MM);
 
   constant IdealGases.Common.DataRecord C2plus(
     name="C2plus",
@@ -4457,7 +4460,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3836292.81,-6242.062449999999,2.779245639,0.006065865859999999,-2.452799858e-006,
         3.8829425e-010,-2.190639912e-014},
     bhigh={285744.7553,0.729738349},
-    R_s=346.1371897916990);
+    R_s=R_NASA_2002/C2plus.MM);
 
   constant IdealGases.Common.DataRecord C2minus(
     name="C2minus",
@@ -4471,7 +4474,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4478136.25,-11541.45714,13.10143499,-0.001862700578,4.00693125e-008,
         3.7102136e-011,-3.33726687e-015},
     bhigh={132535.6168,-69.75964399999999},
-    R_s=346.1213800116116);
+    R_s=R_NASA_2002/C2minus.MM);
 
   constant IdealGases.Common.DataRecord C2CL(
     name="C2CL",
@@ -4485,7 +4488,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={213736.8408,-1630.519518,8.62349025,-0.000425351786,9.04001864e-008,
         -1.007541495e-011,4.570764750000001e-016},
     bhigh={71710.9328,-24.13014598},
-    R_s=139.7998130287990);
+    R_s=R_NASA_2002/C2CL.MM);
 
   constant IdealGases.Common.DataRecord C2CL2(
     name="C2CL2",
@@ -4499,7 +4502,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2.961995390e+005,-2.044290845e+003,1.187529729e+001,-5.115031340e-004,1.072666588e-007,
         -1.183417569e-011,5.326530480e-016},
     bhigh={3.636802500e+004,-4.000826050e+001},
-    R_s=87.58864725240922);
+    R_s=R_NASA_2002/C2CL2.MM);
 
   constant IdealGases.Common.DataRecord C2CL3(
     name="C2CL3",
@@ -4513,7 +4516,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-220402.8219,-1072.926248,13.78367377,-0.0003093322915,
         6.77752895e-008,-7.72730182e-012,3.56669022e-016},
     bhigh={24310.20015,-43.42161815},
-    R_s=63.77116499105693);
+    R_s=R_NASA_2002/C2CL3.MM);
 
   constant IdealGases.Common.DataRecord C2CL4(
     name="C2CL4",
@@ -4527,7 +4530,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3.001289625e+005,-1.132413909e+003,1.683073063e+001,-3.288820170e-004,7.220975400e-008,
        -8.245417760e-012,3.810154710e-016},
     bhigh={-2.292758158e+003,-5.980164420e+001},
-    R_s=50.13809139600150);
+    R_s=R_NASA_2002/C2CL4.MM);
 
   constant IdealGases.Common.DataRecord C2CL6(
     name="C2CL6",
@@ -4541,7 +4544,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-5.577351940e+005,-4.976576790e+002,2.237042798e+001,-1.477797229e-004,3.257641460e-008,
        -3.727218070e-012,1.723860648e-016},
     bhigh={-2.335217699e+004,-8.381736910e+001},
-    R_s=35.12120592588587);
+    R_s=R_NASA_2002/C2CL6.MM);
 
   constant IdealGases.Common.DataRecord C2F(
     name="C2F",
@@ -4555,7 +4558,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={289877.6676,-2016.644658,8.87504571,-0.000516684113,1.092094306e-007,
         -1.212216787e-011,5.48228768e-016},
     bhigh={52412.8792,-27.7308958},
-    R_s=193.2716884209271);
+    R_s=R_NASA_2002/C2F.MM);
 
   constant IdealGases.Common.DataRecord C2FCL(
     name="C2FCL",
@@ -4569,7 +4572,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={347145.489,-2348.4611,12.06875617,-0.000580469823,1.21273434e-007,-1.334214186e-011,
         5.99255661e-016},
     bhigh={15020.61224,-42.52445687},
-    R_s=105.9540332567093);
+    R_s=R_NASA_2002/C2FCL.MM);
 
   constant IdealGases.Common.DataRecord C2FCL3(
     name="C2FCL3",
@@ -4583,7 +4586,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-282950.5545,-1473.853145,17.07879074,-0.000426521339,
         9.357199850000001e-008,-1.067932796e-011,4.93326161e-016},
     bhigh={-17384.33314,-61.97054796},
-    R_s=55.66057447165302);
+    R_s=R_NASA_2002/C2FCL3.MM);
 
   constant IdealGases.Common.DataRecord C2F2(
     name="C2F2",
@@ -4597,7 +4600,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={419389.094,-2715.359989,12.30403413,-0.0006649305540000001,
         1.385254301e-007,-1.520813764e-011,6.81982103e-016},
     bhigh={-4179.221939999999,-46.7038623},
-    R_s=134.0656314111012);
+    R_s=R_NASA_2002/C2F2.MM);
 
   constant IdealGases.Common.DataRecord C2F2CL2(
     name="C2F2CL2",
@@ -4611,7 +4614,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-870256.566,726.472448,15.30689121,0.0003045597224,-7.04546804e-008,
         8.28592434e-012,-3.89858107e-016},
     bhigh={-52088.8871,-49.98300753},
-    R_s=62.55075900155986);
+    R_s=R_NASA_2002/C2F2CL2.MM);
 
   constant IdealGases.Common.DataRecord C2F3(
     name="C2F3",
@@ -4625,7 +4628,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-124260.3837,-2137.292446,14.55051371,-0.0006093891980000001,
         1.331427672e-007,-1.515124358e-011,6.98411206e-016},
     bhigh={-19771.46179,-54.21039870000001},
-    R_s=102.6272271951504);
+    R_s=R_NASA_2002/C2F3.MM);
 
   constant IdealGases.Common.DataRecord C2F3CL(
     name="C2F3CL",
@@ -4639,7 +4642,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-216272.4659,-2195.103372,17.59605428,-0.000628261729,
         1.37416661e-007,-1.565004037e-011,7.218309900000001e-016},
     bhigh={-55151.095,-69.21931823999999},
-    R_s=71.38780690134639);
+    R_s=R_NASA_2002/C2F3CL.MM);
 
   constant IdealGases.Common.DataRecord C2F4(
     name="C2F4",
@@ -4653,7 +4656,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-162991.5758,-2603.903955,17.88488423,-0.000739703801,
         1.61446034e-007,-1.835820392e-011,8.45764107e-016},
     bhigh={-70063.7166,-74.54165860000001},
-    R_s=83.13261946610480);
+    R_s=R_NASA_2002/C2F4.MM);
 
   constant IdealGases.Common.DataRecord C2F6(
     name="C2F6",
@@ -4667,7 +4670,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1011551.484,-942.2140710000001,22.02553906,-0.000131451875,
         1.8660453e-008,-3.46711861e-012,2.488311205e-016},
     bhigh={-165743.4402,-93.02161150000001},
-    R_s=60.24491270527358);
+    R_s=R_NASA_2002/C2F6.MM);
 
   constant IdealGases.Common.DataRecord C2H(
     name="C2H",
@@ -4681,7 +4684,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3922334.57,-12047.51703,17.5617292,-0.00365544294,6.98768543e-007,-6.82516201e-011,
         2.719262793e-015},
     bhigh={143326.6627,-95.6163438},
-    R_s=332.1905411808701);
+    R_s=R_NASA_2002/C2H.MM);
 
   constant IdealGases.Common.DataRecord C2HCL(
     name="C2HCL",
@@ -4695,7 +4698,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1.152149855e+006,-4.461204350e+003,1.281367818e+001,-6.797397460e-004,1.151395389e-007,
         -1.046657798e-011,3.949939170e-016},
     bhigh={5.233955000e+004,-5.320661700e+001},
-    R_s=137.4707268471765);
+    R_s=R_NASA_2002/C2HCL.MM);
 
   constant IdealGases.Common.DataRecord C2HCL3(
     name="C2HCL3",
@@ -4709,7 +4712,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6.049298240e+005,-4.237003190e+003,1.846274582e+001,-8.137243260e-004,1.551223511e-007,
         -1.584645594e-011,6.701006540e-016},
     bhigh={1.848292676e+004,-7.698375250e+001},
-    R_s=63.28238072071425);
+    R_s=R_NASA_2002/C2HCL3.MM);
 
   constant IdealGases.Common.DataRecord C2HF(
     name="C2HF",
@@ -4723,7 +4726,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1234347.179,-4819.58196,13.02337752,-0.000749543582,1.285452942e-007,
         -1.184559365e-011,4.53678476e-016},
     bhigh={32368.1171,-56.4079182},
-    R_s=188.8470631399522);
+    R_s=R_NASA_2002/C2HF.MM);
 
   constant IdealGases.Common.DataRecord C2HFCL2(
     name="C2HFCL2",
@@ -4737,7 +4740,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={407124.352,-3808.20452,18.2114405,-0.000727896606,1.381532849e-007,-1.405342513e-011,
         5.92000972e-016},
     bhigh={-2676.849943,-75.67353566999999},
-    R_s=72.34176638214635);
+    R_s=R_NASA_2002/C2HFCL2.MM);
 
   constant IdealGases.Common.DataRecord C2HF2CL(
     name="C2HF2CL",
@@ -4751,7 +4754,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={583037.47,-3810.31741,17.99003171,-0.000588821086,1.002861284e-007,-9.149788100000001e-012,
         3.45998516e-016},
     bhigh={-22058.75409,-75.90948533},
-    R_s=84.42914367096910);
+    R_s=R_NASA_2002/C2HF2CL.MM);
 
   constant IdealGases.Common.DataRecord C2HF3(
     name="C2HF3",
@@ -4765,7 +4768,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={691741.378,-5260.30164,19.15276614,-0.001072493938,2.099276744e-007,
         -2.195126633e-011,9.472702399999999e-016},
     bhigh={-32476.4021,-87.5045695},
-    R_s=101.3661158829454);
+    R_s=R_NASA_2002/C2HF3.MM);
 
   constant IdealGases.Common.DataRecord C2H2_vinylidene(
     name="C2H2_vinylidene",
@@ -4779,7 +4782,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1940838.725,-6892.718150000001,13.39582494,-0.0009368968669999999,
         1.470804368e-007,-1.220040365e-011,4.12239166e-016},
     bhigh={91071.1293,-63.3750293},
-    R_s=319.3309746640202);
+    R_s=R_NASA_2002/C2H2_vinylidene.MM);
 
   constant IdealGases.Common.DataRecord C2H2CL2(
     name="C2H2CL2",
@@ -4793,7 +4796,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1561121.185,-7358.096350000001,20.11869185,-0.001310978834,
         2.411885716e-007,-2.38416674e-011,9.78541575e-016},
     bhigh={41222.009,-95.50252712000001},
-    R_s=85.76674938170031);
+    R_s=R_NASA_2002/C2H2CL2.MM);
 
   constant IdealGases.Common.DataRecord C2H2FCL(
     name="C2H2FCL",
@@ -4807,7 +4810,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1527690.968,-6689.712229999999,19.5055383,-0.001040920895,
         1.780587502e-007,-1.633098515e-011,6.213465560000001e-016},
     bhigh={17052.66451,-91.94078300999999},
-    R_s=103.3003606151678);
+    R_s=R_NASA_2002/C2H2FCL.MM);
 
   constant IdealGases.Common.DataRecord C2H2F2(
     name="C2H2F2",
@@ -4821,7 +4824,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-822719.275,-2915.718833,18.30163995,-0.001039630129,
         2.546725128e-007,-3.157578705e-011,1.55154096e-015},
     bhigh={-31100.28589,-84.00834700000002},
-    R_s=129.8450632693028);
+    R_s=R_NASA_2002/C2H2F2.MM);
 
   constant IdealGases.Common.DataRecord CH2CO_ketene(
     name="CH2CO_ketene",
@@ -4835,7 +4838,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2013564.915,-8200.88746,17.59694074,-0.001464544521,2.695886969e-007,
        -2.66567484e-011,1.094204522e-015},
     bhigh={4.177776880e+004,-8.725803580e+001},
-    R_s=197.7917856500561);
+    R_s=R_NASA_2002/CH2CO_ketene.MM);
 
   constant IdealGases.Common.DataRecord O_CH_2O(
     name="O_CH_2O",
@@ -4849,7 +4852,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={267806.3593,-4436.61748,17.81696797,-0.000709717378,1.272621878e-007,
         -1.237226678e-011,5.025057520e-016},
     bhigh={-4.479608280e+003,-8.156700640e+001},
-    R_s=143.2645002901643);
+    R_s=R_NASA_2002/O_CH_2O.MM);
 
   constant IdealGases.Common.DataRecord HO_CO_2OH(
     name="HO_CO_2OH",
@@ -4863,7 +4866,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1805560.696,-9240.33315,26.25742604,-0.001418458557,2.526840574e-007,
         -2.521005198e-011,1.040036111e-015},
     bhigh={-3.754286460e+004,-1.326879788e+002},
-    R_s=92.34765459786253);
+    R_s=R_NASA_2002/HO_CO_2OH.MM);
 
   constant IdealGases.Common.DataRecord C2H3_vinyl(
     name="C2H3_vinyl",
@@ -4877,7 +4880,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2718080.093,-10309.56829,18.36579807,-0.001580131153,
         2.680594939e-007,-2.439003999e-011,9.20909639e-016},
     bhigh={97650.55589999999,-97.6008686},
-    R_s=307.4299266191956);
+    R_s=R_NASA_2002/C2H3_vinyl.MM);
 
   constant IdealGases.Common.DataRecord CH2BrminusCOOH(
     name="CH2BrminusCOOH",
@@ -4891,7 +4894,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2486349.85,-11402.56346,27.56020307,-0.00184318701,3.26539274e-007,
         -3.122663159e-011,1.223452495e-015},
     bhigh={1.837013127e+004,-1.420040888e+002},
-    R_s=59.83899590652677);
+    R_s=R_NASA_2002/CH2BrminusCOOH.MM);
 
   constant IdealGases.Common.DataRecord C2H3CL(
     name="C2H3CL",
@@ -4905,7 +4908,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2.456178566e+006,-1.047452720e+004,2.178736544e+001,-1.816893523e-003,3.296374030e-007,
         -3.214400710e-011,1.302256512e-015},
     bhigh={6.346231290e+004,-1.149890773e+002},
-    R_s=133.0365874576306);
+    R_s=R_NASA_2002/C2H3CL.MM);
 
   constant IdealGases.Common.DataRecord CH2CLminusCOOH(
     name="CH2CLminusCOOH",
@@ -4919,7 +4922,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2.472881709e+006,-1.152275613e+004,2.766275288e+001,-1.886429520e-003,3.361772590e-007,
         -3.231268060e-011,1.273273865e-015},
     bhigh={1.370384800e+004,-1.443191119e+002},
-    R_s=87.98728675450323);
+    R_s=R_NASA_2002/CH2CLminusCOOH.MM);
 
   constant IdealGases.Common.DataRecord C2H3F(
     name="C2H3F",
@@ -4933,7 +4936,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2478832.34,-10759.32307,21.94796688,-0.00186911411,3.39528067e-007,-3.31538293e-011,
         1.345081799e-015},
     bhigh={45634.5555,-118.0410277},
-    R_s=180.5789688592535);
+    R_s=R_NASA_2002/C2H3F.MM);
 
   constant IdealGases.Common.DataRecord CH3CN(
     name="CH3CN",
@@ -4947,7 +4950,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2923231.393,-12337.92258,23.24477222,-0.002411565845,
         4.622157170000001e-007,-4.74060124e-011,2.010639467e-015},
     bhigh={80585.65550000001,-129.2249102},
-    R_s=202.5364465291757);
+    R_s=R_NASA_2002/CH3CN.MM);
 
   constant IdealGases.Common.DataRecord CH3CO_acetyl(
     name="CH3CO_acetyl",
@@ -4961,7 +4964,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2485388.15,-11207.14204,22.77525438,-0.00231426055,4.53618917e-007,-4.74263555e-011,
         2.044663903e-015},
     bhigh={63800.8841,-121.5350925},
-    R_s=193.1602602137039);
+    R_s=R_NASA_2002/CH3CO_acetyl.MM);
 
   constant IdealGases.Common.DataRecord C2H4(
     name="C2H4",
@@ -4975,7 +4978,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3408763.67,-13748.47903,23.65898074,-0.002423804419,4.43139566e-007,
         -4.35268339e-011,1.775410633e-015},
     bhigh={88204.2938,-137.1278108},
-    R_s=296.3840793693117);
+    R_s=R_NASA_2002/C2H4.MM);
 
   constant IdealGases.Common.DataRecord C2H4O_ethylen_o(
     name="C2H4O_ethylen_o",
@@ -4989,7 +4992,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3151809.957,-14236.46316,27.08080476,-0.002606238456,
         4.853891929999999e-007,-4.85214476e-011,2.011778721e-015},
     bhigh={76625.61440000001,-156.3952401},
-    R_s=188.7406770457835);
+    R_s=R_NASA_2002/C2H4O_ethylen_o.MM);
 
   constant IdealGases.Common.DataRecord CH3CHO_ethanal(
     name="CH3CHO_ethanal",
@@ -5003,7 +5006,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3321176.59,-14497.19957,27.08421279,-0.002879320054,5.55630992e-007,
         -5.73267488e-011,2.443965239e-015},
     bhigh={65077.5564,-153.6236027},
-    R_s=188.7406770457835);
+    R_s=R_NASA_2002/CH3CHO_ethanal.MM);
 
   constant IdealGases.Common.DataRecord CH3COOH(
     name="CH3COOH",
@@ -5017,7 +5020,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2103514.223,-14678.22192,33.8280283,-0.00569485868,1.343221353e-006,
         -1.606041158e-010,7.652794250000001e-015},
     bhigh={29242.28407,-193.527885},
-    R_s=138.4552644076896);
+    R_s=R_NASA_2002/CH3COOH.MM);
 
   constant IdealGases.Common.DataRecord OHCH2COOH(
     name="OHCH2COOH",
@@ -5031,7 +5034,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1946628.253,-9804.020200000001,28.44111243,-0.000787640475,
         6.416275950000001e-008,1.069321262e-012,-3.23717828e-016},
     bhigh={-16946.5047,-147.4109363},
-    R_s=109.3275649508438);
+    R_s=R_NASA_2002/OHCH2COOH.MM);
 
   constant IdealGases.Common.DataRecord C2H5(
     name="C2H5",
@@ -5045,7 +5048,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4169220.4,-16629.82142,27.95442134,-0.003051715761,
         5.685160040000001e-007,-5.6828636e-011,2.355648561e-015},
     bhigh={113701.0087,-163.9357995},
-    R_s=286.1044489024848);
+    R_s=R_NASA_2002/C2H5.MM);
 
   constant IdealGases.Common.DataRecord C2H5Br(
     name="C2H5Br",
@@ -5059,7 +5062,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2378649.403,-12670.33647,27.77558646,-0.002010898783,4.43608341e-007,
         -5.34819809e-011,2.63983585e-015},
     bhigh={64140.6205,-152.8277085},
-    R_s=76.30433964636384);
+    R_s=R_NASA_2002/C2H5Br.MM);
 
   constant IdealGases.Common.DataRecord C2H6(
     name="C2H6",
@@ -5073,7 +5076,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5025782.13,-20330.22397,33.2255293,-0.00383670341,7.23840586e-007,-7.3191825e-011,
         3.065468699e-015},
     bhigh={111596.395,-203.9410584},
-    R_s=276.5139824883003);
+    R_s=R_NASA_2002/C2H6.MM);
 
   constant IdealGases.Common.DataRecord CH3N2CH3(
     name="CH3N2CH3",
@@ -5087,7 +5090,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4993357.09,-21609.96161,39.6444992,-0.00419645011,
         8.023361980000001e-007,-8.212260020000001e-011,3.47723744e-015},
     bhigh={144996.261,-237.2109745},
-    R_s=143.1501500281324);
+    R_s=R_NASA_2002/CH3N2CH3.MM);
 
   constant IdealGases.Common.DataRecord C2H5OH(
     name="C2H5OH",
@@ -5101,7 +5104,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4694817.65,-19297.98213,34.4758404,-0.00323616598,5.78494772e-007,-5.56460027e-011,
         2.2262264e-015},
     bhigh={86016.22709999999,-203.4801732},
-    R_s=180.4816920216964);
+    R_s=R_NASA_2002/C2H5OH.MM);
 
   constant IdealGases.Common.DataRecord CH3OCH3(
     name="CH3OCH3",
@@ -5115,7 +5118,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4933577.19,-20830.94065,36.2905061,-0.004108351640000001,
         7.90322031e-007,-8.13143563e-011,3.45816611e-015},
     bhigh={101330.1012,-218.5447466},
-    R_s=180.4816920216964);
+    R_s=R_NASA_2002/CH3OCH3.MM);
 
   constant IdealGases.Common.DataRecord CH3O2CH3(
     name="CH3O2CH3",
@@ -5129,7 +5132,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5316368.47,-22212.67874,40.3433509,-0.00461274809,
         8.792987200000001e-007,-9.068221189999999e-011,3.865664890000001e-015},
     bhigh={116159.6028,-239.5296055},
-    R_s=133.9584235571916);
+    R_s=R_NASA_2002/CH3O2CH3.MM);
 
   constant IdealGases.Common.DataRecord CCN(
     name="CCN",
@@ -5143,7 +5146,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={79486.74890000001,-1344.786906,8.309986459999999,-0.0002220105361,
         1.753683113e-008,2.545998719e-012,-2.645649117e-016},
     bhigh={102318.7495,-22.5979394},
-    R_s=218.6412153118352);
+    R_s=R_NASA_2002/CCN.MM);
 
   constant IdealGases.Common.DataRecord CNC(
     name="CNC",
@@ -5157,7 +5160,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-90313.13559999999,-831.32365,8.11473595,-0.0002447691991,
         5.39750877e-008,-6.18398486e-012,2.865172411e-016},
     bhigh={84518.33600000001,-21.02937255},
-    R_s=218.6412153118352);
+    R_s=R_NASA_2002/CNC.MM);
 
   constant IdealGases.Common.DataRecord OCCN(
     name="OCCN",
@@ -5171,7 +5174,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={935913.1680000001,-4441.082289999999,13.68959297,-0.001647530917,
         3.81987344e-007,-3.945161e-011,1.509598839e-015},
     bhigh={49512.2278,-54.1708968},
-    R_s=153.8939215074386);
+    R_s=R_NASA_2002/OCCN.MM);
 
   constant IdealGases.Common.DataRecord C2N2(
     name="C2N2",
@@ -5185,7 +5188,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={793442.372,-3997.37627,13.1449743,-0.0008747782000000001,
         2.059156733e-007,-2.200469389e-011,9.97448577e-016},
     bhigh={58636.323,-54.73201251},
-    R_s=159.7874883731657);
+    R_s=R_NASA_2002/C2N2.MM);
 
   constant IdealGases.Common.DataRecord C2O(
     name="C2O",
@@ -5199,7 +5202,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-634805.659,1184.133091,4.87917334,0.001757538773,-3.95755227e-007,
         3.98917994e-011,-1.546043135e-015},
     bhigh={24898.03938,0.980904059},
-    R_s=207.7547175468756);
+    R_s=R_NASA_2002/C2O.MM);
 
   constant IdealGases.Common.DataRecord C3(
     name="C3",
@@ -5213,7 +5216,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4508098.93,-14610.33761,22.81974644,-0.008544340610000001,
         2.146069341e-006,-2.103867761e-010,6.351589060000001e-015},
     bhigh={191197.6065,-127.1869723},
-    R_s=230.7528564807491);
+    R_s=R_NASA_2002/C3.MM);
 
   constant IdealGases.Common.DataRecord C3H3_1_propynl(
     name="C3H3_1_propynl",
@@ -5227,7 +5230,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4550654.87,-16405.74172,27.12605991,-0.00447460038,1.037712415e-006,
         -1.250211369e-010,6.02658205e-015},
     bhigh={153408.7662,-156.5931809},
-    R_s=212.8873164426801);
+    R_s=R_NASA_2002/C3H3_1_propynl.MM);
 
   constant IdealGases.Common.DataRecord C3H3_2_propynl(
     name="C3H3_2_propynl",
@@ -5241,7 +5244,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2989723.833,-11189.54446,22.22225052,-0.002068106902,4.12188364e-007,
         -4.43898059e-011,1.970824701e-015},
     bhigh={106187.8289,-118.6744583},
-    R_s=212.8873164426801);
+    R_s=R_NASA_2002/C3H3_2_propynl.MM);
 
   constant IdealGases.Common.DataRecord C3H4_allene(
     name="C3H4_allene",
@@ -5255,7 +5258,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3479355.1,-14304.12453,27.02534756,-0.002557412369,4.70664675e-007,-4.65168807e-011,
         1.908219044e-015},
     bhigh={107231.2354,-154.8846158},
-    R_s=207.5314260782661);
+    R_s=R_NASA_2002/C3H4_allene.MM);
 
   constant IdealGases.Common.DataRecord C3H4_propyne(
     name="C3H4_propyne",
@@ -5269,7 +5272,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3710441.42,-14891.45507,27.32397127,-0.00264526477,
         4.858300350000001e-007,-4.79412848e-011,1.964338121e-015},
     bhigh={110489.8462,-156.7992462},
-    R_s=207.5314260782661);
+    R_s=R_NASA_2002/C3H4_propyne.MM);
 
   constant IdealGases.Common.DataRecord C3H4_cyclo(
     name="C3H4_cyclo",
@@ -5283,7 +5286,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3168399.58,-13710.44699,26.64303646,-0.00242040805,4.42799413e-007,-4.3518202e-011,
         1.775948955e-015},
     bhigh={113368.3702,-152.2619086},
-    R_s=207.5314260782661);
+    R_s=R_NASA_2002/C3H4_cyclo.MM);
 
   constant IdealGases.Common.DataRecord C3H5_allyl(
     name="C3H5_allyl",
@@ -5297,7 +5300,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4094570.59,-16766.76186,31.23006342,-0.002885449982,5.21134354e-007,
         -5.05828422e-011,2.039932554e-015},
     bhigh={118572.0481,-182.3070197},
-    R_s=202.438412730876);
+    R_s=R_NASA_2002/C3H5_allyl.MM);
 
   constant IdealGases.Common.DataRecord C3H6_propylene(
     name="C3H6_propylene",
@@ -5311,7 +5314,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5017620.34,-20860.84035,36.4415634,-0.00388119117,7.27867719e-007,-7.321204500000001e-011,
         3.052176369e-015},
     bhigh={126124.5355,-219.5715757},
-    R_s=197.589386246208);
+    R_s=R_NASA_2002/C3H6_propylene.MM);
 
   constant IdealGases.Common.DataRecord C3H6_cyclo(
     name="C3H6_cyclo",
@@ -5325,7 +5328,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4785000.67,-20421.18175,36.3149578,-0.00356131944,6.47624124e-007,-6.328430100000001e-011,
         2.568705857e-015},
     bhigh={126827.4126,-222.3729099},
-    R_s=197.589386246208);
+    R_s=R_NASA_2002/C3H6_cyclo.MM);
 
   constant IdealGases.Common.DataRecord C3H6O_propylox(
     name="C3H6O_propylox",
@@ -5339,7 +5342,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4789729.989999999,-21068.95971,39.5464773,-0.00391092998,
         7.32553151e-007,-7.35708597e-011,3.0606185e-015},
     bhigh={112034.454,-237.2004192},
-    R_s=143.1582836798203);
+    R_s=R_NASA_2002/C3H6O_propylox.MM);
 
   constant IdealGases.Common.DataRecord C3H6O_acetone(
     name="C3H6O_acetone",
@@ -5353,7 +5356,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5001601.92,-21701.55542,39.6449399,-0.00417994505,7.96242953e-007,-8.122558050000001e-011,
         3.42878096e-015},
     bhigh={101514.5028,-236.8533477},
-    R_s=143.1582836798203);
+    R_s=R_NASA_2002/C3H6O_acetone.MM);
 
   constant IdealGases.Common.DataRecord C3H6O_propanal(
     name="C3H6O_propanal",
@@ -5367,7 +5370,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4830933.489999999,-20754.51152,39.2485518,-0.004095514,
         7.88169216e-007,-8.107684080000001e-011,3.43710543e-015},
     bhigh={99449.37879999999,-231.6690627},
-    R_s=143.1582836798203);
+    R_s=R_NASA_2002/C3H6O_propanal.MM);
 
   constant IdealGases.Common.DataRecord C3H7_n_propyl(
     name="C3H7_n_propyl",
@@ -5381,7 +5384,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5646512.94,-22910.87136,39.8727518,-0.004106232870000001,
         7.56255777e-007,-7.47826302e-011,3.068983677e-015},
     bhigh={148300.6853,-240.378119},
-    R_s=192.9672240417678);
+    R_s=R_NASA_2002/C3H7_n_propyl.MM);
 
   constant IdealGases.Common.DataRecord C3H7_i_propyl(
     name="C3H7_i_propyl",
@@ -5395,7 +5398,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5807002.520000001,-24112.19997,40.852884,-0.00451785133,
         8.499427170000001e-007,-8.573514339999999e-011,3.58338396e-015},
     bhigh={154650.405,-248.7098372},
-    R_s=192.9672240417678);
+    R_s=R_NASA_2002/C3H7_i_propyl.MM);
 
   constant IdealGases.Common.DataRecord C3H8(
     name="C3H8",
@@ -5409,7 +5412,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6420731.680000001,-26597.91134,45.3435684,-0.00502066392,
         9.471216939999999e-007,-9.57540523e-011,4.00967288e-015},
     bhigh={145558.2459,-281.8374734},
-    R_s=188.5563690906262);
+    R_s=R_NASA_2002/C3H8.MM);
 
   constant IdealGases.Common.DataRecord C3H8O_1propanol(
     name="C3H8O_1propanol",
@@ -5423,7 +5426,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6308672.12,-26422.10376,47.1511259,-0.004642511930000001,
         8.59346536e-007,-8.68209182e-011,3.64222401e-015},
     bhigh={125500.3155,-285.9463804},
-    R_s=138.3560567913947);
+    R_s=R_NASA_2002/C3H8O_1propanol.MM);
 
   constant IdealGases.Common.DataRecord C3H8O_2propanol(
     name="C3H8O_2propanol",
@@ -5437,7 +5440,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6001074.75,-25058.7683,46.22096120000001,-0.00427246631,
         7.69367877e-007,-7.45058484e-011,2.998959935e-015},
     bhigh={114851.8732,-279.6132222},
-    R_s=138.3560567913947);
+    R_s=R_NASA_2002/C3H8O_2propanol.MM);
 
   constant IdealGases.Common.DataRecord CNCOCN(
     name="CNCOCN",
@@ -5451,7 +5454,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={700052.2440000001,-5086.002009999999,19.4675349,-0.001302852727,
         2.75360075e-007,-3.056290852e-011,1.382140838e-015},
     bhigh={55393.3888,-86.2755086},
-    R_s=103.8729724212562);
+    R_s=R_NASA_2002/CNCOCN.MM);
 
   constant IdealGases.Common.DataRecord C3O2(
     name="C3O2",
@@ -5465,7 +5468,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={696869.9889999999,-4624.73319,16.63905725,-0.001175486554,
         2.478106444e-007,-2.745165984e-011,1.239566766e-015},
     bhigh={12525.80069,-72.75968780000001},
-    R_s=122.2166691900298);
+    R_s=R_NASA_2002/C3O2.MM);
 
   constant IdealGases.Common.DataRecord C4(
     name="C4",
@@ -5479,7 +5482,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={920068.513,-1530.3118,6.0500692,0.00525274367,-1.779154772e-006,
         2.589873632e-010,-1.385553481e-014},
     bhigh={133438.9611,-7.26114882},
-    R_s=173.0646423605619);
+    R_s=R_NASA_2002/C4.MM);
 
   constant IdealGases.Common.DataRecord C4H2_butadiyne(
     name="C4H2_butadiyne",
@@ -5493,7 +5496,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2328179.913,-8925.186090000001,21.14326883,-0.001368871276,
         2.327503159e-007,-2.124517624e-011,8.053313019999999e-016},
     bhigh={105778.8416,-108.8313574},
-    R_s=166.0952705904351);
+    R_s=R_NASA_2002/C4H2_butadiyne.MM);
 
   constant IdealGases.Common.DataRecord C4H4_1_3minuscyclo(
     name="C4H4_1_3minuscyclo",
@@ -5507,7 +5510,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2991498.949,-14167.81502,30.01978876,-0.002579200423,4.78999045e-007,
         -4.77532971e-011,1.974923662e-015},
     bhigh={127466.692,-172.7532057},
-    R_s=159.6654873320101);
+    R_s=R_NASA_2002/C4H4_1_3minuscyclo.MM);
 
   constant IdealGases.Common.DataRecord C4H6_butadiene(
     name="C4H6_butadiene",
@@ -5521,7 +5524,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-23619031.88,56513.2337,-32.7573832,0.02293070572,-2.297106441e-006,
         4.29259621e-011,4.23676604e-015},
     bhigh={-367135.862,301.3437302},
-    R_s=153.7149633095978);
+    R_s=R_NASA_2002/C4H6_butadiene.MM);
 
   constant IdealGases.Common.DataRecord C4H6_1butyne(
     name="C4H6_1butyne",
@@ -5535,7 +5538,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6364402.7,-23920.87731,40.7375041,-0.00317672649,1.199856984e-007,
         3.20180251e-011,-2.854392633e-015},
     bhigh={163433.5546,-246.0284791},
-    R_s=153.7149633095978);
+    R_s=R_NASA_2002/C4H6_1butyne.MM);
 
   constant IdealGases.Common.DataRecord C4H6_2butyne(
     name="C4H6_2butyne",
@@ -5549,7 +5552,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3981304.33,-18730.32899,36.5456149,-0.002369686378,3.99021181e-007,-3.69870727e-011,
         1.442072006e-015},
     bhigh={126146.0214,-215.5866205},
-    R_s=153.7149633095978);
+    R_s=R_NASA_2002/C4H6_2butyne.MM);
 
   constant IdealGases.Common.DataRecord C4H6_cyclo(
     name="C4H6_cyclo",
@@ -5563,7 +5566,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4517367.819999999,-20973.11985,40.0803917,-0.00394979398,
         7.44848499e-007,-7.52975417e-011,3.153253502e-015},
     bhigh={140646.9848,-243.4836999},
-    R_s=153.7149633095978);
+    R_s=R_NASA_2002/C4H6_cyclo.MM);
 
   constant IdealGases.Common.DataRecord C4H8_1_butene(
     name="C4H8_1_butene",
@@ -5577,7 +5580,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6257948.609999999,-26603.76305,47.6492005,-0.00438326711,
         7.12883844e-007,-5.991020839999999e-011,2.051753504e-015},
     bhigh={156925.2657,-291.3869761},
-    R_s=148.1920396846559);
+    R_s=R_NASA_2002/C4H8_1_butene.MM);
 
   constant IdealGases.Common.DataRecord C4H8_cis2_buten(
     name="C4H8_cis2_buten",
@@ -5591,7 +5594,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6461018.35,-27753.76432,48.6353236,-0.00486238635,
         8.412626100000001e-007,-7.63389037e-011,2.861702826e-015},
     bhigh={163085.6187,-300.3105998},
-    R_s=148.1920396846559);
+    R_s=R_NASA_2002/C4H8_cis2_buten.MM);
 
   constant IdealGases.Common.DataRecord C4H8_isobutene(
     name="C4H8_isobutene",
@@ -5605,7 +5608,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6484970.99,-27325.04764,48.3632108,-0.00476800405,8.23387584e-007,-7.449252999999999e-011,
         2.782303056e-015},
     bhigh={159594.1773,-298.2986237},
-    R_s=148.1920396846559);
+    R_s=R_NASA_2002/C4H8_isobutene.MM);
 
   constant IdealGases.Common.DataRecord C4H8_cyclo(
     name="C4H8_cyclo",
@@ -5619,7 +5622,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4456213.810000001,-23010.18492,44.9244846,-0.003080145176,
         5.317165260000001e-007,-5.08107938e-011,2.048919092e-015},
     bhigh={135548.7603,-277.1801965},
-    R_s=148.1920396846559);
+    R_s=R_NASA_2002/C4H8_cyclo.MM);
 
   constant IdealGases.Common.DataRecord C4H9_n_butyl(
     name="C4H9_n_butyl",
@@ -5633,7 +5636,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7198686.94,-29592.41524,52.4204281,-0.00544157244,
         9.917758369999999e-007,-9.464455870000001e-011,3.72948704e-015},
     bhigh={183456.6472,-321.420917},
-    R_s=145.5767788990000);
+    R_s=R_NASA_2002/C4H9_n_butyl.MM);
 
   constant IdealGases.Common.DataRecord C4H9_i_butyl(
     name="C4H9_i_butyl",
@@ -5647,7 +5650,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6752936.06,-28374.23721,51.4068761,-0.00498239901,8.80150663e-007,-8.12573869e-011,
         3.099140009e-015},
     bhigh={174344.848,-314.9940745},
-    R_s=145.5767788990000);
+    R_s=R_NASA_2002/C4H9_i_butyl.MM);
 
   constant IdealGases.Common.DataRecord C4H9_s_butyl(
     name="C4H9_s_butyl",
@@ -5661,7 +5664,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7224744.35,-30352.91099,52.8855183,-0.00565208355,1.060032692e-006,-1.066129835e-010,
         4.443810960000001e-015},
     bhigh={188349.4279,-325.571988},
-    R_s=145.5767788990000);
+    R_s=R_NASA_2002/C4H9_s_butyl.MM);
 
   constant IdealGases.Common.DataRecord C4H9_t_butyl(
     name="C4H9_t_butyl",
@@ -5675,7 +5678,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7151064.95,-31712.2441,54.4251032,-0.006392331160000001,
         1.241097612e-006,-1.2872483e-010,5.51261874e-015},
     bhigh={193450.6997,-339.9325290000001},
-    R_s=145.5767788990000);
+    R_s=R_NASA_2002/C4H9_t_butyl.MM);
 
   constant IdealGases.Common.DataRecord C4H10_n_butane(
     name="C4H10_n_butane",
@@ -5689,7 +5692,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7682322.45,-32560.5151,57.3673275,-0.00619791681,1.180186048e-006,-1.221893698e-010,
         5.250635250000001e-015},
     bhigh={177452.656,-358.791876},
-    R_s=143.0522244512424);
+    R_s=R_NASA_2002/C4H10_n_butane.MM);
 
   constant IdealGases.Common.DataRecord C4H10_isobutane(
     name="C4H10_isobutane",
@@ -5703,7 +5706,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7528018.92,-32025.1706,57.00161,-0.00606001309,1.143975809e-006,-1.157061835e-010,
         4.84604291e-015},
     bhigh={172850.0802,-357.617689},
-    R_s=143.0522244512424);
+    R_s=R_NASA_2002/C4H10_isobutane.MM);
 
   constant IdealGases.Common.DataRecord C4N2(
     name="C4N2",
@@ -5717,7 +5720,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1167686.152,-6198.644179999999,20.62070093,-0.001518619449,
         3.16236168e-007,-3.4699228e-011,1.555154128e-015},
     bhigh={96674.09389999999,-96.69734738000001},
-    R_s=109.3206076559176);
+    R_s=R_NASA_2002/C4N2.MM);
 
   constant IdealGases.Common.DataRecord C5(
     name="C5",
@@ -5731,7 +5734,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={217205.5356,-2958.510027,15.61080967,-0.0008200361920000001,
         1.776898025e-007,-2.009853583e-011,9.222677770000001e-016},
     bhigh={139520.8064,-64.33077179999999},
-    R_s=138.4517138884495);
+    R_s=R_NASA_2002/C5.MM);
 
   constant IdealGases.Common.DataRecord C5H6_1_3cyclo(
     name="C5H6_1_3cyclo",
@@ -5745,7 +5748,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4428478.19,-21235.47976,43.0981901,-0.003914783460000001,
         7.31184701e-007,-7.32724119e-011,3.044403403e-015},
     bhigh={138254.2782,-260.5959678},
-    R_s=125.78466876668);
+    R_s=R_NASA_2002/C5H6_1_3cyclo.MM);
 
   constant IdealGases.Common.DataRecord C5H8_cyclo(
     name="C5H8_cyclo",
@@ -5759,7 +5762,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4569848.1,-24060.18294,48.8100646,-0.00341305498,6.04700166e-007,-5.927495780000001e-011,
         2.44786539e-015},
     bhigh={141398.3093,-298.9533527},
-    R_s=122.0621512802527);
+    R_s=R_NASA_2002/C5H8_cyclo.MM);
 
   constant IdealGases.Common.DataRecord C5H10_1_pentene(
     name="C5H10_1_pentene",
@@ -5773,7 +5776,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3744014.97,-21044.85321,47.3612699,-0.00042442012,-3.89897505e-008,
         1.367074243e-011,-9.31319423e-016},
     bhigh={115409.1373,-278.6177449000001},
-    R_s=118.5536317477247);
+    R_s=R_NASA_2002/C5H10_1_pentene.MM);
 
   constant IdealGases.Common.DataRecord C5H10_cyclo(
     name="C5H10_cyclo",
@@ -5787,7 +5790,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7501938.73,-35058.6485,63.2248075,-0.00694035658,1.337306593e-006,-1.377905033e-010,
         5.86735764e-015},
     bhigh={195492.5511,-402.65509},
-    R_s=118.5536317477247);
+    R_s=R_NASA_2002/C5H10_cyclo.MM);
 
   constant IdealGases.Common.DataRecord C5H11_pentyl(
     name="C5H11_pentyl",
@@ -5801,7 +5804,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5697252.899999999,-28917.06175,58.1102968,-0.00359399501,
         4.41996763e-007,-1.509664551e-011,-6.62696443e-016},
     bhigh={171700.955,-352.247712},
-    R_s=116.873936265020);
+    R_s=R_NASA_2002/C5H11_pentyl.MM);
 
   constant IdealGases.Common.DataRecord C5H11_t_pentyl(
     name="C5H11_t_pentyl",
@@ -5815,7 +5818,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={8602108.26,-38052.05770000001,66.4969037,-0.007533860630000001,
         1.451612787e-006,-1.495593207e-010,6.368022329999999e-015},
     bhigh={228185.8805,-416.940855},
-    R_s=116.873936265020);
+    R_s=R_NASA_2002/C5H11_t_pentyl.MM);
 
   constant IdealGases.Common.DataRecord C5H12_n_pentane(
     name="C5H12_n_pentane",
@@ -5829,7 +5832,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2530779.286,-8972.59326,45.3622326,-0.002626989916,3.135136419e-006,
         -5.31872894e-010,2.886896868e-014},
     bhigh={14846.16529,-251.6550384},
-    R_s=115.2411724772061);
+    R_s=R_NASA_2002/C5H12_n_pentane.MM);
 
   constant IdealGases.Common.DataRecord C5H12_i_pentane(
     name="C5H12_i_pentane",
@@ -5843,7 +5846,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={11568885.94,-45562.4687,74.9544363,-0.007845415580000001,
         1.444393314e-006,-1.464370213e-010,6.230285000000001e-015},
     bhigh={254492.7135,-480.198578},
-    R_s=115.2411724772061);
+    R_s=R_NASA_2002/C5H12_i_pentane.MM);
 
   constant IdealGases.Common.DataRecord CH3C_CH3_2CH3(
     name="CH3C_CH3_2CH3",
@@ -5857,7 +5860,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={16847055.2,-59794.3057,86.85451479999999,-0.0096219176,
         1.653363091e-006,-1.674727926e-010,7.37211936e-015},
     bhigh={345849.682,-576.046697},
-    R_s=115.2411724772061);
+    R_s=R_NASA_2002/CH3C_CH3_2CH3.MM);
 
   constant IdealGases.Common.DataRecord C6D5_phenyl(
     name="C6D5_phenyl",
@@ -5871,7 +5874,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1411628.125,-13625.69472,40.2898494,-0.00349098927,7.37961213e-007,-8.19224405e-011,
         3.70533097e-015},
     bhigh={108807.3731,-229.3621057},
-    R_s=101.2301620106773);
+    R_s=R_NASA_2002/C6D5_phenyl.MM);
 
   constant IdealGases.Common.DataRecord C6D6(
     name="C6D6",
@@ -5885,7 +5888,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1758057.871,-15721.21558,44.6816249,-0.004003361919999999,
         8.4454344e-007,-9.36055698e-011,4.22847553e-015},
     bhigh={89620.45359999999,-261.5332268},
-    R_s=98.80721786066331);
+    R_s=R_NASA_2002/C6D6.MM);
 
   constant IdealGases.Common.DataRecord C6H2(
     name="C6H2",
@@ -5899,7 +5902,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2592848.577,-10833.61978,28.47459495,-0.001876727704,3.41213428e-007,
         -3.33739289e-011,1.356853889e-015},
     bhigh={141851.7294,-149.4853494},
-    R_s=112.2367848414851);
+    R_s=R_NASA_2002/C6H2.MM);
 
   constant IdealGases.Common.DataRecord C6H5_phenyl(
     name="C6H5_phenyl",
@@ -5913,7 +5916,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3670279.23,-18946.01209,41.8058182,-0.00350391415,6.56182174e-007,-6.594714449999999e-011,
         2.748094212e-015},
     bhigh={147674.4628,-247.5301142},
-    R_s=107.8351419318608);
+    R_s=R_NASA_2002/C6H5_phenyl.MM);
 
   constant IdealGases.Common.DataRecord C6H5O_phenoxy(
     name="C6H5O_phenoxy",
@@ -5927,7 +5930,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3678640.34,-19729.80806,45.4118441,-0.00375106439,7.11445078e-007,-7.233328850000001e-011,
         3.045637067e-015},
     bhigh={116359.5961,-268.1058539},
-    R_s=89.30413852140579);
+    R_s=R_NASA_2002/C6H5O_phenoxy.MM);
 
   constant IdealGases.Common.DataRecord C6H6(
     name="C6H6",
@@ -5941,7 +5944,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4538575.72,-22605.02547,46.940073,-0.004206676830000001,
         7.90799433e-007,-7.9683021e-011,3.32821208e-015},
     bhigh={139146.4686,-286.8751333},
-    R_s=106.4436582213401);
+    R_s=R_NASA_2002/C6H6.MM);
 
   constant IdealGases.Common.DataRecord C6H5OH_phenol(
     name="C6H5OH_phenol",
@@ -5955,7 +5958,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4462081.569999999,-21655.21026,48.1501505,-0.00356828243,
         6.32717573e-007,-6.039905720000001e-011,2.399168678e-015},
     bhigh={111372.6204,-286.0454446},
-    R_s=88.34768301852149);
+    R_s=R_NASA_2002/C6H5OH_phenol.MM);
 
   constant IdealGases.Common.DataRecord C6H10_cyclo(
     name="C6H10_cyclo",
@@ -5969,7 +5972,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7510128.98,-35568.5821,67.03034940000001,-0.00704535187,
         1.3581664e-006,-1.400074492e-010,5.964551700000001e-015},
     bhigh={206027.4332,-423.819766},
-    R_s=101.219206365438);
+    R_s=R_NASA_2002/C6H10_cyclo.MM);
 
   constant IdealGases.Common.DataRecord C6H12_1_hexene(
     name="C6H12_1_hexene",
@@ -5983,7 +5986,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={733290.696,-14488.48641,46.7121549,0.00317297847,-5.24264652e-007,
         4.28035582e-011,-1.472353254e-015},
     bhigh={66977.4041,-262.3643854},
-    R_s=98.79469312310390);
+    R_s=R_NASA_2002/C6H12_1_hexene.MM);
 
   constant IdealGases.Common.DataRecord C6H12_cyclo(
     name="C6H12_cyclo",
@@ -5997,7 +6000,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5225149.47,-33641.9458,71.74607469999999,-0.006698979119999999,
         1.318443254e-006,-1.390794789e-010,6.06010224e-015},
     bhigh={173253.7609,-454.681417},
-    R_s=98.79469312310390);
+    R_s=R_NASA_2002/C6H12_cyclo.MM);
 
   constant IdealGases.Common.DataRecord C6H13_n_hexyl(
     name="C6H13_n_hexyl",
@@ -6011,7 +6014,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5967938.62,-32990.2316,68.6907344,-0.00422500906,
         5.496523820000001e-007,-2.292851471e-011,-5.08634189e-016},
     bhigh={190697.8683,-418.5362},
-    R_s=97.62547697229762);
+    R_s=R_NASA_2002/C6H13_n_hexyl.MM);
 
   constant IdealGases.Common.DataRecord C6H14_n_hexane(
     name="C6H14_n_hexane",
@@ -6025,7 +6028,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3106625.684,-7346.087920000001,46.94131760000001,0.001693963977,
         2.068996667e-006,-4.21214168e-010,2.452345845e-014},
     bhigh={523.750312,-254.9967718},
-    R_s=96.48361202088394);
+    R_s=R_NASA_2002/C6H14_n_hexane.MM);
 
   constant IdealGases.Common.DataRecord C7H7_benzyl(
     name="C7H7_benzyl",
@@ -6039,7 +6042,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5297322.16,-25999.09398,55.0975079,-0.00497766147,9.46315243e-007,-9.639008860000001e-011,
         4.06447042e-015},
     bhigh={173838.2912,-334.382955},
-    R_s=91.23742133257720);
+    R_s=R_NASA_2002/C7H7_benzyl.MM);
 
   constant IdealGases.Common.DataRecord C7H8(
     name="C7H8",
@@ -6053,7 +6056,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6184538.350000001,-29902.84056,59.8200597,-0.00569698396,
         1.080748416e-006,-1.098702235e-010,4.62474022e-015},
     bhigh={178204.7857,-369.808225},
-    R_s=90.23933772686790);
+    R_s=R_NASA_2002/C7H8.MM);
 
   constant IdealGases.Common.DataRecord C7H8O_cresol_mx(
     name="C7H8O_cresol_mx",
@@ -6067,7 +6070,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6017373.45,-28498.82774,60.81543070000001,-0.004996807109999999,
         9.13427995e-007,-8.979444109999999e-011,3.66775697e-015},
     bhigh={147221.84,-367.485014},
-    R_s=76.88808596289439);
+    R_s=R_NASA_2002/C7H8O_cresol_mx.MM);
 
   constant IdealGases.Common.DataRecord C7H14_1_heptene(
     name="C7H14_1_heptene",
@@ -6081,7 +6084,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1927608.174,-9125.024420000002,47.4817797,0.00606766053,-8.684859080000001e-007,
         5.81399526e-011,-1.473979569e-015},
     bhigh={26009.14656,-256.2880707},
-    R_s=84.68116553408906);
+    R_s=R_NASA_2002/C7H14_1_heptene.MM);
 
   constant IdealGases.Common.DataRecord C7H15_n_heptyl(
     name="C7H15_n_heptyl",
@@ -6095,7 +6098,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5444527.57,-34568.2929,76.38651949999999,-0.003298972,
         2.343496957e-007,2.467674021e-011,-3.162012849e-015},
     bhigh={193907.9354,-464.142466},
-    R_s=83.82069480008872);
+    R_s=R_NASA_2002/C7H15_n_heptyl.MM);
 
   constant IdealGases.Common.DataRecord C7H16_n_heptane(
     name="C7H16_n_heptane",
@@ -6109,7 +6112,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={9135632.469999999,-39233.1969,78.8978085,-0.00465425193,
         2.071774142e-006,-3.4425393e-010,1.976834775e-014},
     bhigh={205070.8295,-485.110402},
-    R_s=82.97753516548681);
+    R_s=R_NASA_2002/C7H16_n_heptane.MM);
 
   constant IdealGases.Common.DataRecord C7H16_2_methylh(
     name="C7H16_2_methylh",
@@ -6123,7 +6126,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1289912.969,-1784.340963,10.83537673,0.05270609239999999,-1.886832314e-005,
         2.432255843e-009,-1.135553789e-013},
     bhigh={-16375.29884,-29.8186241},
-    R_s=82.97753516548681);
+    R_s=R_NASA_2002/C7H16_2_methylh.MM);
 
   constant IdealGases.Common.DataRecord C8H8_styrene(
     name="C8H8_styrene",
@@ -6137,7 +6140,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-6629183.62,15145.94166,1.609822364,0.033833186,-1.093737395e-005,
         1.338825116e-009,-6.03253492e-014},
     bhigh={-89973.2415,43.1128279},
-    R_s=79.83274366600506);
+    R_s=R_NASA_2002/C8H8_styrene.MM);
 
   constant IdealGases.Common.DataRecord C8H10_ethylbenz(
     name="C8H10_ethylbenz",
@@ -6151,7 +6154,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5551564.100000001,-28313.80598,60.6124072,0.001042112857,-1.327426719e-006,
         2.166031743e-010,-1.142545514e-014},
     bhigh={164224.1062,-369.176982},
-    R_s=78.31686525691141);
+    R_s=R_NASA_2002/C8H10_ethylbenz.MM);
 
   constant IdealGases.Common.DataRecord C8H16_1_octene(
     name="C8H16_1_octene",
@@ -6165,7 +6168,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4409336.07,-4383.678800000001,49.39154259999999,
         0.007912339629999999,-7.88866951e-007,9.97021235e-012,1.913144872e-015},
     bhigh={-11226.19342,-257.7650649},
-    R_s=74.09601984232792);
+    R_s=R_NASA_2002/C8H16_1_octene.MM);
 
   constant IdealGases.Common.DataRecord C8H17_n_octyl(
     name="C8H17_n_octyl",
@@ -6179,7 +6182,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5632173.390000001,-38211.4367,86.37927500000001,-0.00360893158,
         2.544260445e-007,2.908638837e-011,-3.67954974e-015},
     bhigh={210313.547,-526.242283},
-    R_s=73.43638409200872);
+    R_s=R_NASA_2002/C8H17_n_octyl.MM);
 
   constant IdealGases.Common.DataRecord C8H18_n_octane(
     name="C8H18_n_octane",
@@ -6193,7 +6196,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6365406.949999999,-31053.64657,69.6916234,0.01048059637,-4.12962195e-006,
         5.543226319999999e-010,-2.651436499e-014},
     bhigh={150096.8785,-416.989565},
-    R_s=72.78838944950000);
+    R_s=R_NASA_2002/C8H18_n_octane.MM);
 
   constant IdealGases.Common.DataRecord C8H18_isooctane(
     name="C8H18_isooctane",
@@ -6207,7 +6210,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={13527650.32,-46633.7034,77.95313179999999,0.01423729984,-5.073593909999999e-006,
         7.24823297e-010,-3.81919011e-014},
     bhigh={254117.8017,-493.388719},
-    R_s=72.78838944950000);
+    R_s=R_NASA_2002/C8H18_isooctane.MM);
 
   constant IdealGases.Common.DataRecord C9H19_n_nonyl(
     name="C9H19_n_nonyl",
@@ -6221,7 +6224,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5277361.74,-40257.0196,94.57296720000001,-0.002940301447,
         6.97810699e-009,6.80525024e-011,-5.90709533e-015},
     bhigh={216532.0614,-575.44495},
-    R_s=65.34141901477409);
+    R_s=R_NASA_2002/C9H19_n_nonyl.MM);
 
   constant IdealGases.Common.DataRecord C10H8_naphthale(
     name="C10H8_naphthale",
@@ -6235,7 +6238,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5906172.11,-31632.2924,70.3034203,-0.00601886554,1.142052144e-006,-1.161605689e-010,
         4.89284402e-015},
     bhigh={196256.7046,-434.7848950000001},
-    R_s=64.87068945339381);
+    R_s=R_NASA_2002/C10H8_naphthale.MM);
 
   constant IdealGases.Common.DataRecord C10H21_n_decyl(
     name="C10H21_n_decyl",
@@ -6249,7 +6252,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4967237.76,-42424.6844,102.8853417,-0.00232484818,-2.2842339e-007,
         1.056127364e-010,-8.0680659e-015},
     bhigh={223542.989,-625.5191159999999},
-    R_s=58.85389598944574);
+    R_s=R_NASA_2002/C10H21_n_decyl.MM);
 
   constant IdealGases.Common.DataRecord C12H9_o_bipheny(
     name="C12H9_o_bipheny",
@@ -6263,7 +6266,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6736469.42,-36321.9435,82.102396,-0.00750234286,1.456251733e-006,-1.507145019e-010,
         6.43647043e-015},
     bhigh={255552.4521,-504.246297},
-    R_s=54.27230808174368);
+    R_s=R_NASA_2002/C12H9_o_bipheny.MM);
 
   constant IdealGases.Common.DataRecord C12H10_biphenyl(
     name="C12H10_biphenyl",
@@ -6277,7 +6280,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7480385.359999999,-39280.8723,86.61482219999999,-0.007946398570000001,
         1.531868544e-006,-1.576450171e-010,6.70060273e-015},
     bhigh={243805.0641,-538.138149},
-    R_s=53.91757096593039);
+    R_s=R_NASA_2002/C12H10_biphenyl.MM);
 
   constant IdealGases.Common.DataRecord Ca(
     name="Ca",
@@ -6290,7 +6293,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7547341.239999999,-21486.42662,25.30849567,-0.01103773705,
         2.293249636e-006,-1.209075383e-010,-4.015333268e-015},
     bhigh={158586.2323,-160.9512955},
-    R_s=207.4582064973302);
+    R_s=R_NASA_2002/Ca.MM);
 
   constant IdealGases.Common.DataRecord Caplus(
     name="Caplus",
@@ -6303,7 +6306,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3747070.82,-11747.07738,16.72546969,-0.00833479771,2.394593294e-006,
         -2.988243468e-010,1.356563002e-014},
     bhigh={166432.9088,-95.8282126},
-    R_s=207.4610462879883);
+    R_s=R_NASA_2002/Caplus.MM);
 
   constant IdealGases.Common.DataRecord CaBr(
     name="CaBr",
@@ -6317,7 +6320,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2783236.402,-8458.203729999999,14.3175656,-0.00543078168,
         1.522218659e-006,-1.831824807e-010,7.86428866e-015},
     bhigh={49312.7068,-65.37001100000001},
-    R_s=69.29797803003784);
+    R_s=R_NASA_2002/CaBr.MM);
 
   constant IdealGases.Common.DataRecord CaBr2(
     name="CaBr2",
@@ -6331,7 +6334,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-22198.46426,-4.46315533,7.50375511,-1.641654626e-006,
         3.87942806e-010,-4.68342426e-014,2.259325541e-018},
     bhigh={-48854.3682,-5.59032425},
-    R_s=41.59625986812483);
+    R_s=R_NASA_2002/CaBr2.MM);
 
   constant IdealGases.Common.DataRecord CaCL(
     name="CaCL",
@@ -6345,7 +6348,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1629182.545,-4766.22302,9.65892977,-0.002523044131,5.83354216e-007,-4.10172699e-011,
         8.813177639999999e-017},
     bhigh={16625.99241,-33.98731174},
-    R_s=110.0807615416187);
+    R_s=R_NASA_2002/CaCL.MM);
 
   constant IdealGases.Common.DataRecord CaCLplus(
     name="CaCLplus",
@@ -6359,7 +6362,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={177028.0396,-589.137239,5.1033688,-0.0002356761168,5.48373287e-008,
         2.137973112e-014,-5.57288731e-016},
     bhigh={58534.17249999999,-2.191253644},
-    R_s=110.0815610907364);
+    R_s=R_NASA_2002/CaCLplus.MM);
 
   constant IdealGases.Common.DataRecord CaCL2(
     name="CaCL2",
@@ -6373,7 +6376,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-35957.6878,-8.796495630000001,7.50725691,-3.129465934e-006,
         7.322886480000001e-010,-8.776403220000001e-014,4.21048604e-018},
     bhigh={-60667.7966,-8.553523451},
-    R_s=74.91629424061126);
+    R_s=R_NASA_2002/CaCL2.MM);
 
   constant IdealGases.Common.DataRecord CaF(
     name="CaF",
@@ -6387,7 +6390,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={519588.2669999999,-1512.321567,5.86927625,-0.000388252448,-2.484582298e-008,
         3.74991596e-011,-3.47097645e-015},
     bhigh={-24888.14584,-8.6146637},
-    R_s=140.7416421722845);
+    R_s=R_NASA_2002/CaF.MM);
 
   constant IdealGases.Common.DataRecord CaFplus(
     name="CaFplus",
@@ -6401,7 +6404,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-139867.0845,219.1526375,4.21432434,0.0002142798048,-5.7786726e-008,
         9.98575631e-012,-6.05962188e-016},
     bhigh={28416.05897,2.740342729},
-    R_s=140.7429491506670);
+    R_s=R_NASA_2002/CaFplus.MM);
 
   constant IdealGases.Common.DataRecord CaF2(
     name="CaF2",
@@ -6415,7 +6418,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-82804.0944,-31.15950071,7.02357737,-9.521000020000001e-006,
         2.118160895e-009,-2.440713888e-013,1.135135468e-017},
     bhigh={-97294.66770000001,-7.54624334},
-    R_s=106.4941481558384);
+    R_s=R_NASA_2002/CaF2.MM);
 
   constant IdealGases.Common.DataRecord CaH(
     name="CaH",
@@ -6429,7 +6432,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2696952.529,8607.05975,-7.02745482,0.007467916309999999,-2.318610699e-006,
         3.42307242e-010,-1.892679792e-014},
     bhigh={-27738.19107,78.45822010000001},
-    R_s=202.368742202320);
+    R_s=R_NASA_2002/CaH.MM);
 
   constant IdealGases.Common.DataRecord CaI(
     name="CaI",
@@ -6443,7 +6446,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1771071.309,-5683.64373,11.53857476,-0.0041940202,1.291359961e-006,-1.730043579e-010,
         8.38076235e-015},
     bhigh={35832.932,-44.0591757},
-    R_s=49.79271177387663);
+    R_s=R_NASA_2002/CaI.MM);
 
   constant IdealGases.Common.DataRecord CaI2(
     name="CaI2",
@@ -6457,7 +6460,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-16237.27104,-2.859530722,7.50243219,-1.071178707e-006,
         2.544559095e-010,-3.083631004e-014,1.491836724e-018},
     bhigh={-33463.4117,-3.56730574},
-    R_s=28.29152598614964);
+    R_s=R_NASA_2002/CaI2.MM);
 
   constant IdealGases.Common.DataRecord CaO(
     name="CaO",
@@ -6471,7 +6474,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-49131061.7,149586.595,-168.1654149,0.09381950259999999,-2.455529428e-005,
         3.07498072e-009,-1.485914237e-013},
     bhigh={-946151.172,1235.694769},
-    R_s=148.2684646577766);
+    R_s=R_NASA_2002/CaO.MM);
 
   constant IdealGases.Common.DataRecord CaOplus(
     name="CaOplus",
@@ -6485,7 +6488,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={939784.313,-2993.362243,8.33619182,-0.002303295087,7.37396753e-007,-1.052888279e-010,
         5.25713841e-015},
     bhigh={102809.8401,-24.61547836},
-    R_s=148.2699151685966);
+    R_s=R_NASA_2002/CaOplus.MM);
 
   constant IdealGases.Common.DataRecord CaOH(
     name="CaOH",
@@ -6499,7 +6502,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1979972.994,-5598.88099,11.51348706,-0.001668264707,3.31257391e-007,
         -1.789056647e-011,-3.58071641e-016},
     bhigh={13401.96822,-46.46084260000001},
-    R_s=145.6505295405090);
+    R_s=R_NASA_2002/CaOH.MM);
 
   constant IdealGases.Common.DataRecord CaOHplus(
     name="CaOHplus",
@@ -6513,7 +6516,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={863761.537,-2347.302046,7.9819112,0.0001003160947,-6.24007417e-008,
         1.019540904e-011,-5.69892528e-016},
     bhigh={58305.80119999999,-21.52181937},
-    R_s=145.6519292807646);
+    R_s=R_NASA_2002/CaOHplus.MM);
 
   constant IdealGases.Common.DataRecord Ca_OH_2(
     name="Ca_OH_2",
@@ -6527,7 +6530,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1721854.884,-4702.21767,13.96947691,0.0001983791405,-1.243050592e-007,
         2.033402404e-011,-1.137157819e-015},
     bhigh={-44437.6135,-52.8744486},
-    R_s=112.2176981585765);
+    R_s=R_NASA_2002/Ca_OH_2.MM);
 
   constant IdealGases.Common.DataRecord CaS(
     name="CaS",
@@ -6541,7 +6544,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-15683532.14,52938.5581,-63.2246724,0.0402772638,-1.114855081e-005,
         1.464389344e-009,-7.37607897e-014},
     bhigh={-317202.267,479.9606012},
-    R_s=115.2504054447417);
+    R_s=R_NASA_2002/CaS.MM);
 
   constant IdealGases.Common.DataRecord Ca2(
     name="Ca2",
@@ -6555,7 +6558,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={240596.6267,57.7580382,2.347436675,0.0001199275034,-4.32915031e-008,
         7.01530269e-012,-3.70566032e-016},
     bhigh={40818.754,18.95399607},
-    R_s=103.7291032486651);
+    R_s=R_NASA_2002/Ca2.MM);
 
   constant IdealGases.Common.DataRecord Cd(
     name="Cd",
@@ -6569,7 +6572,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-269975.7467,786.600114,1.628169079,0.000459412329,-1.150420443e-007,
         1.074836707e-011,8.790199554999999e-017},
     bhigh={7675.14826,12.20006052},
-    R_s=73.96527030272838);
+    R_s=R_NASA_2002/Cd.MM);
 
   constant IdealGases.Common.DataRecord Cdplus(
     name="Cdplus",
@@ -6583,7 +6586,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={14848.80812,-46.6915368,2.557883006,-3.6247017e-005,1.21374757e-008,
         -2.072802814e-012,1.420665367e-016},
     bhigh={118107.0109,6.21641448},
-    R_s=73.96563127759133);
+    R_s=R_NASA_2002/Cdplus.MM);
 
   constant IdealGases.Common.DataRecord CL(
     name="CL",
@@ -6597,7 +6600,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-169793.293,608.172646,2.12866409,0.0001307367034,-2.644883596e-008,
         2.842504775e-012,-1.252911731e-016},
     bhigh={9934.3874,8.844772103},
-    R_s=234.5220432685527);
+    R_s=R_NASA_2002/CL.MM);
 
   constant IdealGases.Common.DataRecord CLplus(
     name="CLplus",
@@ -6611,7 +6614,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={40564.0948,-49.6016572,3.10165363,-0.000586873829,2.252039316e-007,-3.29970302e-011,
         1.708780842e-015},
     bhigh={165298.2337,2.574942598},
-    R_s=234.5256723206452);
+    R_s=R_NASA_2002/CLplus.MM);
 
   constant IdealGases.Common.DataRecord CLminus(
     name="CLminus",
@@ -6623,7 +6626,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={-28883.89093,4.200642023},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={-28883.89093,4.200642023},
-    R_s=234.5184143287705);
+    R_s=R_NASA_2002/CLminus.MM);
 
   constant IdealGases.Common.DataRecord CLCN(
     name="CLCN",
@@ -6637,7 +6640,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={346757.312,-1957.85737,8.807806149999999,-0.0004388362779999999,
         1.024761895e-007,-1.110675026e-011,4.98617942e-016},
     bhigh={25819.23944,-26.36885363},
-    R_s=135.2603854863479);
+    R_s=R_NASA_2002/CLCN.MM);
 
   constant IdealGases.Common.DataRecord CLF(
     name="CLF",
@@ -6651,7 +6654,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3045867.173,-9979.32826,16.84162254,-0.007465850620000001,
         2.336213612e-006,-3.36586546e-010,1.763082415e-014},
     bhigh={54471.20800000001,-87.07987094000001},
-    R_s=152.6959731315060);
+    R_s=R_NASA_2002/CLF.MM);
 
   constant IdealGases.Common.DataRecord CLF3(
     name="CLF3",
@@ -6665,7 +6668,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-229495.6235,-122.0741,10.09124644,-3.64972475e-005,8.05891075e-009,
         -9.23084995e-013,4.27256949e-017},
     bhigh={-22828.40447,-25.11605479},
-    R_s=89.93694995257107);
+    R_s=R_NASA_2002/CLF3.MM);
 
   constant IdealGases.Common.DataRecord CLF5(
     name="CLF5",
@@ -6679,7 +6682,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-426932.7449999999,-205.805739,16.15465278,-6.21268818e-005,
         1.376637959e-008,-1.581335709e-012,7.33642249e-017},
     bhigh={-33614.666,-57.57531175},
-    R_s=63.73957591449872);
+    R_s=R_NASA_2002/CLF5.MM);
 
   constant IdealGases.Common.DataRecord CLO(
     name="CLO",
@@ -6693,7 +6696,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={409376.052,-1765.985112,7.08790063,-0.001828450169,7.1038181e-007,-1.209332942e-010,
         7.07644104e-015},
     bhigh={21518.91784,-16.68645548},
-    R_s=161.5961548926775);
+    R_s=R_NASA_2002/CLO.MM);
 
   constant IdealGases.Common.DataRecord CLO2(
     name="CLO2",
@@ -6707,7 +6710,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-163379.3802,-316.148067,7.00978726,0.0002837971144,-1.179925338e-007,
         2.920383252e-011,-2.024030202e-015},
     bhigh={11849.46452,-10.91168827},
-    R_s=123.2659469428540);
+    R_s=R_NASA_2002/CLO2.MM);
 
   constant IdealGases.Common.DataRecord CL2(
     name="CL2",
@@ -6721,7 +6724,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6092569.42,-19496.27662,28.54535795,-0.01449968764,4.46389077e-006,-6.35852586e-010,
         3.32736029e-014},
     bhigh={121211.7724,-169.0778824},
-    R_s=117.2610216342763);
+    R_s=R_NASA_2002/CL2.MM);
 
   constant IdealGases.Common.DataRecord CL2O(
     name="CL2O",
@@ -6735,7 +6738,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-127174.3461,-67.4196322,7.05002245,-1.988084386e-005,
         4.366209050000001e-009,-4.978580680000001e-013,2.295679186e-017},
     bhigh={7387.2893,-8.797477254},
-    R_s=95.67311122208747);
+    R_s=R_NASA_2002/CL2O.MM);
 
   constant IdealGases.Common.DataRecord Co(
     name="Co",
@@ -6749,7 +6752,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1381841.305,-3756.03668,6.65713065,-0.001269246675,1.464092329e-007,
         6.57494657e-012,-1.102384178e-015},
     bhigh={74944.42909999999,-22.58500836},
-    R_s=141.0836336733794);
+    R_s=R_NASA_2002/Co.MM);
 
   constant IdealGases.Common.DataRecord Coplus(
     name="Coplus",
@@ -6763,7 +6766,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2907386.174,-8619.705749999999,11.88134934,-0.00351064742,
         5.74800468e-007,-2.534065135e-011,2.976607469e-016},
     bhigh={197741.9221,-60.9653344},
-    R_s=141.0849470112251);
+    R_s=R_NASA_2002/Coplus.MM);
 
   constant IdealGases.Common.DataRecord Cominus(
     name="Cominus",
@@ -6777,7 +6780,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-574139.417,1763.109207,1.415561988,0.000377686969,-7.53417998e-008,
         7.99570154e-012,-3.49044e-016},
     bhigh={30834.93114,16.34360353},
-    R_s=141.0823203599847);
+    R_s=R_NASA_2002/Cominus.MM);
 
   constant IdealGases.Common.DataRecord Cr(
     name="Cr",
@@ -6791,7 +6794,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-11202207.89,34011.63690000001,-36.5706217,0.02110296902,-5.51818014e-006,
         7.17360171e-010,-3.505127367e-014},
     bhigh={-168899.344,286.4481267},
-    R_s=159.9064160581274);
+    R_s=R_NASA_2002/Cr.MM);
 
   constant IdealGases.Common.DataRecord Crplus(
     name="Crplus",
@@ -6805,7 +6808,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3342330.79,-10642.61051,15.57884307,-0.00770897148,2.158300274e-006,
         -2.36810811e-010,8.952805604e-015},
     bhigh={193299.767,-86.0435667},
-    R_s=159.9081032151531);
+    R_s=R_NASA_2002/Crplus.MM);
 
   constant IdealGases.Common.DataRecord Crminus(
     name="Crminus",
@@ -6817,7 +6820,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={38586.2787,6.56683537},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={38586.2787,6.56683537},
-    R_s=159.9047289367030);
+    R_s=R_NASA_2002/Crminus.MM);
 
   constant IdealGases.Common.DataRecord CrN(
     name="CrN",
@@ -6831,7 +6834,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1110672.49,-3690.47854,8.59905668,-0.002125587223,5.28235848e-007,-4.92113915e-011,
         1.404331106e-015},
     bhigh={82548.04580000001,-27.99968411},
-    R_s=125.9720799723648);
+    R_s=R_NASA_2002/CrN.MM);
 
   constant IdealGases.Common.DataRecord CrO(
     name="CrO",
@@ -6845,7 +6848,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1092367.332,-3749.75865,9.00787021,-0.002545445236,
         6.928051680000001e-007,-6.390831950000001e-011,1.659741645e-015},
     bhigh={44470.9821,-29.42600453},
-    R_s=122.2802979608945);
+    R_s=R_NASA_2002/CrO.MM);
 
   constant IdealGases.Common.DataRecord CrO2(
     name="CrO2",
@@ -6859,7 +6862,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-432710.914,191.5584657,7.18824737,-0.000569484619,3.54636613e-007,-5.65512306e-011,
         2.908946349e-015},
     bhigh={-17433.39545,-10.0642472},
-    R_s=98.9882719069848);
+    R_s=R_NASA_2002/CrO2.MM);
 
   constant IdealGases.Common.DataRecord CrO3(
     name="CrO3",
@@ -6873,7 +6876,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-628331.401,692.8158179999999,8.971274599999999,0.000682336564,-2.235048825e-007,
         3.36678579e-011,-1.614026492e-015},
     bhigh={-47238.802,-19.45305345},
-    R_s=83.1498395408538);
+    R_s=R_NASA_2002/CrO3.MM);
 
   constant IdealGases.Common.DataRecord CrO3minus(
     name="CrO3minus",
@@ -6887,7 +6890,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-649968.203,452.201762,9.9805759,-0.000421413673,2.631277945e-007,-4.594543650000001e-011,
         2.659097549e-015},
     bhigh={-83500.1973,-24.648109},
-    R_s=83.14938335733427);
+    R_s=R_NASA_2002/CrO3minus.MM);
 
   constant IdealGases.Common.DataRecord Cs(
     name="Cs",
@@ -6901,7 +6904,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6166040.899999999,-18961.75522,24.83229903,-0.01251977234,
         3.30901739e-006,-3.35401202e-010,9.626500908000001e-015},
     bhigh={128511.1231,-152.2942188},
-    R_s=62.559586533133);
+    R_s=R_NASA_2002/Cs.MM);
 
   constant IdealGases.Common.DataRecord Csplus(
     name="Csplus",
@@ -6913,7 +6916,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={54387.3782,6.182757992},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={54387.3782,6.182757992},
-    R_s=62.55984476431055);
+    R_s=R_NASA_2002/Csplus.MM);
 
   constant IdealGases.Common.DataRecord Csminus(
     name="Csminus",
@@ -6925,7 +6928,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={2237.029001,6.182770382},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={2237.029001,6.182770382},
-    R_s=62.5593283040876);
+    R_s=R_NASA_2002/Csminus.MM);
 
   constant IdealGases.Common.DataRecord CsBO2(
     name="CsBO2",
@@ -6939,7 +6942,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={89755.79890000001,-1656.134283,11.16468934,-0.000447636699,
         9.621091809999999e-008,-1.081470115e-011,4.93844674e-016},
     bhigh={-76104.79670000001,-30.36616012},
-    R_s=47.31808992105125);
+    R_s=R_NASA_2002/CsBO2.MM);
 
   constant IdealGases.Common.DataRecord CsBr(
     name="CsBr",
@@ -6953,7 +6956,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-152832.9963,1259.712657,1.704268408,0.002776255318,-1.228389838e-006,
         2.698111786e-010,-1.98353448e-014},
     bhigh={-33278.4203,24.84116659},
-    R_s=39.07021046292822);
+    R_s=R_NASA_2002/CsBr.MM);
 
   constant IdealGases.Common.DataRecord CsCL(
     name="CsCL",
@@ -6967,7 +6970,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3674923.48,11861.52941,-10.63287842,0.009804117919999999,-3.27779746e-006,
         5.53423339e-010,-3.4012315e-014},
     bhigh={-104865.8658,111.4096064},
-    R_s=49.38575996630998);
+    R_s=R_NASA_2002/CsCL.MM);
 
   constant IdealGases.Common.DataRecord CsF(
     name="CsF",
@@ -6981,7 +6984,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1850863.231,5625.298800000001,-2.250022212,0.00410924354,-1.250243837e-006,
         1.941483152e-010,-1.071166179e-014},
     bhigh={-80798.2779,51.3555945},
-    R_s=54.73534623939349);
+    R_s=R_NASA_2002/CsF.MM);
 
   constant IdealGases.Common.DataRecord CsH(
     name="CsH",
@@ -6995,7 +6998,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-911214.6649999999,3576.47275,-1.258058765,0.00431485515,-1.407820502e-006,
         2.154598897e-010,-1.254525606e-014},
     bhigh={-9158.717270000001,39.0880003},
-    R_s=62.08871271199990);
+    R_s=R_NASA_2002/CsH.MM);
 
   constant IdealGases.Common.DataRecord CsI(
     name="CsI",
@@ -7009,7 +7012,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4511259.05,-13417.06362,19.80984712,-0.008359855550000002,
         2.348201245e-006,-2.874285248e-010,1.20808775e-014},
     bhigh={65734.3913,-102.1032592},
-    R_s=32.0022807443226);
+    R_s=R_NASA_2002/CsI.MM);
 
   constant IdealGases.Common.DataRecord CsLi(
     name="CsLi",
@@ -7023,7 +7026,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7481630.23,-28852.97839,46.3110499,-0.02784288108,8.78741349e-006,-1.264901197e-009,
         6.72018628e-014},
     bhigh={194513.7819,-285.7846194},
-    R_s=59.45456606156252);
+    R_s=R_NASA_2002/CsLi.MM);
 
   constant IdealGases.Common.DataRecord CsNO2(
     name="CsNO2",
@@ -7037,7 +7040,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-163350.3154,-846.8879579999999,10.62853461,-0.0002508799215,
         5.54125577e-008,-6.35559195e-012,2.946880031e-016},
     bhigh={-24030.40739,-24.43488888},
-    R_s=46.4728961530862);
+    R_s=R_NASA_2002/CsNO2.MM);
 
   constant IdealGases.Common.DataRecord CsNO3(
     name="CsNO3",
@@ -7051,7 +7054,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-314751.7676,-1367.011655,14.01012848,-0.000401864713,8.8536147e-008,
         -1.013466457e-011,4.69175873e-016},
     bhigh={-35490.2667,-45.00692791},
-    R_s=42.65812461985728);
+    R_s=R_NASA_2002/CsNO3.MM);
 
   constant IdealGases.Common.DataRecord CsNa(
     name="CsNa",
@@ -7065,7 +7068,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3879556.79,-17801.67288,34.913558,-0.02320080793,
         7.861975840000001e-006,-1.171011257e-009,6.323927369999999e-014},
     bhigh={119577.6556,-200.1754433},
-    R_s=53.33396367124021);
+    R_s=R_NASA_2002/CsNa.MM);
 
   constant IdealGases.Common.DataRecord CsO(
     name="CsO",
@@ -7079,7 +7082,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={837554.4350000001,-2418.205772,8.908065349999999,-0.00337818004,
         1.312755917e-006,-2.150508925e-010,1.21913898e-014},
     bhigh={18094.93447,-24.6085858},
-    R_s=55.83773799174439);
+    R_s=R_NASA_2002/CsO.MM);
 
   constant IdealGases.Common.DataRecord CsOH(
     name="CsOH",
@@ -7093,7 +7096,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={896717.113,-2323.978587,7.95964487,0.0001101149275,-6.466013969999999e-008,
         1.045968201e-011,-5.82251417e-016},
     bhigh={-17362.58234,-18.64239624},
-    R_s=55.46231245512809);
+    R_s=R_NASA_2002/CsOH.MM);
 
   constant IdealGases.Common.DataRecord CsRb(
     name="CsRb",
@@ -7107,7 +7110,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-13286933.78,34145.7947,-23.73696406,0.0070704654,3.86345097e-007,-3.158132986e-010,
         2.667747207e-014},
     bhigh={-212400.8997,223.9970251},
-    R_s=38.07476419387448);
+    R_s=R_NASA_2002/CsRb.MM);
 
   constant IdealGases.Common.DataRecord Cs2(
     name="Cs2",
@@ -7121,7 +7124,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-25927395.9,75398.1891,-74.840868,0.0369286679,-8.08249724e-006,
         8.171850729999999e-010,-3.0892859e-014},
     bhigh={-471504.572,586.093375},
-    R_s=31.279793266567);
+    R_s=R_NASA_2002/Cs2.MM);
 
   constant IdealGases.Common.DataRecord Cs2Br2(
     name="Cs2Br2",
@@ -7135,7 +7138,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-7545.84665,-0.2087093009,10.00018042,-8.03426073e-008,
         1.923604258e-011,-2.34469814e-015,1.139365834e-019},
     bhigh={-71058.8354,-7.25179304},
-    R_s=19.53510523146411);
+    R_s=R_NASA_2002/Cs2Br2.MM);
 
   constant IdealGases.Common.DataRecord Cs2CO3(
     name="Cs2CO3",
@@ -7149,7 +7152,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-303714.9985,-1517.0784,17.11941656,-0.000444970012,
         9.798325240000001e-008,-1.121256063e-011,5.189734780000001e-016},
     bhigh={-94204.1477,-56.8200626},
-    R_s=25.51873765805516);
+    R_s=R_NASA_2002/Cs2CO3.MM);
 
   constant IdealGases.Common.DataRecord Cs2CL2(
     name="Cs2CL2",
@@ -7163,7 +7166,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-16251.43966,-0.900613735,10.00077173,-3.41619408e-007,
         8.14496808e-011,-9.897475279999999e-015,4.79833081e-019},
     bhigh={-80565.13219999999,-10.81977337},
-    R_s=24.69287998315499);
+    R_s=R_NASA_2002/Cs2CL2.MM);
 
   constant IdealGases.Common.DataRecord Cs2F2(
     name="Cs2F2",
@@ -7177,7 +7180,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-36779.4642,-4.35575348,10.00366687,-1.603814186e-006,
         3.79146974e-010,-4.57868743e-014,2.209385787e-018},
     bhigh={-110345.6448,-14.15086452},
-    R_s=27.36767311969674);
+    R_s=R_NASA_2002/Cs2F2.MM);
 
   constant IdealGases.Common.DataRecord Cs2I2(
     name="Cs2I2",
@@ -7191,7 +7194,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4983.37601,-0.09461179879999999,10.00008229,-3.68096204e-008,
         8.844660910000001e-012,-1.081178562e-015,5.26614198e-020},
     bhigh={-57605.01040000001,-5.14486489},
-    R_s=16.0011403721613);
+    R_s=R_NASA_2002/Cs2I2.MM);
 
   constant IdealGases.Common.DataRecord Cs2O(
     name="Cs2O",
@@ -7205,7 +7208,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-41191.4741,-10.79255391,7.00850047,-3.54295578e-006,8.08169912e-010,
         -9.499419930000001e-014,4.48912254e-018},
     bhigh={-19343.7785,-1.20397045},
-    R_s=29.503925158165);
+    R_s=R_NASA_2002/Cs2O.MM);
 
   constant IdealGases.Common.DataRecord Cs2Oplus(
     name="Cs2Oplus",
@@ -7219,7 +7222,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-31530.85844,-5.77155903,7.00448263,-1.848241331e-006,4.1808823e-010,
         -4.88237627e-014,2.295419936e-018},
     bhigh={31962.2731,-0.0543435069},
-    R_s=29.50398259355620);
+    R_s=R_NASA_2002/Cs2Oplus.MM);
 
   constant IdealGases.Common.DataRecord Cs2O2(
     name="Cs2O2",
@@ -7233,7 +7236,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-119003.2094,-92.6107526,10.06915777,-2.766227147e-005,
         6.11075296e-009,-7.003595480000001e-013,3.24374252e-017},
     bhigh={-32556.1074,-17.24868948},
-    R_s=27.91886899587220);
+    R_s=R_NASA_2002/Cs2O2.MM);
 
   constant IdealGases.Common.DataRecord Cs2O2H2(
     name="Cs2O2H2",
@@ -7247,7 +7250,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1802857.941,-4656.35475,16.93566597,0.0002117402535,-1.272249096e-007,
         2.066555839e-011,-1.152390667e-015},
     bhigh={-51908.1369,-58.4971916},
-    R_s=27.73115622756404);
+    R_s=R_NASA_2002/Cs2O2H2.MM);
 
   constant IdealGases.Common.DataRecord Cs2SO4(
     name="Cs2SO4",
@@ -7261,7 +7264,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-522339.752,-944.415525,19.70476453,-0.000282122599,
         6.240792279999999e-008,-7.16346407e-012,3.32266719e-016},
     bhigh={-136417.9983,-68.20406795},
-    R_s=22.97628867546256);
+    R_s=R_NASA_2002/Cs2SO4.MM);
 
   constant IdealGases.Common.DataRecord Cu(
     name="Cu",
@@ -7275,7 +7278,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2308090.411,-8503.261,14.67859102,-0.00846713652,2.887821016e-006,-4.27065918e-010,
         2.304265084e-014},
     bhigh={92075.3562,-78.5470156},
-    R_s=130.8423818965788);
+    R_s=R_NASA_2002/Cu.MM);
 
   constant IdealGases.Common.DataRecord Cuplus(
     name="Cuplus",
@@ -7289,7 +7292,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2181443.016,7217.85819,-6.94115475,0.00620824892,-2.139340497e-006,
         3.56643144e-010,-2.081198501e-014},
     bhigh={85164.56659999999,71.16800670000001},
-    R_s=130.843511483813);
+    R_s=R_NASA_2002/Cuplus.MM);
 
   constant IdealGases.Common.DataRecord Cuminus(
     name="Cuminus",
@@ -7301,7 +7304,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={24838.64954,5.07596603},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={24838.64954,5.07596603},
-    R_s=130.8412523288480);
+    R_s=R_NASA_2002/Cuminus.MM);
 
   constant IdealGases.Common.DataRecord CuCL(
     name="CuCL",
@@ -7315,7 +7318,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-25771.2241,-7.10634606,4.50562318,5.39454827e-005,5.38641796e-010,-6.348482770000001e-014,
         3.006622062e-018},
     bhigh={9566.192870000001,2.680067564},
-    R_s=83.98579783634179);
+    R_s=R_NASA_2002/CuCL.MM);
 
   constant IdealGases.Common.DataRecord CuF(
     name="CuF",
@@ -7329,7 +7332,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={509415.483,-1415.00987,5.63234938,-0.000162912841,-1.156611499e-007,
         5.06603408e-011,-4.15320511e-015},
     bhigh={6305.506600000001,-7.40777361},
-    R_s=100.7277256563895);
+    R_s=R_NASA_2002/CuF.MM);
 
   constant IdealGases.Common.DataRecord CuF2(
     name="CuF2",
@@ -7343,7 +7346,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1650355.082,3775.36212,3.88911655,0.000682191264,1.875979026e-007,-5.67736811e-011,
         3.82324873e-015},
     bhigh={-59533.717,15.22659664},
-    R_s=81.88182200959929);
+    R_s=R_NASA_2002/CuF2.MM);
 
   constant IdealGases.Common.DataRecord CuO(
     name="CuO",
@@ -7357,7 +7360,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={358228.017,-913.9366409999999,5.13689867,6.240577240000001e-005,-1.558613495e-007,
         5.23680312e-011,-4.026745619999999e-015},
     bhigh={41507.9286,-2.63407096},
-    R_s=104.5253402459476);
+    R_s=R_NASA_2002/CuO.MM);
 
   constant IdealGases.Common.DataRecord Cu2(
     name="Cu2",
@@ -7371,7 +7374,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-86993.995,320.910387,3.97380288,0.000508080967,-1.707470385e-007,
         3.21910819e-011,-1.958830868e-015},
     bhigh={55060.9019,6.91450217},
-    R_s=65.42119094828942);
+    R_s=R_NASA_2002/Cu2.MM);
 
   constant IdealGases.Common.DataRecord Cu3CL3(
     name="Cu3CL3",
@@ -7385,7 +7388,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-91885.59679999999,-15.7193643,16.0129417,-5.57299237e-006,
         1.302748507e-009,-1.560175322e-013,7.48082757e-018},
     bhigh={-36087.6074,-40.13211395},
-    R_s=27.99526594544726);
+    R_s=R_NASA_2002/Cu3CL3.MM);
 
   constant IdealGases.Common.DataRecord D(
     name="D",
@@ -7398,7 +7401,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={60.50019210000001,-0.1810766064,2.500210817,-1.220711706e-007,
         3.71517217e-011,-5.66068021e-015,3.393920393e-019},
     bhigh={25922.43752,0.590212537},
-    R_s=4128.147432453769);
+    R_s=R_NASA_2002/D.MM);
 
   constant IdealGases.Common.DataRecord Dplus(
     name="Dplus",
@@ -7410,7 +7413,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={184512.0037,-0.1018414521},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={184512.0037,-0.1018414521},
-    R_s=4129.272161344218);
+    R_s=R_NASA_2002/Dplus.MM);
 
   constant IdealGases.Common.DataRecord Dminus(
     name="Dminus",
@@ -7422,7 +7425,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={16423.73393,-0.1010243437},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={16423.73393,-0.1010243437},
-    R_s=4127.023316102554);
+    R_s=R_NASA_2002/Dminus.MM);
 
   constant IdealGases.Common.DataRecord DBr(
     name="DBr",
@@ -7436,7 +7439,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={665400.044,-2594.092228,6.8858794,-0.001103284901,2.894201105e-007,-3.152037514e-011,
         1.011011776e-015},
     bhigh={10378.1314,-19.73703653},
-    R_s=101.4978349962259);
+    R_s=R_NASA_2002/DBr.MM);
 
   constant IdealGases.Common.DataRecord DCL(
     name="DCL",
@@ -7450,7 +7453,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={411728.4899999999,-1764.535217,5.6688771,-0.000347596417,
         5.88268803e-008,3.76025313e-013,-5.16460056e-016},
     bhigh={-1541.258092,-12.75659404},
-    R_s=221.9149482124345);
+    R_s=R_NASA_2002/DCL.MM);
 
   constant IdealGases.Common.DataRecord DF(
     name="DF",
@@ -7464,7 +7467,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={800117.2800000001,-2438.386832,5.62066445,-0.0002020416838,
         1.714418979e-008,2.697462563e-012,-2.88829741e-016},
     bhigh={-18574.47029,-14.73004444},
-    R_s=395.6934178414862);
+    R_s=R_NASA_2002/DF.MM);
 
   constant IdealGases.Common.DataRecord DOCL(
     name="DOCL",
@@ -7478,7 +7481,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={604306.633,-2646.500381,8.61247421,-0.0005532268239999999,
         1.086845232e-007,-1.13738129e-011,4.90429552e-016},
     bhigh={4845.79518,-25.88861801},
-    R_s=155.5087707065632);
+    R_s=R_NASA_2002/DOCL.MM);
 
   constant IdealGases.Common.DataRecord DO2(
     name="DO2",
@@ -7492,7 +7495,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1267224.927,2799.947016,2.325174609,0.00272632507,-6.31450732e-007,
         6.7292892e-011,-2.765192818e-015},
     bhigh={-19594.11733,17.89922833},
-    R_s=244.4516495534548);
+    R_s=R_NASA_2002/DO2.MM);
 
   constant IdealGases.Common.DataRecord DO2minus(
     name="DO2minus",
@@ -7506,7 +7509,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={552766.192,-2796.895783,8.772206669999999,-0.0006291116630000001,
         1.272331622e-007,-1.364440687e-011,6.00519944e-016},
     bhigh={2512.066767,-28.90020381},
-    R_s=244.4477068139626);
+    R_s=R_NASA_2002/DO2minus.MM);
 
   constant IdealGases.Common.DataRecord D2(
     name="D2",
@@ -7520,7 +7523,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={821516.856,-2365.623159,5.34297451,6.92814599e-005,-8.52367102e-008,
         2.456447415e-011,-1.960597698e-015},
     bhigh={14342.14587,-17.12600356},
-    R_s=2064.073716226885);
+    R_s=R_NASA_2002/D2.MM);
 
   constant IdealGases.Common.DataRecord D2plus(
     name="D2plus",
@@ -7534,7 +7537,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={925595.135,-4505.21994,11.03203365,-0.00470608903,1.83806846e-006,-3.135924623e-010,
         1.857684975e-014},
     bhigh={205829.889,-52.8391224},
-    R_s=2064.354860150151);
+    R_s=R_NASA_2002/D2plus.MM);
 
   constant IdealGases.Common.DataRecord D2minus(
     name="D2minus",
@@ -7548,7 +7551,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-57988.05190000001,-312.2959355,4.73038828,5.6959008e-005,
         2.01897543e-008,-2.311492448e-012,1.070266527e-016},
     bhigh={28512.00896,-9.15752792},
-    R_s=2063.792648871018);
+    R_s=R_NASA_2002/D2minus.MM);
 
   constant IdealGases.Common.DataRecord D2O(
     name="D2O",
@@ -7562,7 +7565,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1544193.253,-5474.238899999999,10.17542424,-0.0009619415540000001,
         2.036545675e-007,-2.050566442e-011,8.510770689999999e-016},
     bhigh={2983.24898,-44.6501157},
-    R_s=415.1525065105142);
+    R_s=R_NASA_2002/D2O.MM);
 
   constant IdealGases.Common.DataRecord D2O2(
     name="D2O2",
@@ -7576,7 +7579,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1147867.936,-5225.76093,13.11088701,-0.001179811896,2.729336904e-007,
         -2.961433535e-011,1.310306129e-015},
     bhigh={12195.80532,-56.905382},
-    R_s=230.7854963460187);
+    R_s=R_NASA_2002/D2O2.MM);
 
   constant IdealGases.Common.DataRecord D2S(
     name="D2S",
@@ -7590,7 +7593,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={423581.463,-2823.776231,8.96282184,-0.000646923123,1.634615644e-007,
         -1.797991376e-011,8.16093957e-016},
     bhigh={12046.03509,-31.91047376},
-    R_s=230.3622033665950);
+    R_s=R_NASA_2002/D2S.MM);
 
   constant IdealGases.Common.DataRecord eminus(
     name="eminus",
@@ -7602,7 +7605,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={-745.375,-11.72081224},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={-745.375,-11.72081224},
-    R_s=15156424.71503372);
+    R_s=R_NASA_2002/eminus.MM);
 
   constant IdealGases.Common.DataRecord F(
     name="F",
@@ -7616,7 +7619,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={14735.06226,81.4992736,2.444371819,2.120210026e-005,-4.54691862e-009,
         5.10952873e-013,-2.333894647e-017},
     bhigh={8388.37465,5.47871064},
-    R_s=437.6425698766095);
+    R_s=R_NASA_2002/F.MM);
 
   constant IdealGases.Common.DataRecord Fplus(
     name="Fplus",
@@ -7630,7 +7633,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={16496.35664,133.7351478,2.332522942,0.0001215277877,-4.8010377e-008,
         9.027225149999999e-012,-5.47066494e-016},
     bhigh={211074.5327,6.62581709},
-    R_s=437.655207656974);
+    R_s=R_NASA_2002/Fplus.MM);
 
   constant IdealGases.Common.DataRecord Fminus(
     name="Fminus",
@@ -7642,7 +7645,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={-31425.72443,3.26488271},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={-31425.72443,3.26488271},
-    R_s=437.6299328260836);
+    R_s=R_NASA_2002/Fminus.MM);
 
   constant IdealGases.Common.DataRecord FCN(
     name="FCN",
@@ -7656,7 +7659,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={398187.355,-2302.971079,9.027081389999999,-0.000522871026,
         1.191059272e-007,-1.280287231e-011,5.73380719e-016},
     bhigh={15884.49451,-29.84971982},
-    R_s=184.7020248213632);
+    R_s=R_NASA_2002/FCN.MM);
 
   constant IdealGases.Common.DataRecord FCO(
     name="FCO",
@@ -7670,7 +7673,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-60858.5158,-1022.397533,7.52732256,-0.0001057942328,-1.365311093e-009,
         2.484612871e-012,-9.9979168e-017},
     bhigh={-18050.98416,-16.30331278},
-    R_s=176.8724684686408);
+    R_s=R_NASA_2002/FCO.MM);
 
   constant IdealGases.Common.DataRecord FO(
     name="FO",
@@ -7684,7 +7687,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1597940.503,4377.376380000001,-0.489750764,0.002682336321,-6.90080485e-007,
         7.24647968e-011,-2.726912632e-015},
     bhigh={-16442.48211,35.5992361},
-    R_s=237.5723399690413);
+    R_s=R_NASA_2002/FO.MM);
 
   constant IdealGases.Common.DataRecord FO2_FOO(
     name="FO2_FOO",
@@ -7698,7 +7701,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1213166.895,2493.397189,4.46506574,0.0009416104040000001,-6.426472259999999e-008,
         -1.085643277e-011,1.216995394e-015},
     bhigh={-15968.00286,8.65519318},
-    R_s=163.0385487492773);
+    R_s=R_NASA_2002/FO2_FOO.MM);
 
   constant IdealGases.Common.DataRecord FO2_OFO(
     name="FO2_OFO",
@@ -7712,7 +7715,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-621186.7340000001,936.947459,6.40155875,0.0002136110846,-4.33797765e-008,
         4.66731224e-012,-2.059767432e-016},
     bhigh={36383.5727,-6.15026433},
-    R_s=163.0385487492773);
+    R_s=R_NASA_2002/FO2_OFO.MM);
 
   constant IdealGases.Common.DataRecord F2(
     name="F2",
@@ -7726,7 +7729,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2941167.79,9456.5977,-7.73861615,0.00764471299,-2.241007605e-006,
         2.915845236e-010,-1.425033974e-014},
     bhigh={-60710.0561,84.23835080000001},
-    R_s=218.8212849383047);
+    R_s=R_NASA_2002/F2.MM);
 
   constant IdealGases.Common.DataRecord F2O(
     name="F2O",
@@ -7740,7 +7743,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-188537.4518,-210.0729689,7.15123916,0.0001327687906,
         1.804705706e-008,-1.416973671e-012,6.489389390000001e-017},
     bhigh={1449.129965,-12.57858336},
-    R_s=153.9832250141188);
+    R_s=R_NASA_2002/F2O.MM);
 
   constant IdealGases.Common.DataRecord F2O2(
     name="F2O2",
@@ -7754,7 +7757,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-219056.3532,-391.092081,10.29107144,-0.0001163345202,
         2.570922521e-008,-2.949199983e-012,1.367386916e-016},
     bhigh={827.8020939999999,-27.56752555},
-    R_s=118.7861699845206);
+    R_s=R_NASA_2002/F2O2.MM);
 
   constant IdealGases.Common.DataRecord FS2F(
     name="FS2F",
@@ -7768,7 +7771,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-207709.7921,-109.4539831,10.08136946,-3.23953791e-005,
         7.12522527e-009,-8.13478741e-013,3.75502241e-017},
     bhigh={-43494.4606,-23.46916058},
-    R_s=81.41359054580208);
+    R_s=R_NASA_2002/FS2F.MM);
 
   constant IdealGases.Common.DataRecord Fe(
     name="Fe",
@@ -7782,7 +7785,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1954923.682,6737.161099999999,-5.48641097,0.004378803450000001,-1.116286672e-006,
         1.544348856e-010,-8.023578182e-015},
     bhigh={7137.37006,65.0497986},
-    R_s=148.8854866147372);
+    R_s=R_NASA_2002/Fe.MM);
 
   constant IdealGases.Common.DataRecord Feplus(
     name="Feplus",
@@ -7796,7 +7799,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-817645.009,1925.359408,1.717387154,0.000338533898,-9.813533120000001e-008,
         2.228179208e-011,-1.483964439e-015},
     bhigh={128635.2466,15.00256262},
-    R_s=148.8869492233923);
+    R_s=R_NASA_2002/Feplus.MM);
 
   constant IdealGases.Common.DataRecord Fe_CO_5(
     name="Fe_CO_5",
@@ -7810,7 +7813,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1116600.852,-8067.07473,36.5294241,-0.0020471903,4.44196775e-007,-4.93250713e-011,
         2.235704865e-015},
     bhigh={-48606.6125,-175.4566113},
-    R_s=42.44359875545891);
+    R_s=R_NASA_2002/Fe_CO_5.MM);
 
   constant IdealGases.Common.DataRecord FeCL(
     name="FeCL",
@@ -7824,7 +7827,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={528870.022,-1282.897413,5.79844169,-0.0002896589776,3.34390381e-008,
         -1.469606582e-013,-1.213444602e-016},
     bhigh={37261.9673,-4.075134191},
-    R_s=91.07001248658240);
+    R_s=R_NASA_2002/FeCL.MM);
 
   constant IdealGases.Common.DataRecord FeCL2(
     name="FeCL2",
@@ -7838,7 +7841,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={164412.3697,692.800269,4.63827014,0.002754339782,-8.624218250000001e-007,
         1.170827576e-010,-5.93806195e-015},
     bhigh={-22197.21855,11.16897701},
-    R_s=65.59719449945169);
+    R_s=R_NASA_2002/FeCL2.MM);
 
   constant IdealGases.Common.DataRecord FeCL3(
     name="FeCL3",
@@ -7852,7 +7855,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-59157.40590000001,-10.33382228,10.00849967,-3.65765187e-006,
         8.545873639999999e-010,-1.023070527e-013,4.90406364e-018},
     bhigh={-130501.205,-15.98494171},
-    R_s=51.25958669329980);
+    R_s=R_NASA_2002/FeCL3.MM);
 
   constant IdealGases.Common.DataRecord FeO(
     name="FeO",
@@ -7866,7 +7869,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-119597.148,-362.486478,5.51888075,-0.0009978856889999999,
         4.37691383e-007,-6.79062946e-011,3.63929268e-015},
     bhigh={30379.85806,-3.63365542},
-    R_s=115.7294096686729);
+    R_s=R_NASA_2002/FeO.MM);
 
   constant IdealGases.Common.DataRecord Fe_OH_2(
     name="Fe_OH_2",
@@ -7880,7 +7883,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1612519.19,-6533.24199,18.42922816,-0.002073249635,4.26587436e-007,-4.56406313e-011,
         1.990105746e-015},
     bhigh={-2992.568633,-84.45940589999999},
-    R_s=92.52770541804735);
+    R_s=R_NASA_2002/Fe_OH_2.MM);
 
   constant IdealGases.Common.DataRecord Fe2CL4(
     name="Fe2CL4",
@@ -7894,7 +7897,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={140245.0973,693.606441,13.1380041,0.00275433307,-8.623996010000001e-007,
         1.170782491e-010,-5.93777808e-015},
     bhigh={-59741.72730000001,-17.52491511},
-    R_s=32.79859724972584);
+    R_s=R_NASA_2002/Fe2CL4.MM);
 
   constant IdealGases.Common.DataRecord Fe2CL6(
     name="Fe2CL6",
@@ -7908,7 +7911,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-99991.17999999999,-14.57716085,22.0120846,-5.22948113e-006,
         1.226831608e-009,-1.473195806e-013,7.07827233e-018},
     bhigh={-85514.9619,-61.43757198},
-    R_s=25.62979334664990);
+    R_s=R_NASA_2002/Fe2CL6.MM);
 
   constant IdealGases.Common.DataRecord Ga(
     name="Ga",
@@ -7922,7 +7925,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-55441.8652,880.8624419999999,1.760717716,0.000299325946,-5.61082731e-008,
         2.682832239e-012,3.132134914e-016},
     bhigh={26843.51822,12.52212023},
-    R_s=119.2506059693358);
+    R_s=R_NASA_2002/Ga.MM);
 
   constant IdealGases.Common.DataRecord Gaplus(
     name="Gaplus",
@@ -7936,7 +7939,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={35666.0714,-110.8845546,2.635517951,-8.33897352e-005,
         2.734243614e-008,-4.55567374e-012,3.035050101e-016},
     bhigh={102989.743,4.25707541},
-    R_s=119.2515442737287);
+    R_s=R_NASA_2002/Gaplus.MM);
 
   constant IdealGases.Common.DataRecord GaBr(
     name="GaBr",
@@ -7950,7 +7953,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={335980.503,-840.683668,5.14508473,-3.265526e-005,-7.67102275e-008,
         3.63512382e-011,-3.35817783e-015},
     bhigh={2035.179445,-0.427789408},
-    R_s=55.56824637264665);
+    R_s=R_NASA_2002/GaBr.MM);
 
   constant IdealGases.Common.DataRecord GaBr2(
     name="GaBr2",
@@ -7964,7 +7967,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-330229.436,476.672265,7.1047254,-0.0005522771210000001,
         3.159876015e-007,-5.51363715e-011,3.17329323e-015},
     bhigh={-23656.8362,-1.162714892},
-    R_s=36.22390875306603);
+    R_s=R_NASA_2002/GaBr2.MM);
 
   constant IdealGases.Common.DataRecord GaBr3(
     name="GaBr3",
@@ -7978,7 +7981,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-51030.6375,-9.39520969,10.00768765,-3.2959543e-006,
         7.679838140000001e-010,-9.175147259999999e-014,4.39118694e-018},
     bhigh={-38334.0215,-14.10315914},
-    R_s=26.86997269216475);
+    R_s=R_NASA_2002/GaBr3.MM);
 
   constant IdealGases.Common.DataRecord GaCL(
     name="GaCL",
@@ -7992,7 +7995,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-486484.224,1452.870183,2.719542959,0.001144285628,-3.43145286e-007,
         5.47044048e-011,-3.019622103e-015},
     bhigh={-18950.84035,15.70926145},
-    R_s=79.05330113333841);
+    R_s=R_NASA_2002/GaCL.MM);
 
   constant IdealGases.Common.DataRecord GaCL2(
     name="GaCL2",
@@ -8006,7 +8009,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-344540.53,471.443716,7.10877548,-0.000553943356,3.16363824e-007,-5.51802393e-011,
         3.17535303e-015},
     bhigh={-32309.3616,-3.74484074},
-    R_s=59.12372270299867);
+    R_s=R_NASA_2002/GaCL2.MM);
 
   constant IdealGases.Common.DataRecord GaCL3(
     name="GaCL3",
@@ -8020,7 +8023,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-94669.1731,-25.61468254,10.02010048,-8.35407307e-006,
         1.901439055e-009,-2.231168493e-013,1.052949609e-017},
     bhigh={-55182.0143,-18.64958383},
-    R_s=47.21953408071240);
+    R_s=R_NASA_2002/GaCL3.MM);
 
   constant IdealGases.Common.DataRecord GaF(
     name="GaF",
@@ -8034,7 +8037,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-298339.2279,722.5157870000001,3.63955743,0.000554673676,-1.46490145e-007,
         2.177385396e-011,-1.031058874e-015},
     bhigh={-34085.2871,7.55396},
-    R_s=93.71481626882115);
+    R_s=R_NASA_2002/GaF.MM);
 
   constant IdealGases.Common.DataRecord GaF2(
     name="GaF2",
@@ -8048,7 +8051,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={410025.1359999999,-1723.259472,8.95132922,-0.001059205682,
         2.745755154e-007,-2.907681311e-011,1.084834142e-015},
     bhigh={-53765.716,-21.13835528},
-    R_s=77.18645509931031);
+    R_s=R_NASA_2002/GaF2.MM);
 
   constant IdealGases.Common.DataRecord GaF3(
     name="GaF3",
@@ -8062,7 +8065,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-209696.176,-143.1211274,10.10568378,-4.18493682e-005,
         9.16475945e-009,-1.042661957e-012,4.79916345e-017},
     bhigh={-113667.8134,-23.9253933},
-    R_s=65.61416884160271);
+    R_s=R_NASA_2002/GaF3.MM);
 
   constant IdealGases.Common.DataRecord GaH(
     name="GaH",
@@ -8076,7 +8079,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3257993.99,-11090.99502,18.01126796,-0.008167719110000001,
         2.601293566e-006,-3.81345935e-010,2.028049649e-014},
     bhigh={93697.78240000001,-98.2090022},
-    R_s=117.5512441938422);
+    R_s=R_NASA_2002/GaH.MM);
 
   constant IdealGases.Common.DataRecord GaI(
     name="GaI",
@@ -8090,7 +8093,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1498356.654,-4551.96724,9.803005349999999,-0.002943735609,
         8.658040509999999e-007,-1.106638204e-010,5.00783686e-015},
     bhigh={32918.1191,-32.2735977},
-    R_s=42.28559722606409);
+    R_s=R_NASA_2002/GaI.MM);
 
   constant IdealGases.Common.DataRecord GaI2(
     name="GaI2",
@@ -8104,7 +8107,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-320287.975,479.650233,7.10233396,-0.000551265783,3.157543452e-007,-5.51087194e-011,
         3.17197773e-015},
     bhigh={-9180.919610000001,0.727520488},
-    R_s=25.69919371793709);
+    R_s=R_NASA_2002/GaI2.MM);
 
   constant IdealGases.Common.DataRecord GaI3(
     name="GaI3",
@@ -8118,7 +8121,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-31640.4013,-4.20866283,10.00352001,-1.53265018e-006,3.61153154e-010,
         -4.35097887e-014,2.095704875e-018},
     bhigh={-17000.58453,-10.90291552},
-    R_s=18.45878755671638);
+    R_s=R_NASA_2002/GaI3.MM);
 
   constant IdealGases.Common.DataRecord GaO(
     name="GaO",
@@ -8132,7 +8135,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2937313.804,-11183.14112,18.59366773,-0.00685475345,1.665399251e-006,
         -1.887560878e-010,7.97268692e-015},
     bhigh={85302.48080000001,-99.04040480000001},
-    R_s=96.9934346215225);
+    R_s=R_NASA_2002/GaO.MM);
 
   constant IdealGases.Common.DataRecord GaOH(
     name="GaOH",
@@ -8146,7 +8149,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={842905.101,-2372.324595,8.009071090000001,8.77723071e-005,-5.94306891e-008,
         9.841943439999999e-012,-5.53155279e-016},
     bhigh={-3751.78825,-21.71053719},
-    R_s=95.86622167052498);
+    R_s=R_NASA_2002/GaOH.MM);
 
   constant IdealGases.Common.DataRecord Ga2Br2(
     name="Ga2Br2",
@@ -8160,7 +8163,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-18853.73131,-1.263621802,10.00108034,-4.774975660000001e-007,
         1.137227648e-010,-1.380820486e-014,6.69024243e-019},
     bhigh={-19510.53843,-11.41667594},
-    R_s=27.78412318632332);
+    R_s=R_NASA_2002/Ga2Br2.MM);
 
   constant IdealGases.Common.DataRecord Ga2Br4(
     name="Ga2Br4",
@@ -8174,7 +8177,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-57421.6721,-7.16013737,16.00598947,-2.60818227e-006,6.14645595e-010,
         -7.40543865e-014,3.56712663e-018},
     bhigh={-54933.8976,-34.79271660000001},
-    R_s=18.11195437653302);
+    R_s=R_NASA_2002/Ga2Br4.MM);
 
   constant IdealGases.Common.DataRecord Ga2Br6(
     name="Ga2Br6",
@@ -8188,7 +8191,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-95261.73,-14.4468188,22.01192546,-5.14500674e-006,1.204348449e-009,
         -1.443806473e-013,6.928270740000001e-018},
     bhigh={-87822.23300000001,-57.6589512},
-    R_s=13.43498634608238);
+    R_s=R_NASA_2002/Ga2Br6.MM);
 
   constant IdealGases.Common.DataRecord Ga2CL2(
     name="Ga2CL2",
@@ -8202,7 +8205,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-36689.542,-4.43458068,10.00373051,-1.630793333e-006,3.85375332e-010,
         -4.65252773e-014,2.244498791e-018},
     bhigh={-29656.33085,-14.69535817},
-    R_s=39.52665056666920);
+    R_s=R_NASA_2002/Ga2CL2.MM);
 
   constant IdealGases.Common.DataRecord Ga2CL4(
     name="Ga2CL4",
@@ -8216,7 +8219,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-112711.0409,-21.38517542,16.01738077,-7.41556464e-006,
         1.721694751e-009,-2.051361953e-013,9.797311499999999e-018},
     bhigh={-77468.53380000001,-41.4728087},
-    R_s=29.56186135149933);
+    R_s=R_NASA_2002/Ga2CL4.MM);
 
   constant IdealGases.Common.DataRecord Ga2CL6(
     name="Ga2CL6",
@@ -8230,7 +8233,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-189844.5426,-44.1365524,22.03505047,-1.470071128e-005,
         3.36951281e-009,-3.9754628e-013,1.884231868e-017},
     bhigh={-122696.9998,-67.45332883},
-    R_s=23.60976704035620);
+    R_s=R_NASA_2002/Ga2CL6.MM);
 
   constant IdealGases.Common.DataRecord Ga2F2(
     name="Ga2F2",
@@ -8244,7 +8247,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-87732.34929999999,-19.8377587,10.0159403,-6.744402830000001e-006,
         1.556129063e-009,-1.845316975e-013,8.780884020000001e-018},
     bhigh={-76073.6863,-19.08325521},
-    R_s=46.85740813441057);
+    R_s=R_NASA_2002/Ga2F2.MM);
 
   constant IdealGases.Common.DataRecord Ga2F4(
     name="Ga2F4",
@@ -8258,7 +8261,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-270436.609,-104.9957196,16.07903965,-3.17889592e-005,
         7.04958272e-009,-8.10237952e-013,3.76054053e-017},
     bhigh={-164416.9589,-48.9659173},
-    R_s=38.59322754965515);
+    R_s=R_NASA_2002/Ga2F4.MM);
 
   constant IdealGases.Common.DataRecord Ga2F6(
     name="Ga2F6",
@@ -8272,7 +8275,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-436866.48,-212.8208368,22.15886373,-6.34628791e-005,
         1.399738556e-008,-1.601732039e-012,7.407584420000001e-017},
     bhigh={-249429.8707,-77.87635830000001},
-    R_s=32.80708442080135);
+    R_s=R_NASA_2002/Ga2F6.MM);
 
   constant IdealGases.Common.DataRecord Ga2I2(
     name="Ga2I2",
@@ -8286,7 +8289,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-12190.56501,-0.528755447,10.00045392,-2.011599344e-007,
         4.79946781e-011,-5.83478108e-015,2.829565069e-019},
     bhigh={-1393.258606,-9.052614910000001},
-    R_s=21.14279861303205);
+    R_s=R_NASA_2002/Ga2I2.MM);
 
   constant IdealGases.Common.DataRecord Ga2I4(
     name="Ga2I4",
@@ -8300,7 +8303,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-31712.9976,-2.287068836,16.00194812,-8.58896438e-007,
         2.041966602e-010,-2.476145769e-014,1.198551944e-018},
     bhigh={-24019.40505,-30.08672521},
-    R_s=12.84959685896855);
+    R_s=R_NASA_2002/Ga2I4.MM);
 
   constant IdealGases.Common.DataRecord Ga2I6(
     name="Ga2I6",
@@ -8314,7 +8317,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-60156.9815,-6.32920923,22.0053304,-2.332008629e-006,5.51386848e-010,
         -6.659445350000001e-014,3.21367043e-018},
     bhigh={-44886.9938,-51.6100875},
-    R_s=9.22939377835819);
+    R_s=R_NASA_2002/Ga2I6.MM);
 
   constant IdealGases.Common.DataRecord Ga2O(
     name="Ga2O",
@@ -8328,7 +8331,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-119387.4986,-87.19341610000001,7.0646782,-2.571524542e-005,
         5.65110849e-009,-6.44819054e-013,2.975374645e-017},
     bhigh={-13936.94796,-6.9428013},
-    R_s=53.4882987852970);
+    R_s=R_NASA_2002/Ga2O.MM);
 
   constant IdealGases.Common.DataRecord Ge(
     name="Ge",
@@ -8342,7 +8345,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-856541.384,3917.95866,-1.809888212,0.002276482224,-5.36562755e-007,
         5.984958090000001e-011,-2.541700646e-015},
     bhigh={19565.18798,38.41408752},
-    R_s=114.4618667400881);
+    R_s=R_NASA_2002/Ge.MM);
 
   constant IdealGases.Common.DataRecord Geplus(
     name="Geplus",
@@ -8356,7 +8359,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2244860.57,5165.53114,-0.386751651,0.000852873094,-1.386040003e-007,
         1.155945775e-011,-3.784413134e-016},
     bhigh={100682.3985,29.65845411},
-    R_s=114.4627311984352);
+    R_s=R_NASA_2002/Geplus.MM);
 
   constant IdealGases.Common.DataRecord Geminus(
     name="Geminus",
@@ -8370,7 +8373,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={13520.40246,-0.504851878,2.500140247,-3.65294416e-009,-6.7167222e-012,
         1.378119925e-015,-8.475212940000001e-020},
     bhigh={28817.39757,7.577953867},
-    R_s=114.4610022947982);
+    R_s=R_NASA_2002/Geminus.MM);
 
   constant IdealGases.Common.DataRecord GeBr(
     name="GeBr",
@@ -8384,7 +8387,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={225675.0476,-731.071546,6.26328381,-0.001198085447,4.00037777e-007,-5.42993788e-011,
         2.510481953e-015},
     bhigh={19428.63606,-6.106507844},
-    R_s=54.50565082861338);
+    R_s=R_NASA_2002/GeBr.MM);
 
   constant IdealGases.Common.DataRecord GeBr2(
     name="GeBr2",
@@ -8398,7 +8401,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-26366.55245,-3.99050902,7.00332744,-1.445749787e-006,
         3.40159136e-010,-4.09345703e-014,1.969987842e-018},
     bhigh={-9484.999249999999,-1.673617098},
-    R_s=35.76933335627754);
+    R_s=R_NASA_2002/GeBr2.MM);
 
   constant IdealGases.Common.DataRecord GeBr3(
     name="GeBr3",
@@ -8412,7 +8415,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-54339.267,-9.28032795,10.00765019,-3.29732215e-006,7.71292926e-010,
         -9.24157185e-014,4.43287623e-018},
     bhigh={-17426.97092,-13.66946296},
-    R_s=26.61903877676468);
+    R_s=R_NASA_2002/GeBr3.MM);
 
   constant IdealGases.Common.DataRecord GeBr4(
     name="GeBr4",
@@ -8426,7 +8429,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-69777.5791,-11.79873115,13.00953955,-4.02493875e-006,
         9.203567209999999e-010,-1.076853369e-013,5.0409548e-018},
     bhigh={-39041.4816,-26.8943607},
-    R_s=21.19664198890521);
+    R_s=R_NASA_2002/GeBr4.MM);
 
   constant IdealGases.Common.DataRecord GeCL(
     name="GeCL",
@@ -8440,7 +8443,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-378419.325,1429.309204,3.19485464,0.0008119939119999999,-2.652459954e-007,
         5.15195788e-011,-3.53421457e-015},
     bhigh={-2087.046335,13.8503382},
-    R_s=76.91996706539740);
+    R_s=R_NASA_2002/GeCL.MM);
 
   constant IdealGases.Common.DataRecord GeCL2(
     name="GeCL2",
@@ -8454,7 +8457,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-48901.28920000001,-11.26210418,7.00906353,-3.83918073e-006,
         8.86563357e-010,-1.05200054e-013,5.00842222e-018},
     bhigh={-22752.54424,-4.656641298},
-    R_s=57.9222688197512);
+    R_s=R_NASA_2002/GeCL2.MM);
 
   constant IdealGases.Common.DataRecord GeCL3(
     name="GeCL3",
@@ -8468,7 +8471,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-75744.9982,-15.7921342,10.01278835,-5.44173831e-006,
         1.260936724e-009,-1.500137106e-013,7.15640081e-018},
     bhigh={-35251.3172,-17.19719944},
-    R_s=46.45003603372086);
+    R_s=R_NASA_2002/GeCL3.MM);
 
   constant IdealGases.Common.DataRecord GeCL4(
     name="GeCL4",
@@ -8482,7 +8485,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-137626.121,-36.037695,13.0281667,-1.16495696e-005,2.63619338e-009,-3.07292672e-013,
         1.43980875e-017},
     bhigh={-64262.8178,-33.18158305},
-    R_s=38.77096040139519);
+    R_s=R_NASA_2002/GeCL4.MM);
 
   constant IdealGases.Common.DataRecord GeF(
     name="GeF",
@@ -8496,7 +8499,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-515048.058,1659.711777,2.999610299,0.0008198511679999999,-2.271982948e-007,
         3.62418386e-011,-2.133840473e-015},
     bhigh={-20515.29487,13.7315423},
-    R_s=90.73172065049690);
+    R_s=R_NASA_2002/GeF.MM);
 
   constant IdealGases.Common.DataRecord GeF2(
     name="GeF2",
@@ -8510,7 +8513,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-127532.7716,-71.6259135,7.05300237,-2.101910441e-005,4.6078937e-009,
         -5.24639467e-013,2.416218951e-017},
     bhigh={-71126.3763,-8.483841439000001},
-    R_s=75.15139193316412);
+    R_s=R_NASA_2002/GeF2.MM);
 
   constant IdealGases.Common.DataRecord GeF3(
     name="GeF3",
@@ -8524,7 +8527,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-206958.0129,-111.0233803,10.08234122,-3.27167626e-005,
         7.1838967e-009,-8.19038812e-013,3.77632244e-017},
     bhigh={-99997.4909,-23.0346594},
-    R_s=64.13774487390501);
+    R_s=R_NASA_2002/GeF3.MM);
 
   constant IdealGases.Common.DataRecord GeF4(
     name="GeF4",
@@ -8538,7 +8541,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-325303.268,-253.8279448,13.18792173,-7.46005855e-005,
         1.637384721e-008,-1.866482733e-012,8.605530500000001e-017},
     bhigh={-146617.6526,-41.22237561},
-    R_s=55.93963467192260);
+    R_s=R_NASA_2002/GeF4.MM);
 
   constant IdealGases.Common.DataRecord GeH4(
     name="GeH4",
@@ -8552,7 +8555,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3809805.88,10931.67093,-5.14967541,0.009485931369999999,-1.649459859e-006,
         1.419674126e-010,-5.00463975e-015},
     bhigh={-61585.1852,71.68961272999999},
-    R_s=108.4429260525649);
+    R_s=R_NASA_2002/GeH4.MM);
 
   constant IdealGases.Common.DataRecord GeI(
     name="GeI",
@@ -8566,7 +8569,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-213314.8437,-295.3079008,6.87660736,-0.002102579132,8.59629938e-007,
         -1.44769276e-010,8.401042789999999e-015},
     bhigh={24523.26136,-8.549783749},
-    R_s=41.66745387632140);
+    R_s=R_NASA_2002/GeI.MM);
 
   constant IdealGases.Common.DataRecord GeO(
     name="GeO",
@@ -8580,7 +8583,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1044508.485,2734.866048,1.298071298,0.001832638634,-5.06098635e-007,
         6.37495802e-011,-2.172371872e-015},
     bhigh={-23621.04658,23.50906051},
-    R_s=93.80151490195107);
+    R_s=R_NASA_2002/GeO.MM);
 
   constant IdealGases.Common.DataRecord GeO2(
     name="GeO2",
@@ -8594,7 +8597,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-172734.7526,-296.1154443,7.72072625,-8.82493339e-005,
         1.949874702e-008,-2.235834829e-012,1.036128507e-016},
     bhigh={-13879.83288,-16.69845695},
-    R_s=79.45914899635699);
+    R_s=R_NASA_2002/GeO2.MM);
 
   constant IdealGases.Common.DataRecord GeS(
     name="GeS",
@@ -8608,7 +8611,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2351367.441,7211.58186,-4.36252631,0.00545173775,-1.721002774e-006,
         2.632908084e-010,-1.39437404e-014},
     bhigh={-35833.1725,65.05566890999999},
-    R_s=79.40891074924788);
+    R_s=R_NASA_2002/GeS.MM);
 
   constant IdealGases.Common.DataRecord GeS2(
     name="GeS2",
@@ -8622,7 +8625,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-89709.8036,-33.64377,7.52543372,-1.026368137e-005,2.282230718e-009,
         -2.62874877e-013,1.222218614e-017},
     bhigh={11952.32103,-11.35170616},
-    R_s=60.79191343130804);
+    R_s=R_NASA_2002/GeS2.MM);
 
   constant IdealGases.Common.DataRecord Ge2(
     name="Ge2",
@@ -8636,7 +8639,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1969461.258,-5248.6871,10.58277303,-0.00333655151,1.052745838e-006,-1.484534793e-010,
         7.475431760000001e-015},
     bhigh={89256.65990000001,-37.50233948},
-    R_s=57.23093337004406);
+    R_s=R_NASA_2002/Ge2.MM);
 
   constant IdealGases.Common.DataRecord H(
     name="H",
@@ -8649,7 +8652,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={60.78774250000001,-0.1819354417,2.500211817,-1.226512864e-007,
         3.73287633e-011,-5.68774456e-015,3.410210197e-019},
     bhigh={25474.86398,-0.448191777},
-    R_s=8249.012838065759);
+    R_s=R_NASA_2002/H.MM);
 
   constant IdealGases.Common.DataRecord Hplus(
     name="Hplus",
@@ -8661,7 +8664,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={184021.4877,-1.140646644},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={184021.4877,-1.140646644},
-    R_s=8253.50504282645);
+    R_s=R_NASA_2002/Hplus.MM);
 
   constant IdealGases.Common.DataRecord Hminus(
     name="Hminus",
@@ -8673,7 +8676,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={15976.15494,-1.139013868},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={15976.15494,-1.139013868},
-    R_s=8244.525520665280);
+    R_s=R_NASA_2002/Hminus.MM);
 
   constant IdealGases.Common.DataRecord HALO(
     name="HALO",
@@ -8687,7 +8690,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={78474.67049999999,-1515.62885,8.572776230000001,-0.0004142611439999999,
         8.9350817e-008,-1.007036446e-011,4.60801725e-016},
     bhigh={6663.24189,-26.72948642},
-    R_s=189.0139139261520);
+    R_s=R_NASA_2002/HALO.MM);
 
   constant IdealGases.Common.DataRecord HALO2(
     name="HALO2",
@@ -8701,7 +8704,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={698570.544,-2864.935042,10.86721494,-5.3683127e-005,-2.836877559e-008,
         6.29164119e-012,-3.88903311e-016},
     bhigh={-27643.92495,-37.7588634},
-    R_s=138.6022449252502);
+    R_s=R_NASA_2002/HALO2.MM);
 
   constant IdealGases.Common.DataRecord HBO(
     name="HBO",
@@ -8715,7 +8718,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={886186.0229999999,-3913.06805,9.8886448,-0.0008222269139999999,
         1.621530554e-007,-1.703550237e-011,7.372740020000001e-016},
     bhigh={-3161.852029,-40.3681272},
-    R_s=298.8859148317262);
+    R_s=R_NASA_2002/HBO.MM);
 
   constant IdealGases.Common.DataRecord HBOplus(
     name="HBOplus",
@@ -8729,7 +8732,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={18360.83606,-1212.975446,6.82290196,0.0009142272500000001,-2.665355457e-007,
         3.29704981e-011,-1.530684082e-015},
     bhigh={146361.7504,-16.99646159},
-    R_s=298.8918092181826);
+    R_s=R_NASA_2002/HBOplus.MM);
 
   constant IdealGases.Common.DataRecord HBO2(
     name="HBO2",
@@ -8743,7 +8746,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1049369.185,-4479.145479999999,11.97755861,-0.00047357434,
         6.08020714e-008,-3.64156544e-012,6.15597317e-017},
     bhigh={-42211.4947,-49.11366819999999},
-    R_s=189.7521414842482);
+    R_s=R_NASA_2002/HBO2.MM);
 
   constant IdealGases.Common.DataRecord HBS(
     name="HBS",
@@ -8757,7 +8760,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-202183.6183,-505.202662,6.41521828,0.001049432932,-3.68314669e-007,
         5.34296831e-011,-2.154140451e-015},
     bhigh={6485.47562,-13.31379864},
-    R_s=189.4658957240394);
+    R_s=R_NASA_2002/HBS.MM);
 
   constant IdealGases.Common.DataRecord HBSplus(
     name="HBSplus",
@@ -8771,7 +8774,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={661065.836,-2791.498527,9.131267640000001,-0.000506379529,
         7.751213140000001e-008,-4.19113293e-012,2.687149095e-017},
     bhigh={151073.4114,-30.81426166},
-    R_s=189.4682642964555);
+    R_s=R_NASA_2002/HBSplus.MM);
 
   constant IdealGases.Common.DataRecord HCN(
     name="HCN",
@@ -8785,7 +8788,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1236889.278,-4446.732410000001,9.73887485,-0.000585518264,
         1.07279144e-007,-1.013313244e-011,3.34824798e-016},
     bhigh={42215.1377,-40.05774072000001},
-    R_s=307.6560738921324);
+    R_s=R_NASA_2002/HCN.MM);
 
   constant IdealGases.Common.DataRecord HCO(
     name="HCO",
@@ -8799,7 +8802,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={694960.6120000001,-3656.22338,9.604731170000001,-0.001117129278,
         2.875328019e-007,-3.62624774e-011,1.808329595e-015},
     bhigh={25437.0444,-35.8247372},
-    R_s=286.5290005803287);
+    R_s=R_NASA_2002/HCO.MM);
 
   constant IdealGases.Common.DataRecord HCOplus(
     name="HCOplus",
@@ -8813,7 +8816,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1219060.653,-4714.29489,10.21192493,-0.000885451707,1.667408026e-007,
         -1.683285548e-011,7.04005178e-016},
     bhigh={127798.9027,-43.5115846},
-    R_s=286.5344176512791);
+    R_s=R_NASA_2002/HCOplus.MM);
 
   constant IdealGases.Common.DataRecord HCCN(
     name="HCCN",
@@ -8827,7 +8830,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={939562.031,-4091.06775,12.72233302,-0.000687440531,1.231169968e-007,
         -1.186956238e-011,4.76061035e-016},
     bhigh={95851.6482,-52.48695794},
-    R_s=212.9957341984484);
+    R_s=R_NASA_2002/HCCN.MM);
 
   constant IdealGases.Common.DataRecord HCCO(
     name="HCCO",
@@ -8841,7 +8844,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1093922.002,-4498.228209999999,12.46446433,-0.00063433174,
         1.108549019e-007,-1.125488678e-011,5.68915194e-016},
     bhigh={46522.803,-50.9907043},
-    R_s=202.6508735096423);
+    R_s=R_NASA_2002/HCCO.MM);
 
   constant IdealGases.Common.DataRecord HCL(
     name="HCL",
@@ -8855,7 +8858,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={915774.951,-2770.550211,5.97353979,-0.000362981006,4.73552919e-008,
         2.810262054e-012,-6.65610422e-016},
     bhigh={5674.95805,-16.42825822},
-    R_s=228.0388273039587);
+    R_s=R_NASA_2002/HCL.MM);
 
   constant IdealGases.Common.DataRecord HD(
     name="HD",
@@ -8869,7 +8872,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={845583.0000000001,-1956.578537,4.40437387,0.000575168109,-2.131983152e-007,
         4.03612668e-011,-2.727170705e-015},
     bhigh={12272.54163,-10.84742878},
-    R_s=2751.288698171634);
+    R_s=R_NASA_2002/HD.MM);
 
   constant IdealGases.Common.DataRecord HDplus(
     name="HDplus",
@@ -8883,7 +8886,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1340083.03,-5730.069570000001,12.13836576,-0.00524333812,
         1.976302344e-006,-3.30657353e-010,1.937902763e-014},
     bhigh={213534.8051,-61.2875839},
-    R_s=2751.788238226832);
+    R_s=R_NASA_2002/HDplus.MM);
 
   constant IdealGases.Common.DataRecord HDO(
     name="HDO",
@@ -8897,7 +8900,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1711376.798,-5322.8723,9.124351519999999,-0.000340066415,
         4.152343519999999e-008,-4.78076857e-014,-1.46803517e-016},
     bhigh={3245.22468,-37.7460068},
-    R_s=437.1124965184028);
+    R_s=R_NASA_2002/HDO.MM);
 
   constant IdealGases.Common.DataRecord HDO2(
     name="HDO2",
@@ -8911,7 +8914,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1313180.619,-5175.63712,12.16490975,-0.000613669948,1.227560176e-007,
         -1.079624939e-011,3.87401372e-016},
     bhigh={13032.0967,-50.85276870000001},
-    R_s=237.4160507048917);
+    R_s=R_NASA_2002/HDO2.MM);
 
   constant IdealGases.Common.DataRecord HF(
     name="HF",
@@ -8925,7 +8928,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={725708.904,-1484.797741,3.85552747,0.000713898985,-2.106757333e-007,
         3.050092453e-011,-1.639495583e-015},
     bhigh={-23554.5666,-3.20385683},
-    R_s=415.5936903051829);
+    R_s=R_NASA_2002/HF.MM);
 
   constant IdealGases.Common.DataRecord HI(
     name="HI",
@@ -8939,7 +8942,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={472492.145,-1923.465741,5.75804897,-0.000406626638,
         9.474332049999999e-008,-1.033534431e-011,4.61161479e-016},
     bhigh={13948.57037,-11.82487652},
-    R_s=65.00158975974263);
+    R_s=R_NASA_2002/HI.MM);
 
   constant IdealGases.Common.DataRecord HNC(
     name="HNC",
@@ -8953,7 +8956,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1198791.66,-3918.94186,9.11802009,-0.00034177611,3.31480968e-008,-5.70157474e-013,
         -7.789455389999999e-017},
     bhigh={46588.103,-34.68575882},
-    R_s=307.6560738921324);
+    R_s=R_NASA_2002/HNC.MM);
 
   constant IdealGases.Common.DataRecord HNCO(
     name="HNCO",
@@ -8967,7 +8970,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1253216.926,-5021.091539999999,12.47789314,-0.000689165525,
         1.097738448e-007,-9.3064038e-012,3.24260695e-016},
     bhigh={14531.55559,-53.06419819},
-    R_s=193.2495117925175);
+    R_s=R_NASA_2002/HNCO.MM);
 
   constant IdealGases.Common.DataRecord HNO(
     name="HNO",
@@ -8981,7 +8984,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-5795614.98,19454.57427,-21.52568374,0.01797428992,-4.97604067e-006,
         6.397924169999999e-010,-3.142619368e-014},
     bhigh={-110419.2372,181.8650338},
-    R_s=268.0885818164934);
+    R_s=R_NASA_2002/HNO.MM);
 
   constant IdealGases.Common.DataRecord HNO2(
     name="HNO2",
@@ -8995,7 +8998,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={878790.4129999999,-3990.45503,11.87349269,-0.000488190061,
         7.13363679e-008,-5.37630334e-012,1.581778986e-016},
     bhigh={12463.43241,-46.08874688},
-    R_s=176.8538953967206);
+    R_s=R_NASA_2002/HNO2.MM);
 
   constant IdealGases.Common.DataRecord HNO3(
     name="HNO3",
@@ -9009,7 +9012,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-94978.0964,-2733.024468,14.49426995,-0.000782186805,
         1.702693665e-007,-1.930543961e-011,8.870455120000001e-016},
     bhigh={-4882.51778,-59.28392985000001},
-    R_s=131.9494566504223);
+    R_s=R_NASA_2002/HNO3.MM);
 
   constant IdealGases.Common.DataRecord HOCL(
     name="HOCL",
@@ -9023,7 +9026,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={853045.781,-2847.760552,7.94832904,-0.0001048782013,-1.482405043e-008,
         4.59167827e-012,-3.060073987e-016},
     bhigh={7250.964950000001,-22.4983169},
-    R_s=158.4913479401773);
+    R_s=R_NASA_2002/HOCL.MM);
 
   constant IdealGases.Common.DataRecord HOF(
     name="HOF",
@@ -9037,7 +9040,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={881201.823,-3120.013169,8.223710069999999,-0.0002298036315,
         1.459115709e-008,1.095883303e-012,-1.404445608e-016},
     bhigh={6300.54671,-25.90150427},
-    R_s=230.9217713911818);
+    R_s=R_NASA_2002/HOF.MM);
 
   constant IdealGases.Common.DataRecord HO2(
     name="HO2",
@@ -9051,7 +9054,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1810669.724,4963.19203,-1.039498992,0.004560148530000001,-1.061859447e-006,
         1.144567878e-010,-4.763064160e-015},
     bhigh={-3.200817190e+004,4.066850920e+001},
-    R_s=251.9033991239365);
+    R_s=R_NASA_2002/HO2.MM);
 
   constant IdealGases.Common.DataRecord HO2minus(
     name="HO2minus",
@@ -9065,7 +9068,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={793330.6,-2503.312417,7.54896233,8.308390149999999e-005,-5.96973091e-008,
         9.955377000000001e-012,-5.606477280e-016},
     bhigh={2.512079084e+003,-2.070065846e+001},
-    R_s=251.8992123454818);
+    R_s=R_NASA_2002/HO2minus.MM);
 
   constant IdealGases.Common.DataRecord HPO(
     name="HPO",
@@ -9079,7 +9082,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={384245.945,-2434.951707,8.582173920000001,-0.000405844857,-1.66948874e-008,
         2.253640566e-011,-1.943063011e-015},
     bhigh={5761.63212,-26.49097544},
-    R_s=173.2871865528888);
+    R_s=R_NASA_2002/HPO.MM);
 
   constant IdealGases.Common.DataRecord HSO3F(
     name="HSO3F",
@@ -9093,7 +9096,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={554404.708,-3974.42432,17.78869264,-0.000440932203,5.94441139e-008,-3.92701581e-012,
         8.891284000000001e-017},
     bhigh={-71534.3827,-76.13127849},
-    R_s=83.08731841997657);
+    R_s=R_NASA_2002/HSO3F.MM);
 
   constant IdealGases.Common.DataRecord H2(
     name="H2",
@@ -9107,7 +9110,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={560812.801,-837.150474,2.975364532,0.001252249124,-3.74071619e-007,
         5.936625200000001e-011,-3.6069941e-015},
     bhigh={5339.82441,-2.202774769},
-    R_s=4124.506419032879);
+    R_s=R_NASA_2002/H2.MM);
 
   constant IdealGases.Common.DataRecord H2plus(
     name="H2plus",
@@ -9121,7 +9124,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1672225.964,-6595.18499,12.79321925,-0.00550934526,2.030669412e-006,
         -3.35102748e-010,1.946089104e-014},
     bhigh={218999.9548,-67.9271078},
-    R_s=4125.629164513588);
+    R_s=R_NASA_2002/H2plus.MM);
 
   constant IdealGases.Common.DataRecord H2minus(
     name="H2minus",
@@ -9135,7 +9138,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={95992.7562,-914.4682879999999,5.14941881,-0.0001016559478,
         5.446919560000001e-008,-6.155174449999999e-012,2.822451181e-016},
     bhigh={32341.0518,-14.4078098},
-    R_s=4123.384284472061);
+    R_s=R_NASA_2002/H2minus.MM);
 
   constant IdealGases.Common.DataRecord HBOH(
     name="HBOH",
@@ -9149,7 +9152,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1534611.049,-5753.66643,12.70893665,-0.000705962825,1.027679375e-007,
         -7.67092674e-012,2.211854768e-016},
     bhigh={27793.70419,-56.0886008},
-    R_s=288.4350668903514);
+    R_s=R_NASA_2002/HBOH.MM);
 
   constant IdealGases.Common.DataRecord HCOOH(
     name="HCOOH",
@@ -9163,7 +9166,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={487233.645,-7632.238079999999,21.32788153,-0.004402546540000001,
         1.102001695e-006,-1.364343517e-010,6.64842975e-015},
     bhigh={-5781.43191,-111.1790688},
-    R_s=180.6505454164637);
+    R_s=R_NASA_2002/HCOOH.MM);
 
   constant IdealGases.Common.DataRecord H2F2(
     name="H2F2",
@@ -9177,7 +9180,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1464995.601,-3335.07492,9.187487040000001,0.001051127249,-3.27860557e-007,
         4.45604623e-011,-2.281370136e-015},
     bhigh={-48254.42090000001,-26.39128168},
-    R_s=207.7968451525914);
+    R_s=R_NASA_2002/H2F2.MM);
 
   constant IdealGases.Common.DataRecord H2O(
     name="H2O",
@@ -9191,7 +9194,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1034972.096,-2412.698562,4.64611078,0.002291998307,-6.836830479999999e-007,
         9.426468930000001e-011,-4.82238053e-015},
     bhigh={-13842.86509,-7.97814851},
-    R_s=461.5254384056201);
+    R_s=R_NASA_2002/H2O.MM);
 
   constant IdealGases.Common.DataRecord H2Oplus(
     name="H2Oplus",
@@ -9205,7 +9208,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={622871.426,-2864.257487,7.71756556,-0.000902780167,6.17743686e-007,-1.201457479e-010,
         7.407709940000001e-015},
     bhigh={134208.6651,-26.3661792},
-    R_s=461.5394931727930);
+    R_s=R_NASA_2002/H2Oplus.MM);
 
   constant IdealGases.Common.DataRecord H2O2(
     name="H2O2",
@@ -9219,7 +9222,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1489428.027,-5170.82178,11.2820497,-8.04239779e-005,-1.818383769e-008,
         6.94726559e-012,-4.8278319e-016},
     bhigh={14182.51038,-46.50855660000001},
-    R_s=244.4388716871657);
+    R_s=R_NASA_2002/H2O2.MM);
 
   constant IdealGases.Common.DataRecord H2S(
     name="H2S",
@@ -9233,7 +9236,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1430040.22,-5284.02865,10.16182124,-0.000970384996,2.154003405e-007,
         -2.1696957e-011,9.318163070000001e-016},
     bhigh={29086.96214,-43.49160391},
-    R_s=243.9640643081986);
+    R_s=R_NASA_2002/H2S.MM);
 
   constant IdealGases.Common.DataRecord H2SO4(
     name="H2SO4",
@@ -9247,7 +9250,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1437877.914,-6614.90253,21.57662058,-0.000480625597,3.010775121e-008,
         2.334842469e-012,-2.946330375e-016},
     bhigh={-52590.92950000001,-102.3603724},
-    R_s=84.77405033193827);
+    R_s=R_NASA_2002/H2SO4.MM);
 
   constant IdealGases.Common.DataRecord H2BOH(
     name="H2BOH",
@@ -9261,7 +9264,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2294795.193,-9382.923559999999,17.98228329,-0.001506116214,
         2.635641095e-007,-2.483163637e-011,9.736759120000001e-016},
     bhigh={20397.38953,-94.48201210000001},
-    R_s=278.690376353060);
+    R_s=R_NASA_2002/H2BOH.MM);
 
   constant IdealGases.Common.DataRecord HB_OH_2(
     name="HB_OH_2",
@@ -9275,7 +9278,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2122674.609,-8615.948939999998,19.6617952,-0.00081484115,
         8.955082040000001e-008,-3.34483051e-012,-6.919578139999999e-017},
     bhigh={-27887.90377,-99.8355961},
-    R_s=181.4063562947897);
+    R_s=R_NASA_2002/HB_OH_2.MM);
 
   constant IdealGases.Common.DataRecord H3BO3(
     name="H3BO3",
@@ -9289,7 +9292,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2297369.132,-8933.57179,21.93496552,-0.000309478349,-5.06405299e-008,
         1.482296684e-011,-9.7644209e-016},
     bhigh={-69702.9847,-112.2292829},
-    R_s=134.4671503995762);
+    R_s=R_NASA_2002/H3BO3.MM);
 
   constant IdealGases.Common.DataRecord H3B3O3(
     name="H3B3O3",
@@ -9303,7 +9306,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1286220.713,-10932.58784,32.1351867,-0.002595402269,5.35376647e-007,
         -5.833567379999999e-011,2.600757913e-015},
     bhigh={-87528.5689,-177.0847815},
-    R_s=99.62863827724203);
+    R_s=R_NASA_2002/H3B3O3.MM);
 
   constant IdealGases.Common.DataRecord H3B3O6(
     name="H3B3O6",
@@ -9317,7 +9320,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1952433.352,-11549.32896,38.9267611,-0.00111385228,1.280317726e-007,
         -5.72846482e-012,-2.214529572e-017},
     bhigh={-212092.7136,-207.5566801},
-    R_s=63.25071382808272);
+    R_s=R_NASA_2002/H3B3O6.MM);
 
   constant IdealGases.Common.DataRecord H3F3(
     name="H3F3",
@@ -9331,7 +9334,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2515790.373,-8789.42332,20.23933445,-0.001131704646,1.692779921e-007,
         -1.308662105e-011,3.978322e-016},
     bhigh={-54717.1365,-99.07787640000001},
-    R_s=138.5312301017276);
+    R_s=R_NASA_2002/H3F3.MM);
 
   constant IdealGases.Common.DataRecord H3Oplus(
     name="H3Oplus",
@@ -9345,7 +9348,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2955126.2,-9185.669409999999,13.41398696,-0.000559033921,
         1.138387119e-008,7.25992721e-012,-6.13373436e-016},
     bhigh={129053.4257,-70.2182818},
-    R_s=437.0842467478043);
+    R_s=R_NASA_2002/H3Oplus.MM);
 
   constant IdealGases.Common.DataRecord H4F4(
     name="H4F4",
@@ -9359,7 +9362,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3354037.99,-11719.2204,27.65243565,-0.001508934621,2.257027572e-007,
         -1.744867255e-011,5.304351740000001e-016},
     bhigh={-74202.13160000001,-138.8603332},
-    R_s=103.898422576296);
+    R_s=R_NASA_2002/H4F4.MM);
 
   constant IdealGases.Common.DataRecord H5F5(
     name="H5F5",
@@ -9373,7 +9376,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4192290.73,-14649.03043,35.0655492,-0.001886170471,2.821289954e-007,
         -2.181090984e-011,6.63047416e-016},
     bhigh={-93687.042,-178.8592044},
-    R_s=83.11873806103655);
+    R_s=R_NASA_2002/H5F5.MM);
 
   constant IdealGases.Common.DataRecord H6F6(
     name="H6F6",
@@ -9387,7 +9390,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5024520.319999999,-17428.17868,42.148705,-0.002084564791,
         2.930051519e-007,-2.052079159e-011,5.2069373e-016},
     bhigh={-115449.7653,-216.3947001},
-    R_s=69.26561505086380);
+    R_s=R_NASA_2002/H6F6.MM);
 
   constant IdealGases.Common.DataRecord H7F7(
     name="H7F7",
@@ -9401,7 +9404,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5868789.83,-20508.63473,49.8917611,-0.002640634895,3.94979633e-007,-3.053515088e-011,
         9.28260178e-016},
     bhigh={-133017.7809,-259.2385142},
-    R_s=59.37052718645469);
+    R_s=R_NASA_2002/H7F7.MM);
 
   constant IdealGases.Common.DataRecord He(
     name="He",
@@ -9413,7 +9416,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={-745.375,0.9287239740000001},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={-745.375,0.9287239740000001},
-    R_s=2077.27623181121);
+    R_s=R_NASA_2002/He.MM);
 
   constant IdealGases.Common.DataRecord Heplus(
     name="Heplus",
@@ -9425,7 +9428,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={285323.3739,1.621665557},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={285323.3739,1.621665557},
-    R_s=2077.560984068828);
+    R_s=R_NASA_2002/Heplus.MM);
 
   constant IdealGases.Common.DataRecord Hg(
     name="Hg",
@@ -9438,7 +9441,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={51465.7351,-168.1269855,2.718343098,-0.0001445026192,5.15897766e-008,
         -9.47248501e-012,7.034797406e-016},
     bhigh={7688.68493,5.27123609},
-    R_s=41.45027169848946);
+    R_s=R_NASA_2002/Hg.MM);
 
   constant IdealGases.Common.DataRecord Hgplus(
     name="Hgplus",
@@ -9452,7 +9455,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-12299.84728,27.32269908,2.48418216,-4.42679761e-006,
         7.489685859999999e-009,-2.549887287e-012,2.819873366e-016},
     bhigh={128318.8257,7.62524457},
-    R_s=41.45038506247193);
+    R_s=R_NASA_2002/Hgplus.MM);
 
   constant IdealGases.Common.DataRecord HgBr2(
     name="HgBr2",
@@ -9466,7 +9469,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-22436.4929,-3.31265227,7.50276517,-1.202360213e-006,
         2.830526999e-010,-3.4076867e-014,1.640497921e-018},
     bhigh={-13274.83366,-4.3685556},
-    R_s=23.07035555136265);
+    R_s=R_NASA_2002/HgBr2.MM);
 
   constant IdealGases.Common.DataRecord I(
     name="I",
@@ -9480,7 +9483,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-778586.0569999999,2303.279568,0.002886686091,0.001180878463,-2.264074866e-007,
         1.963511339e-011,-6.243525940999999e-016},
     bhigh={-2616.792742,25.58922997},
-    R_s=65.51786552514660);
+    R_s=R_NASA_2002/I.MM);
 
   constant IdealGases.Common.DataRecord Iplus(
     name="Iplus",
@@ -9494,7 +9497,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-778838.5329999999,2404.962651,-0.1791751142,0.001227311979,-1.80149403e-007,
         9.923983959999999e-012,-9.775286439000001e-017},
     bhigh={118853.1631,27.10544347},
-    R_s=65.5181487559611);
+    R_s=R_NASA_2002/Iplus.MM);
 
   constant IdealGases.Common.DataRecord Iminus(
     name="Iminus",
@@ -9506,7 +9509,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={-24149.70936,6.11346538},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={-24149.70936,6.11346538},
-    R_s=65.51758229678082);
+    R_s=R_NASA_2002/Iminus.MM);
 
   constant IdealGases.Common.DataRecord IF5(
     name="IF5",
@@ -9520,7 +9523,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-362050.626,-163.9236093,16.12272743,-4.91443155e-005,
         1.086015052e-008,-1.244672691e-012,5.76359362e-017},
     bhigh={-106164.2293,-53.9877336},
-    R_s=37.47021933461353);
+    R_s=R_NASA_2002/IF5.MM);
 
   constant IdealGases.Common.DataRecord IF7(
     name="IF7",
@@ -9534,7 +9537,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-561442.264,-264.6288326,22.19879891,-7.984221469999999e-005,
         1.768835964e-008,-2.031523755e-012,9.423767390000001e-017},
     bhigh={-122524.5322,-87.74010730000001},
-    R_s=31.99201458113507);
+    R_s=R_NASA_2002/IF7.MM);
 
   constant IdealGases.Common.DataRecord I2(
     name="I2",
@@ -9548,7 +9551,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-5632594.16,17939.6156,-17.23055169,0.0124421408,-3.33276858e-006,
         4.12547794e-010,-1.960461713e-014},
     bhigh={-106850.5292,160.0531883},
-    R_s=32.75893276257330);
+    R_s=R_NASA_2002/I2.MM);
 
   constant IdealGases.Common.DataRecord In(
     name="In",
@@ -9562,7 +9565,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1683608.899,2210.473186,3.47221937,-0.001082267422,3.47969998e-007,
         -5.15809241e-011,3.183043089e-015},
     bhigh={10959.65206,2.557189088},
-    R_s=72.41469107631208);
+    R_s=R_NASA_2002/In.MM);
 
   constant IdealGases.Common.DataRecord Inplus(
     name="Inplus",
@@ -9576,7 +9579,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={45369.9514,-144.5142103,2.681812441,-0.000115748006,3.94771481e-008,
         -6.87924362e-012,4.81920492e-016},
     bhigh={1004.26144,4.68375918},
-    R_s=72.4150370751044);
+    R_s=R_NASA_2002/Inplus.MM);
 
   constant IdealGases.Common.DataRecord InBr(
     name="InBr",
@@ -9590,7 +9593,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={794837.442,-2318.183711,7.03288958,-0.001245920568,3.27669335e-007,-3.003771106e-011,
         5.85319277e-016},
     bhigh={6957.627289999999,-12.7350266},
-    R_s=42.69938681813046);
+    R_s=R_NASA_2002/InBr.MM);
 
   constant IdealGases.Common.DataRecord InBr2(
     name="InBr2",
@@ -9604,7 +9607,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-321716.203,479.2682100000001,7.10264948,-0.000551401978,
         3.157862421e-007,-5.51125451e-011,3.17216139e-015},
     bhigh={-23709.23659,0.1193263347},
-    R_s=30.27575684749441);
+    R_s=R_NASA_2002/InBr2.MM);
 
   constant IdealGases.Common.DataRecord InBr3(
     name="InBr3",
@@ -9618,7 +9621,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-35057.831,-4.85872132,10.00406131,-1.767620958e-006,4.16401606e-010,
         -5.01552887e-014,2.415414123e-018},
     bhigh={-33931.7924,-12.29069868},
-    R_s=23.45220432685527);
+    R_s=R_NASA_2002/InBr3.MM);
 
   constant IdealGases.Common.DataRecord InCL(
     name="InCL",
@@ -9632,7 +9635,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-274575.1636,894.0986909999999,3.26811839,0.0009180277780000001,-3.083262431e-007,
         5.74545881e-011,-3.64527575e-015},
     bhigh={-15616.0343,12.66880374},
-    R_s=55.33010361280621);
+    R_s=R_NASA_2002/InCL.MM);
 
   constant IdealGases.Common.DataRecord InCL2(
     name="InCL2",
@@ -9646,7 +9649,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-332871.984,475.769161,7.10544369,-0.000552578696,3.160567738e-007,-5.51445368e-011,
         3.17368038e-015},
     bhigh={-29950.95917,-2.294555511},
-    R_s=44.76809674570869);
+    R_s=R_NASA_2002/InCL2.MM);
 
   constant IdealGases.Common.DataRecord InCL3(
     name="InCL3",
@@ -9660,7 +9663,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-71140.4363,-16.28425068,10.01309622,-5.54452888e-006,
         1.279877732e-009,-1.518261505e-013,7.22656277e-018},
     bhigh={-47589.7417,-16.69761011},
-    R_s=37.59210948697197);
+    R_s=R_NASA_2002/InCL3.MM);
 
   constant IdealGases.Common.DataRecord InF(
     name="InF",
@@ -9674,7 +9677,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-468900.12,1321.019051,2.881329353,0.001041591078,-3.090754867e-007,
         4.92664656e-011,-2.699156425e-015},
     bhigh={-33083.6981,13.96688303},
-    R_s=62.13371306635150);
+    R_s=R_NASA_2002/InF.MM);
 
   constant IdealGases.Common.DataRecord InF2(
     name="InF2",
@@ -9688,7 +9691,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={431896.034,-1688.47242,8.925863010000001,-0.001049188835,
         2.72393419e-007,-2.882959902e-011,1.073493779e-015},
     bhigh={-46736.91940000001,-19.32464363},
-    R_s=54.40906019431374);
+    R_s=R_NASA_2002/InF2.MM);
 
   constant IdealGases.Common.DataRecord InF3(
     name="InF3",
@@ -9702,7 +9705,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-165685.5506,-79.6588929,10.05913347,-2.350816639e-005,
         5.16351293e-009,-5.88804881e-013,2.715090697e-017},
     bhigh={-106868.2627,-21.32968218},
-    R_s=48.39272847155986);
+    R_s=R_NASA_2002/InF3.MM);
 
   constant IdealGases.Common.DataRecord InH(
     name="InH",
@@ -9716,7 +9719,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={779740.666,-3646.88208,9.54296735,-0.00348128172,1.304805603e-006,-2.182950701e-010,
         1.274009748e-014},
     bhigh={46432.9546,-36.5932923},
-    R_s=71.78452426114565);
+    R_s=R_NASA_2002/InH.MM);
 
   constant IdealGases.Common.DataRecord InI(
     name="InI",
@@ -9730,7 +9733,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1529221.772,-4690.373680000001,10.04593462,-0.00314043411,
         9.460834390000001e-007,-1.253862848e-010,5.94980564e-015},
     bhigh={31524.78143,-32.9769749},
-    R_s=34.39692635939059);
+    R_s=R_NASA_2002/InI.MM);
 
   constant IdealGases.Common.DataRecord InI2(
     name="InI2",
@@ -9744,7 +9747,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-313067.1665,481.38107,7.10091418,-0.000550655992,3.156120735e-007,-5.50917054e-011,
         3.17116283e-015},
     bhigh={-10430.1275,2.141662307},
-    R_s=22.55535094640668);
+    R_s=R_NASA_2002/InI2.MM);
 
   constant IdealGases.Common.DataRecord InI3(
     name="InI3",
@@ -9758,7 +9761,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-21967.42567,-2.151167521,10.001822,-8.002214699999999e-007,
         1.897343164e-010,-2.29625246e-014,1.109838196e-018},
     bhigh={-15724.06335,-9.17088869},
-    R_s=16.7789767352992);
+    R_s=R_NASA_2002/InI3.MM);
 
   constant IdealGases.Common.DataRecord InO(
     name="InO",
@@ -9772,7 +9775,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-805213.0950000001,1693.064203,4.76086358,-0.00073407184,
         3.22959776e-007,-4.58015038e-011,1.954611725e-015},
     bhigh={4005.51981,3.50074246},
-    R_s=63.55813523277484);
+    R_s=R_NASA_2002/InO.MM);
 
   constant IdealGases.Common.DataRecord InOH(
     name="InOH",
@@ -9786,7 +9789,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={852512.8929999999,-2350.317172,7.98451514,9.91581562e-005,-6.21238545e-008,
         1.016169575e-011,-5.682557639999999e-016},
     bhigh={-1536.21361,-20.43107643},
-    R_s=63.07216806723198);
+    R_s=R_NASA_2002/InOH.MM);
 
   constant IdealGases.Common.DataRecord In2Br2(
     name="In2Br2",
@@ -9800,7 +9803,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-12907.81804,-0.607540124,10.00052163,-2.312058331e-007,
         5.51731572e-011,-6.708620190000001e-015,3.25384165e-019},
     bhigh={-26631.36878,-9.149949469999999},
-    R_s=21.34969340906523);
+    R_s=R_NASA_2002/In2Br2.MM);
 
   constant IdealGases.Common.DataRecord In2Br4(
     name="In2Br4",
@@ -9814,7 +9817,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-44534.6371,-4.91152398,16.00413764,-1.810579975e-006,
         4.28171574e-010,-5.17199802e-014,2.496142837e-018},
     bhigh={-57391.7541,-31.7490639},
-    R_s=15.13787842374721);
+    R_s=R_NASA_2002/In2Br4.MM);
 
   constant IdealGases.Common.DataRecord In2Br6(
     name="In2Br6",
@@ -9828,7 +9831,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-69450.3948,-8.402368170000001,22.00703884,-3.068251799e-006,
         7.23596573e-010,-8.722870580000001e-014,4.20346991e-018},
     bhigh={-82357.59850000001,-53.221928},
-    R_s=11.72610216342764);
+    R_s=R_NASA_2002/In2Br6.MM);
 
   constant IdealGases.Common.DataRecord In2CL2(
     name="In2CL2",
@@ -9842,7 +9845,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-26166.06332,-2.401955489,10.00203984,-8.97519003e-007,
         2.130755553e-010,-2.5811409e-014,1.248404822e-018},
     bhigh={-30980.16735,-12.34946505},
-    R_s=27.66505180640310);
+    R_s=R_NASA_2002/In2CL2.MM);
 
   constant IdealGases.Common.DataRecord In2CL4(
     name="In2CL4",
@@ -9856,7 +9859,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-85037.7179,-15.52464614,16.01269668,-5.44154987e-006,
         1.267594997e-009,-1.514110365e-013,7.24540454e-018},
     bhigh={-74619.21740000001,-36.91150615},
-    R_s=22.38404837285434);
+    R_s=R_NASA_2002/In2CL4.MM);
 
   constant IdealGases.Common.DataRecord In2CL6(
     name="In2CL6",
@@ -9870,7 +9873,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-149940.0484,-29.88680816,22.02425362,-1.033652301e-005,
         2.397911922e-009,-2.855307516e-013,1.363051661e-017},
     bhigh={-113011.0233,-62.93985679999999},
-    R_s=18.79605474348599);
+    R_s=R_NASA_2002/In2CL6.MM);
 
   constant IdealGases.Common.DataRecord In2F2(
     name="In2F2",
@@ -9884,7 +9887,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-64097.1544,-11.63740672,10.00956511,-4.11408691e-006,
         9.60882832e-010,-1.150013486e-013,5.511437479999999e-018},
     bhigh={-67142.7785,-16.61718474},
-    R_s=31.06685653317575);
+    R_s=R_NASA_2002/In2F2.MM);
 
   constant IdealGases.Common.DataRecord In2F4(
     name="In2F4",
@@ -9898,7 +9901,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-220597.7486,-78.2208377,16.05923872,-2.39402324e-005,
         5.32958279e-009,-6.14460957e-013,2.859099598e-017},
     bhigh={-159571.6347,-44.6957458},
-    R_s=27.20453009715687);
+    R_s=R_NASA_2002/In2F4.MM);
 
   constant IdealGases.Common.DataRecord In2F6(
     name="In2F6",
@@ -9912,7 +9915,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-317096.638,-116.7440973,22.08847456,-3.57773393e-005,
         7.96895904e-009,-9.191681699999999e-013,4.278494150000001e-017},
     bhigh={-242666.1118,-71.5532856},
-    R_s=24.19636423577993);
+    R_s=R_NASA_2002/In2F6.MM);
 
   constant IdealGases.Common.DataRecord In2I2(
     name="In2I2",
@@ -9926,7 +9929,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-8148.157299999999,-0.2444544443,10.00021086,-9.37678925e-008,
         2.24298818e-011,-2.732299303e-015,1.327135699e-019},
     bhigh={-6352.6515,-6.94772542},
-    R_s=17.19846317969530);
+    R_s=R_NASA_2002/In2I2.MM);
 
   constant IdealGases.Common.DataRecord In2I4(
     name="In2I4",
@@ -9940,7 +9943,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-25056.99251,-1.642155234,16.00140149,-6.18706628e-007,
         1.472308565e-010,-1.786593333e-014,8.652338779999999e-019},
     bhigh={-28796.55333,-27.57790375},
-    R_s=11.2776754732033);
+    R_s=R_NASA_2002/In2I4.MM);
 
   constant IdealGases.Common.DataRecord In2I6(
     name="In2I6",
@@ -9954,7 +9957,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-43119.0585,-3.39035059,22.00288128,-1.268348706e-006,3.0121219e-010,
         -3.64967671e-014,1.765530622e-018},
     bhigh={-45138.2027,-48.0686837},
-    R_s=8.389488367649591);
+    R_s=R_NASA_2002/In2I6.MM);
 
   constant IdealGases.Common.DataRecord In2O(
     name="In2O",
@@ -9968,7 +9971,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-92327.8636,-52.0112728,7.03872362,-1.543821179e-005,3.39970087e-009,
         -3.8854571e-013,1.79512527e-017},
     bhigh={-6270.9268,-4.42182041},
-    R_s=33.84898919292578);
+    R_s=R_NASA_2002/In2O.MM);
 
   constant IdealGases.Common.DataRecord K(
     name="K",
@@ -9982,7 +9985,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3566422.36,10852.89825,-10.54134898,0.00800980135,-2.696681041e-006,
         4.71529415e-010,-2.97689735e-014},
     bhigh={-58753.3701,97.3855124},
-    R_s=212.6565605154188);
+    R_s=R_NASA_2002/K.MM);
 
   constant IdealGases.Common.DataRecord Kplus(
     name="Kplus",
@@ -9994,7 +9997,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={61075.1686,4.34740444},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={61075.1686,4.34740444},
-    R_s=212.6595444054105);
+    R_s=R_NASA_2002/Kplus.MM);
 
   constant IdealGases.Common.DataRecord Kminus(
     name="Kminus",
@@ -10006,7 +10009,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={3394.15071,4.34744653},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={3394.15071,4.34744653},
-    R_s=212.6535767091617);
+    R_s=R_NASA_2002/Kminus.MM);
 
   constant IdealGases.Common.DataRecord KALF4(
     name="KALF4",
@@ -10020,7 +10023,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-343513.537,-242.0680834,16.1802925,-7.19381768e-005,
         1.585712708e-008,-1.814017733e-012,8.388391179999999e-017},
     bhigh={-233965.8121,-52.338987},
-    R_s=58.5226159650653);
+    R_s=R_NASA_2002/KALF4.MM);
 
   constant IdealGases.Common.DataRecord KBO2(
     name="KBO2",
@@ -10034,7 +10037,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={88907.266,-1671.432436,11.1748393,-0.000451376026,9.69900346e-008,-1.09002769e-011,
         4.9768458e-016},
     bhigh={-73753.36080000001,-32.7474937},
-    R_s=101.5102291470563);
+    R_s=R_NASA_2002/KBO2.MM);
 
   constant IdealGases.Common.DataRecord KBr(
     name="KBr",
@@ -10048,7 +10051,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1562614.367,-4384.89478,9.045464600000001,-0.0020456809,
         4.40192385e-007,-1.448178289e-011,-2.27333876e-015},
     bhigh={5315.34201,-28.64647026},
-    R_s=69.86848153355020);
+    R_s=R_NASA_2002/KBr.MM);
 
   constant IdealGases.Common.DataRecord KCN(
     name="KCN",
@@ -10062,7 +10065,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={361566.387,-1749.018011,8.680702670000001,-0.000440235004,
         9.249499710000001e-008,-1.021916855e-011,4.604767189999999e-016},
     bhigh={18137.34856,-22.81619241},
-    R_s=127.6882533705389);
+    R_s=R_NASA_2002/KCN.MM);
 
   constant IdealGases.Common.DataRecord KCL(
     name="KCL",
@@ -10076,7 +10079,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-212294.5722,934.61589,2.866264958,0.001468386693,-5.83426078e-007,
         1.255777709e-010,-9.150147999999999e-015},
     bhigh={-32737.8764,14.01864636},
-    R_s=111.5273643786225);
+    R_s=R_NASA_2002/KCL.MM);
 
   constant IdealGases.Common.DataRecord KF(
     name="KF",
@@ -10090,7 +10093,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1483743.237,4550.04804,-1.081464319,0.00350396588,-1.093902537e-006,
         1.771028824e-010,-1.029032783e-014},
     bhigh={-69633.2981,40.8863592},
-    R_s=143.1150055344276);
+    R_s=R_NASA_2002/KF.MM);
 
   constant IdealGases.Common.DataRecord KH(
     name="KH",
@@ -10104,7 +10107,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3752276.52,11727.78444,-10.14137678,0.008854548899999998,-2.517188074e-006,
         3.34407236e-010,-1.701157835e-014},
     bhigh={-60251.033,101.030459},
-    R_s=207.3121289854147);
+    R_s=R_NASA_2002/KH.MM);
 
   constant IdealGases.Common.DataRecord KI(
     name="KI",
@@ -10118,7 +10121,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3293747.78,-10028.24194,16.29302044,-0.00669639675,2.001412089e-006,
         -2.677673023e-010,1.273359646e-014},
     bhigh={46763.4867,-78.5912337},
-    R_s=50.08657385656878);
+    R_s=R_NASA_2002/KI.MM);
 
   constant IdealGases.Common.DataRecord KLi(
     name="KLi",
@@ -10132,7 +10135,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={12112968.43,-40810.0487,56.8379212,-0.03128695515,
         8.975062200000001e-006,-1.189303691e-009,5.88012918e-014},
     bhigh={273879.2595,-366.96936},
-    R_s=180.5959256548210);
+    R_s=R_NASA_2002/KLi.MM);
 
   constant IdealGases.Common.DataRecord KNO2(
     name="KNO2",
@@ -10146,7 +10149,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-168941.4093,-851.5973150000001,10.63209586,-0.000252325481,
         5.57364441e-008,-6.39318592e-012,2.964484049e-016},
     bhigh={-21877.01436,-27.55200432},
-    R_s=97.69845764818962);
+    R_s=R_NASA_2002/KNO2.MM);
 
   constant IdealGases.Common.DataRecord KNO3(
     name="KNO3",
@@ -10160,7 +10163,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-318368.287,-1375.234449,14.01587531,-0.000404066008,8.90084778e-008,
         -1.018771993e-011,4.71598202e-016},
     bhigh={-35138.5322,-48.04256439},
-    R_s=82.23785201655338);
+    R_s=R_NASA_2002/KNO3.MM);
 
   constant IdealGases.Common.DataRecord KNa(
     name="KNa",
@@ -10174,7 +10177,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6260326.62,-25635.93614,43.7333545,-0.0267265511,8.23270579e-006,-1.12850359e-009,
         5.66326489e-014},
     bhigh={169727.4909,-266.4117219},
-    R_s=133.9147762202948);
+    R_s=R_NASA_2002/KNa.MM);
 
   constant IdealGases.Common.DataRecord KO(
     name="KO",
@@ -10188,7 +10191,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={696010.338,-3304.83529,10.05743444,-0.004331112,1.747281632e-006,-3.012370548e-010,
         1.79082787e-014},
     bhigh={26049.72496,-34.4878152},
-    R_s=150.9048472077781);
+    R_s=R_NASA_2002/KO.MM);
 
   constant IdealGases.Common.DataRecord KOH(
     name="KOH",
@@ -10202,7 +10205,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={891727.195,-2334.179072,7.97257871,0.0001038863156,-6.315893469999999e-008,
         1.027938106e-011,-5.73668582e-016},
     bhigh={-14436.96469,-20.76401416},
-    R_s=148.1938357712344);
+    R_s=R_NASA_2002/KOH.MM);
 
   constant IdealGases.Common.DataRecord K2(
     name="K2",
@@ -10216,7 +10219,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-27344707.45,65621.80009999999,-44.7635044,0.008938859150000001,
         2.984557092e-006,-1.064158914e-009,8.334936929999999e-014},
     bhigh={-422624.383,386.714251},
-    R_s=106.3282802577094);
+    R_s=R_NASA_2002/K2.MM);
 
   constant IdealGases.Common.DataRecord K2plus(
     name="K2plus",
@@ -10230,7 +10233,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={11079507.39,-41774.8382,64.48659840000001,-0.0402499803,
         1.360587923e-005,-2.361920107e-009,1.67343061e-013},
     bhigh={317761.205,-410.50631},
-    R_s=106.3290262249738);
+    R_s=R_NASA_2002/K2plus.MM);
 
   constant IdealGases.Common.DataRecord K2Br2(
     name="K2Br2",
@@ -10244,7 +10247,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-15892.29976,-0.810137946,10.00069442,-3.074491521e-007,
         7.33102416e-011,-8.908944780000001e-015,4.319245429999999e-019},
     bhigh={-67825.9544,-11.80425726},
-    R_s=34.93424076677510);
+    R_s=R_NASA_2002/K2Br2.MM);
 
   constant IdealGases.Common.DataRecord K2CO3(
     name="K2CO3",
@@ -10258,7 +10261,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-326426.316,-1521.168973,17.12283562,-0.000446458071,9.83337963e-008,
         -1.125478371e-011,5.21006912e-016},
     bhigh={-94882.75099999999,-62.1522063},
-    R_s=60.16048565361002);
+    R_s=R_NASA_2002/K2CO3.MM);
 
   constant IdealGases.Common.DataRecord K2C2N2(
     name="K2C2N2",
@@ -10272,7 +10275,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={726959.95,-3492.10868,18.35676822,-0.000878547514,1.845532919e-007,-2.038717568e-011,
         9.18542099e-016},
     bhigh={15826.00773,-67.28484052},
-    R_s=63.84412668526946);
+    R_s=R_NASA_2002/K2C2N2.MM);
 
   constant IdealGases.Common.DataRecord K2CL2(
     name="K2CL2",
@@ -10286,7 +10289,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-26146.11331,-2.096229095,10.00178456,-7.864803710000001e-007,
         1.869281152e-010,-2.266272348e-014,1.096790704e-018},
     bhigh={-77071.8933,-14.99720802},
-    R_s=55.76368218931125);
+    R_s=R_NASA_2002/K2CL2.MM);
 
   constant IdealGases.Common.DataRecord K2F2(
     name="K2F2",
@@ -10300,7 +10303,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-57408.9253,-9.04618211,10.00750685,-3.25076484e-006,7.63006459e-010,
         -9.165649529999999e-014,4.40504844e-018},
     bhigh={-106541.3546,-18.7403762},
-    R_s=71.55750276721382);
+    R_s=R_NASA_2002/K2F2.MM);
 
   constant IdealGases.Common.DataRecord K2I2(
     name="K2I2",
@@ -10314,7 +10317,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-11796.34729,-0.472476155,10.00040695,-1.807689054e-007,
         4.32056097e-011,-5.259699430000001e-015,2.553419144e-019},
     bhigh={-53402.10230000001,-9.6644405},
-    R_s=25.04328692828439);
+    R_s=R_NASA_2002/K2I2.MM);
 
   constant IdealGases.Common.DataRecord K2O(
     name="K2O",
@@ -10328,7 +10331,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-46114.6458,-13.63119524,7.01053044,-4.32365826e-006,
         9.747788419999999e-010,-1.135283694e-013,5.325860600000001e-018},
     bhigh={-11072.22244,-5.76871872},
-    R_s=88.26818548558326);
+    R_s=R_NASA_2002/K2O.MM);
 
   constant IdealGases.Common.DataRecord K2Oplus(
     name="K2Oplus",
@@ -10342,7 +10345,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-37800.335,-8.84953739,7.00684789,-2.815510856e-006,6.3550015e-010,-7.408551990000001e-014,
         3.478334960000001e-018},
     bhigh={42145.19680000001,-4.41827661},
-    R_s=88.26869956482847);
+    R_s=R_NASA_2002/K2Oplus.MM);
 
   constant IdealGases.Common.DataRecord K2O2(
     name="K2O2",
@@ -10356,7 +10359,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-147607.3073,-102.193204,10.07664713,-3.076517991e-005,
         6.81525281e-009,-7.82865445e-013,3.6325061e-017},
     bhigh={-25920.56324,-21.62287184},
-    R_s=75.45242360388910);
+    R_s=R_NASA_2002/K2O2.MM);
 
   constant IdealGases.Common.DataRecord K2O2H2(
     name="K2O2H2",
@@ -10370,7 +10373,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1773523.196,-4665.292469999999,16.94308128,0.0002085297143,-1.264714762e-007,
         2.057506565e-011,-1.148042134e-015},
     bhigh={-50512.63310000001,-63.3477392},
-    R_s=74.09691788561720);
+    R_s=R_NASA_2002/K2O2H2.MM);
 
   constant IdealGases.Common.DataRecord K2SO4(
     name="K2SO4",
@@ -10384,7 +10387,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-544612.564,-959.0667229999999,19.71591285,-0.0002866586009,
         6.342480639999999e-008,-7.281462539999999e-012,3.37788693e-016},
     bhigh={-133787.3384,-73.99103550999999},
-    R_s=47.71346362200676);
+    R_s=R_NASA_2002/K2SO4.MM);
 
   constant IdealGases.Common.DataRecord Kr(
     name="Kr",
@@ -10397,7 +10400,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={264.3639057,-0.7910050820000001,2.500920585,-5.32816411e-007,
         1.620730161e-010,-2.467898017e-014,1.47858504e-018},
     bhigh={-740.348894,5.48439815},
-    R_s=99.21849642004774);
+    R_s=R_NASA_2002/Kr.MM);
 
   constant IdealGases.Common.DataRecord Krplus(
     name="Krplus",
@@ -10411,7 +10414,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-221656.7015,1166.16784,0.486965532,0.001429223599,-3.94962861e-007,
         4.98285351e-011,-2.406719258e-015},
     bhigh={155600.2861,20.59230986},
-    R_s=99.21914596209399);
+    R_s=R_NASA_2002/Krplus.MM);
 
   constant IdealGases.Common.DataRecord Li(
     name="Li",
@@ -10424,7 +10427,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1125610.652,-3463.53673,6.56661192,-0.002260983356,5.92228916e-007,-6.2816351e-011,
         2.884948238e-015},
     bhigh={40346.374,-26.55918195},
-    R_s=1197.883590260769);
+    R_s=R_NASA_2002/Li.MM);
 
   constant IdealGases.Common.DataRecord Liplus(
     name="Liplus",
@@ -10436,7 +10439,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={81727.24550000001,1.754357228},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={81727.24550000001,1.754357228},
-    R_s=1197.978275591700);
+    R_s=R_NASA_2002/Liplus.MM);
 
   constant IdealGases.Common.DataRecord Liminus(
     name="Liminus",
@@ -10448,7 +10451,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={10496.98659,1.754594332},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={10496.98659,1.754594332},
-    R_s=1197.788919896059);
+    R_s=R_NASA_2002/Liminus.MM);
 
   constant IdealGases.Common.DataRecord LiALF4(
     name="LiALF4",
@@ -10462,7 +10465,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-402070.0930000001,-278.3355146,16.20791185,-8.316341570000001e-005,
         1.83690569e-008,-2.104932808e-012,9.74725302e-017},
     bhigh={-227869.6416,-55.9730484},
-    R_s=75.64411544149525);
+    R_s=R_NASA_2002/LiALF4.MM);
 
   constant IdealGases.Common.DataRecord LiBO2(
     name="LiBO2",
@@ -10476,7 +10479,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={85544.04520000001,-1731.920898,11.2146209,-0.000465916217,
         9.999875689999999e-008,-1.122880592e-011,5.12352946e-016},
     bhigh={-71547.4382,-36.1239729},
-    R_s=167.1231417384243);
+    R_s=R_NASA_2002/LiBO2.MM);
 
   constant IdealGases.Common.DataRecord LiBr(
     name="LiBr",
@@ -10490,7 +10493,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={63801.9142,-259.7050764,4.65676887,0.0001022867706,-5.178252340000001e-008,
         2.058203991e-011,-1.942190308e-015},
     bhigh={-17933.63752,-0.2290806613},
-    R_s=95.73965110253900);
+    R_s=R_NASA_2002/LiBr.MM);
 
   constant IdealGases.Common.DataRecord LiCL(
     name="LiCL",
@@ -10504,7 +10507,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-235276.9705,612.004692,3.63429373,0.0006810973320000001,-2.174238799e-007,
         4.22040361e-011,-2.848628426e-015},
     bhigh={-28623.58494,5.618511135},
-    R_s=196.1246874557720);
+    R_s=R_NASA_2002/LiCL.MM);
 
   constant IdealGases.Common.DataRecord LiF(
     name="LiF",
@@ -10518,7 +10521,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-378424.649,766.806246,3.5854734,0.0006031084350000001,-1.588764206e-007,
         2.569397177e-011,-1.406798386e-015},
     bhigh={-47564.6945,4.38516329},
-    R_s=320.5359019208275);
+    R_s=R_NASA_2002/LiF.MM);
 
   constant IdealGases.Common.DataRecord LiH(
     name="LiH",
@@ -10532,7 +10535,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2633686.357,6996.429169999999,-3.23353306,0.00403393598,-9.09957964e-007,
         8.775909869999999e-011,-2.889490251e-015},
     bhigh={-29900.43016,49.71984499999999},
-    R_s=1045.989779769378);
+    R_s=R_NASA_2002/LiH.MM);
 
   constant IdealGases.Common.DataRecord LiI(
     name="LiI",
@@ -10546,7 +10549,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1616342.632,-4877.71708,9.987186550000001,-0.002889137815,
         8.03731377e-007,-9.028172610000001e-011,3.078321954e-015},
     bhigh={19377.18764,-37.2927631},
-    R_s=62.12021968319137);
+    R_s=R_NASA_2002/LiI.MM);
 
   constant IdealGases.Common.DataRecord LiN(
     name="LiN",
@@ -10560,7 +10563,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-59934.8998,-40.3113455,4.52962421,8.744156930000001e-005,
         2.557428364e-009,-2.9057518e-013,1.336125922e-017},
     bhigh={38948.3113,-1.214952896},
-    R_s=396.9175613551846);
+    R_s=R_NASA_2002/LiN.MM);
 
   constant IdealGases.Common.DataRecord LiNO2(
     name="LiNO2",
@@ -10574,7 +10577,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-219667.116,-861.004271,10.63956465,-0.0002554392587,5.64447854e-008,
         -6.47614005e-012,3.003536591e-016},
     bhigh={-23135.47535,-32.38277103},
-    R_s=157.0360647068267);
+    R_s=R_NASA_2002/LiNO2.MM);
 
   constant IdealGases.Common.DataRecord LiNO3(
     name="LiNO3",
@@ -10588,7 +10591,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-355940.245,-1447.644737,14.06684061,-0.000423637128,
         9.320824509999999e-008,-1.065894872e-011,4.93078062e-016},
     bhigh={-34348.2746,-52.75382697000001},
-    R_s=120.5946981618922);
+    R_s=R_NASA_2002/LiNO3.MM);
 
   constant IdealGases.Common.DataRecord LiO(
     name="LiO",
@@ -10602,7 +10605,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1612392.133,-5551.31234,11.20573851,-0.00343722688,
         9.133194659999999e-007,-1.027902258e-010,3.822991e-015},
     bhigh={42015.7547,-48.5735458},
-    R_s=362.4396261617060);
+    R_s=R_NASA_2002/LiO.MM);
 
   constant IdealGases.Common.DataRecord LiOF(
     name="LiOF",
@@ -10616,7 +10619,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-183356.3281,-211.0049301,7.15681817,-6.24946201e-005,
         1.376567002e-008,-1.574099067e-012,7.277167140000001e-017},
     bhigh={-12545.30277,-12.72130479},
-    R_s=198.2533922188796);
+    R_s=R_NASA_2002/LiOF.MM);
 
   constant IdealGases.Common.DataRecord LiOH(
     name="LiOH",
@@ -10630,7 +10633,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={850075.137,-2430.540791,8.055314620000001,6.895680879999999e-005,-5.527207459999999e-008,
         9.368054029999999e-012,-5.31378568e-016},
     bhigh={-13658.94396,-24.57598093},
-    R_s=347.1852328804418);
+    R_s=R_NASA_2002/LiOH.MM);
 
   constant IdealGases.Common.DataRecord LiON(
     name="LiON",
@@ -10644,7 +10647,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-97406.29139999999,-511.1560940000001,7.37849387,-0.0001508777884,
         3.32991498e-008,-3.81751429e-012,1.769558455e-016},
     bhigh={22110.06635,-14.5410504},
-    R_s=225.0382303347218);
+    R_s=R_NASA_2002/LiON.MM);
 
   constant IdealGases.Common.DataRecord Li2(
     name="Li2",
@@ -10658,7 +10661,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={37676454,-118574.7185,148.2167789,-0.0837853211,2.424919798e-005,-3.27582024e-009,
         1.652000081e-013},
     bhigh={772307.201,-1021.697298},
-    R_s=598.9417951303847);
+    R_s=R_NASA_2002/Li2.MM);
 
   constant IdealGases.Common.DataRecord Li2plus(
     name="Li2plus",
@@ -10672,7 +10675,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={12799310.73,-34928.6139,38.4478536,-0.01380635397,2.53139425e-006,-2.197815991e-010,
         7.08766925e-015},
     bhigh={311796.445,-250.9543641},
-    R_s=598.9654655276177);
+    R_s=R_NASA_2002/Li2plus.MM);
 
   constant IdealGases.Common.DataRecord Li2Br2(
     name="Li2Br2",
@@ -10686,7 +10689,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-89009.8336,-19.88916335,10.01596418,-6.74913405e-006,
         1.556299963e-009,-1.844693069e-013,8.774879919999999e-018},
     bhigh={-62799.8996,-19.43063525},
-    R_s=47.8698255512695);
+    R_s=R_NASA_2002/Li2Br2.MM);
 
   constant IdealGases.Common.DataRecord Li2F2(
     name="Li2F2",
@@ -10700,7 +10703,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-218893.1683,-92.5981453,10.06970757,-2.803632163e-005,
         6.217549520000001e-009,-7.14626702e-013,3.3168573e-017},
     bhigh={-115661.1527,-27.29853181},
-    R_s=160.2679509604137);
+    R_s=R_NASA_2002/Li2F2.MM);
 
   constant IdealGases.Common.DataRecord Li2I2(
     name="Li2I2",
@@ -10714,7 +10717,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-69735.8706,-13.16825508,10.01074855,-4.60020378e-006,
         1.070510527e-009,-1.277717768e-013,6.11061224e-018},
     bhigh={-46774.7005,-17.21894034},
-    R_s=31.06010984159569);
+    R_s=R_NASA_2002/Li2I2.MM);
 
   constant IdealGases.Common.DataRecord Li2O(
     name="Li2O",
@@ -10728,7 +10731,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={726148.7039999999,-9543.783720000001,28.87491643,-0.01959494099,
         8.086339840000001e-006,-1.370211764e-009,8.11172719e-014},
     bhigh={29907.26399,-156.4517822},
-    R_s=278.2503497158768);
+    R_s=R_NASA_2002/Li2O.MM);
 
   constant IdealGases.Common.DataRecord Li2Oplus(
     name="Li2Oplus",
@@ -10742,7 +10745,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-130216.6086,-146.6759528,7.61072945,-4.46942669e-005,
         9.947160640000001e-009,-1.147038806e-012,5.33924147e-017},
     bhigh={50987.6231,-15.28011047},
-    R_s=278.2554582765336);
+    R_s=R_NASA_2002/Li2Oplus.MM);
 
   constant IdealGases.Common.DataRecord Li2O2(
     name="Li2O2",
@@ -10756,7 +10759,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-293923.2153,-235.9107937,10.17463402,-6.931624359999999e-005,
         1.521202834e-008,-1.733841909e-012,7.99315462e-017},
     bhigh={-36184.8191,-29.04221044},
-    R_s=181.2198130808530);
+    R_s=R_NASA_2002/Li2O2.MM);
 
   constant IdealGases.Common.DataRecord Li2O2H2(
     name="Li2O2H2",
@@ -10770,7 +10773,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1215377.492,-3982.05744,15.85877373,0.000750914568,-2.585218184e-007,
         3.6468417e-011,-1.904139406e-015},
     bhigh={-67387.4838,-66.472084},
-    R_s=173.5926164402209);
+    R_s=R_NASA_2002/Li2O2H2.MM);
 
   constant IdealGases.Common.DataRecord Li2SO4(
     name="Li2SO4",
@@ -10784,7 +10787,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-603875.0870000001,-1064.550976,19.79557349,-0.000318897825,
         7.062411120000001e-008,-8.11443907e-012,3.76683021e-016},
     bhigh={-126890.8595,-80.14316674},
-    R_s=75.62454181469576);
+    R_s=R_NASA_2002/Li2SO4.MM);
 
   constant IdealGases.Common.DataRecord Li3plus(
     name="Li3plus",
@@ -10798,7 +10801,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-43550.9806,-6.05643275,7.00472289,-1.953320933e-006,
         4.429152229999999e-010,-5.18198319e-014,2.439894871e-018},
     bhigh={88799.02870000001,-10.66880792},
-    R_s=399.305050124886);
+    R_s=R_NASA_2002/Li3plus.MM);
 
   constant IdealGases.Common.DataRecord Li3Br3(
     name="Li3Br3",
@@ -10812,7 +10815,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-158467.0201,-40.4136094,16.03177633,-1.322713911e-005,
         3.014221791e-009,-3.54029216e-013,1.672030783e-017},
     bhigh={-104247.0448,-44.05478160000001},
-    R_s=31.9132170341797);
+    R_s=R_NASA_2002/Li3Br3.MM);
 
   constant IdealGases.Common.DataRecord Li3CL3(
     name="Li3CL3",
@@ -10826,7 +10829,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-200593.0356,-59.3940019,16.04590929,-1.885890854e-005,
         4.25351737e-009,-4.95556094e-013,2.325408214e-017},
     bhigh={-122492.7071,-48.44413629},
-    R_s=65.37489581859069);
+    R_s=R_NASA_2002/Li3CL3.MM);
 
   constant IdealGases.Common.DataRecord Li3F3(
     name="Li3F3",
@@ -10840,7 +10843,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-361866.499,-193.7051395,16.14457133,-5.7756285e-005,
         1.274057038e-008,-1.458168875e-012,6.744850030000001e-017},
     bhigh={-188208.1974,-56.3361288},
-    R_s=106.8453006402758);
+    R_s=R_NASA_2002/Li3F3.MM);
 
   constant IdealGases.Common.DataRecord Li3I3(
     name="Li3I3",
@@ -10854,7 +10857,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-126669.6511,-27.83891914,16.02228068,-9.399364930000001e-006,
         2.163919735e-009,-2.561731922e-013,1.217394107e-017},
     bhigh={-78695.5068,-40.9172406},
-    R_s=20.70673989439712);
+    R_s=R_NASA_2002/Li3I3.MM);
 
   constant IdealGases.Common.DataRecord Mg(
     name="Mg",
@@ -10867,7 +10870,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-536483.155,1973.709576,-0.36337769,0.002071795561,-7.738051719999999e-007,
         1.359277788e-010,-7.766898397000001e-015},
     bhigh={4829.188109999999,23.39104998},
-    R_s=342.0905163546595);
+    R_s=R_NASA_2002/Mg.MM);
 
   constant IdealGases.Common.DataRecord Mgplus(
     name="Mgplus",
@@ -10880,7 +10883,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-19147.58821,48.7734792,2.457662661,1.218104674e-005,
         1.897261686e-009,-1.580433756e-012,2.135732238e-016},
     bhigh={106102.2394,4.64644286},
-    R_s=342.0982380207109);
+    R_s=R_NASA_2002/Mgplus.MM);
 
   constant IdealGases.Common.DataRecord MgBr(
     name="MgBr",
@@ -10894,7 +10897,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={24776.04216,-641.7687520000001,6.01993209,-0.001391004302,
         6.44333096e-007,-1.197734078e-010,7.421644240000001e-015},
     bhigh={2824.060334,-6.26443992},
-    R_s=79.78687061578175);
+    R_s=R_NASA_2002/MgBr.MM);
 
   constant IdealGases.Common.DataRecord MgBr2(
     name="MgBr2",
@@ -10908,7 +10911,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-43268.9901,-12.83036001,7.5100243,-4.1523324e-006,9.42649918e-010,-1.103873928e-013,
         5.20110431e-018},
     bhigh={-39198.8602,-7.40916803},
-    R_s=45.15982032773351);
+    R_s=R_NASA_2002/MgBr2.MM);
 
   constant IdealGases.Common.DataRecord MgCL(
     name="MgCL",
@@ -10922,7 +10925,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1041328.453,-3380.15833,8.637775469999999,-0.002447789643,
         7.84196944e-007,-1.12640938e-010,5.81062073e-015},
     bhigh={13271.88977,-27.03802395},
-    R_s=139.1363499447772);
+    R_s=R_NASA_2002/MgCL.MM);
 
   constant IdealGases.Common.DataRecord MgCLplus(
     name="MgCLplus",
@@ -10936,7 +10939,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-12683919.21,34788.2454,-30.0422295,0.01481739497,-2.470965605e-006,
         1.424433718e-010,2.789613105e-016},
     bhigh={-148701.374,255.2015117},
-    R_s=139.1376272783949);
+    R_s=R_NASA_2002/MgCLplus.MM);
 
   constant IdealGases.Common.DataRecord MgCL2(
     name="MgCL2",
@@ -10950,7 +10953,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-68352.1701,-24.90899393,7.5187832,-7.56451826e-006,1.67929377e-009,
         -1.931706275e-013,8.971657820000001e-018},
     bhigh={-50326.8691,-10.53268382},
-    R_s=87.32719958828287);
+    R_s=R_NASA_2002/MgCL2.MM);
 
   constant IdealGases.Common.DataRecord MgF(
     name="MgF",
@@ -10964,7 +10967,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-169588.3782,358.875763,3.93600165,0.000481304414,-1.658385409e-007,
         3.33605229e-011,-2.270104205e-015},
     bhigh={-31693.2399,4.4105659},
-    R_s=192.0059252987303);
+    R_s=R_NASA_2002/MgF.MM);
 
   constant IdealGases.Common.DataRecord MgFplus(
     name="MgFplus",
@@ -10978,7 +10981,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-10568523.62,20771.22379,-6.11952356,0.002245834831,-9.51573861e-008,
         -2.263502341e-011,2.284524246e-015},
     bhigh={-83315.4988,87.2710238},
-    R_s=192.0083578046608);
+    R_s=R_NASA_2002/MgFplus.MM);
 
   constant IdealGases.Common.DataRecord MgF2(
     name="MgF2",
@@ -10992,7 +10995,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-124441.9584,-86.87343749999999,7.56358123,-2.499267978e-005,
         5.44012914e-009,-6.15824576e-013,2.822792666e-017},
     bhigh={-90600.19439999999,-14.2079699},
-    R_s=133.4553599717134);
+    R_s=R_NASA_2002/MgF2.MM);
 
   constant IdealGases.Common.DataRecord MgF2plus(
     name="MgF2plus",
@@ -11006,7 +11009,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-150231.687,77.2528956,7.27156936,0.000223752977,-1.003070865e-007,
         1.996274309e-011,-1.233278721e-015},
     bhigh={66991.175,-10.94528006},
-    R_s=133.4565351263261);
+    R_s=R_NASA_2002/MgF2plus.MM);
 
   constant IdealGases.Common.DataRecord MgH(
     name="MgH",
@@ -11020,7 +11023,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-100574.8598,1952.890106,-1.317191549,0.0056036658,-2.13733498e-006,
         3.3248805e-010,-1.824672746e-014},
     bhigh={15985.82755,34.3123316},
-    R_s=328.4687594566258);
+    R_s=R_NASA_2002/MgH.MM);
 
   constant IdealGases.Common.DataRecord MgI(
     name="MgI",
@@ -11034,7 +11037,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2370562.811,6916.45248,-3.18389449,0.00405155114,-9.774290750000001e-007,
         1.0233294e-010,-3.79030487e-015},
     bhigh={-38185.5111,59.9310438},
-    R_s=54.98670156042475);
+    R_s=R_NASA_2002/MgI.MM);
 
   constant IdealGases.Common.DataRecord MgI2(
     name="MgI2",
@@ -11048,7 +11051,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-33402.9918,-9.34351178,7.50746854,-3.14770789e-006,
         7.241336470000001e-010,-8.56766495e-014,4.0696917e-018},
     bhigh={-22945.55505,-5.24127259},
-    R_s=29.89605627103769);
+    R_s=R_NASA_2002/MgI2.MM);
 
   constant IdealGases.Common.DataRecord MgN(
     name="MgN",
@@ -11062,7 +11065,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-60185.891,-40.1086478,4.52949895,4.76049091e-005,2.547271298e-009,-2.894058118e-013,
         1.330639131e-017},
     bhigh={33412.857,0.7925250209},
-    R_s=217.0227371795039);
+    R_s=R_NASA_2002/MgN.MM);
 
   constant IdealGases.Common.DataRecord MgO(
     name="MgO",
@@ -11076,7 +11079,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-15867383.67,34204.681,-17.74087677,0.00700496305,-1.104138249e-006,
         8.957488529999999e-011,-3.052513649e-015},
     bhigh={-230050.4434,173.8984472},
-    R_s=206.2928613253144);
+    R_s=R_NASA_2002/MgO.MM);
 
   constant IdealGases.Common.DataRecord MgOH(
     name="MgOH",
@@ -11090,7 +11093,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={664866.475,-1770.750355,7.26999927,0.000533684276,-1.980894443e-007,
         3.025677088e-011,-1.554849476e-015},
     bhigh={-6149.11456,-16.71027009},
-    R_s=201.2597204612472);
+    R_s=R_NASA_2002/MgOH.MM);
 
   constant IdealGases.Common.DataRecord MgOHplus(
     name="MgOHplus",
@@ -11104,7 +11107,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={829633.954,-2459.700177,8.11873202,3.5005791e-005,-4.67057475e-008,
         8.312358260000001e-012,-4.80283622e-016},
     bhigh={88016.61709999999,-24.38155217},
-    R_s=201.262393090027);
+    R_s=R_NASA_2002/MgOHplus.MM);
 
   constant IdealGases.Common.DataRecord Mg_OH_2(
     name="Mg_OH_2",
@@ -11118,7 +11121,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1713709.254,-4730.00535,14.48925967,0.0001907819857,-1.226834131e-007,
         2.015343753e-011,-1.128993279e-015},
     bhigh={-38877.2467,-58.4049812},
-    R_s=142.5678261609117);
+    R_s=R_NASA_2002/Mg_OH_2.MM);
 
   constant IdealGases.Common.DataRecord MgS(
     name="MgS",
@@ -11132,7 +11135,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={26507943.28,-77113.5586,84.63771680000001,-0.0364425068,
         8.403084420000002e-006,-9.53988217e-010,4.264658029999999e-014},
     bhigh={507893.117,-583.4656096},
-    R_s=147.4988469043818);
+    R_s=R_NASA_2002/MgS.MM);
 
   constant IdealGases.Common.DataRecord Mg2(
     name="Mg2",
@@ -11146,7 +11149,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={30382.24994,59.4524046,2.352706666,0.0001378537924,-5.89569204e-008,
         1.104045317e-011,-6.558868290000001e-016},
     bhigh={33510.3656,15.88177377},
-    R_s=171.0452581773298);
+    R_s=R_NASA_2002/Mg2.MM);
 
   constant IdealGases.Common.DataRecord Mg2F4(
     name="Mg2F4",
@@ -11160,7 +11163,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-298061.0166,-120.1299868,16.09110864,-3.68745629e-005,
         8.22031705e-009,-9.48886978e-013,4.41979533e-017},
     bhigh={-211734.969,-53.08655469999999},
-    R_s=66.72767998585672);
+    R_s=R_NASA_2002/Mg2F4.MM);
 
   constant IdealGases.Common.DataRecord Mn(
     name="Mn",
@@ -11174,7 +11177,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5855.15582,883.8588440000001,-0.0364866258,0.002703720687,-1.324971998e-006,
         2.87260329e-010,-1.92363357e-014},
     bhigh={28678.03487,22.92541198},
-    R_s=151.3433795219048);
+    R_s=R_NASA_2002/Mn.MM);
 
   constant IdealGases.Common.DataRecord Mnplus(
     name="Mnplus",
@@ -11188,7 +11191,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={647131.41,-2403.796253,5.93771575,-0.002341014594,7.46416564e-007,-9.075969730000001e-011,
         4.467879847e-015},
     bhigh={134990.2108,-17.02666341},
-    R_s=151.344890820697);
+    R_s=R_NASA_2002/Mnplus.MM);
 
   constant IdealGases.Common.DataRecord Mo(
     name="Mo",
@@ -11202,7 +11205,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={5573271,-16623.65811,21.35147077,-0.01003069377,2.409784357e-006,-1.811267352e-010,
         1.034189087e-015},
     bhigh={184264.6473,-127.5326434},
-    R_s=86.66364394413175);
+    R_s=R_NASA_2002/Mo.MM);
 
   constant IdealGases.Common.DataRecord Moplus(
     name="Moplus",
@@ -11216,7 +11219,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={12988911.2,-39482.7623,48.6659978,-0.02605352326,7.21543192e-006,-8.719164960000001e-010,
         3.78842304e-014},
     bhigh={411894.857,-321.679103},
-    R_s=86.66413950330343);
+    R_s=R_NASA_2002/Moplus.MM);
 
   constant IdealGases.Common.DataRecord Mominus(
     name="Mominus",
@@ -11228,7 +11231,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={69051.2369,7.48565954},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={69051.2369,7.48565954},
-    R_s=86.66314839062741);
+    R_s=R_NASA_2002/Mominus.MM);
 
   constant IdealGases.Common.DataRecord MoO(
     name="MoO",
@@ -11242,7 +11245,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1573131.992,-5241.48358,11.02656868,-0.00390299662,1.147334134e-006,
         -1.358975691e-010,5.77526858e-015},
     bhigh={74489.72,-42.5361293},
-    R_s=74.27688552913452);
+    R_s=R_NASA_2002/MoO.MM);
 
   constant IdealGases.Common.DataRecord MoO2(
     name="MoO2",
@@ -11256,7 +11259,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={309614.3654,-1932.750274,9.428673180000001,-0.001630508855,
         5.752760170000001e-007,-7.59045747e-011,3.46133778e-015},
     bhigh={7327.72518,-25.33315948},
-    R_s=64.98818184944678);
+    R_s=R_NASA_2002/MoO2.MM);
 
   constant IdealGases.Common.DataRecord MoO3(
     name="MoO3",
@@ -11270,7 +11273,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-409759.727,237.9066513,9.3111008,0.000657933891,-2.895307725e-007,
         5.69263726e-011,-3.48965731e-015},
     bhigh={-49237.38720000001,-21.14864892},
-    R_s=57.76444335138275);
+    R_s=R_NASA_2002/MoO3.MM);
 
   constant IdealGases.Common.DataRecord MoO3minus(
     name="MoO3minus",
@@ -11284,7 +11287,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-488109.872,18.48536991,10.42644941,-0.000626555791,3.020554347e-007,
         -4.73319589e-011,2.527517727e-015},
     bhigh={-83378.155,-27.01522825},
-    R_s=57.764223191253);
+    R_s=R_NASA_2002/MoO3minus.MM);
 
   constant IdealGases.Common.DataRecord Mo2O6(
     name="Mo2O6",
@@ -11298,7 +11301,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-631223.816,-664.282755,22.4938357,-0.0001968470329,4.33674061e-008,
         -4.959777990000001e-012,2.293212733e-016},
     bhigh={-143057.325,-86.69628539999999},
-    R_s=28.88222167569138);
+    R_s=R_NASA_2002/Mo2O6.MM);
 
   constant IdealGases.Common.DataRecord Mo3O9(
     name="Mo3O9",
@@ -11312,7 +11315,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-923029.054,-1076.171759,34.8000726,-0.00031896338,7.02839704e-008,-8.03964264e-012,
         3.71787953e-016},
     bhigh={-235742.2166,-144.8769485},
-    R_s=19.25481445046092);
+    R_s=R_NASA_2002/Mo3O9.MM);
 
   constant IdealGases.Common.DataRecord Mo4O12(
     name="Mo4O12",
@@ -11326,7 +11329,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1225283.388,-1368.141197,47.0168781,-0.00040529102,
         8.928472389999999e-008,-1.021091158e-011,4.721091689999999e-016},
     bhigh={-325647.777,-204.7486535},
-    R_s=14.44111083784569);
+    R_s=R_NASA_2002/Mo4O12.MM);
 
   constant IdealGases.Common.DataRecord Mo5O15(
     name="Mo5O15",
@@ -11340,7 +11343,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1535389.516,-1710.367122,59.2712578,-0.0005066836290000001,
         1.116223706e-007,-1.276562233e-011,5.90231891e-016},
     bhigh={-412897.2380000001,-265.1287167},
-    R_s=11.55288867027655);
+    R_s=R_NASA_2002/Mo5O15.MM);
 
   constant IdealGases.Common.DataRecord N(
     name="N",
@@ -11353,7 +11356,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={88765.0138,-107.12315,2.362188287,0.0002916720081,-1.7295151e-007,
         4.01265788e-011,-2.677227571e-015},
     bhigh={56973.5133,4.865231506},
-    R_s=593.6094868884177);
+    R_s=R_NASA_2002/N.MM);
 
   constant IdealGases.Common.DataRecord Nplus(
     name="Nplus",
@@ -11367,7 +11370,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={290497.0374,-855.7908610000001,3.47738929,-0.000528826719,
         1.352350307e-007,-1.389834122e-011,5.046166279e-016},
     bhigh={231080.9984,-1.994146545},
-    R_s=593.6327376841008);
+    R_s=R_NASA_2002/Nplus.MM);
 
   constant IdealGases.Common.DataRecord Nminus(
     name="Nminus",
@@ -11381,7 +11384,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2404.189576,0.2954965336,2.499789368,8.30756497e-008,-1.82994277e-011,
         2.100136461e-015,-9.754986710000001e-020},
     bhigh={56214.13890000001,5.006484157},
-    R_s=593.586237913990);
+    R_s=R_NASA_2002/Nminus.MM);
 
   constant IdealGases.Common.DataRecord NCO(
     name="NCO",
@@ -11395,7 +11398,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={108944.5289,-1735.459316,8.65561033,-0.000405322926,7.59971641e-008,
         -7.25380415e-012,3.24487241e-016},
     bhigh={23657.92776,-26.1953297},
-    R_s=197.8853696616591);
+    R_s=R_NASA_2002/NCO.MM);
 
   constant IdealGases.Common.DataRecord ND(
     name="ND",
@@ -11409,7 +11412,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={543965.796,-2084.583507,5.83408972,-0.000418939336,
         9.768929529999999e-008,-1.056317654e-011,4.68307921e-016},
     bhigh={54666.3341,-14.80810939},
-    R_s=518.9821333538733);
+    R_s=R_NASA_2002/ND.MM);
 
   constant IdealGases.Common.DataRecord ND2(
     name="ND2",
@@ -11423,7 +11426,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1631308.357,-6564.63749,12.80547961,-0.003094456779,
         9.181660230000001e-007,-1.241119284e-010,6.22629986e-015},
     bhigh={61089.2958,-61.24502693},
-    R_s=461.0232469216360);
+    R_s=R_NASA_2002/ND2.MM);
 
   constant IdealGases.Common.DataRecord ND3(
     name="ND3",
@@ -11437,7 +11440,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2599516.958,-10134.20124,17.98028169,-0.0035826098,1.009922e-006,-1.537638609e-010,
         9.106175650000001e-015},
     bhigh={53972.0566,-98.10988569},
-    R_s=414.7093377098096);
+    R_s=R_NASA_2002/ND3.MM);
 
   constant IdealGases.Common.DataRecord NF(
     name="NF",
@@ -11451,7 +11454,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={800298.733,-3237.69658,8.703408870000001,-0.002701025798,
         9.15004211e-007,-1.36525663e-010,7.23462441e-015},
     bhigh={46428.19450000001,-30.19933248},
-    R_s=251.9158916006662);
+    R_s=R_NASA_2002/NF.MM);
 
   constant IdealGases.Common.DataRecord NF2(
     name="NF2",
@@ -11465,7 +11468,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-194501.0078,-353.603407,7.26349436,-8.4023804e-005,2.326721111e-008,
         -2.667577562e-012,1.236070614e-016},
     bhigh={3435.44059,-13.36102511},
-    R_s=159.8836419999556);
+    R_s=R_NASA_2002/NF2.MM);
 
   constant IdealGases.Common.DataRecord NF3(
     name="NF3",
@@ -11479,7 +11482,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-349626.876,-497.372867,10.36866128,8.90068765e-005,5.88265436e-008,
         -3.157737664e-012,1.714329953e-016},
     bhigh={-17131.83352,-30.98920858},
-    R_s=117.1026250820724);
+    R_s=R_NASA_2002/NF3.MM);
 
   constant IdealGases.Common.DataRecord NH(
     name="NH",
@@ -11493,7 +11496,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1958141.991,-5782.861300000001,9.33574202,-0.002292910311,
         6.07609248e-007,-6.647942750000001e-011,2.384234783e-015},
     bhigh={78989.1234,-41.169704},
-    R_s=553.7601967146732);
+    R_s=R_NASA_2002/NH.MM);
 
   constant IdealGases.Common.DataRecord NHplus(
     name="NHplus",
@@ -11507,7 +11510,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1405709.438,-4136.21571,7.63201448,-0.001228325778,2.721187746e-007,
         -2.010098289e-011,3.71719018e-017},
     bhigh={225897.596,-27.86785234},
-    R_s=553.7804305627179);
+    R_s=R_NASA_2002/NHplus.MM);
 
   constant IdealGases.Common.DataRecord NHF(
     name="NHF",
@@ -11521,7 +11524,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={901390.2720000001,-3463.39705,8.705804860000001,-0.0004018963409999999,
         2.322774501e-008,6.28048733e-012,-6.28309569e-016},
     bhigh={33370.6534,-29.00483634},
-    R_s=244.4506347494363);
+    R_s=R_NASA_2002/NHF.MM);
 
   constant IdealGases.Common.DataRecord NHF2(
     name="NHF2",
@@ -11535,7 +11538,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={739427.899,-4004.47177,12.2132232,-0.000697043773,1.271073981e-007,-1.247136898e-011,
         5.08651759e-016},
     bhigh={9134.195979999999,-48.67843963},
-    R_s=156.8436736712017);
+    R_s=R_NASA_2002/NHF2.MM);
 
   constant IdealGases.Common.DataRecord NH2(
     name="NH2",
@@ -11549,7 +11552,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2111053.74,-6880.62723,11.32305924,-0.001829236741,5.64389009e-007,-7.88645248e-011,
         4.078593449999999e-015},
     bhigh={65037.7856,-53.59155744},
-    R_s=518.9245427390595);
+    R_s=R_NASA_2002/NH2.MM);
 
   constant IdealGases.Common.DataRecord NH2F(
     name="NH2F",
@@ -11563,7 +11566,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1927205.34,-7500.447160000001,13.9558958,-0.00118480442,
         2.05067867e-007,-1.90876131e-011,7.38923621e-016},
     bhigh={35529.2734,-67.31185490999999},
-    R_s=237.4150934745887);
+    R_s=R_NASA_2002/NH2F.MM);
 
   constant IdealGases.Common.DataRecord NH3(
     name="NH3",
@@ -11577,7 +11580,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2452389.535,-8040.89424,12.71346201,-0.000398018658,3.55250275e-008,
         2.53092357e-012,-3.32270053e-016},
     bhigh={43861.91959999999,-64.62330602},
-    R_s=488.2123387894204);
+    R_s=R_NASA_2002/NH3.MM);
 
   constant IdealGases.Common.DataRecord NH2OH(
     name="NH2OH",
@@ -11591,7 +11594,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4878285.05,-15336.04636,22.2723999,-0.002514583678,3.33958973e-007,-1.881744532e-011,
         1.918174365e-016},
     bhigh={89230.2071,-126.9053624},
-    R_s=251.7266163526888);
+    R_s=R_NASA_2002/NH2OH.MM);
 
   constant IdealGases.Common.DataRecord NH4plus(
     name="NH4plus",
@@ -11605,7 +11608,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4141889,-14420.72042,20.11893564,-0.001971492619,3.112721421e-007,-2.602979969e-011,
         8.894342129999999e-016},
     bhigh={166419.6236,-120.1535761},
-    R_s=460.946382073925);
+    R_s=R_NASA_2002/NH4plus.MM);
 
   constant IdealGases.Common.DataRecord NO(
     name="NO",
@@ -11619,7 +11622,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={223901.8716,-1289.651623,5.43393603,-0.00036560349,
         9.880966450000001e-008,-1.416076856e-011,9.380184619999999e-016},
     bhigh={17503.17656,-8.50166909},
-    R_s=277.0939908885193);
+    R_s=R_NASA_2002/NO.MM);
 
   constant IdealGases.Common.DataRecord NOCL(
     name="NOCL",
@@ -11633,7 +11636,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-613341.333,-391.929883,9.13891722,-0.002605664613,1.295687247e-006,
         -2.215378352e-010,1.280394898e-014},
     bhigh={4517.32842,-23.07323335},
-    R_s=127.0183977476012);
+    R_s=R_NASA_2002/NOCL.MM);
 
   constant IdealGases.Common.DataRecord NOF(
     name="NOF",
@@ -11647,7 +11650,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1889069.274,-6731.02266,14.19018767,-0.00369312462,9.93857514e-007,-1.080748188e-010,
         4.21035443e-015},
     bhigh={32099.0078,-63.70266962},
-    R_s=169.668284689396);
+    R_s=R_NASA_2002/NOF.MM);
 
   constant IdealGases.Common.DataRecord NOF3(
     name="NOF3",
@@ -11661,7 +11664,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-278562.5217,-1252.321663,13.90824337,-0.00035666875,7.78501106e-008,
         -8.85041197e-012,4.07598003e-016},
     bhigh={-20256.51446,-51.06881858999999},
-    R_s=95.56764189213999);
+    R_s=R_NASA_2002/NOF3.MM);
 
   constant IdealGases.Common.DataRecord NO2(
     name="NO2",
@@ -11675,7 +11678,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={721300.157,-3832.6152,11.13963285,-0.002238062246,6.54772343e-007,-7.6113359e-011,
         3.32836105e-015},
     bhigh={25024.97403,-43.0513004},
-    R_s=180.7286085359359);
+    R_s=R_NASA_2002/NO2.MM);
 
   constant IdealGases.Common.DataRecord NO2minus(
     name="NO2minus",
@@ -11689,7 +11692,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={132571.0335,-1557.032129,8.12672192,-0.000272862678,-4.7075418e-008,
         2.826729008e-011,-2.353985481e-015},
     bhigh={-17157.95217,-22.28576043},
-    R_s=180.7264534342121);
+    R_s=R_NASA_2002/NO2minus.MM);
 
   constant IdealGases.Common.DataRecord NO2CL(
     name="NO2CL",
@@ -11703,7 +11706,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-108677.3327,-1452.231167,11.05656962,-0.000400009928,
         9.101543039999999e-008,-1.036656913e-011,4.78166481e-016},
     bhigh={6294.26732,-35.21239681},
-    R_s=102.0705021575403);
+    R_s=R_NASA_2002/NO2CL.MM);
 
   constant IdealGases.Common.DataRecord NO2F(
     name="NO2F",
@@ -11717,7 +11720,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-100857.7842,-1704.722752,11.22954945,-0.000468521597,
         1.047692566e-007,-1.189150595e-011,5.470307120000001e-016},
     bhigh={-6891.71918,-38.49788492},
-    R_s=127.9078576930747);
+    R_s=R_NASA_2002/NO2F.MM);
 
   constant IdealGases.Common.DataRecord NO3(
     name="NO3",
@@ -11731,7 +11734,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-394387.271,-824.426353,10.61325843,-0.0002448749816,5.40606032e-008,
         -6.19546675e-012,2.870000149e-016},
     bhigh={8982.01173,-34.44666597},
-    R_s=134.0944022165990);
+    R_s=R_NASA_2002/NO3.MM);
 
   constant IdealGases.Common.DataRecord NO3minus(
     name="NO3minus",
@@ -11745,7 +11748,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-311000.5758,-1369.087552,11.01342913,-0.000403687882,
         8.90208647e-008,-1.01973348e-011,4.72333079e-016},
     bhigh={-33643.2109,-38.78432657},
-    R_s=134.0932158016836);
+    R_s=R_NASA_2002/NO3minus.MM);
 
   constant IdealGases.Common.DataRecord NO3F(
     name="NO3F",
@@ -11759,7 +11762,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-341179.33,-2353.908798,16.28114887,-0.001910415273,4.69087356e-007,
         -5.68604014e-011,2.720906921e-015},
     bhigh={9760.583979999999,-65.58153684},
-    R_s=102.6440857537770);
+    R_s=R_NASA_2002/NO3F.MM);
 
   constant IdealGases.Common.DataRecord N2(
     name="N2",
@@ -11773,7 +11776,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={587712.406,-2239.249073,6.06694922,-0.00061396855,1.491806679e-007,-1.923105485e-011,
         1.061954386e-015},
     bhigh={12832.10415,-15.86640027},
-    R_s=296.8047434442088);
+    R_s=R_NASA_2002/N2.MM);
 
   constant IdealGases.Common.DataRecord N2plus(
     name="N2plus",
@@ -11787,7 +11790,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2845599.002,7058.89303,-2.884886385,0.003068677059,-4.36165231e-007,
         2.102514545e-011,5.41199647e-016},
     bhigh={134038.8483,50.90897022},
-    R_s=296.810556029295);
+    R_s=R_NASA_2002/N2plus.MM);
 
   constant IdealGases.Common.DataRecord N2minus(
     name="N2minus",
@@ -11801,7 +11804,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={216963.7706,-1275.098516,5.3910957,-0.000319890751,
         7.311051349999999e-008,-8.202017370000001e-012,3.7400447e-016},
     bhigh={24249.64308,-9.014934294},
-    R_s=296.7989310867801);
+    R_s=R_NASA_2002/N2minus.MM);
 
   constant IdealGases.Common.DataRecord NCN(
     name="NCN",
@@ -11815,7 +11818,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-164188.0975,-776.784075,7.99998187,-0.0001659081508,
         2.983403318e-008,-3.120157047e-012,1.99269872e-016},
     bhigh={61844.24479999999,-21.4910882},
-    R_s=207.7375881031678);
+    R_s=R_NASA_2002/NCN.MM);
 
   constant IdealGases.Common.DataRecord N2D2_cis(
     name="N2D2_cis",
@@ -11829,7 +11832,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={879807.471,-5299.36204,13.55007485,-0.001316635227,2.755816197e-007,
         -3.036294387e-011,1.365324117e-015},
     bhigh={53563.11889999999,-62.71215875},
-    R_s=259.4910666769367);
+    R_s=R_NASA_2002/N2D2_cis.MM);
 
   constant IdealGases.Common.DataRecord N2F2(
     name="N2F2",
@@ -11843,7 +11846,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-182488.386,-953.402996,10.6979548,-0.00027599687,6.0554397e-008,-6.91121508e-012,
         3.19258723e-016},
     bhigh={9283.46696,-32.46968772},
-    R_s=125.9579458003331);
+    R_s=R_NASA_2002/N2F2.MM);
 
   constant IdealGases.Common.DataRecord N2F4(
     name="N2F4",
@@ -11857,7 +11860,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-518859.471,-670.225651,16.50109262,-0.0002006404436,4.43675251e-008,
         -5.08980888e-012,2.359374159e-016},
     bhigh={-5281.4889,-60.40513435},
-    R_s=79.94182099997779);
+    R_s=R_NASA_2002/N2F4.MM);
 
   constant IdealGases.Common.DataRecord N2H2(
     name="N2H2",
@@ -11871,7 +11874,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6217567.87,-17539.52096,20.22730509,-0.000975729766,-4.20841674e-007,
         1.117921171e-010,-7.627102210000001e-015},
     bhigh={137415.2574,-119.9559168},
-    R_s=276.8800983573366);
+    R_s=R_NASA_2002/N2H2.MM);
 
   constant IdealGases.Common.DataRecord NH2NO2(
     name="NH2NO2",
@@ -11885,7 +11888,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1654040.575,-8125.220880000001,20.21742772,-0.001244291821,
         2.122804183e-007,-1.948359653e-011,7.43935136e-016},
     bhigh={42308.2258,-101.6190179},
-    R_s=134.0442909082467);
+    R_s=R_NASA_2002/NH2NO2.MM);
 
   constant IdealGases.Common.DataRecord N2H4(
     name="N2H4",
@@ -11899,7 +11902,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3293486.7,-11998.50628,21.04406814,-0.001399381724,1.933173351e-007,
         -1.318016127e-011,3.16640017e-016},
     bhigh={83484.337,-115.5751024},
-    R_s=259.4622713695297);
+    R_s=R_NASA_2002/N2H4.MM);
 
   constant IdealGases.Common.DataRecord N2O(
     name="N2O",
@@ -11913,7 +11916,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={343844.804,-2404.557558,9.125636220000001,-0.000540166793,
         1.315124031e-007,-1.4142151e-011,6.38106687e-016},
     bhigh={21986.32638,-31.47805016},
-    R_s=188.9111803838883);
+    R_s=R_NASA_2002/N2O.MM);
 
   constant IdealGases.Common.DataRecord N2Oplus(
     name="N2Oplus",
@@ -11927,7 +11930,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-29835.53254,-1179.455967,8.30018669,-0.0002887267217,
         5.70510501e-008,-5.95888512e-012,2.835725557e-016},
     bhigh={164602.1769,-22.87356617},
-    R_s=188.9135351071816);
+    R_s=R_NASA_2002/N2Oplus.MM);
 
   constant IdealGases.Common.DataRecord N2O3(
     name="N2O3",
@@ -11941,7 +11944,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={778388.186,-4483.02466,16.66668024,-0.002062143878,
         5.309541710000001e-007,-6.19045122e-011,2.692956658e-015},
     bhigh={33609.1245,-67.39212388},
-    R_s=109.384751801041);
+    R_s=R_NASA_2002/N2O3.MM);
 
   constant IdealGases.Common.DataRecord N2O4(
     name="N2O4",
@@ -11955,7 +11958,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-458284.3760000001,-1604.749805,16.74102133,-0.0005091385080000001,
         1.14363467e-007,-1.316288176e-011,5.976316620000001e-016},
     bhigh={4306.90052,-65.69450380000001},
-    R_s=90.36430426796797);
+    R_s=R_NASA_2002/N2O4.MM);
 
   constant IdealGases.Common.DataRecord N2O5(
     name="N2O5",
@@ -11969,7 +11972,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-53255.7896,-3109.277389,20.36088958,-0.000995990114,
         2.401398635e-007,-3.057161911e-011,1.495915511e-015},
     bhigh={13369.57281,-82.98623341000001},
-    R_s=76.97879093124365);
+    R_s=R_NASA_2002/N2O5.MM);
 
   constant IdealGases.Common.DataRecord N3(
     name="N3",
@@ -11983,7 +11986,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={252926.4658,-2362.876591,9.135267130000001,-0.000621287085,
         1.324094351e-007,-1.47898964e-011,6.721230470000001e-016},
     bhigh={64126.95389999999,-31.35825973},
-    R_s=197.8698289628059);
+    R_s=R_NASA_2002/N3.MM);
 
   constant IdealGases.Common.DataRecord N3H(
     name="N3H",
@@ -11997,7 +12000,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1170469.241,-5102.45199,12.7828891,-0.000840948716,1.592142834e-007,
         -1.512289051e-011,6.102906629999999e-016},
     bhigh={64283.4447,-55.13119107999999},
-    R_s=193.2346906807747);
+    R_s=R_NASA_2002/N3H.MM);
 
   constant IdealGases.Common.DataRecord Na(
     name="Na",
@@ -12010,7 +12013,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={952572.3380000001,-2623.807254,5.16259662,-0.001210218586,
         2.306301844e-007,-1.249597843e-011,7.226771190000001e-016},
     bhigh={29129.63564,-15.19717061},
-    R_s=361.6612954370574);
+    R_s=R_NASA_2002/Na.MM);
 
   constant IdealGases.Common.DataRecord Naplus(
     name="Naplus",
@@ -12022,7 +12025,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={72565.3707,3.55084508},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={72565.3707,3.55084508},
-    R_s=361.6699258897041);
+    R_s=R_NASA_2002/Naplus.MM);
 
   constant IdealGases.Common.DataRecord Naminus(
     name="Naminus",
@@ -12034,7 +12037,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={5082.19967,3.55091679},
     ahigh={0,0,2.500000001,0,0,0,0},
     bhigh={5082.19967,3.55091679},
-    R_s=361.6526653962943);
+    R_s=R_NASA_2002/Naminus.MM);
 
   constant IdealGases.Common.DataRecord NaALF4(
     name="NaALF4",
@@ -12048,7 +12051,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-357117.793,-249.6543879,16.18634511,-7.449049300000001e-005,
         1.644510872e-008,-1.883696066e-012,8.719877450000001e-017},
     bhigh={-227953.3538,-53.7066514},
-    R_s=66.00655124613074);
+    R_s=R_NASA_2002/NaALF4.MM);
 
   constant IdealGases.Common.DataRecord NaBO2(
     name="NaBO2",
@@ -12062,7 +12065,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={85958.14049999999,-1691.902222,11.18847517,-0.000456420231,
         9.80450516e-008,-1.101655008e-011,5.02917276e-016},
     bhigh={-69492.9206,-34.1635313},
-    R_s=126.361160110925);
+    R_s=R_NASA_2002/NaBO2.MM);
 
   constant IdealGases.Common.DataRecord NaBr(
     name="NaBr",
@@ -12076,7 +12079,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={897851.3019999999,-2697.899721,7.54537716,-0.001566692184,
         4.47039274e-007,-4.83281021e-011,1.4239613e-015},
     bhigh={-1750.862247,-18.56478949},
-    R_s=80.80673883365340);
+    R_s=R_NASA_2002/NaBr.MM);
 
   constant IdealGases.Common.DataRecord NaCN(
     name="NaCN",
@@ -12090,7 +12093,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={366557.029,-1782.094358,8.69962263,-0.0004463297,9.36222931e-008,-1.03307132e-011,
         4.650466810000001e-016},
     bhigh={20109.26347,-24.19276094},
-    R_s=169.6590519305644);
+    R_s=R_NASA_2002/NaCN.MM);
 
   constant IdealGases.Common.DataRecord NaCL(
     name="NaCL",
@@ -12104,7 +12107,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={331449.8760000001,-896.831565,5.27728738,-0.0001475674008,-1.491128988e-008,
         2.465673596e-011,-2.730355213e-015},
     bhigh={-17362.77667,-3.99828856},
-    R_s=142.2675550799526);
+    R_s=R_NASA_2002/NaCL.MM);
 
   constant IdealGases.Common.DataRecord NaF(
     name="NaF",
@@ -12118,7 +12121,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1092926.912,3293.30364,0.413591984,0.00263499447,-8.384295630000001e-007,
         1.417053025e-010,-8.600270160000001e-015},
     bhigh={-57728.8463,29.09489906},
-    R_s=198.0202844357134);
+    R_s=R_NASA_2002/NaF.MM);
 
   constant IdealGases.Common.DataRecord NaH(
     name="NaH",
@@ -12132,7 +12135,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4756184.75,14520.47626,-13.27563485,0.01055828277,-2.990041189e-006,
         3.90532288e-010,-1.923931194e-014},
     bhigh={-76329.2227,122.207006},
-    R_s=346.4709757722716);
+    R_s=R_NASA_2002/NaH.MM);
 
   constant IdealGases.Common.DataRecord NaI(
     name="NaI",
@@ -12146,7 +12149,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2281549.408,-7093.15663,13.04994968,-0.00501349233,1.581735155e-006,
         -2.285837754e-010,1.19588995e-014},
     bhigh={32538.9362,-56.4002332},
-    R_s=55.46917613378606);
+    R_s=R_NASA_2002/NaI.MM);
 
   constant IdealGases.Common.DataRecord NaLi(
     name="NaLi",
@@ -12160,7 +12163,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={10916648.6,-34800.1064,46.14311919999999,-0.02260951051,
         5.68532437e-006,-6.458143299999999e-010,2.696508992e-014},
     bhigh={239443.1755,-296.1780126},
-    R_s=277.7913832487437);
+    R_s=R_NASA_2002/NaLi.MM);
 
   constant IdealGases.Common.DataRecord NaNO2(
     name="NaNO2",
@@ -12174,7 +12177,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-176555.7495,-863.521295,10.6410594,-0.0002559465044,5.65446563e-008,
         -6.48671032e-012,3.008171243e-016},
     bhigh={-18684.35672,-29.21304474},
-    R_s=120.5084058660833);
+    R_s=R_NASA_2002/NaNO2.MM);
 
   constant IdealGases.Common.DataRecord NaNO3(
     name="NaNO3",
@@ -12188,7 +12191,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-322559.219,-1396.782195,14.03092409,-0.000409816177,
         9.023845720000001e-008,-1.032543966e-011,4.77867155e-016},
     bhigh={-31388.89875,-49.59121431},
-    R_s=97.82389883977432);
+    R_s=R_NASA_2002/NaNO3.MM);
 
   constant IdealGases.Common.DataRecord NaO(
     name="NaO",
@@ -12202,7 +12205,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={256974.4011,-2269.334161,9.22439762,-0.0036512691,1.446811119e-006,-2.443068386e-010,
         1.428508328e-014},
     bhigh={24132.39357,-29.89159486},
-    R_s=213.2517824821611);
+    R_s=R_NASA_2002/NaO.MM);
 
   constant IdealGases.Common.DataRecord NaOH(
     name="NaOH",
@@ -12216,7 +12219,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={875378.776,-2342.514649,7.97846989,0.0001016451512,-6.26853195e-008,
         1.022715136e-011,-5.71328641e-016},
     bhigh={-9509.90171,-22.02310401},
-    R_s=207.87776916882);
+    R_s=R_NASA_2002/NaOH.MM);
 
   constant IdealGases.Common.DataRecord NaOHplus(
     name="NaOHplus",
@@ -12230,7 +12233,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={881541.365,-2363.159755,8.053203930000001,7.27127974e-005,-5.89741789e-008,
         1.007487881e-011,-5.47440621e-016},
     bhigh={95844.41650000001,-20.79484012},
-    R_s=207.8806204575376);
+    R_s=R_NASA_2002/NaOHplus.MM);
 
   constant IdealGases.Common.DataRecord Na2(
     name="Na2",
@@ -12244,7 +12247,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={19299407.58,-62692.8012,82.67682110000001,-0.0456513781,
         1.259515667e-005,-1.560445735e-009,7.02467717e-014},
     bhigh={409082.08,-550.997089},
-    R_s=180.8306477185287);
+    R_s=R_NASA_2002/Na2.MM);
 
   constant IdealGases.Common.DataRecord Na2Br2(
     name="Na2Br2",
@@ -12258,7 +12261,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-30217.30975,-2.65923278,10.00225819,-9.935490630000001e-007,
         2.358676253e-010,-2.857194816e-014,1.381909879e-018},
     bhigh={-60900.3992,-14.94517863},
-    R_s=40.40336941682670);
+    R_s=R_NASA_2002/Na2Br2.MM);
 
   constant IdealGases.Common.DataRecord Na2CL2(
     name="Na2CL2",
@@ -12272,7 +12275,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-44121.0523,-5.39349128,10.00453407,-1.981155641e-006,4.6801882e-010,
         -5.64894068e-014,2.724721177e-018},
     bhigh={-70980.6341,-17.87230397},
-    R_s=71.13377753997629);
+    R_s=R_NASA_2002/Na2CL2.MM);
 
   constant IdealGases.Common.DataRecord Na2F2(
     name="Na2F2",
@@ -12286,7 +12289,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-90307.50689999999,-18.93938035,10.01535518,-6.53967545e-006,
         1.516333603e-009,-1.804877459e-013,8.61347492e-018},
     bhigh={-103489.6664,-21.78860202},
-    R_s=99.01014221785672);
+    R_s=R_NASA_2002/Na2F2.MM);
 
   constant IdealGases.Common.DataRecord Na2I2(
     name="Na2I2",
@@ -12300,7 +12303,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-22312.36397,-1.515570558,10.00129413,-5.71503538e-007,
         1.360287207e-010,-1.650916036e-014,7.996149680000001e-019},
     bhigh={-45969.2175,-12.76523965},
-    R_s=27.73458806689303);
+    R_s=R_NASA_2002/Na2I2.MM);
 
   constant IdealGases.Common.DataRecord Na2O(
     name="Na2O",
@@ -12314,7 +12317,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-66005.2516,-25.69021634,7.51938542,-7.81163524e-006,1.73501589e-009,
         -1.996634558e-013,9.27643355e-018},
     bhigh={-4297.33965,-10.63530214},
-    R_s=134.1505679187156);
+    R_s=R_NASA_2002/Na2O.MM);
 
   constant IdealGases.Common.DataRecord Na2Oplus(
     name="Na2Oplus",
@@ -12328,7 +12331,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-57409.0933,-19.89178143,7.51529526,-6.25833323e-006,
         1.407321045e-009,-1.635833952e-013,7.66244513e-018},
     bhigh={60329.77469999999,-9.42652674},
-    R_s=134.1517553487198);
+    R_s=R_NASA_2002/Na2Oplus.MM);
 
   constant IdealGases.Common.DataRecord Na2O2(
     name="Na2O2",
@@ -12342,7 +12345,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-173229.5239,-113.7561118,10.08529143,-3.42209894e-005,
         7.577721890000001e-009,-8.70125673e-013,4.03606139e-017},
     bhigh={-17803.00574,-23.8678919},
-    R_s=106.6258912410805);
+    R_s=R_NASA_2002/Na2O2.MM);
 
   constant IdealGases.Common.DataRecord Na2O2H2(
     name="Na2O2H2",
@@ -12356,7 +12359,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1675713.839,-4704.921170000001,16.97343934,0.0001961487616,-1.236951748e-007,
         2.025311778e-011,-1.132991623e-015},
     bhigh={-48562.4557,-68.1348098},
-    R_s=103.93888458441);
+    R_s=R_NASA_2002/Na2O2H2.MM);
 
   constant IdealGases.Common.DataRecord Na2SO4(
     name="Na2SO4",
@@ -12370,7 +12373,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-575448.311,-981.7060339999999,19.73310397,-0.000293639552,
         6.498708169999999e-008,-7.462479400000001e-012,3.46249166e-016},
     bhigh={-127059.7762,-76.67871596000001},
-    R_s=58.53551629115134);
+    R_s=R_NASA_2002/Na2SO4.MM);
 
   constant IdealGases.Common.DataRecord Na3CL3(
     name="Na3CL3",
@@ -12384,7 +12387,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-71602.9797,-9.57349381,16.00799614,-3.47835697e-006,
         8.190943689999999e-010,-9.86321003e-014,4.74900535e-018},
     bhigh={-114725.2948,-40.31342160000001},
-    R_s=47.42251835998420);
+    R_s=R_NASA_2002/Na3CL3.MM);
 
   constant IdealGases.Common.DataRecord Na3F3(
     name="Na3F3",
@@ -12398,7 +12401,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-155399.5698,-35.5197019,16.02841159,-1.198056094e-005,
         2.75724873e-009,-3.26330097e-013,1.550483212e-017},
     bhigh={-167214.1773,-47.5378068},
-    R_s=66.00676147857115);
+    R_s=R_NASA_2002/Na3F3.MM);
 
   constant IdealGases.Common.DataRecord Nb(
     name="Nb",
@@ -12412,7 +12415,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1096553.196,2546.650713,2.236054882,-0.001280029198,
         8.464237990000001e-007,-1.486269508e-010,8.714309406000001e-015},
     bhigh={68791.24550000001,13.9816903},
-    R_s=89.49342337953540);
+    R_s=R_NASA_2002/Nb.MM);
 
   constant IdealGases.Common.DataRecord Nbplus(
     name="Nbplus",
@@ -12426,7 +12429,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1077639.646,2159.046421,2.310604767,-0.0005363991760000001,
         5.05791509e-007,-1.032401533e-010,6.629241279999999e-015},
     bhigh={151794.5546,12.10678502},
-    R_s=89.49395182959420);
+    R_s=R_NASA_2002/Nbplus.MM);
 
   constant IdealGases.Common.DataRecord Nbminus(
     name="Nbminus",
@@ -12440,7 +12443,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={111745.8019,134.0072834,2.391474129,4.52481343e-005,-1.025345e-008,
         1.195577988e-012,-5.606330449999999e-017},
     bhigh={74739.9675,9.67531561},
-    R_s=89.49289493571743);
+    R_s=R_NASA_2002/Nbminus.MM);
 
   constant IdealGases.Common.DataRecord NbCL5(
     name="NbCL5",
@@ -12454,7 +12457,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-156381.6638,-44.5052128,16.0354463,-1.489949737e-005,
         3.42077792e-009,-4.04112442e-013,1.917266128e-017},
     bhigh={-89628.15120000001,-43.74582607},
-    R_s=30.77494736859248);
+    R_s=R_NASA_2002/NbCL5.MM);
 
   constant IdealGases.Common.DataRecord NbO(
     name="NbO",
@@ -12468,7 +12471,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={553225.878,-1287.669306,4.98006604,0.0001116014163,4.03183868e-008,
         1.04877371e-011,-1.893595022e-015},
     bhigh={32684.5779,-1.868958549},
-    R_s=76.34590193468152);
+    R_s=R_NASA_2002/NbO.MM);
 
   constant IdealGases.Common.DataRecord NbOCL3(
     name="NbOCL3",
@@ -12482,7 +12485,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-151555.1427,53.0554523,12.28915282,-0.0001527366571,
         6.778576440000001e-008,-9.36517065e-012,4.67003693e-016},
     bhigh={-94907.68120000001,-27.45263834},
-    R_s=38.62457202706361);
+    R_s=R_NASA_2002/NbOCL3.MM);
 
   constant IdealGases.Common.DataRecord NbO2(
     name="NbO2",
@@ -12496,7 +12499,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-685185.99,911.224932,6.33919984,-8.2300803e-005,1.984439605e-007,-3.26117149e-011,
         1.602430854e-015},
     bhigh={-33250.2732,-3.55955655},
-    R_s=66.56657474093548);
+    R_s=R_NASA_2002/NbO2.MM);
 
   constant IdealGases.Common.DataRecord Ne(
     name="Ne",
@@ -12508,7 +12511,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={-745.375,3.35532272},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={-745.375,3.35532272},
-    R_s=412.0234691298682);
+    R_s=R_NASA_2002/Ne.MM);
 
   constant IdealGases.Common.DataRecord Neplus(
     name="Neplus",
@@ -12522,7 +12525,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-111274.2658,476.569797,2.196650531,0.0001102593151,-2.287564425e-008,
         2.510218183e-012,-1.126646096e-016},
     bhigh={247253.6944,7.46614054},
-    R_s=412.0346705957119);
+    R_s=R_NASA_2002/Neplus.MM);
 
   constant IdealGases.Common.DataRecord Ni(
     name="Ni",
@@ -12536,7 +12539,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-493826.221,1092.909991,2.410485014,-1.599071827e-005,-1.047414069e-008,
         4.62479521e-012,-4.448865218e-017},
     bhigh={43360.7217,9.677195599999999},
-    R_s=141.6600503634139);
+    R_s=R_NASA_2002/Ni.MM);
 
   constant IdealGases.Common.DataRecord Niplus(
     name="Niplus",
@@ -12550,7 +12553,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3961999.32,10170.84853,-6.02933129,0.002770858029,-8.9020777e-008,-5.54100058e-011,
         5.235342833e-015},
     bhigh={73403.9512,71.37503100000001},
-    R_s=141.6613744548795);
+    R_s=R_NASA_2002/Niplus.MM);
 
   constant IdealGases.Common.DataRecord Niminus(
     name="Niminus",
@@ -12564,7 +12567,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-543342.48,1182.64533,2.12644124,3.73045594e-005,6.95360843e-009,-1.945719381e-012,
         1.271571579e-016},
     bhigh={28547.59122,10.43462235},
-    R_s=141.6587262967004);
+    R_s=R_NASA_2002/Niminus.MM);
 
   constant IdealGases.Common.DataRecord NiCL(
     name="NiCL",
@@ -12578,7 +12581,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3905769.19,9961.53399,-3.83943234,0.002767979391,-7.00595938e-008,-5.74140366e-011,
         5.3076358e-015},
     bhigh={-45053.9705,67.69402548000001},
-    R_s=88.31468861262884);
+    R_s=R_NASA_2002/NiCL.MM);
 
   constant IdealGases.Common.DataRecord NiCL2(
     name="NiCL2",
@@ -12592,7 +12595,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={158588.9817,-1161.488738,9.608015379999999,-0.0009461224509999999,
         2.608172043e-007,-3.26463725e-011,1.525950893e-015},
     bhigh={-4578.98554,-22.12397347},
-    R_s=64.15546676913628);
+    R_s=R_NASA_2002/NiCL2.MM);
 
   constant IdealGases.Common.DataRecord NiO(
     name="NiO",
@@ -12606,7 +12609,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-72340.9194,-80.3555427,4.55922102,2.30515451e-005,
         5.139832819999999e-009,-5.85347491e-013,2.697077329e-017},
     bhigh={34611.4385,1.209414814},
-    R_s=111.3160840134524);
+    R_s=R_NASA_2002/NiO.MM);
 
   constant IdealGases.Common.DataRecord NiS(
     name="NiS",
@@ -12620,7 +12623,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-735812.898,1178.231095,4.83786558,-0.000393120139,1.341974852e-007,
         -1.569591708e-011,6.67704506e-016},
     bhigh={32755.6594,3.690652283},
-    R_s=91.61146516465695);
+    R_s=R_NASA_2002/NiS.MM);
 
   constant IdealGases.Common.DataRecord O(
     name="O",
@@ -12634,7 +12637,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={261902.0262,-729.872203,3.31717727,-0.000428133436,1.036104594e-007,
         -9.438304329999999e-012,2.725038297e-016},
     bhigh={33924.2806,-0.667958535},
-    R_s=519.6763628636074);
+    R_s=R_NASA_2002/O.MM);
 
   constant IdealGases.Common.DataRecord Oplus(
     name="Oplus",
@@ -12647,7 +12650,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-216651.3208,666.545615,1.702064364,0.000471499281,-1.427131823e-007,
         2.016595903e-011,-9.107157761999999e-016},
     bhigh={183719.1966,10.05690382},
-    R_s=519.694182546130);
+    R_s=R_NASA_2002/Oplus.MM);
 
   constant IdealGases.Common.DataRecord Ominus(
     name="Ominus",
@@ -12661,7 +12664,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={9769.363179999999,7.15960478,2.494961726,1.968240938e-006,-4.30417485e-010,
         4.912083080000001e-014,-2.271600083e-018},
     bhigh={11495.54438,4.83703644},
-    R_s=519.6585444030738);
+    R_s=R_NASA_2002/Ominus.MM);
 
   constant IdealGases.Common.DataRecord OD(
     name="OD",
@@ -12675,7 +12678,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7.832473160e+005,-2.532992554e+003,5.952124650e+000,-3.743595280e-004,4.959527620e-008,
         3.454454730e-012,-7.380626800e-016},
     bhigh={1.930492973e+004,-1.568898441e+001},
-    R_s=461.5709926920374);
+    R_s=R_NASA_2002/OD.MM);
 
   constant IdealGases.Common.DataRecord ODminus(
     name="ODminus",
@@ -12689,7 +12692,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3.029467029e+005,-1.079684654e+003,4.211417380e+000,6.260830070e-004,-2.411665054e-007,
         4.248425540e-011,-2.387099102e-015},
     bhigh={-1.188935343e+004,-4.724898790e+000},
-    R_s=461.5569360063860);
+    R_s=R_NASA_2002/ODminus.MM);
 
   constant IdealGases.Common.DataRecord OH(
     name="OH",
@@ -12703,7 +12706,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1017393.379,-2509.957276,5.11654786,0.000130529993,-8.284322259999999e-008,
         2.006475941e-011,-1.556993656e-015},
     bhigh={20196.40206,-11.01282337},
-    R_s=488.8777433743314);
+    R_s=R_NASA_2002/OH.MM);
 
   constant IdealGases.Common.DataRecord OHplus(
     name="OHplus",
@@ -12717,7 +12720,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={504072.91,-1380.052958,4.1254622,0.000833194884,-3.44285629e-007,
         6.792853949999999e-011,-4.36387213e-015},
     bhigh={164383.9235,-3.99705849},
-    R_s=488.8935134466341);
+    R_s=R_NASA_2002/OHplus.MM);
 
   constant IdealGases.Common.DataRecord OHminus(
     name="OHminus",
@@ -12731,7 +12734,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={471133.117,-857.233669,3.16618121,0.001233581296,-3.99924458e-007,
         6.23908167e-011,-3.35434322e-015},
     bhigh={-12248.49139,1.48773626},
-    R_s=488.8619743193756);
+    R_s=R_NASA_2002/OHminus.MM);
 
   constant IdealGases.Common.DataRecord O2(
     name="O2",
@@ -12745,7 +12748,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1037939.022,2344.830282,1.819732036,0.001267847582,-2.188067988e-007,
         2.053719572e-011,-8.193467050000001e-016},
     bhigh={-16890.10929,17.38716506},
-    R_s=259.8381814318037);
+    R_s=R_NASA_2002/O2.MM);
 
   constant IdealGases.Common.DataRecord O2plus(
     name="O2plus",
@@ -12759,7 +12762,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={73846.5488,-845.955954,4.98516416,-0.000161101089,6.42708399e-008,-1.504939874e-011,
         1.578465409e-015},
     bhigh={144632.1044,-5.81123065},
-    R_s=259.842636276056);
+    R_s=R_NASA_2002/O2plus.MM);
 
   constant IdealGases.Common.DataRecord O2minus(
     name="O2minus",
@@ -12773,7 +12776,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-56552.0805,-236.7815862,4.67583367,-2.1972453e-005,1.71150928e-008,
         -1.757645062e-012,8.24817279e-017},
     bhigh={-5960.17775,-2.436885556},
-    R_s=259.8337267403000);
+    R_s=R_NASA_2002/O2minus.MM);
 
   constant IdealGases.Common.DataRecord O3(
     name="O3",
@@ -12787,7 +12790,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-38696624.8,102334.4994,-89.615516,0.0370614497,-4.13763874e-006,-2.725018591e-010,
         5.24818811e-014},
     bhigh={-651791.818,702.9109520000001},
-    R_s=173.2254542878692);
+    R_s=R_NASA_2002/O3.MM);
 
   constant IdealGases.Common.DataRecord P(
     name="P",
@@ -12801,7 +12804,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1261794.642,-4559.83819,8.91807931,-0.00438140146,1.454286224e-006,-2.030782763e-010,
         1.021022887e-014},
     bhigh={65417.23959999999,-39.15974795},
-    R_s=268.4372104504842);
+    R_s=R_NASA_2002/P.MM);
 
   constant IdealGases.Common.DataRecord Pplus(
     name="Pplus",
@@ -12815,7 +12818,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-559424.936,1722.576545,0.8430381089999999,0.0006287368940000001,-6.317195459999999e-008,
         -1.810842484e-012,4.31811257e-016},
     bhigh={149049.3431,18.45275207},
-    R_s=268.4419650316930);
+    R_s=R_NASA_2002/Pplus.MM);
 
   constant IdealGases.Common.DataRecord Pminus(
     name="Pminus",
@@ -12829,7 +12832,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={15434.88016,9.495009339999999,2.493170861,2.700167711e-006,-5.94921039e-010,
         6.82376629e-014,-3.16695991e-018},
     bhigh={27975.72693,6.246793872},
-    R_s=268.4324560376965);
+    R_s=R_NASA_2002/Pminus.MM);
 
   constant IdealGases.Common.DataRecord PCL(
     name="PCL",
@@ -12843,7 +12846,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-347168.151,993.555793,3.39943027,0.00040197117,
         8.295588390000001e-008,-3.090212484e-011,2.106384858e-015},
     bhigh={8433.59115,10.64902238},
-    R_s=125.1680779678539);
+    R_s=R_NASA_2002/PCL.MM);
 
   constant IdealGases.Common.DataRecord PCL2(
     name="PCL2",
@@ -12857,7 +12860,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-83498.33970000001,-26.2524947,7.02036181,-8.388768680000001e-006,
         1.89678474e-009,-2.21487992e-013,1.04165355e-017},
     bhigh={-8742.99368,-6.23402319},
-    R_s=81.61100809806572);
+    R_s=R_NASA_2002/PCL2.MM);
 
   constant IdealGases.Common.DataRecord PCL2minus(
     name="PCL2minus",
@@ -12871,7 +12874,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-85649.8676,-31.8555594,7.02449496,-1.002251172e-005,
         2.253747944e-009,-2.619657192e-013,1.227059658e-017},
     bhigh={-45038.1143,-6.721522361},
-    R_s=81.6105686431876);
+    R_s=R_NASA_2002/PCL2minus.MM);
 
   constant IdealGases.Common.DataRecord PCL3(
     name="PCL3",
@@ -12885,7 +12888,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-133307.693,-41.4588321,10.0318606,-1.30194616e-005,2.92291689e-009,
         -3.39186924e-013,1.58642553e-017},
     bhigh={-38003.3668,-20.50737678},
-    R_s=60.54280085434240);
+    R_s=R_NASA_2002/PCL3.MM);
 
   constant IdealGases.Common.DataRecord PCL5(
     name="PCL5",
@@ -12899,7 +12902,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-225590.689,-69.38542820000001,16.0535963,-2.20215696e-005,
         4.97139229e-009,-5.79986005e-013,2.72597077e-017},
     bhigh={-50342.3422,-48.7245487},
-    R_s=39.92777310080135);
+    R_s=R_NASA_2002/PCL5.MM);
 
   constant IdealGases.Common.DataRecord PF(
     name="PF",
@@ -12913,7 +12916,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1132572.282,3200.03855,0.778050237,0.001969518902,-4.36581897e-007,
         5.243648570000001e-011,-2.618755712e-015},
     bhigh={-27667.73009,27.59312302},
-    R_s=166.3828279824631);
+    R_s=R_NASA_2002/PF.MM);
 
   constant IdealGases.Common.DataRecord PFplus(
     name="PFplus",
@@ -12927,7 +12930,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-40115.2518,-159.7504413,4.62139748,-2.378072183e-005,
         1.431831329e-008,-2.300109157e-012,1.694069882e-016},
     bhigh={107863.3756,-0.04072343949999999},
-    R_s=166.3846545717846);
+    R_s=R_NASA_2002/PFplus.MM);
 
   constant IdealGases.Common.DataRecord PFminus(
     name="PFminus",
@@ -12941,7 +12944,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-130379.3388,271.5526386,4.13761981,0.0002728610614,-7.64441625e-008,
         1.182073001e-011,-6.083906640000001e-016},
     bhigh={-22907.99827,3.7485261},
-    R_s=166.3810014332462);
+    R_s=R_NASA_2002/PFminus.MM);
 
   constant IdealGases.Common.DataRecord PFCL(
     name="PFCL",
@@ -12955,7 +12958,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-128214.3211,-97.3904355,7.07266166,-2.903614134e-005,
         6.408504490000001e-009,-7.33899377e-013,3.39672317e-017},
     bhigh={-36006.4926,-7.626493035},
-    R_s=97.33092207506697);
+    R_s=R_NASA_2002/PFCL.MM);
 
   constant IdealGases.Common.DataRecord PFCLminus(
     name="PFCLminus",
@@ -12969,7 +12972,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-123156.515,-97.6586111,7.07402957,-2.997070692e-005,
         6.685280620000001e-009,-7.7222622e-013,3.5993823e-017},
     bhigh={-65588.1722,-8.208878059},
-    R_s=97.33029702036036);
+    R_s=R_NASA_2002/PFCLminus.MM);
 
   constant IdealGases.Common.DataRecord PFCL2(
     name="PFCL2",
@@ -12983,7 +12986,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-186458.9813,-114.8004379,10.08599754,-3.44745652e-005,
         7.62797201e-009,-8.75309743e-013,4.05778835e-017},
     bhigh={-64504.7219,-21.74054563},
-    R_s=68.7842180184269);
+    R_s=R_NASA_2002/PFCL2.MM);
 
   constant IdealGases.Common.DataRecord PFCL4(
     name="PFCL4",
@@ -12997,7 +13000,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-295437.588,-132.5154294,16.1000538,-4.03535917e-005,
         8.971130739999999e-009,-1.03328881e-012,4.80446835e-017},
     bhigh={-81357.19399999999,-50.62403920000001},
-    R_s=43.35347516664257);
+    R_s=R_NASA_2002/PFCL4.MM);
 
   constant IdealGases.Common.DataRecord PF2(
     name="PF2",
@@ -13011,7 +13014,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-170846.712,-169.205154,7.1254916,-4.990852849999999e-005,
         1.09733523e-008,-1.25287026e-012,5.78479114e-017},
     bhigh={-63382.9584,-10.41715673},
-    R_s=120.5515673342134);
+    R_s=R_NASA_2002/PF2.MM);
 
   constant IdealGases.Common.DataRecord PF2minus(
     name="PF2minus",
@@ -13025,7 +13028,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-165397.6056,-164.0604822,7.12409152,-5.0154314e-005,
         1.117302152e-008,-1.289308601e-012,6.00470667e-017},
     bhigh={-87002.23319999999,-11.09074866},
-    R_s=120.5506084605040);
+    R_s=R_NASA_2002/PF2minus.MM);
 
   constant IdealGases.Common.DataRecord PF2CL(
     name="PF2CL",
@@ -13039,7 +13042,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-240928.1185,-203.348467,10.15150769,-6.04836731e-005,
         1.333942001e-008,-1.526772528e-012,7.063339179999999e-017},
     bhigh={-91011.1059,-24.17825549},
-    R_s=79.62292619395801);
+    R_s=R_NASA_2002/PF2CL.MM);
 
   constant IdealGases.Common.DataRecord PF2CL3(
     name="PF2CL3",
@@ -13053,7 +13056,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-365527.254,-202.969416,16.15238015,-6.11879657e-005,
         1.355610375e-008,-1.55712964e-012,7.22435997e-017},
     bhigh={-110494.1533,-53.87308191},
-    R_s=47.42217826290034);
+    R_s=R_NASA_2002/PF2CL3.MM);
 
   constant IdealGases.Common.DataRecord PF3(
     name="PF3",
@@ -13067,7 +13070,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-295704.0675,-299.7689931,10.22297023,-8.890263450000001e-005,
         1.958901359e-008,-2.240491075e-012,1.035952523e-016},
     bhigh={-117374.3464,-27.77419177},
-    R_s=94.51639530723348);
+    R_s=R_NASA_2002/PF3.MM);
 
   constant IdealGases.Common.DataRecord PF3CL2(
     name="PF3CL2",
@@ -13081,7 +13084,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-422383.8050000001,-320.796522,16.24013,-9.62365531e-005,
         2.129279712e-008,-2.443515401e-012,1.13290435e-016},
     bhigh={-139264.2151,-55.31285745},
-    R_s=52.33366822099038);
+    R_s=R_NASA_2002/PF3CL2.MM);
 
   constant IdealGases.Common.DataRecord PF4CL(
     name="PF4CL",
@@ -13095,7 +13098,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-478114.004,-426.481283,16.31812121,-0.0001271374903,
         2.806715254e-008,-3.2151663e-012,1.488512118e-016},
     bhigh={-168048.8362,-57.35844805},
-    R_s=58.38006022702912);
+    R_s=R_NASA_2002/PF4CL.MM);
 
   constant IdealGases.Common.DataRecord PF5(
     name="PF5",
@@ -13109,7 +13112,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-566872.784,-667.791791,16.49789569,-0.000199009944,4.3950071e-008,-5.03684954e-012,
         2.332945909e-016},
     bhigh={-194432.1623,-62.61721040000001},
-    R_s=66.00610259404029);
+    R_s=R_NASA_2002/PF5.MM);
 
   constant IdealGases.Common.DataRecord PH(
     name="PH",
@@ -13123,7 +13126,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={781473.0649999999,-3038.451204,7.46748102,-0.001837522255,
         7.1659477e-007,-1.142128853e-010,6.175410560000001e-015},
     bhigh={45362.6018,-24.6729814},
-    R_s=259.9771037819408);
+    R_s=R_NASA_2002/PH.MM);
 
   constant IdealGases.Common.DataRecord PH2(
     name="PH2",
@@ -13137,7 +13140,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1127884.913,-4715.238249999999,10.214983,-0.00116757382,
         2.150542671e-007,-1.624213739e-011,3.76622524e-016},
     bhigh={41830.7463,-42.3162325},
-    R_s=252.0339642374405);
+    R_s=R_NASA_2002/PH2.MM);
 
   constant IdealGases.Common.DataRecord PH2minus(
     name="PH2minus",
@@ -13151,7 +13154,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1382525.815,-5213.40067,10.21694832,-0.001116316349,2.215004171e-007,
         -2.338005187e-011,1.015580932e-015},
     bhigh={29906.83733,-43.78711584999999},
-    R_s=252.0297731177635);
+    R_s=R_NASA_2002/PH2minus.MM);
 
   constant IdealGases.Common.DataRecord PH3(
     name="PH3",
@@ -13165,7 +13168,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1334801.106,-6725.46352,14.45857073,-0.001639736883,3.40921857e-007,
         -3.73627208e-011,1.672947506e-015},
     bhigh={39103.2571,-71.9878119},
-    R_s=244.5618116183031);
+    R_s=R_NASA_2002/PH3.MM);
 
   constant IdealGases.Common.DataRecord PN(
     name="PN",
@@ -13179,7 +13182,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-249562.5593,176.043883,4.14412196,0.0002478018097,-5.674896300000001e-008,
         4.263645119999999e-012,3.063920924e-016},
     bhigh={17703.17267,1.325517397},
-    R_s=184.8471495212110);
+    R_s=R_NASA_2002/PN.MM);
 
   constant IdealGases.Common.DataRecord PO(
     name="PO",
@@ -13193,7 +13196,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-336666.744,622.9355840000001,3.56560546,0.0006516620719999999,-2.061770841e-007,
         3.18441323e-011,-1.573691908e-015},
     bhigh={-8939.79039,6.954859188},
-    R_s=177.0055457838999);
+    R_s=R_NASA_2002/PO.MM);
 
   constant IdealGases.Common.DataRecord POminus(
     name="POminus",
@@ -13207,7 +13210,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-848.0294779999999,347.054487,2.877890167,0.001622182445,-4.87019099e-007,
         6.64575227e-011,-3.39570376e-015},
     bhigh={-19872.0954,10.75444355},
-    R_s=177.0034785585680);
+    R_s=R_NASA_2002/POminus.MM);
 
   constant IdealGases.Common.DataRecord POCL3(
     name="POCL3",
@@ -13221,7 +13224,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-218593.797,-508.026968,13.3778465,-0.000151073105,3.34098678e-008,-3.83532976e-012,
         1.77932988e-016},
     bhigh={-70093.15090000001,-39.84746301},
-    R_s=54.2254798065489);
+    R_s=R_NASA_2002/POCL3.MM);
 
   constant IdealGases.Common.DataRecord POFCL2(
     name="POFCL2",
@@ -13235,7 +13238,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-270764.7503,-655.650227,13.48668421,-0.0001942765035,
         4.29118449e-008,-4.9218448e-012,2.282079808e-016},
     bhigh={-96543.92140000001,-41.64963494},
-    R_s=60.74414056529507);
+    R_s=R_NASA_2002/POFCL2.MM);
 
   constant IdealGases.Common.DataRecord POF2CL(
     name="POF2CL",
@@ -13249,7 +13252,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-334708.659,-817.6104810000001,13.6066432,-0.0002420426112,
         5.34371272e-008,-6.126461349999999e-012,2.839570116e-016},
     bhigh={-123340.1194,-44.96103437000001},
-    R_s=69.04422121057948);
+    R_s=R_NASA_2002/POF2CL.MM);
 
   constant IdealGases.Common.DataRecord POF3(
     name="POF3",
@@ -13263,7 +13266,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-369060.242,-1005.55254,13.7452994,-0.000297103711,6.55452664e-008,-7.50998733e-012,
         3.47896991e-016},
     bhigh={-149976.173,-48.82214181000001},
-    R_s=79.97153318857534);
+    R_s=R_NASA_2002/POF3.MM);
 
   constant IdealGases.Common.DataRecord PO2(
     name="PO2",
@@ -13277,7 +13280,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={492621.0990000001,-2605.465745,9.51760561,-0.001180371565,
         2.532912819e-007,-1.789964539e-011,1.800381054e-016},
     bhigh={-20288.84763,-29.69743125},
-    R_s=132.0338551897230);
+    R_s=R_NASA_2002/PO2.MM);
 
   constant IdealGases.Common.DataRecord PO2minus(
     name="PO2minus",
@@ -13291,7 +13294,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1628679.152,-5989.19998,13.69318836,-0.00362384379,
         9.488198340000001e-007,-1.040308759e-010,4.01903366e-015},
     bhigh={-36859.595,-59.5679622},
-    R_s=132.0327049563390);
+    R_s=R_NASA_2002/PO2minus.MM);
 
   constant IdealGases.Common.DataRecord PS(
     name="PS",
@@ -13305,7 +13308,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-270272.9081,888.354822,3.16919012,0.001022480817,-3.80374048e-007,
         7.019861879999999e-011,-4.26912231e-015},
     bhigh={11215.10462,11.47334049},
-    R_s=131.8952001610565);
+    R_s=R_NASA_2002/PS.MM);
 
   constant IdealGases.Common.DataRecord P2(
     name="P2",
@@ -13319,7 +13322,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-780693.649,2307.91087,1.41174313,0.00210823742,-7.36085662e-007,
         1.25936012e-010,-7.07975249e-015},
     bhigh={1329.82474,21.69741365},
-    R_s=134.2186052252421);
+    R_s=R_NASA_2002/P2.MM);
 
   constant IdealGases.Common.DataRecord P2O3(
     name="P2O3",
@@ -13333,7 +13336,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-217534.411,-1369.902,14.0114296,-0.000402385696,8.86834578e-008,-1.01565728e-011,
         4.70435606e-016},
     bhigh={-79227.56999999999,-47.39487232000001},
-    R_s=75.62377006355919);
+    R_s=R_NASA_2002/P2O3.MM);
 
   constant IdealGases.Common.DataRecord P2O4(
     name="P2O4",
@@ -13347,7 +13350,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-367011.486,-1638.42373,17.2118861,-0.000482658015,1.0644619e-007,-1.21961007e-011,
         5.65065458e-016},
     bhigh={-109043.593,-67.14276593},
-    R_s=66.01692759486151);
+    R_s=R_NASA_2002/P2O4.MM);
 
   constant IdealGases.Common.DataRecord P2O5(
     name="P2O5",
@@ -13361,7 +13364,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-324708.016,-2016.97508,20.4869934,-0.000591064115,1.30199302e-007,-1.49068294e-011,
         6.90357341e-016},
     bhigh={-130629.016,-80.31642952},
-    R_s=58.57577230067393);
+    R_s=R_NASA_2002/P2O5.MM);
 
   constant IdealGases.Common.DataRecord P3(
     name="P3",
@@ -13375,7 +13378,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-125351.306,-83.0673462,7.56195677,-2.47440395e-005,5.45727693e-009,
         -6.24466057e-013,2.88772422e-017},
     bhigh={23087.2228,-12.28310621},
-    R_s=89.47907015016139);
+    R_s=R_NASA_2002/P3.MM);
 
   constant IdealGases.Common.DataRecord P3O6(
     name="P3O6",
@@ -13389,7 +13392,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-878796.8100000001,-1651.988071,27.72258397,-0.00048593267,
         1.067867708e-007,-1.218015776e-011,5.61491196e-016},
     bhigh={-190916.5548,-122.0665277},
-    R_s=44.01128506324101);
+    R_s=R_NASA_2002/P3O6.MM);
 
   constant IdealGases.Common.DataRecord P4(
     name="P4",
@@ -13403,7 +13406,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-185870.586,-62.8454689,10.0484488,-1.98766885e-005,
         4.482408440000001e-009,-5.22610367e-013,2.45579129e-017},
     bhigh={3848.21092,-24.77297797},
-    R_s=67.10930261262105);
+    R_s=R_NASA_2002/P4.MM);
 
   constant IdealGases.Common.DataRecord P4O6(
     name="P4O6",
@@ -13417,7 +13420,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1008997.24,-887.275399,28.6606483,-0.000263601894,5.81094072e-008,-6.64808696e-012,
         3.07439193e-016},
     bhigh={-199713.89,-128.1853821},
-    R_s=37.81188503177960);
+    R_s=R_NASA_2002/P4O6.MM);
 
   constant IdealGases.Common.DataRecord P4O7(
     name="P4O7",
@@ -13431,7 +13434,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1102947.375,-1511.077128,32.109795,-0.000437180376,
         9.516639610000001e-008,-1.075204176e-011,4.91102568e-016},
     bhigh={-242909.654,-147.3140859},
-    R_s=35.24727733815731);
+    R_s=R_NASA_2002/P4O7.MM);
 
   constant IdealGases.Common.DataRecord P4O8(
     name="P4O8",
@@ -13445,7 +13448,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1173177.311,-2200.632995,35.6301013,-0.000648984974,
         1.429623989e-007,-1.635821725e-011,7.571070759999999e-016},
     bhigh={-278384.3144,-167.963696},
-    R_s=33.00846379743076);
+    R_s=R_NASA_2002/P4O8.MM);
 
   constant IdealGases.Common.DataRecord P4O9(
     name="P4O9",
@@ -13459,7 +13462,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1233696.783,-2917.032808,39.1775711,-0.000873640298,
         1.937914895e-007,-2.230510118e-011,1.037248818e-015},
     bhigh={-312963.7516,-189.717642},
-    R_s=31.03707136958232);
+    R_s=R_NASA_2002/P4O9.MM);
 
   constant IdealGases.Common.DataRecord P4O10(
     name="P4O10",
@@ -13473,7 +13476,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1337201.132,-3516.38233,42.6040331,-0.001037406404,2.287613089e-007,
         -2.620219946e-011,1.213529528e-015},
     bhigh={-345951.505,-211.5498906},
-    R_s=29.28788615033696);
+    R_s=R_NASA_2002/P4O10.MM);
 
   constant IdealGases.Common.DataRecord Pb(
     name="Pb",
@@ -13487,7 +13490,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-9084313.07,26726.7318,-26.26244039,0.01358282305,-2.685523566e-006,
         2.3524328e-010,-7.324114532e-015},
     bhigh={-148165.0666,215.4011624},
-    R_s=40.12794401544402);
+    R_s=R_NASA_2002/Pb.MM);
 
   constant IdealGases.Common.DataRecord Pbplus(
     name="Pbplus",
@@ -13501,7 +13504,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1320690.183,-4096.04801,7.38910151,-0.002807751909,7.83099165e-007,-9.31060091e-011,
         4.016371727e-015},
     bhigh={135434.7306,-27.22020908},
-    R_s=40.12805026181648);
+    R_s=R_NASA_2002/Pbplus.MM);
 
   constant IdealGases.Common.DataRecord Pbminus(
     name="Pbminus",
@@ -13513,7 +13516,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={17762.2614,8.2351321},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={17762.2614,8.2351321},
-    R_s=40.12783776963417);
+    R_s=R_NASA_2002/Pbminus.MM);
 
   constant IdealGases.Common.DataRecord PbBr(
     name="PbBr",
@@ -13527,7 +13530,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2581831.67,7143.49076,-2.65819364,0.00310772226,-4.63138154e-007,
         1.095529211e-011,1.508555088e-015},
     bhigh={-39704.4098,59.5923865},
-    R_s=28.95992393000446);
+    R_s=R_NASA_2002/PbBr.MM);
 
   constant IdealGases.Common.DataRecord PbBr2(
     name="PbBr2",
@@ -13541,7 +13544,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-13204.21479,-1.143074947,7.00097254,-4.28447161e-007,
         1.018044861e-010,-1.234016791e-014,5.97133765e-019},
     bhigh={-14622.1375,0.8868582650000001},
-    R_s=22.65484676083355);
+    R_s=R_NASA_2002/PbBr2.MM);
 
   constant IdealGases.Common.DataRecord PbBr3(
     name="PbBr3",
@@ -13555,7 +13558,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-27879.30766,-2.633265111,10.00223199,-9.80776141e-007,
         2.326232632e-010,-2.81599446e-014,1.361283735e-018},
     bhigh={-15569.81182,-10.81765474},
-    R_s=18.60435611485035);
+    R_s=R_NASA_2002/PbBr3.MM);
 
   constant IdealGases.Common.DataRecord PbBr4(
     name="PbBr4",
@@ -13569,7 +13572,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-38802.1603,-4.38293377,13.00369823,-1.620061335e-006,
         3.83413088e-010,-4.63396718e-014,2.237427066e-018},
     bhigh={-25923.27065,-22.87710636},
-    R_s=15.78256924618842);
+    R_s=R_NASA_2002/PbBr4.MM);
 
   constant IdealGases.Common.DataRecord PbCL(
     name="PbCL",
@@ -13583,7 +13586,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-385428.553,692.21975,4.50997124,-0.0006853421299999999,
         5.0873955e-007,-9.772753809999999e-011,5.807471579999999e-015},
     bhigh={-5269.68472,6.646491015},
-    R_s=34.26502042010608);
+    R_s=R_NASA_2002/PbCL.MM);
 
   constant IdealGases.Common.DataRecord PbCL2(
     name="PbCL2",
@@ -13597,7 +13600,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-31491.92744,-5.56547758,7.00459954,-1.986025455e-006,
         4.65171959e-010,-5.57913701e-014,2.67814357e-018},
     bhigh={-23274.39309,-2.140739285},
-    R_s=29.896909811367);
+    R_s=R_NASA_2002/PbCL2.MM);
 
   constant IdealGases.Common.DataRecord PbCL3(
     name="PbCL3",
@@ -13611,7 +13614,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-56644.1279,-9.329514789999999,10.00771099,-3.32972757e-006,
         7.79933081e-010,-9.3546061e-014,4.4905897e-018},
     bhigh={-24485.08643,-15.0749087},
-    R_s=26.51657263864217);
+    R_s=R_NASA_2002/PbCL3.MM);
 
   constant IdealGases.Common.DataRecord PbCL4(
     name="PbCL4",
@@ -13625,7 +13628,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-82666.7956,-16.39486405,13.01336711,-5.7161414e-006,1.32936839e-009,
         -1.585922492e-013,7.58176361e-018},
     bhigh={-43439.84220000001,-28.74559263},
-    R_s=23.82299175959566);
+    R_s=R_NASA_2002/PbCL4.MM);
 
   constant IdealGases.Common.DataRecord PbF(
     name="PbF",
@@ -13639,7 +13642,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-473420.275,1027.785283,3.88865873,-0.0001649813448,2.93116326e-007,
         -5.76645965e-011,3.24748619e-015},
     bhigh={-20261.65076,9.319483890000001},
-    R_s=36.75759811906577);
+    R_s=R_NASA_2002/PbF.MM);
 
   constant IdealGases.Common.DataRecord PbF2(
     name="PbF2",
@@ -13653,7 +13656,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-85058.99769999999,-30.74244334,7.02334604,-9.455183590000001e-006,
         2.108489027e-009,-2.434212002e-013,1.133872429e-017},
     bhigh={-55522.3677,-5.49607322},
-    R_s=33.90953627037126);
+    R_s=R_NASA_2002/PbF2.MM);
 
   constant IdealGases.Common.DataRecord PbF3(
     name="PbF3",
@@ -13667,7 +13670,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-145970.4258,-48.2039643,10.03685845,-1.501095764e-005,
         3.36247499e-009,-3.89602071e-013,1.820152103e-017},
     bhigh={-62068.6959,-20.06978661},
-    R_s=31.47108538640211);
+    R_s=R_NASA_2002/PbF3.MM);
 
   constant IdealGases.Common.DataRecord PbF4(
     name="PbF4",
@@ -13681,7 +13684,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-213261.6322,-85.7862195,13.06428551,-2.575563598e-005,
         5.69332459e-009,-6.526219550000001e-013,3.02234196e-017},
     bhigh={-100290.8979,-35.9024028},
-    R_s=29.35980765170704);
+    R_s=R_NASA_2002/PbF4.MM);
 
   constant IdealGases.Common.DataRecord PbI(
     name="PbI",
@@ -13695,7 +13698,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3901070.25,11479.76718,-8.17610902,0.0065234547,-1.522611682e-006,
         1.626692202e-010,-6.55332888e-015},
     bhigh={-61544.3369,99.38404970000001},
-    R_s=24.88595857457400);
+    R_s=R_NASA_2002/PbI.MM);
 
   constant IdealGases.Common.DataRecord PbI2(
     name="PbI2",
@@ -13709,7 +13712,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-10883.39477,-0.816441837,7.0006973,-3.079876763e-007,
         7.331718140000001e-011,-8.89919388e-015,4.3107125e-019},
     bhigh={-3352.09638,2.458605463},
-    R_s=18.03546369404463);
+    R_s=R_NASA_2002/PbI2.MM);
 
   constant IdealGases.Common.DataRecord PbI3(
     name="PbI3",
@@ -13723,7 +13726,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-16242.29573,-1.002945584,10.00085839,-3.79667974e-007,
         9.04675172e-011,-1.098840054e-014,5.325388290000001e-019},
     bhigh={-413.825893,-7.57941711},
-    R_s=14.14240576686285);
+    R_s=R_NASA_2002/PbI3.MM);
 
   constant IdealGases.Common.DataRecord PbI4(
     name="PbI4",
@@ -13737,7 +13740,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-19584.77744,-1.223385179,13.00104732,-4.63329569e-007,
         1.104213978e-010,-1.341397771e-014,6.50170611e-019},
     bhigh={-8893.193200000002,-18.40570345},
-    R_s=11.63164804999002);
+    R_s=R_NASA_2002/PbI4.MM);
 
   constant IdealGases.Common.DataRecord PbO(
     name="PbO",
@@ -13751,7 +13754,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={242699.685,-110.7731354,3.18068449,0.001991815065,-1.079782025e-006,
         2.540990941e-010,-1.834652493e-014},
     bhigh={8339.391539999999,10.50920926},
-    R_s=37.25148902730025);
+    R_s=R_NASA_2002/PbO.MM);
 
   constant IdealGases.Common.DataRecord PbO2(
     name="PbO2",
@@ -13765,7 +13768,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-130779.667,-73.1436145,7.55408341,-2.143421561e-005,
         4.696463999999999e-009,-5.34497218e-013,2.460760535e-017},
     bhigh={14133.86101,-12.52684909},
-    R_s=34.75983157106140);
+    R_s=R_NASA_2002/PbO2.MM);
 
   constant IdealGases.Common.DataRecord PbS(
     name="PbS",
@@ -13779,7 +13782,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2105441.649,-5520.41358,9.36924926,-0.001410262019,-1.642683362e-007,
         1.451447577e-010,-1.393564925e-014},
     bhigh={50093.3453,-32.17417657},
-    R_s=34.75021419764696);
+    R_s=R_NASA_2002/PbS.MM);
 
   constant IdealGases.Common.DataRecord PbS2(
     name="PbS2",
@@ -13793,7 +13796,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-54167.003,-13.43600342,7.51070036,-4.497318629999999e-006,
         1.032444494e-009,-1.219580043e-013,5.78580465e-018},
     bhigh={27012.29533,-8.714618097000001},
-    R_s=30.64353370434526);
+    R_s=R_NASA_2002/PbS2.MM);
 
   constant IdealGases.Common.DataRecord Rb(
     name="Rb",
@@ -13807,7 +13810,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1138274.064,3804.04194,-2.750899258,0.0038914607,-1.632296823e-006,
         3.51189314e-010,-2.521064422e-014},
     bhigh={-14664.54849,42.53442370000001},
-    R_s=97.28236833052917);
+    R_s=R_NASA_2002/Rb.MM);
 
   constant IdealGases.Common.DataRecord Rbplus(
     name="Rbplus",
@@ -13819,7 +13822,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={58203.2736,5.52050692},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={58203.2736,5.52050692},
-    R_s=97.28299276978971);
+    R_s=R_NASA_2002/Rbplus.MM);
 
   constant IdealGases.Common.DataRecord Rbminus(
     name="Rbminus",
@@ -13831,7 +13834,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={2600.405796,5.52052617},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={2600.405796,5.52052617},
-    R_s=97.28174389928485);
+    R_s=R_NASA_2002/Rbminus.MM);
 
   constant IdealGases.Common.DataRecord RbBO2(
     name="RbBO2",
@@ -13845,7 +13848,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={91544.63399999999,-1668.328341,11.17268757,-0.000450553353,
         9.68133059e-008,-1.088037652e-011,4.96773366e-016},
     bhigh={-75079.0325,-31.31951149},
-    R_s=64.81653850711271);
+    R_s=R_NASA_2002/RbBO2.MM);
 
   constant IdealGases.Common.DataRecord RbBr(
     name="RbBr",
@@ -13859,7 +13862,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1609092.474,-4466.77459,9.06409206,-0.001995333358,4.01663352e-007,-4.1630914e-012,
         -3.092443341e-015},
     bhigh={4427.46769,-27.57714089},
-    R_s=50.27767733071781);
+    R_s=R_NASA_2002/RbBr.MM);
 
   constant IdealGases.Common.DataRecord RbCL(
     name="RbCL",
@@ -13873,7 +13876,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1143043.004,4003.86188,-1.096156782,0.00403358128,-1.454151464e-006,
         2.719263762e-010,-1.81046398e-014},
     bhigh={-52976.86040000001,43.11317822},
-    R_s=68.75996520036256);
+    R_s=R_NASA_2002/RbCL.MM);
 
   constant IdealGases.Common.DataRecord RbF(
     name="RbF",
@@ -13887,7 +13890,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-854481.1149999999,2633.756505,1.216216506,0.002136494067,-6.72842608e-007,
         1.134905135e-010,-6.825624440000001e-015},
     bhigh={-58101.7911,25.88118896},
-    R_s=79.59042968262104);
+    R_s=R_NASA_2002/RbF.MM);
 
   constant IdealGases.Common.DataRecord RbH(
     name="RbH",
@@ -13901,7 +13904,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2937703.53,9379.81726,-7.54256346,0.007493226800000001,-2.159228887e-006,
         2.871300173e-010,-1.459981256e-014},
     bhigh={-45955.18829999999,83.65664320000001},
-    R_s=96.14846892319164);
+    R_s=R_NASA_2002/RbH.MM);
 
   constant IdealGases.Common.DataRecord RbI(
     name="RbI",
@@ -13915,7 +13918,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4297424.85,-12969.11161,19.58730402,-0.008458425589999999,
         2.463480035e-006,-3.19157573e-010,1.458455589e-014},
     bhigh={64329.4804,-100.9499336},
-    R_s=39.15063864034603);
+    R_s=R_NASA_2002/RbI.MM);
 
   constant IdealGases.Common.DataRecord RbK(
     name="RbK",
@@ -13929,7 +13932,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4175391.07,5918.588510000001,9.20264942,-0.010609336,
         4.96482606e-006,-8.716698790000001e-010,5.22188796e-014},
     bhigh={-32727.6904,-13.72401997},
-    R_s=66.74777487615009);
+    R_s=R_NASA_2002/RbK.MM);
 
   constant IdealGases.Common.DataRecord RbLi(
     name="RbLi",
@@ -13943,7 +13946,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={10855151.94,-38051.0697,55.1655504,-0.03128845612,9.26165025e-006,-1.264671408e-009,
         6.43166205e-014},
     bhigh={254396.4131,-352.075871},
-    R_s=89.9753053821714);
+    R_s=R_NASA_2002/RbLi.MM);
 
   constant IdealGases.Common.DataRecord RbNO2(
     name="RbNO2",
@@ -13957,7 +13960,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-164499.4453,-849.944344,10.63080575,-0.0002517893988,
         5.56142012e-008,-6.378805599999999e-012,2.957679896e-016},
     bhigh={-21285.90982,-25.68367325},
-    R_s=63.24105350668160);
+    R_s=R_NASA_2002/RbNO2.MM);
 
   constant IdealGases.Common.DataRecord RbNO3(
     name="RbNO3",
@@ -13971,7 +13974,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-314741.3867,-1371.457846,14.01319759,-0.000403027502,
         8.878332289999999e-008,-1.016221214e-011,4.704254090000001e-016},
     bhigh={-35043.3994,-46.19379241},
-    R_s=56.37999439896333);
+    R_s=R_NASA_2002/RbNO3.MM);
 
   constant IdealGases.Common.DataRecord RbNa(
     name="RbNa",
@@ -13985,7 +13988,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4297114.27,-18310.13588,34.543942,-0.02230134993,7.33987453e-006,-1.064784996e-009,
         5.61759846e-014},
     bhigh={124261.0951,-199.366198},
-    R_s=76.6614077744873);
+    R_s=R_NASA_2002/RbNa.MM);
 
   constant IdealGases.Common.DataRecord RbO(
     name="RbO",
@@ -13999,7 +14002,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={617075.688,-2175.08962,8.29041221,-0.002996487663,1.233144275e-006,-2.115810631e-010,
         1.24260743e-014},
     bhigh={18281.64827,-21.17386042},
-    R_s=81.94283472885820);
+    R_s=R_NASA_2002/RbO.MM);
 
   constant IdealGases.Common.DataRecord RbOH(
     name="RbOH",
@@ -14013,7 +14016,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={895858.313,-2332.339,7.97119248,0.0001044439355,-6.32825775e-008,
         1.029358824e-011,-5.74327779e-016},
     bhigh={-15155.68947,-19.50051629},
-    R_s=81.13684938610477);
+    R_s=R_NASA_2002/RbOH.MM);
 
   constant IdealGases.Common.DataRecord Rb2Br2(
     name="Rb2Br2",
@@ -14027,7 +14030,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-10145.35336,-0.360155032,10.00031058,-1.380745805e-007,
         3.30206795e-011,-4.02158182e-015,1.953006729e-019},
     bhigh={-69379.6088,-9.12256236},
-    R_s=25.13883866535890);
+    R_s=R_NASA_2002/Rb2Br2.MM);
 
   constant IdealGases.Common.DataRecord Rb2CL2(
     name="Rb2CL2",
@@ -14041,7 +14044,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-18188.75133,-1.13790358,10.00097318,-4.3021564e-007,
         1.024725787e-010,-1.244291058e-014,6.02891239e-019},
     bhigh={-77408.9767,-12.04843385},
-    R_s=34.37998260018128);
+    R_s=R_NASA_2002/Rb2CL2.MM);
 
   constant IdealGases.Common.DataRecord Rb2F2(
     name="Rb2F2",
@@ -14055,7 +14058,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-43765.7439,-5.76145204,10.00482691,-2.104159548e-006,
         4.96241627e-010,-5.98217497e-014,2.882751742e-018},
     bhigh={-105917.6154,-16.03254014},
-    R_s=39.79521484131052);
+    R_s=R_NASA_2002/Rb2F2.MM);
 
   constant IdealGases.Common.DataRecord Rb2I2(
     name="Rb2I2",
@@ -14069,7 +14072,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-6799.83464,-0.1642527699,10.000142,-6.321420729999999e-008,
         1.51281117e-011,-1.843027189e-015,8.951244179999999e-020},
     bhigh={-55075.7962,-6.94804539},
-    R_s=19.57531932017302);
+    R_s=R_NASA_2002/Rb2I2.MM);
 
   constant IdealGases.Common.DataRecord Rb2O(
     name="Rb2O",
@@ -14083,7 +14086,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-38463.6009,-10.82831019,7.00842189,-3.47622812e-006,7.86978506e-010,
         -9.195683850000001e-014,4.325201520000001e-018},
     bhigh={-15253.73768,-3.23038878},
-    R_s=44.47808061625699);
+    R_s=R_NASA_2002/Rb2O.MM);
 
   constant IdealGases.Common.DataRecord Rb2O2(
     name="Rb2O2",
@@ -14097,7 +14100,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-131856.7396,-96.47737790000001,10.07222726,-2.894921706e-005,
         6.4056391e-009,-7.35141939e-013,3.40856171e-017},
     bhigh={-28821.79733,-19.10948823},
-    R_s=40.97141736442910);
+    R_s=R_NASA_2002/Rb2O2.MM);
 
   constant IdealGases.Common.DataRecord Rb2O2H2(
     name="Rb2O2H2",
@@ -14111,7 +14114,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1792711.652,-4659.406599999999,16.93822422,0.0002106246492,-1.26961747e-007,
         2.063382927e-011,-1.150861507e-015},
     bhigh={-50241.1763,-60.27054920000001},
-    R_s=40.56842469305239);
+    R_s=R_NASA_2002/Rb2O2H2.MM);
 
   constant IdealGases.Common.DataRecord Rb2SO4(
     name="Rb2SO4",
@@ -14125,7 +14128,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-530289.831,-951.543545,19.71013517,-0.0002842916301,
         6.289142939999999e-008,-7.2193243e-012,3.34871819e-016},
     bhigh={-133871.3151,-70.56246881999999},
-    R_s=31.1406968286678);
+    R_s=R_NASA_2002/Rb2SO4.MM);
 
   constant IdealGases.Common.DataRecord Rn(
     name="Rn",
@@ -14139,7 +14142,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={27301.90029,-82.84672620000001,2.598178483,-5.81372985e-005,
         1.819136527e-008,-2.866656182e-012,1.789322176e-016},
     bhigh={-220.280934,6.25500571},
-    R_s=37.44977875627878);
+    R_s=R_NASA_2002/Rn.MM);
 
   constant IdealGases.Common.DataRecord Rnplus(
     name="Rnplus",
@@ -14153,7 +14156,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-19982.85319,59.3067566,2.432476003,3.71602592e-005,-1.012057848e-008,
         1.192256661e-012,-3.18452198e-017},
     bhigh={124352.8478,8.821997789999999},
-    R_s=37.44987129398476);
+    R_s=R_NASA_2002/Rnplus.MM);
 
   constant IdealGases.Common.DataRecord S(
     name="S",
@@ -14167,7 +14170,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-485424.479,1438.830408,1.258504116,0.000379799043,1.630685864e-009,
         -9.547095849999999e-012,8.041466646e-016},
     bhigh={23349.9527,15.59554855},
-    R_s=259.301730859192);
+    R_s=R_NASA_2002/S.MM);
 
   constant IdealGases.Common.DataRecord Splus(
     name="Splus",
@@ -14180,7 +14183,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1346218.684,-4056.87151,7.15343655,-0.002523562352,6.42953961e-007,-6.43167216e-011,
         2.141387919e-015},
     bhigh={179282.3835,-27.86935079},
-    R_s=259.3061673277216);
+    R_s=R_NASA_2002/Splus.MM);
 
   constant IdealGases.Common.DataRecord Sminus(
     name="Sminus",
@@ -14194,7 +14197,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2730.311692,141.4072078,2.403340775,3.69357753e-005,-7.94408044e-009,
         8.95220838e-013,-4.09966282e-017},
     bhigh={6931.1957,6.574986902},
-    R_s=259.2972945424673);
+    R_s=R_NASA_2002/Sminus.MM);
 
   constant IdealGases.Common.DataRecord SCL(
     name="SCL",
@@ -14208,7 +14211,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-94051.23449999999,362.976085,4.06995936,0.0003034029742,-8.24830139e-008,
         1.252700734e-011,-6.41746365e-016},
     bhigh={15231.11069,6.014528409},
-    R_s=123.1450872359963);
+    R_s=R_NASA_2002/SCL.MM);
 
   constant IdealGases.Common.DataRecord SCL2(
     name="SCL2",
@@ -14222,7 +14225,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-234103.9963,428.7569580000001,6.47141539,0.000317947674,-9.74748308e-008,
         1.39331857e-011,-6.39479517e-016},
     bhigh={-7210.4737,-2.774273151},
-    R_s=80.7461324062115);
+    R_s=R_NASA_2002/SCL2.MM);
 
   constant IdealGases.Common.DataRecord SCL2plus(
     name="SCL2plus",
@@ -14236,7 +14239,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-233940.3605,551.628326,6.12521216,0.000677105632,-2.674382769e-007,
         4.93593888e-011,-2.955831247e-015},
     bhigh={102678.7381,0.1365611954},
-    R_s=80.74656260077346);
+    R_s=R_NASA_2002/SCL2plus.MM);
 
   constant IdealGases.Common.DataRecord SD(
     name="SD",
@@ -14250,7 +14253,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={245673.249,-1180.034105,5.28469005,-0.0002384319882,
         6.009960290000001e-008,-7.13116364e-012,4.0358587e-016},
     bhigh={22655.45124,-8.350483655},
-    R_s=243.9767925809782);
+    R_s=R_NASA_2002/SD.MM);
 
   constant IdealGases.Common.DataRecord SF(
     name="SF",
@@ -14264,7 +14267,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={763458.075,-2423.63843,7.35219871,-0.001598026079,4.86851502e-007,-6.47800053e-011,
         2.98029731e-015},
     bhigh={15774.61591,-19.02584835},
-    R_s=162.8271810916042);
+    R_s=R_NASA_2002/SF.MM);
 
   constant IdealGases.Common.DataRecord SFplus(
     name="SFplus",
@@ -14278,7 +14281,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-937494.39,2377.21424,2.052929113,0.001081609837,-1.535468024e-007,
         8.2226919e-012,3.25974688e-017},
     bhigh={102684.9122,18.87705768},
-    R_s=162.8289304452634);
+    R_s=R_NASA_2002/SFplus.MM);
 
   constant IdealGases.Common.DataRecord SFminus(
     name="SFminus",
@@ -14292,7 +14295,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={206892.3125,-1324.372811,6.64621124,-0.001641781588,6.78388312e-007,
         -1.198331099e-010,7.12173954e-015},
     bhigh={-21509.94816,-14.70239183},
-    R_s=162.8254317755329);
+    R_s=R_NASA_2002/SFminus.MM);
 
   constant IdealGases.Common.DataRecord SF2(
     name="SF2",
@@ -14306,7 +14309,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-170261.2287,-149.7038204,7.11093414,-4.4077416e-005,9.68220831e-009,
         -1.104468959e-012,5.09530878e-017},
     bhigh={-37042.8949,-10.9525396},
-    R_s=118.6739313076004);
+    R_s=R_NASA_2002/SF2.MM);
 
   constant IdealGases.Common.DataRecord SF2plus(
     name="SF2plus",
@@ -14320,7 +14323,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-384753.102,532.789302,6.2819089,0.000452279012,-1.426421096e-007,
         2.079708115e-011,-9.69170989e-016},
     bhigh={78842.1381,-4.21611053},
-    R_s=118.6748605589550);
+    R_s=R_NASA_2002/SF2plus.MM);
 
   constant IdealGases.Common.DataRecord SF2minus(
     name="SF2minus",
@@ -14334,7 +14337,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-93766.18949999999,-36.3899527,7.02794282,-1.142143365e-005,
         2.566295898e-009,-2.981125977e-013,1.395700722e-017},
     bhigh={-49670.5033,-8.483087898999999},
-    R_s=118.6730020707982);
+    R_s=R_NASA_2002/SF2minus.MM);
 
   constant IdealGases.Common.DataRecord SF3(
     name="SF3",
@@ -14348,7 +14351,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-241128.346,-141.8950375,10.10590548,-4.231526910000001e-005,
         9.336120599999999e-009,-1.068727665e-012,4.9443426e-017},
     bhigh={-63584.4586,-24.89561796},
-    R_s=93.35830262856243);
+    R_s=R_NASA_2002/SF3.MM);
 
   constant IdealGases.Common.DataRecord SF3plus(
     name="SF3plus",
@@ -14362,7 +14365,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-377826.075,-162.1770252,9.96026597,0.0001237729568,-6.442207889999999e-008,
         1.300856025e-011,-7.915106980000001e-016},
     bhigh={44154.26809999999,-26.7390077},
-    R_s=93.35887770783228);
+    R_s=R_NASA_2002/SF3plus.MM);
 
   constant IdealGases.Common.DataRecord SF3minus(
     name="SF3minus",
@@ -14376,7 +14379,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-225386.0964,-130.8890242,10.0997238,-4.05234553e-005,
         9.064565220000001e-009,-1.049320641e-012,4.89920126e-017},
     bhigh={-98002.272,-25.24368023},
-    R_s=93.35772755637736);
+    R_s=R_NASA_2002/SF3minus.MM);
 
   constant IdealGases.Common.DataRecord SF4(
     name="SF4",
@@ -14390,7 +14393,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-377712.516,-293.7595659,13.21902007,-8.74766945e-005,
         1.929905265e-008,-2.209423506e-012,1.022335559e-016},
     bhigh={-94831.7534,-42.43061278},
-    R_s=76.944445098411);
+    R_s=R_NASA_2002/SF4.MM);
 
   constant IdealGases.Common.DataRecord SF4plus(
     name="SF4plus",
@@ -14404,7 +14407,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-418917.275,40.0288964,12.83873264,0.0001340235036,-4.81813518e-008,
         7.574595959999999e-012,-3.69667078e-016},
     bhigh={44699.4423,-37.60378598},
-    R_s=76.94483573767371);
+    R_s=R_NASA_2002/SF4plus.MM);
 
   constant IdealGases.Common.DataRecord SF4minus(
     name="SF4minus",
@@ -14418,7 +14421,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={320882.208,-1710.416599,14.94425485,-0.001057207329,2.74284692e-007,
         -2.905761211e-011,1.084482543e-015},
     bhigh={-100523.1225,-51.64256578},
-    R_s=76.94405446311376);
+    R_s=R_NASA_2002/SF4minus.MM);
 
   constant IdealGases.Common.DataRecord SF5(
     name="SF5",
@@ -14432,7 +14435,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-389242.637,-182.5826536,16.13765057,-5.54483423e-005,
         1.231433706e-008,-1.417173409e-012,6.5848894e-017},
     bhigh={-113567.1054,-55.77524201},
-    R_s=65.43920408141807);
+    R_s=R_NASA_2002/SF5.MM);
 
   constant IdealGases.Common.DataRecord SF5plus(
     name="SF5plus",
@@ -14446,7 +14449,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-981434.232,720.881739,15.64386818,-0.0002452519972,2.241690996e-007,
         -3.99003589e-011,2.279087545e-015},
     bhigh={9090.95319,-55.31460631},
-    R_s=65.43948663253957);
+    R_s=R_NASA_2002/SF5plus.MM);
 
   constant IdealGases.Common.DataRecord SF5minus(
     name="SF5minus",
@@ -14460,7 +14463,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-373321.92,-179.3729521,16.13699748,-5.57753997e-005,
         1.249477046e-008,-1.448104799e-012,6.7674623e-017},
     bhigh={-149855.4401,-56.31439391},
-    R_s=65.4389215327365);
+    R_s=R_NASA_2002/SF5minus.MM);
 
   constant IdealGases.Common.DataRecord SF6(
     name="SF6",
@@ -14474,7 +14477,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-730672.65,-636.705655,19.47442853,-0.0001894325671,4.17872283e-008,
         -4.78374495e-012,2.213516129e-016},
     bhigh={-151060.9837,-81.47574587},
-    R_s=56.92709004254462);
+    R_s=R_NASA_2002/SF6.MM);
 
   constant IdealGases.Common.DataRecord SF6minus(
     name="SF6minus",
@@ -14488,7 +14491,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-681807.3509999999,-594.742996,19.45009842,-0.0001820212649,
         4.05707957e-008,-4.683820930000001e-012,2.182263999e-016},
     bhigh={-165890.2452,-79.65845887},
-    R_s=56.92687621902157);
+    R_s=R_NASA_2002/SF6minus.MM);
 
   constant IdealGases.Common.DataRecord SH(
     name="SH",
@@ -14502,7 +14505,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1682631.601,-5177.15221,9.198168519999999,-0.002323550224,
         6.543914779999999e-007,-8.468470419999999e-011,3.86474155e-015},
     bhigh={48992.14490000001,-37.70400275},
-    R_s=251.3991801152241);
+    R_s=R_NASA_2002/SH.MM);
 
   constant IdealGases.Common.DataRecord SHminus(
     name="SHminus",
@@ -14516,7 +14519,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1198715.402,-3894.84682,7.66042233,-0.00135523759,3.34237024e-007,-3.35072231e-011,
         9.05508478e-016},
     bhigh={13174.77387,-28.18370616},
-    R_s=251.3950100806723);
+    R_s=R_NASA_2002/SHminus.MM);
 
   constant IdealGases.Common.DataRecord SN(
     name="SN",
@@ -14530,7 +14533,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-483728.446,1058.07559,3.086198804,0.000911136078,-2.764061722e-007,
         4.157370109999999e-011,-2.128351755e-015},
     bhigh={23793.45477,10.33222139},
-    R_s=180.4689212683708);
+    R_s=R_NASA_2002/SN.MM);
 
   constant IdealGases.Common.DataRecord SO(
     name="SO",
@@ -14544,7 +14547,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1443410.557,4113.87436,-0.538369578,0.002794153269,-6.63335226e-007,
         7.838221189999999e-011,-3.56050907e-015},
     bhigh={-27088.38059,36.15358329},
-    R_s=172.9868676192775);
+    R_s=R_NASA_2002/SO.MM);
 
   constant IdealGases.Common.DataRecord SOminus(
     name="SOminus",
@@ -14558,7 +14561,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={176715.6147,-663.398736,5.17727981,-0.0002853461125,7.21442153e-008,
         -3.67646949e-012,-2.910092894e-016},
     bhigh={-9984.43801,-3.951456757},
-    R_s=172.9848931951214);
+    R_s=R_NASA_2002/SOminus.MM);
 
   constant IdealGases.Common.DataRecord SOF2(
     name="SOF2",
@@ -14572,7 +14575,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-251055.5779,-607.4439609999999,10.45046709,-0.0001796384979,
         3.96416973e-008,-4.54305524e-012,2.104969923e-016},
     bhigh={-70720.71710000001,-29.04334504},
-    R_s=96.61159014382582);
+    R_s=R_NASA_2002/SOF2.MM);
 
   constant IdealGases.Common.DataRecord SO2(
     name="SO2",
@@ -14586,7 +14589,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-112764.0116,-825.226138,7.61617863,-0.000199932761,5.65563143e-008,
         -5.45431661e-012,2.918294102e-016},
     bhigh={-33513.0869,-16.55776085},
-    R_s=129.7848394881352);
+    R_s=R_NASA_2002/SO2.MM);
 
   constant IdealGases.Common.DataRecord SO2minus(
     name="SO2minus",
@@ -14600,7 +14603,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-179340.0005,-366.316876,7.27444105,-0.0001101944663,
         2.443328132e-008,-2.809735019e-012,1.305160431e-016},
     bhigh={-49730.7261,-12.61421156},
-    R_s=129.7837281061498);
+    R_s=R_NASA_2002/SO2minus.MM);
 
   constant IdealGases.Common.DataRecord SO2CL2(
     name="SO2CL2",
@@ -14614,7 +14617,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-237663.9109,-964.7740410000001,13.71469904,-0.0002850327057,
         6.29350962e-008,-7.21784426e-012,3.34684022e-016},
     bhigh={-41900.7299,-44.81942574999999},
-    R_s=61.60274372489253);
+    R_s=R_NASA_2002/SO2CL2.MM);
 
   constant IdealGases.Common.DataRecord SO2FCL(
     name="SO2FCL",
@@ -14628,7 +14631,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-291540.2438,-1107.134423,13.81845158,-0.000325851446,7.184741e-008,
         -8.230625200000001e-012,3.81292562e-016},
     bhigh={-65524.7269,-47.09166446},
-    R_s=70.15564058873419);
+    R_s=R_NASA_2002/SO2FCL.MM);
 
   constant IdealGases.Common.DataRecord SO2F2(
     name="SO2F2",
@@ -14642,7 +14645,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-340390.445,-1309.288764,13.96601541,-0.000384008815,
         8.456688780000001e-008,-9.678246870000001e-012,4.48001428e-016},
     bhigh={-89019.9414,-51.0927005},
-    R_s=81.46639818514737);
+    R_s=R_NASA_2002/SO2F2.MM);
 
   constant IdealGases.Common.DataRecord SO3(
     name="SO3",
@@ -14656,7 +14659,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-216692.3781,-1301.022399,10.96287985,-0.000383710002,
         8.466889039999999e-008,-9.70539929e-012,4.49839754e-016},
     bhigh={-43982.83990000001,-36.55217314},
-    R_s=103.8493340261194);
+    R_s=R_NASA_2002/SO3.MM);
 
   constant IdealGases.Common.DataRecord S2(
     name="S2",
@@ -14670,7 +14673,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-15881.28788,631.548088,2.449628069,0.001986240565,-6.50792724e-007,
         1.002813651e-010,-5.59699005e-015},
     bhigh={10855.08427,14.58544515},
-    R_s=129.650865429596);
+    R_s=R_NASA_2002/S2.MM);
 
   constant IdealGases.Common.DataRecord S2minus(
     name="S2minus",
@@ -14684,7 +14687,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={483020.403,-1319.171302,6.03177848,-0.0007965560690000001,
         2.28224169e-007,-2.504364698e-011,7.28055078e-016},
     bhigh={2660.25849,-9.010480318999999},
-    R_s=129.6497563409274);
+    R_s=R_NASA_2002/S2minus.MM);
 
   constant IdealGases.Common.DataRecord S2CL2(
     name="S2CL2",
@@ -14698,7 +14701,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={632881.6,-3442.7058,15.1963735,-0.002960877176,6.88828437e-007,-7.990692529999999e-011,
         3.69246606e-015},
     bhigh={15266.72656,-54.53315445000001},
-    R_s=61.5725436179982);
+    R_s=R_NASA_2002/S2CL2.MM);
 
   constant IdealGases.Common.DataRecord S2F2(
     name="S2F2",
@@ -14712,7 +14715,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-259175.7719,-105.9653069,10.06588551,-2.274618148e-005,
         5.41234314e-009,-9.91138714e-013,9.621861440000001e-017},
     bhigh={-51476.75180000001,-23.7566614},
-    R_s=81.41359054580208);
+    R_s=R_NASA_2002/S2F2.MM);
 
   constant IdealGases.Common.DataRecord S2O(
     name="S2O",
@@ -14726,7 +14729,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-144213.979,-327.643013,7.24428611,-9.7765383e-005,2.1627127e-008,-2.48278222e-012,
         1.15177875e-016},
     bhigh={-7438.55393,-10.85180744},
-    R_s=103.7635374781291);
+    R_s=R_NASA_2002/S2O.MM);
 
   constant IdealGases.Common.DataRecord S3(
     name="S3",
@@ -14740,7 +14743,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-111780.5401,-51.97908390000001,7.03876084,-1.546804022e-005,
         3.40834041e-009,-3.89686236e-013,1.800860389e-017},
     bhigh={15254.06485,-7.610045099},
-    R_s=86.43391028639743);
+    R_s=R_NASA_2002/S3.MM);
 
   constant IdealGases.Common.DataRecord S4(
     name="S4",
@@ -14754,7 +14757,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-206833.3537,-96.96151430000001,10.0724321,-2.895047053e-005,
         6.38780619e-009,-7.31176743e-013,3.38226529e-017},
     bhigh={13211.0953,-23.44872237},
-    R_s=64.82543271479807);
+    R_s=R_NASA_2002/S4.MM);
 
   constant IdealGases.Common.DataRecord S5(
     name="S5",
@@ -14768,7 +14771,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4038495.16,8601.80388,7.4437809,0.001533393812,-2.532718676e-007,
         2.145210795e-011,-7.213102680000001e-016},
     bhigh={-46869.2542,11.04229196},
-    R_s=51.8603461718385);
+    R_s=R_NASA_2002/S5.MM);
 
   constant IdealGases.Common.DataRecord S6(
     name="S6",
@@ -14782,7 +14785,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3686845.06,-7695.0179,18.60721995,0.002290382548,-1.219834021e-006,
         2.060780798e-010,-1.190354318e-014},
     bhigh={60324.8648,-74.90245718},
-    R_s=43.21695514319871);
+    R_s=R_NASA_2002/S6.MM);
 
   constant IdealGases.Common.DataRecord S7(
     name="S7",
@@ -14796,7 +14799,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-272639.6041,-73.7321522,19.05771987,-2.394575885e-005,
         5.4426713e-009,-6.379663479999999e-013,3.008212993e-017},
     bhigh={7308.458830000001,-61.59112428},
-    R_s=37.04310440845604);
+    R_s=R_NASA_2002/S7.MM);
 
   constant IdealGases.Common.DataRecord S8(
     name="S8",
@@ -14810,7 +14813,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-8727921.130000001,12216.27968,22.09959617,-0.00349406483,
         1.397604162e-006,-2.169815281e-010,1.212304364e-014},
     bhigh={-86581.10819999999,-64.35742508},
-    R_s=32.4127163573990);
+    R_s=R_NASA_2002/S8.MM);
 
   constant IdealGases.Common.DataRecord Sc(
     name="Sc",
@@ -14824,7 +14827,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={8810382.649999999,-27112.32975,34.7658866,-0.01861104581,
         5.290283900000001e-006,-6.58540806e-010,2.997850429e-014},
     bhigh={216246.0097,-222.5618519},
-    R_s=184.9480969242976);
+    R_s=R_NASA_2002/Sc.MM);
 
   constant IdealGases.Common.DataRecord Scplus(
     name="Scplus",
@@ -14838,7 +14841,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1973658.531,-4954.3841,6.36062735,-0.000716878592,2.464991123e-008,
         9.632373790000001e-012,-8.544709642000001e-016},
     bhigh={154342.3764,-22.61925782},
-    R_s=184.9503538859327);
+    R_s=R_NASA_2002/Scplus.MM);
 
   constant IdealGases.Common.DataRecord Scminus(
     name="Scminus",
@@ -14850,7 +14853,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={41657.4639,8.270420720000001},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={41657.4639,8.270420720000001},
-    R_s=184.9458400177455);
+    R_s=R_NASA_2002/Scminus.MM);
 
   constant IdealGases.Common.DataRecord ScO(
     name="ScO",
@@ -14864,7 +14867,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1224192.443,-3918.91572,8.679848809999999,-0.001995893306,
         4.06698985e-007,-1.504459913e-011,-8.4729989e-016},
     bhigh={16773.22594,-29.51656272},
-    R_s=136.4033748659469);
+    R_s=R_NASA_2002/ScO.MM);
 
   constant IdealGases.Common.DataRecord ScOplus(
     name="ScOplus",
@@ -14878,7 +14881,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1814357.141,5853.42532,-3.65710121,0.00573436451,-2.092878161e-006,
         3.69564502e-010,-2.214038347e-014},
     bhigh={29553.64078,56.6088941},
-    R_s=136.4046025123150);
+    R_s=R_NASA_2002/ScOplus.MM);
 
   constant IdealGases.Common.DataRecord ScO2(
     name="ScO2",
@@ -14892,7 +14895,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-190390.2542,-231.558882,7.17210491,-6.85920964e-005,
         1.510998557e-008,-1.727951588e-012,7.9889805e-017},
     bhigh={-51129.74750000001,-10.90764597},
-    R_s=108.0441989840518);
+    R_s=R_NASA_2002/ScO2.MM);
 
   constant IdealGases.Common.DataRecord Sc2O(
     name="Sc2O",
@@ -14906,7 +14909,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-135088.0396,-185.4540692,7.13829408,-5.52943214e-005,
         1.221589315e-008,-1.400490463e-012,6.48885811e-017},
     bhigh={-4240.235140000001,-9.37271095},
-    R_s=78.50452482749232);
+    R_s=R_NASA_2002/Sc2O.MM);
 
   constant IdealGases.Common.DataRecord Sc2O2(
     name="Sc2O2",
@@ -14920,7 +14923,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-297734.8677,-580.367792,10.43318377,-0.0001734165462,
         3.83608979e-008,-4.403078029999999e-012,2.042208922e-016},
     bhigh={-59648.6628,-28.55828369},
-    R_s=68.20168743297344);
+    R_s=R_NASA_2002/Sc2O2.MM);
 
   constant IdealGases.Common.DataRecord Si(
     name="Si",
@@ -14934,7 +14937,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-616929.885,2240.683927,-0.444861932,0.001710056321,-4.10771416e-007,
         4.55888478e-011,-1.889515353e-015},
     bhigh={39535.5876,26.79668061},
-    R_s=296.0427978850296);
+    R_s=R_NASA_2002/Si.MM);
 
   constant IdealGases.Common.DataRecord Siplus(
     name="Siplus",
@@ -14948,7 +14951,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={59193.9023,-48.5673095,2.556312024,-3.50339716e-005,1.190298787e-008,
         -2.082923821e-012,1.471452049e-016},
     bhigh={149143.1392,5.24426714},
-    R_s=296.0485806644480);
+    R_s=R_NASA_2002/Siplus.MM);
 
   constant IdealGases.Common.DataRecord Siminus(
     name="Siminus",
@@ -14962,7 +14965,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-6162070.100000001,18833.10402,-18.9930245,0.01111021657,-2.535790208e-006,
         2.699962923e-010,-1.105062911e-014},
     bhigh={-83140.8931,159.5298253},
-    R_s=296.0370153315195);
+    R_s=R_NASA_2002/Siminus.MM);
 
   constant IdealGases.Common.DataRecord SiBr(
     name="SiBr",
@@ -14976,7 +14979,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1317799.94,-3669.79502,8.51168612,-0.001987602041,5.03541489e-007,-4.49012019e-011,
         8.23567007e-016},
     bhigh={43328.5155,-24.67075472},
-    R_s=76.99368920126494);
+    R_s=R_NASA_2002/SiBr.MM);
 
   constant IdealGases.Common.DataRecord SiBr2(
     name="SiBr2",
@@ -14990,7 +14993,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-51473.4394,-12.77719997,7.01020224,-4.29633186e-006,
         9.877651970000001e-010,-1.168133105e-013,5.54668138e-018},
     bhigh={-8319.54225,-3.61182661},
-    R_s=44.25118484673499);
+    R_s=R_NASA_2002/SiBr2.MM);
 
   constant IdealGases.Common.DataRecord SiBr3(
     name="SiBr3",
@@ -15004,7 +15007,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-88880.24740000001,-22.67879074,10.01791167,-7.48115075e-006,
         1.70924269e-009,-2.011596627e-013,9.51553415e-018},
     bhigh={-22030.26938,-15.37574366},
-    R_s=31.04775063247416);
+    R_s=R_NASA_2002/SiBr3.MM);
 
   constant IdealGases.Common.DataRecord SiBr4(
     name="SiBr4",
@@ -15018,7 +15021,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-127140.9281,-37.6808795,13.02910642,-1.194958251e-005,
         2.693843051e-009,-3.137193207e-013,1.471642663e-017},
     bhigh={-54089.9883,-29.4038433},
-    R_s=23.9127815094269);
+    R_s=R_NASA_2002/SiBr4.MM);
 
   constant IdealGases.Common.DataRecord SiC(
     name="SiC",
@@ -15032,7 +15035,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-62688.06030000001,720.983692,2.162879732,0.002201299585,-6.569466590000001e-007,
         9.177110259999999e-011,-4.96916674e-015},
     bhigh={83212.2585,16.01675317},
-    R_s=207.3640394850384);
+    R_s=R_NASA_2002/SiC.MM);
 
   constant IdealGases.Common.DataRecord SiC2(
     name="SiC2",
@@ -15046,7 +15049,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={7026893.09,-24661.48437,39.15453030000001,-0.02002884068,
         6.30735369e-006,-8.84838351e-010,4.53054985e-014},
     bhigh={226732.5155,-236.6622024},
-    R_s=159.5663913992196);
+    R_s=R_NASA_2002/SiC2.MM);
 
   constant IdealGases.Common.DataRecord SiCL(
     name="SiCL",
@@ -15060,7 +15063,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={376729.456,-1147.956509,5.73540843,-0.0005784890810000001,
         1.517304648e-007,-1.291391394e-011,1.55462842e-016},
     bhigh={23062.78401,-6.098515228},
-    R_s=130.857826357248);
+    R_s=R_NASA_2002/SiCL.MM);
 
   constant IdealGases.Common.DataRecord SiCL2(
     name="SiCL2",
@@ -15074,7 +15077,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-80508.7157,-26.61025523,7.02041472,-8.335824719999999e-006,
         1.871092411e-009,-2.171552767e-013,1.015849895e-017},
     bhigh={-21812.94885,-6.638764238},
-    R_s=83.99216094311129);
+    R_s=R_NASA_2002/SiCL2.MM);
 
   constant IdealGases.Common.DataRecord SiCL3(
     name="SiCL3",
@@ -15088,7 +15091,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-147718.0114,-53.3520098,10.04043521,-1.63512106e-005,
         3.64194011e-009,-4.20060059e-013,1.955201587e-017},
     bhigh={-43605.7165,-20.06632444},
-    R_s=61.84343725477800);
+    R_s=R_NASA_2002/SiCL3.MM);
 
   constant IdealGases.Common.DataRecord SiCL4(
     name="SiCL4",
@@ -15102,7 +15105,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-210033.0761,-84.76107710000001,13.06364027,-2.55402042e-005,
         5.65381847e-009,-6.48875267e-013,3.008025543e-017},
     bhigh={-83722.6813,-35.92584781},
-    R_s=48.93838932297415);
+    R_s=R_NASA_2002/SiCL4.MM);
 
   constant IdealGases.Common.DataRecord SiF(
     name="SiF",
@@ -15116,7 +15119,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-365363.788,872.2860040000001,3.37721827,0.000750815243,-2.308898619e-007,
         3.7667818e-011,-2.143080403e-015},
     bhigh={-10116.97664,8.968132819999999},
-    R_s=176.5892255083899);
+    R_s=R_NASA_2002/SiF.MM);
 
   constant IdealGases.Common.DataRecord SiFCL(
     name="SiFCL",
@@ -15130,7 +15133,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-128469.8945,-124.7550173,7.09289385,-3.70731177e-005,
         8.175173009999999e-009,-9.35643521e-013,4.32854434e-017},
     bhigh={-47233.0972,-8.337392707999999},
-    R_s=100.7368786281286);
+    R_s=R_NASA_2002/SiFCL.MM);
 
   constant IdealGases.Common.DataRecord SiF2(
     name="SiF2",
@@ -15144,7 +15147,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-167520.0202,-184.621209,7.13698635,-5.45076986e-005,
         1.199012961e-008,-1.369470187e-012,6.32488999e-017},
     bhigh={-72874.0102,-11.17933348},
-    R_s=125.8205176688567);
+    R_s=R_NASA_2002/SiF2.MM);
 
   constant IdealGases.Common.DataRecord SiF3(
     name="SiF3",
@@ -15158,7 +15161,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-290328.3702,-342.787694,10.25536335,-0.000101979669,
         2.250326132e-008,-2.577117181e-012,1.192923177e-016},
     bhigh={-121808.8967,-27.25261142},
-    R_s=97.7249724301782);
+    R_s=R_NASA_2002/SiF3.MM);
 
   constant IdealGases.Common.DataRecord SiF4(
     name="SiF4",
@@ -15172,7 +15175,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-384589.232,-656.997991,13.4892572,-5.10047136e-005,5.34632958e-008,
         -4.95959811e-012,2.299314375e-016},
     bhigh={-195728.4479,-46.7389465},
-    R_s=79.88644192209141);
+    R_s=R_NASA_2002/SiF4.MM);
 
   constant IdealGases.Common.DataRecord SiH(
     name="SiH",
@@ -15186,7 +15189,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={404208.649,-2364.796524,7.62749914,-0.002496591233,1.10843641e-006,-1.943991955e-010,
         1.136251507e-014},
     bhigh={57047.3768,-24.48054429},
-    R_s=285.7864178316486);
+    R_s=R_NASA_2002/SiH.MM);
 
   constant IdealGases.Common.DataRecord SiHplus(
     name="SiHplus",
@@ -15200,7 +15203,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={171169.2033,-1045.807287,4.83864824,0.0001277940891,-6.883872450000001e-008,
         1.41884348e-011,-7.85531696e-016},
     bhigh={143172.145,-7.55329914},
-    R_s=285.7918068604209);
+    R_s=R_NASA_2002/SiHplus.MM);
 
   constant IdealGases.Common.DataRecord SiHBr3(
     name="SiHBr3",
@@ -15214,7 +15217,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={219997.3526,-2024.458552,14.35781007,-0.000503701584,
         1.054049755e-007,-1.160828765e-011,5.21725768e-016},
     bhigh={-28420.86214,-45.3643717},
-    R_s=30.9313308540184);
+    R_s=R_NASA_2002/SiHBr3.MM);
 
   constant IdealGases.Common.DataRecord SiHCL(
     name="SiHCL",
@@ -15228,7 +15231,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={101215.289,-1163.239598,7.37636655,0.0001874151313,-1.661351093e-007,
         3.96441404e-011,-2.64058008e-015},
     bhigh={11410.64087,-15.07678798},
-    R_s=128.8143854254394);
+    R_s=R_NASA_2002/SiHCL.MM);
 
   constant IdealGases.Common.DataRecord SiHCL3(
     name="SiHCL3",
@@ -15242,7 +15245,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={172864.4072,-2116.727327,14.41802307,-0.000525524962,
         1.098826178e-007,-1.209327059e-011,5.432187049999999e-016},
     bhigh={-51303.5194,-50.36360893000001},
-    R_s=61.3832427086585);
+    R_s=R_NASA_2002/SiHCL3.MM);
 
   constant IdealGases.Common.DataRecord SiHF(
     name="SiHF",
@@ -15256,7 +15259,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4049752.24,-9295.526819999999,10.71754366,0.00186812422,-1.129820372e-006,
         1.9602501e-010,-1.144682011e-014},
     bhigh={41332.252,-47.363176},
-    R_s=172.8881541392034);
+    R_s=R_NASA_2002/SiHF.MM);
 
   constant IdealGases.Common.DataRecord SiHF3(
     name="SiHF3",
@@ -15270,7 +15273,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={78201.008,-2592.742261,14.75104214,-0.00065310472,1.372428937e-007,-1.516371051e-011,
         6.83249715e-016},
     bhigh={-133661.1887,-58.5145095},
-    R_s=96.58079245791771);
+    R_s=R_NASA_2002/SiHF3.MM);
 
   constant IdealGases.Common.DataRecord SiHI3(
     name="SiHI3",
@@ -15284,7 +15287,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={227942.4252,-1898.603142,14.28134804,-0.000477602695,
         1.003097496e-007,-1.107859145e-011,4.990338200000001e-016},
     bhigh={-1614.547674,-41.2294307},
-    R_s=20.28885071101179);
+    R_s=R_NASA_2002/SiHI3.MM);
 
   constant IdealGases.Common.DataRecord SiH2(
     name="SiH2",
@@ -15298,7 +15301,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4624039.37,-11434.3611,12.6488087,0.00091148995,-8.766611539999999e-007,
         1.646297357e-010,-9.965090370000001e-015},
     bhigh={107247.5101,-66.0607807},
-    R_s=276.2169043412628);
+    R_s=R_NASA_2002/SiH2.MM);
 
   constant IdealGases.Common.DataRecord SiH2Br2(
     name="SiH2Br2",
@@ -15312,7 +15315,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={566585.144,-3973.91962,15.67387912,-0.0009943802290000002,
         2.084856022e-007,-2.299521351e-011,1.034736283e-015},
     bhigh={-2990.69018,-61.9047652},
-    R_s=43.7814603996917);
+    R_s=R_NASA_2002/SiH2Br2.MM);
 
   constant IdealGases.Common.DataRecord SiH2CL2(
     name="SiH2CL2",
@@ -15326,7 +15329,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={540020.458,-4062.33729,15.73118788,-0.001015038389,2.127060243e-007,
         -2.345079226e-011,1.054871984e-015},
     bhigh={-18230.98225,-65.44540499},
-    R_s=82.31586642480976);
+    R_s=R_NASA_2002/SiH2CL2.MM);
 
   constant IdealGases.Common.DataRecord SiH2F2(
     name="SiH2F2",
@@ -15340,7 +15343,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={472653.4080000001,-4388.51769,15.96032597,-0.001102993658,
         2.315838331e-007,-2.556974559e-011,1.151499711e-015},
     bhigh={-73161.8446,-70.9898927},
-    R_s=122.0959094440730);
+    R_s=R_NASA_2002/SiH2F2.MM);
 
   constant IdealGases.Common.DataRecord SiH2I2(
     name="SiH2I2",
@@ -15354,7 +15357,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={594239.083,-3924.81448,15.63850289,-0.0009805706340000001,
         2.054871384e-007,-2.265587199e-011,1.019168663e-015},
     bhigh={15136.27352,-59.4081252},
-    R_s=29.28569134084312);
+    R_s=R_NASA_2002/SiH2I2.MM);
 
   constant IdealGases.Common.DataRecord SiH3(
     name="SiH3",
@@ -15368,7 +15371,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={605632.122,-4721.254059999999,13.29129523,-0.001256824868,
         2.68828594e-007,-3.010741582e-011,1.370945857e-015},
     bhigh={49744.2064,-61.405031},
-    R_s=267.2674941143040);
+    R_s=R_NASA_2002/SiH3.MM);
 
   constant IdealGases.Common.DataRecord SiH3Br(
     name="SiH3Br",
@@ -15382,7 +15385,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={927928.578,-5917.93579,16.99209298,-0.001487507364,3.123451161e-007,
         -3.44907147e-011,1.553431675e-015},
     bhigh={22415.60128,-79.4861159},
-    R_s=74.89650791454575);
+    R_s=R_NASA_2002/SiH3Br.MM);
 
   constant IdealGases.Common.DataRecord SiH3CL(
     name="SiH3CL",
@@ -15396,7 +15399,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={908778.094,-5958.94956,17.02076016,-0.001498450667,3.146813781e-007,
         -3.47516846e-011,1.565281681e-015},
     bhigh={14937.93206,-81.27277864},
-    R_s=124.9131640844250);
+    R_s=R_NASA_2002/SiH3CL.MM);
 
   constant IdealGases.Common.DataRecord SiH3F(
     name="SiH3F",
@@ -15410,7 +15413,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={862431.317,-6103.37057,17.12733597,-0.001540724131,3.23962872e-007,-3.58105689e-011,
         1.61415138e-015},
     bhigh={-12614.87616,-83.99227209999999},
-    R_s=165.9327039628893);
+    R_s=R_NASA_2002/SiH3F.MM);
 
   constant IdealGases.Common.DataRecord SiH3I(
     name="SiH3I",
@@ -15424,7 +15427,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={936114.918,-5859.72029,16.95376698,-0.00147349713,3.094475885e-007,-3.41746247e-011,
         1.539334807e-015},
     bhigh={31274.99231,-78.01700080000001},
-    R_s=52.61888851599598);
+    R_s=R_NASA_2002/SiH3I.MM);
 
   constant IdealGases.Common.DataRecord SiH4(
     name="SiH4",
@@ -15438,7 +15441,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1290378.74,-7813.39978,18.28851664,-0.001975620946,4.15650215e-007,-4.59674561e-011,
         2.072777131e-015},
     bhigh={47668.8795,-98.0169746},
-    R_s=258.8798048152302);
+    R_s=R_NASA_2002/SiH4.MM);
 
   constant IdealGases.Common.DataRecord SiI(
     name="SiI",
@@ -15452,7 +15455,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={852940.2790000001,-2442.039471,7.72297752,-0.001985601243,
         6.542866629999999e-007,-9.49415829e-011,4.89004137e-015},
     bhigh={45781.6094,-17.33975081},
-    R_s=53.64547138114808);
+    R_s=R_NASA_2002/SiI.MM);
 
   constant IdealGases.Common.DataRecord SiI2(
     name="SiI2",
@@ -15466,7 +15469,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={10021.68907,14.33017148,6.70133055,0.00039607699,-2.073866165e-007,
         4.5534571e-011,-3.01679828e-015},
     bhigh={9007.368100000002,0.2887336913},
-    R_s=29.49511881114079);
+    R_s=R_NASA_2002/SiI2.MM);
 
   constant IdealGases.Common.DataRecord SiN(
     name="SiN",
@@ -15480,7 +15483,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2932685.132,5853.68859,1.321451677,0.001258329284,-3.77388636e-007,
         6.88776104e-011,-4.18984259e-015},
     bhigh={6527.14881,25.53145732},
-    R_s=197.5308964606269);
+    R_s=R_NASA_2002/SiN.MM);
 
   constant IdealGases.Common.DataRecord SiO(
     name="SiO",
@@ -15494,7 +15497,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-176513.4162,-31.9917709,4.47744193,4.59176471e-006,3.55814315e-008,
         -1.327012559e-011,1.613253297e-015},
     bhigh={-13508.4236,-0.838695733},
-    R_s=188.602219807689);
+    R_s=R_NASA_2002/SiO.MM);
 
   constant IdealGases.Common.DataRecord SiO2(
     name="SiO2",
@@ -15508,7 +15511,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-146403.1193,-626.144106,7.96456371,-0.0001854119096,4.09521467e-008,
         -4.69720676e-012,2.17805428e-016},
     bhigh={-37918.3477,-20.45285414},
-    R_s=138.3807417245437);
+    R_s=R_NASA_2002/SiO2.MM);
 
   constant IdealGases.Common.DataRecord SiS(
     name="SiS",
@@ -15522,7 +15525,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2102323.897,6228.83618,-3.004120882,0.004495499930000001,-1.368821364e-006,
         1.998097253e-010,-9.882035800000001e-015},
     bhigh={-27955.38166,54.05828786},
-    R_s=138.2284436538350);
+    R_s=R_NASA_2002/SiS.MM);
 
   constant IdealGases.Common.DataRecord SiS2(
     name="SiS2",
@@ -15536,7 +15539,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-126648.9071,-97.7423522,7.57280368,-2.905413928e-005,
         6.40558784e-009,-7.329273340000001e-013,3.38981978e-017},
     bhigh={-1244.672263,-13.52710463},
-    R_s=90.1639095379844);
+    R_s=R_NASA_2002/SiS2.MM);
 
   constant IdealGases.Common.DataRecord Si2(
     name="Si2",
@@ -15550,7 +15553,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1370060.657,-4207.06004,9.337432890000001,-0.002749217168,
         9.586345959999999e-007,-1.372449748e-010,6.765028100000001e-015},
     bhigh={95108.84539999999,-31.6838519},
-    R_s=148.0213989425148);
+    R_s=R_NASA_2002/Si2.MM);
 
   constant IdealGases.Common.DataRecord Si2C(
     name="Si2C",
@@ -15564,7 +15567,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-125382.9442,-341.427779,7.25436533,-0.0001017635503,
         2.250902158e-008,-2.584074852e-012,1.198884876e-016},
     bhigh={66080.0938,-11.46216579},
-    R_s=121.9463580403539);
+    R_s=R_NASA_2002/Si2C.MM);
 
   constant IdealGases.Common.DataRecord Si2F6(
     name="Si2F6",
@@ -15578,7 +15581,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-918630.314,157.3948683,21.41256129,-0.0002681898667,7.21228011e-008,
         -9.18425266e-012,4.53723836e-016},
     bhigh={-296617.6753,-78.4902247},
-    R_s=48.8624862150891);
+    R_s=R_NASA_2002/Si2F6.MM);
 
   constant IdealGases.Common.DataRecord Si2N(
     name="Si2N",
@@ -15592,7 +15595,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-280502.6986,250.2366876,7.0924561,0.0002853120795,-9.79210181e-008,
         1.552154244e-011,-8.03626045e-016},
     bhigh={43420.1479,-10.0957091},
-    R_s=118.4779495480758);
+    R_s=R_NASA_2002/Si2N.MM);
 
   constant IdealGases.Common.DataRecord Si3(
     name="Si3",
@@ -15606,7 +15609,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1699395.561,4697.81538,2.618198124,0.001959082075,-2.581160603e-007,
         6.10344486e-012,6.08630924e-016},
     bhigh={42779.1681,25.86540384},
-    R_s=98.6809326283432);
+    R_s=R_NASA_2002/Si3.MM);
 
   constant IdealGases.Common.DataRecord Sn(
     name="Sn",
@@ -15620,7 +15623,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-5145695.64,11405.75108,-4.17963206,0.002236390679,-3.60321977e-007,
         2.440237836e-011,-2.937628285e-016},
     bhigh={-42150.1357,59.81450930000001},
-    R_s=70.0405189116334);
+    R_s=R_NASA_2002/Sn.MM);
 
   constant IdealGases.Common.DataRecord Snplus(
     name="Snplus",
@@ -15634,7 +15637,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4622916.850000001,-11859.58712,12.37026473,-0.002773624217,
         3.09851349e-007,-5.362951439999999e-012,-8.663474691e-016},
     bhigh={199432.2977,-68.3710828},
-    R_s=70.04084259461079);
+    R_s=R_NASA_2002/Snplus.MM);
 
   constant IdealGases.Common.DataRecord Snminus(
     name="Snminus",
@@ -15648,7 +15651,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-64477.1322,743.05551,1.921380256,0.0002361623997,-5.28066836e-008,
         6.10233938e-012,-2.843422486e-016},
     bhigh={16457.39414,12.65436865},
-    R_s=70.04019523164769);
+    R_s=R_NASA_2002/Snminus.MM);
 
   constant IdealGases.Common.DataRecord SnBr(
     name="SnBr",
@@ -15662,7 +15665,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1815578.541,-6728.26458,13.32464516,-0.0046081023,1.236439537e-006,-1.528863587e-010,
         6.971513500000001e-015},
     bhigh={49255.8309,-56.4096278},
-    R_s=41.86265822147482);
+    R_s=R_NASA_2002/SnBr.MM);
 
   constant IdealGases.Common.DataRecord SnBr2(
     name="SnBr2",
@@ -15676,7 +15679,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-19408.94091,-2.335607932,7.00196926,-8.622241869999999e-007,
         2.039869794e-010,-2.464780359e-014,1.189850894e-018},
     bhigh={-16448.28122,-0.434935475},
-    R_s=29.85268456616808);
+    R_s=R_NASA_2002/SnBr2.MM);
 
   constant IdealGases.Common.DataRecord SnBr3(
     name="SnBr3",
@@ -15690,7 +15693,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-38930.0453,-4.99084417,10.00418437,-1.82499691e-006,4.30564666e-010,
         -5.19188793e-014,2.502455595e-018},
     bhigh={-22172.99473,-12.29854098},
-    R_s=23.19754367756444);
+    R_s=R_NASA_2002/SnBr3.MM);
 
   constant IdealGases.Common.DataRecord SnBr4(
     name="SnBr4",
@@ -15704,7 +15707,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-51768.1292,-7.42612695,13.00619502,-2.692587978e-006,6.3367598e-010,
         -7.62708719e-014,3.671112e-018},
     bhigh={-43001.6634,-24.71455118},
-    R_s=18.96878122675816);
+    R_s=R_NASA_2002/SnBr4.MM);
 
   constant IdealGases.Common.DataRecord SnCL(
     name="SnCL",
@@ -15718,7 +15721,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={774160.568,-3602.04848,9.749059819999999,-0.002596198909,
         6.36771216e-007,-6.75429557e-011,2.484167602e-015},
     bhigh={24424.47662,-32.25454098},
-    R_s=53.93323949326363);
+    R_s=R_NASA_2002/SnCL.MM);
 
   constant IdealGases.Common.DataRecord SnCL2(
     name="SnCL2",
@@ -15732,7 +15735,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-39035.88490000001,-7.94796268,7.00648762,-2.776594714e-006,
         6.461341420000001e-010,-7.1190674e-015,3.68813118e-018},
     bhigh={-26545.29653,-3.368081174},
-    R_s=43.84920048941018);
+    R_s=R_NASA_2002/SnCL2.MM);
 
   constant IdealGases.Common.DataRecord SnCL3(
     name="SnCL3",
@@ -15746,7 +15749,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-74829.66399999999,-15.28523914,10.01240305,-5.28558124e-006,
         1.226095111e-009,-1.459895108e-013,6.96887978e-018},
     bhigh={-38308.7827,-16.63063137},
-    R_s=36.94204888278706);
+    R_s=R_NASA_2002/SnCL3.MM);
 
   constant IdealGases.Common.DataRecord SnCL4(
     name="SnCL4",
@@ -15760,7 +15763,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-107833.6862,-25.54305872,13.02040391,-8.5951259e-006,
         1.976570888e-009,-2.337929994e-013,1.110287624e-017},
     bhigh={-61635.6203,-30.72702622},
-    R_s=31.91480949785431);
+    R_s=R_NASA_2002/SnCL4.MM);
 
   constant IdealGases.Common.DataRecord SnF(
     name="SnF",
@@ -15774,7 +15777,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={25897.15476,-1484.478214,7.37851893,-0.00132424444,2.847634043e-007,
         -2.360371345e-011,6.11678371e-016},
     bhigh={-4776.68897,-16.81202516},
-    R_s=60.3776516667939);
+    R_s=R_NASA_2002/SnF.MM);
 
   constant IdealGases.Common.DataRecord SnF2(
     name="SnF2",
@@ -15788,7 +15791,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-102775.8772,-44.5175162,7.03326876,-1.329882797e-005,
         2.934271938e-009,-3.35841592e-013,1.553358669e-017},
     bhigh={-63621.2588,-6.81008452},
-    R_s=53.05774644387112);
+    R_s=R_NASA_2002/SnF2.MM);
 
   constant IdealGases.Common.DataRecord SnF3(
     name="SnF3",
@@ -15802,7 +15805,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-182931.9689,-75.5735868,10.05671455,-2.275132668e-005,
         5.03469582e-009,-5.77653096e-013,2.67721417e-017},
     bhigh={-80918.97590000001,-21.91673972},
-    R_s=47.32079383945597);
+    R_s=R_NASA_2002/SnF3.MM);
 
   constant IdealGases.Common.DataRecord SnF4(
     name="SnF4",
@@ -15816,7 +15819,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-263569.2764,-144.5469969,13.10690681,-4.23775579e-005,
         9.28687195e-009,-1.057062694e-012,4.86710868e-017},
     bhigh={-127153.9967,-38.039219},
-    R_s=42.70341921462281);
+    R_s=R_NASA_2002/SnF4.MM);
 
   constant IdealGases.Common.DataRecord SnI(
     name="SnI",
@@ -15830,7 +15833,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-55549.91850000001,-1530.457453,7.93260139,-0.002108885464,
         7.8098036e-007,-1.348104887e-010,8.207184700000001e-015},
     bhigh={27448.64953,-16.26822892},
-    R_s=33.85187362943234);
+    R_s=R_NASA_2002/SnI.MM);
 
   constant IdealGases.Common.DataRecord SnI2(
     name="SnI2",
@@ -15844,7 +15847,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-15594.5339,-1.594789414,7.00135116,-5.93532424e-007,
         1.407432564e-010,-1.703457321e-014,8.23361171e-019},
     bhigh={-3100.608319,1.235038509},
-    R_s=22.31969735552238);
+    R_s=R_NASA_2002/SnI2.MM);
 
   constant IdealGases.Common.DataRecord SnI3(
     name="SnI3",
@@ -15858,7 +15861,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-25175.3487,-2.34828289,10.0019913,-8.752764839999999e-007,
         2.07646498e-010,-2.514060336e-014,1.215482266e-018},
     bhigh={-4017.05561,-9.26390846},
-    R_s=16.64821839248585);
+    R_s=R_NASA_2002/SnI3.MM);
 
   constant IdealGases.Common.DataRecord SnI4(
     name="SnI4",
@@ -15872,7 +15875,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-28018.40706,-2.474699366,13.00210215,-9.250962339999999e-007,
         2.196515817e-010,-2.661071614e-014,1.287167546e-018},
     bhigh={-18250.83832,-20.27484281},
-    R_s=13.27501180372172);
+    R_s=R_NASA_2002/SnI4.MM);
 
   constant IdealGases.Common.DataRecord SnO(
     name="SnO",
@@ -15886,7 +15889,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2555955.548,7870.0535,-5.43976873,0.00630781918,-2.06887137e-006,
         3.30707488e-010,-1.848169716e-014},
     bhigh={-48416.6391,71.75952460000001},
-    R_s=61.72182490605704);
+    R_s=R_NASA_2002/SnO.MM);
 
   constant IdealGases.Common.DataRecord SnO2(
     name="SnO2",
@@ -15900,7 +15903,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-157355.8926,-142.7316788,7.60570076,-4.19800853e-005,
         9.218742430000002e-009,-1.051372983e-012,4.84957927e-017},
     bhigh={-523.453187,-14.28360169},
-    R_s=55.16937298950028);
+    R_s=R_NASA_2002/SnO2.MM);
 
   constant IdealGases.Common.DataRecord SnS(
     name="SnS",
@@ -15914,7 +15917,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1797985.129,6141.73632,-4.01950488,0.005993829179999999,-2.188735204e-006,
         3.899542e-010,-2.40656363e-014},
     bhigh={-26113.49815,62.56820705},
-    R_s=55.14515005803350);
+    R_s=R_NASA_2002/SnS.MM);
 
   constant IdealGases.Common.DataRecord SnS2(
     name="SnS2",
@@ -15928,7 +15931,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-67640.84050000001,-19.70189679,7.51533387,-6.33255918e-006,
         1.434207625e-009,-1.676383081e-013,7.886911900000001e-018},
     bhigh={15650.53629,-9.922744838},
-    R_s=45.47423977247867);
+    R_s=R_NASA_2002/SnS2.MM);
 
   constant IdealGases.Common.DataRecord Sn2(
     name="Sn2",
@@ -15942,7 +15945,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4275783.04,12364.21656,-8.43833617,0.00708805629,-1.712012737e-006,
         1.805262952e-010,-7.058656809999999e-015},
     bhigh={-30014.1872,100.5138538},
-    R_s=35.0202594558167);
+    R_s=R_NASA_2002/Sn2.MM);
 
   constant IdealGases.Common.DataRecord Sr(
     name="Sr",
@@ -15956,7 +15959,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={14894144.1,-43753.3505,51.3726628,-0.02592566025,6.58299e-006,-6.949611799999999e-010,
         2.417779662e-014},
     bhigh={297754.5522,-345.489077},
-    R_s=94.89283268660124);
+    R_s=R_NASA_2002/Sr.MM);
 
   constant IdealGases.Common.DataRecord Srplus(
     name="Srplus",
@@ -15970,7 +15973,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3145095.058,-9514.756889999999,13.50086948,-0.00605971712,
         1.594068746e-006,-1.718800946e-010,6.322256169e-015},
     bhigh={145799.1907,-72.3641693},
-    R_s=94.8934268264547);
+    R_s=R_NASA_2002/Srplus.MM);
 
   constant IdealGases.Common.DataRecord SrBr(
     name="SrBr",
@@ -15984,7 +15987,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3009976.114,-9193.19224,15.26033745,-0.00600925395,1.692611858e-006,
         -2.039438429e-010,8.807775840000001e-015},
     bhigh={49228.06129999999,-70.6825383},
-    R_s=49.63175425610659);
+    R_s=R_NASA_2002/SrBr.MM);
 
   constant IdealGases.Common.DataRecord SrBr2(
     name="SrBr2",
@@ -15998,7 +16001,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-11861.73059,-1.404383013,7.50121557,-5.415983190000001e-007,
         1.296969275e-010,-1.580911652e-014,7.68158227e-019},
     bhigh={-51185.75210000001,-3.55203711},
-    R_s=33.60375543592480);
+    R_s=R_NASA_2002/SrBr2.MM);
 
   constant IdealGases.Common.DataRecord SrCL(
     name="SrCL",
@@ -16012,7 +16015,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2070217.324,-6199.89173,11.50315072,-0.00367568546,9.46173235e-007,-9.203765750000001e-011,
         2.707242192e-015},
     bhigh={22714.71632,-45.61058514},
-    R_s=67.55754714681531);
+    R_s=R_NASA_2002/SrCL.MM);
 
   constant IdealGases.Common.DataRecord SrCLplus(
     name="SrCLplus",
@@ -16026,7 +16029,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-21324.75783,-4.05794827,4.50314939,3.82620238e-005,2.67695151e-009,
         5.667610500000001e-014,1.613288103e-018},
     bhigh={47693.2603,3.637722496},
-    R_s=67.55784828707816);
+    R_s=R_NASA_2002/SrCLplus.MM);
 
   constant IdealGases.Common.DataRecord SrCL2(
     name="SrCL2",
@@ -16040,7 +16043,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-25927.16099,-5.26378585,7.00447524,-1.970397814e-006,4.6796712e-010,
         -5.67021588e-014,2.742892387e-018},
     bhigh={-60453.9953,-2.192202775},
-    R_s=52.44887274011834);
+    R_s=R_NASA_2002/SrCL2.MM);
 
   constant IdealGases.Common.DataRecord SrF(
     name="SrF",
@@ -16054,7 +16057,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={870234.0489999999,-2589.81877,7.20026422,-0.001173446296,
         1.996165066e-007,1.103842667e-011,-2.343183859e-015},
     bhigh={-21336.71699,-16.67390309},
-    R_s=77.98381658749135);
+    R_s=R_NASA_2002/SrF.MM);
 
   constant IdealGases.Common.DataRecord SrFplus(
     name="SrFplus",
@@ -16068,7 +16071,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-47520.8206,-25.26802345,4.51929528,2.55642675e-005,3.38254183e-009,
         -1.511394636e-013,9.53749118e-018},
     bhigh={23838.61417,1.892197325},
-    R_s=77.98421785163177);
+    R_s=R_NASA_2002/SrFplus.MM);
 
   constant IdealGases.Common.DataRecord SrF2(
     name="SrF2",
@@ -16082,7 +16085,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-61262.6543,-19.64060822,7.01555775,-6.51252678e-006,
         1.490473613e-009,-1.75643704e-013,8.317093849999999e-018},
     bhigh={-96567.0125,-5.40230876},
-    R_s=66.1894712839953);
+    R_s=R_NASA_2002/SrF2.MM);
 
   constant IdealGases.Common.DataRecord SrH(
     name="SrH",
@@ -16096,7 +16099,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-226982.5428,1345.209458,1.152194421,0.003109555289,-1.188080968e-006,
         2.073091147e-010,-1.300839287e-014},
     bhigh={17355.47062,21.12916944},
-    R_s=93.81364386896504);
+    R_s=R_NASA_2002/SrH.MM);
 
   constant IdealGases.Common.DataRecord SrI(
     name="SrI",
@@ -16110,7 +16113,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2201136.857,-7082.2307,13.32597928,-0.00530586442,1.63607115e-006,-2.205540591e-010,
         1.078496824e-014},
     bhigh={42190.77170000001,-55.308332},
-    R_s=38.75786291419342);
+    R_s=R_NASA_2002/SrI.MM);
 
   constant IdealGases.Common.DataRecord SrI2(
     name="SrI2",
@@ -16124,7 +16127,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-8090.381920000001,-0.734826323,7.50064006,-2.863515042e-007,
         6.87655697e-011,-8.398807359999999e-015,4.08696816e-019},
     bhigh={-35721.0642,-1.693119087},
-    R_s=24.35209505087647);
+    R_s=R_NASA_2002/SrI2.MM);
 
   constant IdealGases.Common.DataRecord SrO(
     name="SrO",
@@ -16138,7 +16141,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-51729330.5,151082.1,-161.4513515,0.08516051790000001,-2.091669402e-005,
         2.452307103e-009,-1.108841292e-013},
     bhigh={-968782.9519999999,1197.846971},
-    R_s=80.24086223236189);
+    R_s=R_NASA_2002/SrO.MM);
 
   constant IdealGases.Common.DataRecord SrOH(
     name="SrOH",
@@ -16152,7 +16155,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2545648.379,-7416.19598,13.81956204,-0.003096481934,7.72389421e-007,
         -7.921280320000001e-011,2.740829111e-015},
     bhigh={22313.02058,-61.4878113},
-    R_s=79.46785228411618);
+    R_s=R_NASA_2002/SrOH.MM);
 
   constant IdealGases.Common.DataRecord SrOHplus(
     name="SrOHplus",
@@ -16166,7 +16169,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={867969.566,-2340.609538,7.97682975,0.0001023752569,-6.28603233e-008,
         1.024851502e-011,-5.72368392e-016},
     bhigh={50731.5772,-20.27046917},
-    R_s=79.46826896576320);
+    R_s=R_NASA_2002/SrOHplus.MM);
 
   constant IdealGases.Common.DataRecord Sr_OH_2(
     name="Sr_OH_2",
@@ -16180,7 +16183,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1750013.518,-4681.6015,13.95548402,0.000203501956,-1.253496115e-007,
         2.044549432e-011,-1.142004855e-015},
     bhigh={-44271.7024,-50.5145685},
-    R_s=68.35640953714845);
+    R_s=R_NASA_2002/Sr_OH_2.MM);
 
   constant IdealGases.Common.DataRecord SrS(
     name="SrS",
@@ -16194,7 +16197,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-13794329.47,39213.3158,-36.0286638,0.01818513386,-3.27585816e-006,
         2.324312746e-010,-3.6145557e-015},
     bhigh={-241024.6179,299.1679642},
-    R_s=69.46994193090195);
+    R_s=R_NASA_2002/SrS.MM);
 
   constant IdealGases.Common.DataRecord Sr2(
     name="Sr2",
@@ -16208,7 +16211,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={209844.5682,103.865013,2.30933233,0.0001330517507,-4.42643339e-008,
         6.71141915e-012,-3.374128e-016},
     bhigh={36366.4269,21.68088517},
-    R_s=47.44641634330062);
+    R_s=R_NASA_2002/Sr2.MM);
 
   constant IdealGases.Common.DataRecord Ta(
     name="Ta",
@@ -16222,7 +16225,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1689726.898,-5986.85466,9.565039670000001,-0.002511649459,
         6.44303117e-007,-7.189237249999999e-011,3.11335207e-015},
     bhigh={130671.0983,-43.3509627},
-    R_s=45.94974575554621);
+    R_s=R_NASA_2002/Ta.MM);
 
   constant IdealGases.Common.DataRecord Taplus(
     name="Taplus",
@@ -16236,7 +16239,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={3656142.13,-12540.73524,18.65022579,-0.007943274660000001,
         2.151786937e-006,-2.816764844e-010,1.413722944e-014},
     bhigh={263687.6455,-106.5864286},
-    R_s=45.94988506695545);
+    R_s=R_NASA_2002/Taplus.MM);
 
   constant IdealGases.Common.DataRecord Taminus(
     name="Taminus",
@@ -16250,7 +16253,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4235467.48,11010.56361,-4.73691107,0.002503562129,-4.82185169e-007,
         4.88640803e-011,-2.030547835e-015},
     bhigh={15746.99408,64.918027},
-    R_s=45.94960644498170);
+    R_s=R_NASA_2002/Taminus.MM);
 
   constant IdealGases.Common.DataRecord TaCL5(
     name="TaCL5",
@@ -16264,7 +16267,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-142644.4545,-38.9434032,16.0314237,-1.333676355e-005,
         3.084307611e-009,-3.66393006e-013,1.745841795e-017},
     bhigh={-97012.9717,-42.56986372},
-    R_s=23.21108480459526);
+    R_s=R_NASA_2002/TaCL5.MM);
 
   constant IdealGases.Common.DataRecord TaO(
     name="TaO",
@@ -16278,7 +16281,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6106591.12,-19841.35246,28.15797433,-0.01330045882,3.87680749e-006,-5.068872769999999e-010,
         2.443666035e-014},
     bhigh={152581.4433,-165.8307106},
-    R_s=42.21692808177620);
+    R_s=R_NASA_2002/TaO.MM);
 
   constant IdealGases.Common.DataRecord TaO2(
     name="TaO2",
@@ -16292,7 +16295,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1297565.964,-4149.217430000001,10.41680373,-0.001045478838,
         2.754904271e-007,-3.29704313e-011,1.356249074e-015},
     bhigh={3418.98567,-33.9264279},
-    R_s=39.04502863862178);
+    R_s=R_NASA_2002/TaO2.MM);
 
   constant IdealGases.Common.DataRecord Ti(
     name="Ti",
@@ -16306,7 +16309,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-170478.6714,1073.852803,1.181955014,0.0002245246352,
         3.091697848e-007,-5.74002728e-011,2.927371014e-015},
     bhigh={49780.69910000001,17.40431368},
-    R_s=173.700252783755);
+    R_s=R_NASA_2002/Ti.MM);
 
   constant IdealGases.Common.DataRecord Tiplus(
     name="Tiplus",
@@ -16320,7 +16323,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-768546.308,2545.8681,0.342386278,0.000709990136,2.706231875e-008,-2.3716601e-011,
         1.895443077e-015},
     bhigh={119882.1489,24.8479915},
-    R_s=173.7022435717890);
+    R_s=R_NASA_2002/Tiplus.MM);
 
   constant IdealGases.Common.DataRecord Timinus(
     name="Timinus",
@@ -16334,7 +16337,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={23411.1764,2.580413872,2.497754577,9.76907204e-007,-2.280024955e-010,
         2.717202291e-014,-1.295670294e-018},
     bhigh={54546.62179999999,7.99982395},
-    R_s=173.6982620413530);
+    R_s=R_NASA_2002/Timinus.MM);
 
   constant IdealGases.Common.DataRecord TiCL(
     name="TiCL",
@@ -16348,7 +16351,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-963322.542,2868.829781,1.973820676,0.001752668011,-4.25543436e-007,
         5.0491034e-011,-2.304720715e-015},
     bhigh={-1811.011561,23.19450287},
-    R_s=99.79008641382623);
+    R_s=R_NASA_2002/TiCL.MM);
 
   constant IdealGases.Common.DataRecord TiCL2(
     name="TiCL2",
@@ -16362,7 +16365,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3190012.95,10157.63826,-4.84079477,0.00682200634,-1.70075327e-006,
         2.118106588e-010,-1.041245457e-014},
     bhigh={-94809.82980000001,78.23195948},
-    R_s=70.00336776876900);
+    R_s=R_NASA_2002/TiCL2.MM);
 
   constant IdealGases.Common.DataRecord TiCL3(
     name="TiCL3",
@@ -16376,7 +16379,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-94087.92310000002,-125.5351109,10.66923972,-0.0002637456897,
         7.95916935e-008,-1.176740054e-011,6.41622348e-016},
     bhigh={-67691.1468,-23.69164216},
-    R_s=53.91120822688782);
+    R_s=R_NASA_2002/TiCL3.MM);
 
   constant IdealGases.Common.DataRecord TiCL4(
     name="TiCL4",
@@ -16390,7 +16393,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-143256.2278,-43.1677485,13.03337752,-1.371365738e-005,
         3.093403483e-009,-3.60424516e-013,1.691384523e-017},
     bhigh={-95889.46999999999,-32.47541011},
-    R_s=43.83463641204351);
+    R_s=R_NASA_2002/TiCL4.MM);
 
   constant IdealGases.Common.DataRecord TiO(
     name="TiO",
@@ -16404,7 +16407,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2330644.03,-7415.79386,12.81799311,-0.004344555950000001,
         1.186303111e-006,-1.367644275e-010,5.70321225e-015},
     bhigh={51448.4136,-57.9399424},
-    R_s=130.1859819873987);
+    R_s=R_NASA_2002/TiO.MM);
 
   constant IdealGases.Common.DataRecord TiOplus(
     name="TiOplus",
@@ -16418,7 +16421,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={342132.953,-2161.85106,8.02517566,-0.002708700692,1.004583805e-006,-1.50576685e-010,
         8.04565811e-015},
     bhigh={93626.4699,-22.61587887},
-    R_s=130.1871002693624);
+    R_s=R_NASA_2002/TiOplus.MM);
 
   constant IdealGases.Common.DataRecord TiOCL(
     name="TiOCL",
@@ -16432,7 +16435,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-127305.9873,-111.111885,7.58288808,-3.3128718e-005,7.31401409e-009,
         -8.37882226e-013,3.87927506e-017},
     bhigh={-31393.56857,-12.47104274},
-    R_s=83.71486336002836);
+    R_s=R_NASA_2002/TiOCL.MM);
 
   constant IdealGases.Common.DataRecord TiOCL2(
     name="TiOCL2",
@@ -16446,7 +16449,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-132295.1633,-96.91212050000002,10.07240769,-2.897248531e-005,
         6.40177504e-009,-7.3384526e-013,3.39928267e-017},
     bhigh={-68474.09640000001,-19.75043469},
-    R_s=61.69297274516148);
+    R_s=R_NASA_2002/TiOCL2.MM);
 
   constant IdealGases.Common.DataRecord TiO2(
     name="TiO2",
@@ -16460,7 +16463,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={154629.9764,-1046.25688,7.78898583,-0.0001546805714,-7.05993595e-008,
         3.100244802e-011,-2.49472543e-015},
     bhigh={-32663.3675,-15.9153466},
-    R_s=104.1060128365333);
+    R_s=R_NASA_2002/TiO2.MM);
 
   constant IdealGases.Common.DataRecord U(
     name="U",
@@ -16474,7 +16477,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4092498.96,12748.88349,-12.18707506,0.00725810568,-7.78777507e-007,
         -3.84435385e-011,7.066508567e-015},
     bhigh={-16993.72664,115.5026301},
-    R_s=34.93067291699987);
+    R_s=R_NASA_2002/U.MM);
 
   constant IdealGases.Common.DataRecord UF(
     name="UF",
@@ -16488,7 +16491,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-5325439.37,15339.67086,-11.75044398,0.00964721093,-2.49877819e-006,
         3.155572896e-010,-1.544694839e-014},
     bhigh={-105719.6525,122.0828149},
-    R_s=32.34874105978867);
+    R_s=R_NASA_2002/UF.MM);
 
   constant IdealGases.Common.DataRecord UFplus(
     name="UFplus",
@@ -16502,7 +16505,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={539509.184,-2923.962095,10.08511948,-0.002425945123,5.92872548e-007,
         -6.79584554e-011,3.152666445e-015},
     bhigh={82672.91220000001,-33.07089704},
-    R_s=32.34881010520256);
+    R_s=R_NASA_2002/UFplus.MM);
 
   constant IdealGases.Common.DataRecord UFminus(
     name="UFminus",
@@ -16516,7 +16519,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4311143.56,19748.17938,-27.60304763,0.02276806261,-6.88874172e-006,
         9.483511059999999e-010,-4.9106881e-014},
     bhigh={-138080.129,224.0758537},
-    R_s=32.34867201466950);
+    R_s=R_NASA_2002/UFminus.MM);
 
   constant IdealGases.Common.DataRecord UF2(
     name="UF2",
@@ -16530,7 +16533,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-471677.682,322.423686,8.214090629999999,-0.000140741378,
         6.54117805e-009,1.818915497e-012,-2.287963719e-016},
     bhigh={-69952.3505,-9.648963156000001},
-    R_s=30.12222958222888);
+    R_s=R_NASA_2002/UF2.MM);
 
   constant IdealGases.Common.DataRecord UF2plus(
     name="UF2plus",
@@ -16544,7 +16547,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3779149.61,12987.37504,-10.27930641,0.01048838051,-2.651047812e-006,
         3.116973593e-010,-1.417216291e-014},
     bhigh={-74334.402,118.9131079},
-    R_s=30.12228945015788);
+    R_s=R_NASA_2002/UF2plus.MM);
 
   constant IdealGases.Common.DataRecord UF2minus(
     name="UF2minus",
@@ -16558,7 +16561,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={10382318.55,-28401.13518,34.9853337,-0.01053216396,1.92462047e-006,-1.69874957e-010,
         5.70985889e-015},
     bhigh={100157.2794,-209.4039075},
-    R_s=30.12216971453784);
+    R_s=R_NASA_2002/UF2minus.MM);
 
   constant IdealGases.Common.DataRecord UF3(
     name="UF3",
@@ -16572,7 +16575,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3828876.42,12968.91783,-7.26555429,0.01048289752,-2.649840687e-006,
         3.115594509e-010,-1.4165794e-014},
     bhigh={-211361.5913,105.4464687},
-    R_s=28.18247542361279);
+    R_s=R_NASA_2002/UF3.MM);
 
   constant IdealGases.Common.DataRecord UF3plus(
     name="UF3plus",
@@ -16586,7 +16589,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1196316.388,3972.78507,4.53590711,0.00413341615,-1.097960689e-006,
         1.319641252e-010,-6.10112918e-015},
     bhigh={-61995.4174,21.37623045},
-    R_s=28.18252782927640);
+    R_s=R_NASA_2002/UF3plus.MM);
 
   constant IdealGases.Common.DataRecord UF3minus(
     name="UF3minus",
@@ -16600,7 +16603,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-191005.3149,-506.918131,11.81482258,-0.0001711879404,-9.38483918e-008,
         2.242009537e-011,-1.42819528e-015},
     bhigh={-143862.8681,-27.74680411},
-    R_s=28.18242301814408);
+    R_s=R_NASA_2002/UF3minus.MM);
 
   constant IdealGases.Common.DataRecord UF4(
     name="UF4",
@@ -16614,7 +16617,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1230291.173,3876.46379,7.62162591,0.004094525220000001,-1.088530094e-006,
         1.308042117e-010,-6.04439087e-015},
     bhigh={-221414.292,6.270300658},
-    R_s=26.47743201940801);
+    R_s=R_NASA_2002/UF4.MM);
 
   constant IdealGases.Common.DataRecord UF4plus(
     name="UF4plus",
@@ -16628,7 +16631,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1617630.159,3765.93477,9.16613853,0.002426641067,-5.695320299999999e-007,
         6.021096599999999e-011,-2.438874329e-015},
     bhigh={-106191.0645,-4.162641042},
-    R_s=26.47747827578622);
+    R_s=R_NASA_2002/UF4plus.MM);
 
   constant IdealGases.Common.DataRecord UF4minus(
     name="UF4minus",
@@ -16642,7 +16645,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-4639200.11,16268.24426,-9.59529105,0.01441556535,-4.008173850000001e-006,
         5.140230790000001e-010,-2.511687821e-014},
     bhigh={-312514.0933,127.4038784},
-    R_s=26.47738576319141);
+    R_s=R_NASA_2002/UF4minus.MM);
 
   constant IdealGases.Common.DataRecord UF5(
     name="UF5",
@@ -16656,7 +16659,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1695373.88,3735.42535,12.1874804,0.002418608203,-5.67852616e-007,
         6.00276561e-011,-2.430740809e-015},
     bhigh={-264510.7342,-18.83137475},
-    R_s=24.96692955565201);
+    R_s=R_NASA_2002/UF5.MM);
 
   constant IdealGases.Common.DataRecord UF5plus(
     name="UF5plus",
@@ -16670,7 +16673,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-262847.8263,-117.4047323,16.08988291,-3.66551671e-005,
         8.221494970000001e-009,-9.53716052e-013,4.46014508e-017},
     bhigh={-107629.3931,-47.63374165000001},
-    R_s=24.96697068483954);
+    R_s=R_NASA_2002/UF5plus.MM);
 
   constant IdealGases.Common.DataRecord UF5minus(
     name="UF5minus",
@@ -16684,7 +16687,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1331518.187,3905.51686,10.58727667,0.00411250727,-1.09327793e-006,
         1.314215436e-010,-6.07577827e-015},
     bhigh={-304950.6955,-7.977511665},
-    R_s=24.96688842659999);
+    R_s=R_NASA_2002/UF5minus.MM);
 
   constant IdealGases.Common.DataRecord UF6(
     name="UF6",
@@ -16698,7 +16701,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-340902.792,-145.8950046,19.10902533,-4.358451129999999e-005,
         9.617604659999999e-009,-1.100915551e-012,5.09264508e-017},
     bhigh={-264364.5561,-65.79130395999999},
-    R_s=23.61947004130590);
+    R_s=R_NASA_2002/UF6.MM);
 
   constant IdealGases.Common.DataRecord UF6minus(
     name="UF6minus",
@@ -16712,7 +16715,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2699676.848,-6574.45967,22.41731997,0.000605779971,-4.51749171e-007,
         7.821820469999999e-011,-4.56033472e-015},
     bhigh={-285566.7984,-91.82896336},
-    R_s=23.61943323190370);
+    R_s=R_NASA_2002/UF6minus.MM);
 
   constant IdealGases.Common.DataRecord UO(
     name="UO",
@@ -16726,7 +16729,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-2458660.003,3942.65216,5.01603072,-0.0005450639469999999,
         2.096321351e-007,-2.654652526e-011,1.361108472e-015},
     bhigh={-26651.49645,5.580598689},
-    R_s=32.73064328932472);
+    R_s=R_NASA_2002/UO.MM);
 
   constant IdealGases.Common.DataRecord UOplus(
     name="UOplus",
@@ -16740,7 +16743,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-106371.4748,-1793.716133,8.024449049999999,-0.001565116442,
         5.06603391e-007,-7.37397747e-011,4.07476643e-015},
     bhigh={77890.8584,-21.1528425},
-    R_s=32.73071397463411);
+    R_s=R_NASA_2002/UOplus.MM);
 
   constant IdealGases.Common.DataRecord UOF(
     name="UOF",
@@ -16754,7 +16757,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-3805936.01,12952.07909,-10.25373631,0.01047841671,-2.648894949e-006,
         3.114551623e-010,-1.416111895e-014},
     bhigh={-147897.6701,118.4570601},
-    R_s=30.45310073344135);
+    R_s=R_NASA_2002/UOF.MM);
 
   constant IdealGases.Common.DataRecord UOF2(
     name="UOF2",
@@ -16768,7 +16771,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1198944.06,3852.17341,4.63910975,0.00408773844,-1.087067018e-006,
         1.306398384e-010,-6.03690152e-015},
     bhigh={-161263.7583,20.18237189},
-    R_s=28.47190030261383);
+    R_s=R_NASA_2002/UOF2.MM);
 
   constant IdealGases.Common.DataRecord UOF3(
     name="UOF3",
@@ -16782,7 +16785,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1658296.049,3714.43468,9.20242554,0.002412862293,-5.66624172e-007,
         5.98906211e-011,-2.42453481e-015},
     bhigh={-210549.1714,-5.670532802},
-    R_s=26.73273715985561);
+    R_s=R_NASA_2002/UOF3.MM);
 
   constant IdealGases.Common.DataRecord UOF4(
     name="UOF4",
@@ -16796,7 +16799,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-299619.0288,-167.7276501,16.12494871,-4.98441446e-005,
         1.098253497e-008,-1.255803231e-012,5.80448098e-017},
     bhigh={-219545.926,-50.24484645},
-    R_s=25.1938111548994);
+    R_s=R_NASA_2002/UOF4.MM);
 
   constant IdealGases.Common.DataRecord UO2(
     name="UO2",
@@ -16810,7 +16813,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1190542.635,3832.18635,2.153236312,0.00408235191,-1.085924847e-006,
         1.305134065e-010,-6.03121575e-015},
     bhigh={-83676.1801,25.90742388},
-    R_s=30.79132137957249);
+    R_s=R_NASA_2002/UO2.MM);
 
   constant IdealGases.Common.DataRecord UO2plus(
     name="UO2plus",
@@ -16824,7 +16827,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1589957.42,3657.74607,3.74678542,0.002394401448,-5.62410144e-007,
         5.93945164e-011,-2.401047056e-015},
     bhigh={-20485.58817,14.64015614},
-    R_s=30.79138393668275);
+    R_s=R_NASA_2002/UO2plus.MM);
 
   constant IdealGases.Common.DataRecord UO2minus(
     name="UO2minus",
@@ -16838,7 +16841,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-273825.164,3228.53442,-0.2805114576,0.006607310710000001,-2.070291015e-006,
         2.851708013e-010,-1.466578192e-014},
     bhigh={-88934.3618,41.45760316},
-    R_s=30.79125882271642);
+    R_s=R_NASA_2002/UO2minus.MM);
 
   constant IdealGases.Common.DataRecord UO2F(
     name="UO2F",
@@ -16852,7 +16855,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1614277.202,3712.77186,6.20330882,0.002412618055,-5.665888019999999e-007,
         5.98882352e-011,-2.424485602e-015},
     bhigh={-147835.7384,8.736139132},
-    R_s=28.76733146339111);
+    R_s=R_NASA_2002/UO2F.MM);
 
   constant IdealGases.Common.DataRecord UO2F2(
     name="UO2F2",
@@ -16866,7 +16869,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-263655.2036,-203.2835065,13.15092994,-6.00648683e-005,
         1.321137913e-008,-1.508668985e-012,6.96618275e-017},
     bhigh={-166444.4818,-35.66258175},
-    R_s=26.99301372882539);
+    R_s=R_NASA_2002/UO2F2.MM);
 
   constant IdealGases.Common.DataRecord UO3(
     name="UO3",
@@ -16880,7 +16883,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1097362.721,2808.784061,5.96612147,0.002861871152,-1.05284381e-006,
         1.849985929e-010,-1.102849619e-014},
     bhigh={-117336.0017,6.672828312},
-    R_s=29.06895783410181);
+    R_s=R_NASA_2002/UO3.MM);
 
   constant IdealGases.Common.DataRecord UO3minus(
     name="UO3minus",
@@ -16894,7 +16897,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1632938.634,3667.49541,6.24003065,0.002396952522,-5.62949023e-007,
         5.94541313e-011,-2.403730982e-015},
     bhigh={-184592.7385,7.032059012},
-    R_s=29.06890207994731);
+    R_s=R_NASA_2002/UO3minus.MM);
 
   constant IdealGases.Common.DataRecord V(
     name="V",
@@ -16908,7 +16911,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1200390.3,-5027.0053,10.58830594,-0.005044326100000001,
         1.488547375e-006,-1.785922508e-010,8.113013866e-015},
     bhigh={91707.40909999999,-47.6833632},
-    R_s=163.2168271448622);
+    R_s=R_NASA_2002/V.MM);
 
   constant IdealGases.Common.DataRecord Vplus(
     name="Vplus",
@@ -16922,7 +16925,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2347072.054,-9021.197190000001,14.77349798,-0.00689189688,
         1.968884877e-006,-2.539798544e-010,1.226783122e-014},
     bhigh={195835.1444,-78.5559293},
-    R_s=163.2185848810040);
+    R_s=R_NASA_2002/Vplus.MM);
 
   constant IdealGases.Common.DataRecord Vminus(
     name="Vminus",
@@ -16936,7 +16939,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={26001.0043,2.096334097,2.498006548,8.991278839999999e-007,-2.139749508e-010,
         2.581021334e-014,-1.240812796e-018},
     bhigh={54700.0708,7.97790024},
-    R_s=163.2150694465790);
+    R_s=R_NASA_2002/Vminus.MM);
 
   constant IdealGases.Common.DataRecord VCL4(
     name="VCL4",
@@ -16950,7 +16953,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1717776.251,4550.441049999999,8.164464799999999,0.002224875998,-4.094111780000001e-007,
         3.2717875e-011,-8.8586908e-016},
     bhigh={-96906.20060000001,4.348293098},
-    R_s=43.13545538732112);
+    R_s=R_NASA_2002/VCL4.MM);
 
   constant IdealGases.Common.DataRecord VN(
     name="VN",
@@ -16964,7 +16967,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1018619.667,-3932.30557,9.856823609999999,-0.00328922171,
         1.005181767e-006,-1.243211436e-010,5.48677656e-015},
     bhigh={85573.18339999999,-35.52830762},
-    R_s=128.0175586082447);
+    R_s=R_NASA_2002/VN.MM);
 
   constant IdealGases.Common.DataRecord VO(
     name="VO",
@@ -16978,7 +16981,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2986190.283,-10113.44974,17.18161749,-0.00787670503,2.562279547e-006,
         -3.54740035e-010,1.770268056e-014},
     bhigh={79612.5488,-87.89993010000001},
-    R_s=124.2067256341041);
+    R_s=R_NASA_2002/VO.MM);
 
   constant IdealGases.Common.DataRecord VO2(
     name="VO2",
@@ -16992,7 +16995,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={121063.2401,-1627.832993,9.252713099999999,-0.001572703139,
         5.23143016e-007,-6.476071140000001e-011,2.847226026e-015},
     bhigh={-20973.06345,-25.47380687},
-    R_s=100.2469245951606);
+    R_s=R_NASA_2002/VO2.MM);
 
   constant IdealGases.Common.DataRecord V4O10(
     name="V4O10",
@@ -17006,7 +17009,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-1360273.27,-1341.69286,40.9913859,-0.000393226553,8.62849412e-008,-9.83594409e-012,
         4.53563729e-016},
     bhigh={-348461.612,-190.7911348},
-    R_s=22.85713107543436);
+    R_s=R_NASA_2002/V4O10.MM);
 
   constant IdealGases.Common.DataRecord W(
     name="W",
@@ -17020,7 +17023,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-8048745.96,14657.00424,-0.2508531501,-0.002596486992,
         1.409225475e-006,-2.233011706e-010,1.262640862e-014},
     bhigh={-3091.130919,39.5582219},
-    R_s=45.22688207136640);
+    R_s=R_NASA_2002/W.MM);
 
   constant IdealGases.Common.DataRecord Wplus(
     name="Wplus",
@@ -17034,7 +17037,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6387743.399999999,-20618.11463,27.59291576,-0.01244535845,
         3.27120049e-006,-4.065463720000001e-010,1.912595872e-014},
     bhigh={324517.443,-171.6919194},
-    R_s=45.22701703405976);
+    R_s=R_NASA_2002/Wplus.MM);
 
   constant IdealGases.Common.DataRecord Wminus(
     name="Wminus",
@@ -17046,7 +17049,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     blow={91429.8137,8.46116967},
     ahigh={0,0,2.5,0,0,0,0},
     bhigh={91429.8137,8.46116967},
-    R_s=45.22674710947855);
+    R_s=R_NASA_2002/Wminus.MM);
 
   constant IdealGases.Common.DataRecord WCL6(
     name="WCL6",
@@ -17060,7 +17063,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-151673.5473,-34.5137925,19.02867176,-1.242486969e-005,
         2.917675103e-009,-3.50598144e-013,1.685355887e-017},
     bhigh={-65357.79790000001,-58.94914959000001},
-    R_s=20.96669339667842);
+    R_s=R_NASA_2002/WCL6.MM);
 
   constant IdealGases.Common.DataRecord WO(
     name="WO",
@@ -17074,7 +17077,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1262156.956,-4177.263120000001,9.35828647,-0.00288761222,
         8.89393396e-007,-8.955318699999999e-011,2.504359614e-015},
     bhigh={73133.8064,-31.4488229},
-    R_s=41.60595958554720);
+    R_s=R_NASA_2002/WO.MM);
 
   constant IdealGases.Common.DataRecord WOCL4(
     name="WOCL4",
@@ -17088,7 +17091,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-304902.8285,-353.942586,16.26432703,-0.0001058245461,
         2.340548846e-008,-2.685852021e-012,1.245412684e-016},
     bhigh={-72725.46739999999,-49.91761253},
-    R_s=24.33623863388237);
+    R_s=R_NASA_2002/WOCL4.MM);
 
   constant IdealGases.Common.DataRecord WO2(
     name="WO2",
@@ -17102,7 +17105,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-753740.6680000001,3204.64305,0.6701965600000001,0.00448823887,-8.858328459999999e-007,
         6.24517175e-011,-9.046613900000001e-016},
     bhigh={-17694.2023,34.0572401},
-    R_s=38.52185056625593);
+    R_s=R_NASA_2002/WO2.MM);
 
   constant IdealGases.Common.DataRecord WO2CL2(
     name="WO2CL2",
@@ -17116,7 +17119,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-240479.173,-306.8379644,13.22814502,-9.10022071e-005,
         2.00658102e-008,-2.296837607e-012,1.062829386e-016},
     bhigh={-83674.93059999999,-34.91556626},
-    R_s=28.99620150042825);
+    R_s=R_NASA_2002/WO2CL2.MM);
 
   constant IdealGases.Common.DataRecord WO3(
     name="WO3",
@@ -17130,7 +17133,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={1732203.64,-6284.719779999999,16.81358864,-0.00347208936,
         8.079935799999999e-007,-6.589378720000001e-011,1.142928957e-015},
     bhigh={-2473.075565,-74.0747409},
-    R_s=35.86341681396767);
+    R_s=R_NASA_2002/WO3.MM);
 
   constant IdealGases.Common.DataRecord WO3minus(
     name="WO3minus",
@@ -17144,7 +17147,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={463783.251,-1347.089334,9.773637559999999,0.001071395459,-3.84240366e-007,
         5.7375319e-011,-3.157605982e-015},
     bhigh={-72395.1557,-23.91116343},
-    R_s=35.86333195036923);
+    R_s=R_NASA_2002/WO3minus.MM);
 
   constant IdealGases.Common.DataRecord Xe(
     name="Xe",
@@ -17157,7 +17160,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={4025.22668,-12.09507521,2.514153347,-8.248102080000001e-006,
         2.530232618e-009,-3.89233323e-013,2.360439138e-017},
     bhigh={-668.5800730000001,6.063710715},
-    R_s=63.3279001926988);
+    R_s=R_NASA_2002/Xe.MM);
 
   constant IdealGases.Common.DataRecord Xeplus(
     name="Xeplus",
@@ -17171,7 +17174,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-12416.83887,-150.0654643,2.964678293,-0.000469339666,
         1.959138719e-007,-3.037761925e-011,1.637361082e-015},
     bhigh={141496.6808,4.565685735},
-    R_s=63.32816480567290);
+    R_s=R_NASA_2002/Xeplus.MM);
 
   constant IdealGases.Common.DataRecord Zn(
     name="Zn",
@@ -17184,7 +17187,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-175559.1489,498.413924,1.969386292,0.0002608808787,-5.62719508e-008,
         2.723336049e-012,4.266685808e-016},
     bhigh={11737.73458,8.961085649999999},
-    R_s=127.1526227251873);
+    R_s=R_NASA_2002/Zn.MM);
 
   constant IdealGases.Common.DataRecord Znplus(
     name="Znplus",
@@ -17198,7 +17201,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-343617.946,956.7355239999999,1.511478952,0.000461346796,-8.786800980000001e-008,
         7.558567779999999e-013,1.168827311e-015},
     bhigh={118532.1933,13.0074267},
-    R_s=127.1536895016679);
+    R_s=R_NASA_2002/Znplus.MM);
 
   constant IdealGases.Common.DataRecord Zr(
     name="Zr",
@@ -17212,7 +17215,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={6006771.84,-15669.60605,17.9698235,-0.00676340965,1.733678968e-006,-2.064699786e-010,
         9.334092610000001e-015},
     bhigh={173463.6249,-105.1117377},
-    R_s=91.1438875734456);
+    R_s=R_NASA_2002/Zr.MM);
 
   constant IdealGases.Common.DataRecord Zrplus(
     name="Zrplus",
@@ -17226,7 +17229,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={729813.716,-2017.117556,5.0374983,-0.000550337195,1.023753499e-007,-1.261537793e-011,
         7.092401041999999e-016},
     bhigh={162088.4945,-9.820640859999999},
-    R_s=91.14443569496429);
+    R_s=R_NASA_2002/Zrplus.MM);
 
   constant IdealGases.Common.DataRecord Zrminus(
     name="Zrminus",
@@ -17240,7 +17243,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={84718.61159999999,317.543934,2.251491246,0.0001018645389,-2.285208242e-008,
         2.647293502e-012,-1.235813604e-016},
     bhigh={64223.376,10.81261057},
-    R_s=91.14333945851938);
+    R_s=R_NASA_2002/Zrminus.MM);
 
   constant IdealGases.Common.DataRecord ZrN(
     name="ZrN",
@@ -17254,7 +17257,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-72557.9089,-81.267966,4.5599244,1.29116165e-005,
         5.203830769999999e-009,-5.92743667e-013,2.731548854e-017},
     bhigh={84686.48390000001,1.493633264},
-    R_s=79.01220841446461);
+    R_s=R_NASA_2002/ZrN.MM);
 
   constant IdealGases.Common.DataRecord ZrO(
     name="ZrO",
@@ -17268,7 +17271,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={464809.831,344.231447,4.81577918,-0.000466063314,2.140489079e-007,-2.054364483e-011,
         4.08466776e-016},
     bhigh={7317.3407,1.502933548},
-    R_s=77.54380107327319);
+    R_s=R_NASA_2002/ZrO.MM);
 
   constant IdealGases.Common.DataRecord ZrOplus(
     name="ZrOplus",
@@ -17282,7 +17285,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={-493716.656,669.990076,4.57535347,-0.00069232379,4.28060094e-007,-7.54766022e-011,
         4.41427986e-015},
     bhigh={80188.80660000001,2.928943704},
-    R_s=77.5441978219953);
+    R_s=R_NASA_2002/ZrOplus.MM);
 
   constant IdealGases.Common.DataRecord ZrO2(
     name="ZrO2",
@@ -17296,7 +17299,7 @@ package SingleGasesData "Ideal gas data based on the NASA Glenn coefficients"
     ahigh={2854363.887,-8738.589889999999,16.21315114,-0.004417922830000001,
         8.959096920000001e-007,-4.054667109999999e-011,-2.147732083e-015},
     bhigh={15275.10023,-74.8199549},
-    R_s=67.47541851021077);
+    R_s=R_NASA_2002/ZrO2.MM);
 
   annotation (Documentation(info="<html>
 <p>This package contains ideal gas models for the 1241 ideal gases from</p>


### PR DESCRIPTION
Recalculated all the `R_s` values for each Ideal gas record in SingleGasesData, using `R=8.314510` specified in the original 
McBride B.J., Zehe M.J., and Gordon S. (2002) (NASA Glenn coefficients) paper.

See #4233 for discussion. 