### PR TITLE
- added partial massFraction to partialMedium

### DIFF
--- a/Modelica/Media/package.mo
+++ b/Modelica/Media/package.mo
@@ -4539,6 +4539,12 @@ This function computes an isentropic state transformation:
               X));
     end specificEnthalpy_psX;
 
+    replaceable partial function massFraction "Return independent mass fractions (if any)"
+      extends Modelica.Icons.Function;
+      input ThermodynamicState state "Thermodynamic state record";
+      output MassFraction Xi[nXi] "(independent) Mass fractions";
+    end massFraction;
+	
     type MassFlowRate = SI.MassFlowRate (
         quantity="MassFlowRate." + mediumName,
         min=-1.0e5,
@@ -4722,6 +4728,14 @@ are described in
               T,
               fill(0, 0)));
     end density_pT;
+
+    redeclare replaceable function massFraction "Return independent mass fractions (if any)"
+      extends Modelica.Icons.Function;
+      input ThermodynamicState state "Thermodynamic state record";
+      output MassFraction Xi[nXi] "Independent mass fractions";
+    algorithm
+      Xi := fill(0,0);
+    end massFraction;
 
     redeclare replaceable partial model extends BaseProperties(final
         standardOrderComponents=true)
@@ -5095,6 +5109,14 @@ to the above list of assumptions</li>
       MassFraction[nX] X(start=reference_X)
         "Mass fractions (= (component mass)/total mass  m_i/m)";
     end ThermodynamicState;
+	
+	redeclare replaceable function massFraction "Return independent mass fractions (if any)"
+      extends Modelica.Icons.Function;
+      input ThermodynamicState state "Thermodynamic state record";
+      output MassFraction Xi[nXi] "Independent mass fractions";
+    algorithm
+      Xi := state.X[1:nXi];
+    end massFraction;
 
     constant FluidConstants[nS] fluidConstants "Constant data for the fluid";
 

--- a/ModelicaTest/Media.mo
+++ b/ModelicaTest/Media.mo
@@ -694,6 +694,7 @@ package Media "Test models for Modelica.Media"
       Real gamma2=Medium.isothermalCompressibility(medium2.state);
       Medium.SpecificEnthalpy h_is=Medium.isentropicEnthalpyApproximation(2.0e5,
           medium.state);
+      Medium.MassFraction Xi[Medium.nXi] = Medium.massFraction(medium.state);
     equation
       der(medium.p) = 1000.0;
       der(medium.T) = 1000;
@@ -789,6 +790,8 @@ is given to compare the approximation.
       Medium.IsentropicExponent gamma=Medium.isentropicExponent(medium.state);
       Medium.SpecificEntropy s=Medium.specificEntropy(medium.state);
       Medium.VelocityOfSound a=Medium.velocityOfSound(medium.state);
+      Medium.MassFraction Xi[Medium.nXi] = Medium.massFraction(medium.state);
+
     equation
 
       m = medium.d*V;
@@ -925,6 +928,7 @@ is given to compare the approximation.
       SI.SpecificEntropy s = Medium.specificEntropy(state);
       SI.SpecificInternalEnergy u = Medium.specificInternalEnergy(state);
       SI.Temperature Tsat = Medium.saturationTemperature(p);
+      Medium.MassFraction Xi[Medium.nXi] = Medium.massFraction(state);
       annotation (experiment(StopTime=1));
     end MoistAir;
 


### PR DESCRIPTION
This is a second pull request replacing #3825 which attempted to resolve #3650.
#3825 should be discarded and archived consequently.

This pull request is based on the most recent master of the MSL andI have taken the critic of #3825 into account:
- The comments now speak of "mass fractions"  instead of "mass fraction" in order to be consistent with the ot´ther comments
- I have extended the examples of ModelicaTest to include calls of this function at 3 examples to cover the pureSubstance case as well as the reduced and non-reduced Mixture case.

The added function is till called massFraction not massFractions for the following reasons:
- to be consistent with the outputType
- to be compatible with the ThermoFluidStream implementation already using this function
- to be compatible with the XRG extensions to their media where they have implemented it.

The following changes are included in the pull request.

- implemented massFraction for partialPureSubstance
- implemented massFraction for PartialMixtureMedium
- added 3 test cases for ModeliceTest covering pure / reduced mixture / non-reduced misture