### PR TITLE
Update version, uses annotation and copyright year

### DIFF
--- a/Complex.mo
+++ b/Complex.mo
@@ -251,7 +251,7 @@ operator record Complex "Complex number with overloaded operators"
 annotation (
 version="4.1.0",
 versionDate="2024-01-12",
-dateModified = "2024-01-10 11:00:00Z",
+dateModified = "2024-01-12 19:40:00Z",
 revisionId="$Format:%h %ci$",
 conversion(
  noneFromVersion="4.0.0",

--- a/Complex.mo
+++ b/Complex.mo
@@ -250,7 +250,7 @@ operator record Complex "Complex number with overloaded operators"
 
 annotation (
 version="4.1.0",
-versionDate="2024-03-15",
+versionDate="2024-01-12",
 dateModified = "2024-01-10 11:00:00Z",
 revisionId="$Format:%h %ci$",
 conversion(

--- a/Complex.mo
+++ b/Complex.mo
@@ -249,11 +249,12 @@ operator record Complex "Complex number with overloaded operators"
   end 'String';
 
 annotation (
-version="4.0.0",
-versionDate="2020-06-04",
-dateModified = "2020-06-04 11:00:00Z",
+version="4.1.0",
+versionDate="2024-03-15",
+dateModified = "2024-01-10 11:00:00Z",
 revisionId="$Format:%h %ci$",
 conversion(
+ noneFromVersion="4.0.0",
  noneFromVersion="3.2.3",
  noneFromVersion="3.2.2",
  noneFromVersion="3.2.1",
@@ -263,7 +264,7 @@ Documentation(info="<html>
 <p>Complex number defined as a record containing real and imaginary part, utilizing operator overloading.</p>
 <p>
 <strong>Licensed by the Modelica Association under the 3-Clause BSD License</strong><br>
-Copyright &copy; 2010-2020, Modelica Association and <a href=\"modelica://Modelica.UsersGuide.Contact\">contributors</a>
+Copyright &copy; 2010-2024, Modelica Association and <a href=\"modelica://Modelica.UsersGuide.Contact\">contributors</a>
 </p>
 
 <p>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 1998-2020, Modelica Association and contributors
+Copyright (c) 1998-2024, Modelica Association and contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Modelica/Blocks/Tables.mo
+++ b/Modelica/Blocks/Tables.mo
@@ -1339,7 +1339,7 @@ initial equation
   dummy = getUsertab(table.y);
 equation
   connect(clock.y, table.u[1]) annotation (Line(points={{-59,10},{-42,10}}, color={0,0,127}));
-  annotation (experiment(StartTime=0, StopTime=5), uses(Modelica(version=\"4.0.0\")));
+  annotation (experiment(StartTime=0, StopTime=5));
 end ExampleCTable;
 </pre></blockquote>
 </html>"), Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},

--- a/Modelica/Blocks/package.mo
+++ b/Modelica/Blocks/package.mo
@@ -3237,7 +3237,7 @@ This library contains input/output blocks to build up block diagrams.
     email: <a href=\"mailto:Martin.Otter@dlr.de\">Martin.Otter@dlr.de</a><br></dd>
 </dl>
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>", revisions="<html>
 <ul>

--- a/Modelica/Clocked/package.mo
+++ b/Modelica/Clocked/package.mo
@@ -47,7 +47,7 @@ Furthermore:
      gives author and acknowledgement information for this library.</li>
 </ul>
 <p>
-<em>Copyright &copy; 2012-2020, Modelica Association and contributors.</em>
+<em>Copyright &copy; 2012-2024, Modelica Association and contributors.</em>
 </p>
 </html>",
 revisions="<html>
@@ -68,7 +68,7 @@ revisions="<html>
 
 <tr><td></td><td>Several releases as <em>Modelica_Synchronous</em> library.</td></tr>
 
-<tr><td> 2019 </td><td>The <em>Modelica_Synchronous</em> library is included as <em>Modelica.Clocked</em> in the Modelica Standard Library 4.0.0.</td></tr>
+<tr><td> 2019 </td><td>The <em>Modelica_Synchronous</em> library is included as <em>Modelica.Clocked</em> in the Modelica Standard Library 4.1.0.</td></tr>
 
 <tr><td></td><td>see <a href=\"modelica://Modelica.Clocked.UsersGuide.ReleaseNotes\">Release Notes</a>.</td></tr>
 

--- a/Modelica/Clocked/package.mo
+++ b/Modelica/Clocked/package.mo
@@ -68,7 +68,7 @@ revisions="<html>
 
 <tr><td></td><td>Several releases as <em>Modelica_Synchronous</em> library.</td></tr>
 
-<tr><td> 2019 </td><td>The <em>Modelica_Synchronous</em> library is included as <em>Modelica.Clocked</em> in the Modelica Standard Library 4.1.0.</td></tr>
+<tr><td> 2019 </td><td>The <em>Modelica_Synchronous</em> library is included as <em>Modelica.Clocked</em> in the Modelica Standard Library.</td></tr>
 
 <tr><td></td><td>see <a href=\"modelica://Modelica.Clocked.UsersGuide.ReleaseNotes\">Release Notes</a>.</td></tr>
 

--- a/Modelica/ComplexBlocks/UsersGuide/Contact.mo
+++ b/Modelica/ComplexBlocks/UsersGuide/Contact.mo
@@ -21,7 +21,7 @@ email: <a href=\"mailto:a.haumer@haumer.at\">a.haumer@haumer.at</a><br>
 <h4>Acknowledgements</h4>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>"));
 end Contact;

--- a/Modelica/Constants.mo
+++ b/Modelica/Constants.mo
@@ -91,7 +91,7 @@ dependent constants and constants from nature. The latter constants
 </dl>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>", revisions="<html>
 <ul>

--- a/Modelica/Electrical/Analog/Basic/package.mo
+++ b/Modelica/Electrical/Analog/Basic/package.mo
@@ -23,7 +23,7 @@ Christoph Clau&szlig;
 </dl>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>"), Icon(graphics={
         Line(points={{-12,60},{-12,-60}}),

--- a/Modelica/Electrical/Analog/Ideal/package.mo
+++ b/Modelica/Electrical/Analog/Ideal/package.mo
@@ -23,7 +23,7 @@ Christoph Clau&szlig;
 </dl>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>"), Icon(graphics={
         Line(points={{-90,0},{-40,0}}),

--- a/Modelica/Electrical/Analog/Interfaces/package.mo
+++ b/Modelica/Electrical/Analog/Interfaces/package.mo
@@ -29,7 +29,7 @@ Christoph Clau&szlig;
 </ul>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>"));
 end Interfaces;

--- a/Modelica/Electrical/Analog/Lines/package.mo
+++ b/Modelica/Electrical/Analog/Lines/package.mo
@@ -24,7 +24,7 @@ Christoph Clau&szlig;
 </dl>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>"), Icon(graphics={
         Line(points={{-60,50},{-90,50}}),

--- a/Modelica/Electrical/Analog/Sensors/package.mo
+++ b/Modelica/Electrical/Analog/Sensors/package.mo
@@ -25,7 +25,7 @@ Christoph Clau&szlig;
 </dl>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>"));
 end Sensors;

--- a/Modelica/Electrical/Analog/Sources/package.mo
+++ b/Modelica/Electrical/Analog/Sources/package.mo
@@ -23,7 +23,7 @@ Christoph Clau&szlig;
 </dl>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>"));
 end Sources;

--- a/Modelica/Electrical/Analog/UsersGuide/ReleaseNotes.mo
+++ b/Modelica/Electrical/Analog/UsersGuide/ReleaseNotes.mo
@@ -3,7 +3,7 @@ class ReleaseNotes "Release Notes"
   extends Modelica.Icons.ReleaseNotes;
   annotation (preferredView="info",Documentation(info="<html>
 
-<h5>Version 4.1.0, 2024-03-15</h5>
+<h5>Version 4.0.0, 2020-06-04</h5>
 <ul>
   <li>Add User's Guide, see
       <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/2990\">#2990</a></li>

--- a/Modelica/Electrical/Analog/UsersGuide/ReleaseNotes.mo
+++ b/Modelica/Electrical/Analog/UsersGuide/ReleaseNotes.mo
@@ -3,7 +3,7 @@ class ReleaseNotes "Release Notes"
   extends Modelica.Icons.ReleaseNotes;
   annotation (preferredView="info",Documentation(info="<html>
 
-<h5>Version 4.0.0, 2020-06-04</h5>
+<h5>Version 4.1.0, 2024-03-15</h5>
 <ul>
   <li>Add User's Guide, see
       <a href=\"https://github.com/modelica/ModelicaStandardLibrary/issues/2990\">#2990</a></li>

--- a/Modelica/Electrical/Digital.mo
+++ b/Modelica/Electrical/Digital.mo
@@ -7169,7 +7169,7 @@ the library is implemented and released for public use.
 </p>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>"), Icon(coordinateSystem(preserveAspectRatio=false,
                 extent={{-100,-100},{100,100}}), graphics={

--- a/Modelica/Electrical/Machines/package.mo
+++ b/Modelica/Electrical/Machines/package.mo
@@ -7,7 +7,7 @@ package Machines "Library for electric machines"
     Documentation(info="<html>
 <p><strong>For a discrimination of various machine models, see <a href=\"modelica://Modelica.Electrical.Machines.UsersGuide.Discrimination\">discrimination</a></strong>.</p>
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>", revisions="<html>
 </html>"),

--- a/Modelica/Electrical/Polyphase/package.mo
+++ b/Modelica/Electrical/Polyphase/package.mo
@@ -4,7 +4,7 @@ package Polyphase "Library for electrical components of one or more phases"
 
   annotation (Documentation(info="<html>
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>", revisions="<html>
   <ul>

--- a/Modelica/Electrical/PowerConverters/package.mo
+++ b/Modelica/Electrical/PowerConverters/package.mo
@@ -16,7 +16,7 @@ This library provides power converters for DC and AC single-phase and polyphase 
 </ul>
 
 <p>
-Copyright &copy; 2013-2020, Modelica Association and contributors
+Copyright &copy; 2013-2024, Modelica Association and contributors
 </p>
 </html>"),
     Icon(graphics={

--- a/Modelica/Electrical/QuasiStatic/Machines/package.mo
+++ b/Modelica/Electrical/QuasiStatic/Machines/package.mo
@@ -30,7 +30,7 @@ package Machines "Quasi-static machine models"
               -100},{-70,-100},{-70,-90}})}), preferredView="info", Documentation(info="<html>
 <p><strong>For a discrimination of various machine models, see <a href=\"modelica://Modelica.Electrical.Machines.UsersGuide.Discrimination\">discrimination</a></strong>.</p>
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 <p>This package hosts models for quasi-static transformers.
 </p>

--- a/Modelica/Electrical/QuasiStatic/package.mo
+++ b/Modelica/Electrical/QuasiStatic/package.mo
@@ -22,7 +22,7 @@ package QuasiStatic "Library for quasi-static electrical single-phase and polyph
 </dd>
 </dl>
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>", revisions="<html>
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">

--- a/Modelica/Fluid/Dissipation.mo
+++ b/Modelica/Fluid/Dissipation.mo
@@ -13140,7 +13140,7 @@ reference 01IS07022B). The project was started in October 2007 and ended in June
 </p>
 
 <p>
-Copyright &copy; 2007-2020, Modelica Association and contributors
+Copyright &copy; 2007-2024, Modelica Association and contributors
 </p>
 
 <h4>Contact</h4>

--- a/Modelica/Fluid/package.mo
+++ b/Modelica/Fluid/package.mo
@@ -1750,7 +1750,7 @@ The following parts are useful, when newly starting with this library:
      contains examples that demonstrate the usage of this library.</li>
 </ul>
 <p>
-Copyright &copy; 2002-2020, Modelica Association and contributors
+Copyright &copy; 2002-2024, Modelica Association and contributors
 </p>
 </html>"));
 end Fluid;

--- a/Modelica/Icons.mo
+++ b/Modelica/Icons.mo
@@ -812,7 +812,7 @@ corresponding library in a future release.
 </dl>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>"));
 end Icons;

--- a/Modelica/Magnetic/FluxTubes/package.mo
+++ b/Modelica/Magnetic/FluxTubes/package.mo
@@ -18,7 +18,7 @@ This library contains components for modelling of electromagnetic devices with l
 </p>
 
 <p>
-Copyright &copy; 2005-2020, Modelica Association and contributors
+Copyright &copy; 2005-2024, Modelica Association and contributors
 </p>
 </html>", revisions="<html>
 <p>

--- a/Modelica/Magnetic/FundamentalWave/package.mo
+++ b/Modelica/Magnetic/FundamentalWave/package.mo
@@ -8,7 +8,7 @@ package FundamentalWave "Library for magnetic fundamental wave effects in electr
 </html>", info="<html>
   <p><strong>For a discrimination of various machine models, see <a href=\"modelica://Modelica.Electrical.Machines.UsersGuide.Discrimination\">discrimination</a></strong>.</p>
 <p>
-Copyright &copy; 2009-2020, Modelica Association and contributors
+Copyright &copy; 2009-2024, Modelica Association and contributors
 </p>
 </html>"),
     Icon(graphics={

--- a/Modelica/Magnetic/QuasiStatic/FundamentalWave/package.mo
+++ b/Modelica/Magnetic/QuasiStatic/FundamentalWave/package.mo
@@ -4,7 +4,7 @@ package FundamentalWave "Quasi-static fundamental wave electric machines"
   annotation (preferredView="info", Documentation(info="<html>
   <p><strong>For a discrimination of various machine models, see <a href=\"modelica://Modelica.Electrical.Machines.UsersGuide.Discrimination\">discrimination</a></strong>.</p>
 <p>
-Copyright &copy; 2013-2020, Modelica Association and contributors
+Copyright &copy; 2013-2024, Modelica Association and contributors
 </p>
 </html>"),
     Icon(graphics={

--- a/Modelica/Math/Polynomials.mo
+++ b/Modelica/Math/Polynomials.mo
@@ -317,7 +317,7 @@ of data points.
 </p>
 
 <p>
-Copyright &copy; 2004-2020, Modelica Association and contributors
+Copyright &copy; 2004-2024, Modelica Association and contributors
 </p>
 </html>",     revisions="<html>
 <ul>

--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -11672,7 +11672,7 @@ email: <a href=\"mailto:Martin.Otter@dlr.de\">Martin.Otter@dlr.de</a>
 </p>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>", revisions="<html>
 <ul>

--- a/Modelica/Mechanics/MultiBody/package.mo
+++ b/Modelica/Mechanics/MultiBody/package.mo
@@ -485,7 +485,7 @@ For an introduction, have especially a look at:
 </ul>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>"), Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
             {100,100}}), graphics={

--- a/Modelica/Mechanics/Rotational/package.mo
+++ b/Modelica/Mechanics/Rotational/package.mo
@@ -44,7 +44,7 @@ positive if heat is flowing out of the heatPort). For an example, see
 </p>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>", revisions=""), Icon(
     coordinateSystem(preserveAspectRatio=true,

--- a/Modelica/Mechanics/Translational/package.mo
+++ b/Modelica/Mechanics/Translational/package.mo
@@ -98,7 +98,7 @@ positive if heat is flowing out of the heatPort). For an example, see
 </p>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>", revisions="<html>
 <ul>

--- a/Modelica/Media/Air/ReferenceAir.mo
+++ b/Modelica/Media/Air/ReferenceAir.mo
@@ -2146,7 +2146,7 @@ Some parts of this library refer to the ThermoFluid library developed at Lund Un
 </p>
 
 <p>
-Copyright &copy; 2013-2020, Modelica Association and contributors
+Copyright &copy; 2013-2024, Modelica Association and contributors
 </p>
 </html>"));
   end ReferenceAir;

--- a/Modelica/Media/Air/ReferenceMoistAir.mo
+++ b/Modelica/Media/Air/ReferenceMoistAir.mo
@@ -4152,7 +4152,7 @@ Some parts of this library refer to the ThermoFluid library developed at Lund Un
 </p>
 
 <p>
-Copyright &copy; 2013-2020, Modelica Association and contributors
+Copyright &copy; 2013-2024, Modelica Association and contributors
 </p>
 </html>"));
 end ReferenceMoistAir;

--- a/Modelica/Media/R134a.mo
+++ b/Modelica/Media/R134a.mo
@@ -9419,7 +9419,7 @@ Some parts of this library refer to the ThermoFluid library developed at Lund Un
 </p>
 
 <p>
-Copyright &copy; 2013-2020, Modelica Association and contributors
+Copyright &copy; 2013-2024, Modelica Association and contributors
 </p>
 </html>"));
 end R134a;

--- a/Modelica/Media/package.mo
+++ b/Modelica/Media/package.mo
@@ -8536,7 +8536,7 @@ The following parts are useful, when newly starting with this library:</p>
      contains examples that demonstrate the usage of this library.</li>
 </ul>
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>", revisions="<html>
 <ul>

--- a/Modelica/Resources/BuildProjects/autotools/configure.ac
+++ b/Modelica/Resources/BuildProjects/autotools/configure.ac
@@ -1,6 +1,6 @@
 dnl Init
 AC_PREREQ([2.63])
-AC_INIT([Modelica Standard Library Tables],[4.0.0],[https://github.com/modelica/ModelicaStandardLibrary],[libmodelicastandardtables],[https://modelica.org])
+AC_INIT([Modelica Standard Library Tables],[4.1.0],[https://github.com/modelica/ModelicaStandardLibrary],[libmodelicastandardtables],[https://modelica.org])
 
 AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_MACRO_DIR([m4])

--- a/Modelica/Resources/C-Sources/ModelicaFFT.c
+++ b/Modelica/Resources/C-Sources/ModelicaFFT.c
@@ -1,7 +1,7 @@
 /* ModelicaFFT.c - FFT functions
 
    Copyright (C) 2015-2024, Modelica Association and contributors
-   Copyright (C) 2003-2024, Mark Borgerding
+   Copyright (C) 2003-2010, Mark Borgerding
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/C-Sources/ModelicaFFT.c
+++ b/Modelica/Resources/C-Sources/ModelicaFFT.c
@@ -1,7 +1,7 @@
 /* ModelicaFFT.c - FFT functions
 
-   Copyright (C) 2015-2020, Modelica Association and contributors
-   Copyright (C) 2003-2010, Mark Borgerding
+   Copyright (C) 2015-2024, Modelica Association and contributors
+   Copyright (C) 2003-2024, Mark Borgerding
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/C-Sources/ModelicaFFT.h
+++ b/Modelica/Resources/C-Sources/ModelicaFFT.h
@@ -1,7 +1,7 @@
 /* ModelicaFFT.h - FFT functions header
 
-   Copyright (C) 2015-2020, Modelica Association and contributors
-   Copyright (C) 2003-2010, Mark Borgerding
+   Copyright (C) 2015-2024, Modelica Association and contributors
+   Copyright (C) 2003-2024, Mark Borgerding
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/C-Sources/ModelicaFFT.h
+++ b/Modelica/Resources/C-Sources/ModelicaFFT.h
@@ -1,7 +1,7 @@
 /* ModelicaFFT.h - FFT functions header
 
    Copyright (C) 2015-2024, Modelica Association and contributors
-   Copyright (C) 2003-2024, Mark Borgerding
+   Copyright (C) 2003-2010, Mark Borgerding
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/C-Sources/ModelicaIO.c
+++ b/Modelica/Resources/C-Sources/ModelicaIO.c
@@ -1,6 +1,6 @@
 /* ModelicaIO.c - Array I/O functions
 
-   Copyright (C) 2016-2020, Modelica Association and contributors
+   Copyright (C) 2016-2024, Modelica Association and contributors
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/C-Sources/ModelicaIO.h
+++ b/Modelica/Resources/C-Sources/ModelicaIO.h
@@ -1,6 +1,6 @@
 /* ModelicaIO.h - Array I/O functions header
 
-   Copyright (C) 2016-2020, Modelica Association and contributors
+   Copyright (C) 2016-2024, Modelica Association and contributors
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/C-Sources/ModelicaInternal.h
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.h
@@ -1,6 +1,6 @@
 /* ModelicaInternal.h - External functions header for Modelica.Utilities
 
-   Copyright (C) 2002-2020, Modelica Association and contributors
+   Copyright (C) 2002-2024, Modelica Association and contributors
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/C-Sources/ModelicaRandom.c
+++ b/Modelica/Resources/C-Sources/ModelicaRandom.c
@@ -1,6 +1,6 @@
 /* ModelicaRandom.c - External functions for Modelica.Math.Random library
 
-   Copyright (C) 2015-2020, Modelica Association and contributors
+   Copyright (C) 2015-2024, Modelica Association and contributors
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/C-Sources/ModelicaRandom.h
+++ b/Modelica/Resources/C-Sources/ModelicaRandom.h
@@ -1,6 +1,6 @@
 /* ModelicaRandom.h - External functions header for Modelica.Math.Random library
 
-   Copyright (C) 2015-2020, Modelica Association and contributors
+   Copyright (C) 2015-2024, Modelica Association and contributors
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/C-Sources/ModelicaStandardTablesUsertab.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTablesUsertab.c
@@ -1,6 +1,6 @@
 /* ModelicaStandardTablesUsertab.c - A dummy usertab function
 
-   Copyright (C) 2013-2020, Modelica Association and contributors
+   Copyright (C) 2013-2024, Modelica Association and contributors
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/C-Sources/ModelicaStrings.h
+++ b/Modelica/Resources/C-Sources/ModelicaStrings.h
@@ -1,6 +1,6 @@
 /* ModelicaStrings.h - External functions header for Modelica.Utilities.Strings
 
-   Copyright (C) 2002-2020, Modelica Association and contributors
+   Copyright (C) 2002-2024, Modelica Association and contributors
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/C-Sources/stdint_wrap.h
+++ b/Modelica/Resources/C-Sources/stdint_wrap.h
@@ -1,6 +1,6 @@
 /* stdint_wrap.h - Wrapper for stdint.h not being available with C89
 
-   Copyright (C) 2024, Modelica Association and contributors
+   Copyright (C) 2020-2024, Modelica Association and contributors
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/C-Sources/stdint_wrap.h
+++ b/Modelica/Resources/C-Sources/stdint_wrap.h
@@ -1,6 +1,6 @@
 /* stdint_wrap.h - Wrapper for stdint.h not being available with C89
 
-   Copyright (C) 2020, Modelica Association and contributors
+   Copyright (C) 2024, Modelica Association and contributors
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/Documentation/Generate-ReleaseNotes.py
+++ b/Modelica/Resources/Documentation/Generate-ReleaseNotes.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 '''
-Copyright (C) 2018-2020, Modelica Association and contributors
+Copyright (C) 2018-2024, Modelica Association and contributors
 All rights reserved.
 
 Generate MSL release notes from closed GitHub issues:

--- a/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt
+++ b/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2016-2020, Modelica Association and contributors
+Copyright (C) 2016-2024, Modelica Association and contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt
+++ b/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2002-2020, Modelica Association and contributors
+Copyright (C) 2002-2024, Modelica Association and contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/Licenses/LICENSE_ModelicaKissFFT.txt
+++ b/Modelica/Resources/Licenses/LICENSE_ModelicaKissFFT.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2015-2020, Modelica Association and contributors
+Copyright (C) 2015-2024, Modelica Association and contributors
 Copyright (C) 2003-2010, Mark Borgerding
 All rights reserved.
 

--- a/Modelica/Resources/Licenses/LICENSE_ModelicaRandom.txt
+++ b/Modelica/Resources/Licenses/LICENSE_ModelicaRandom.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2015-2020, Modelica Association and contributors
+Copyright (C) 2015-2024, Modelica Association and contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/Licenses/LICENSE_ModelicaStandardLibrary.txt
+++ b/Modelica/Resources/Licenses/LICENSE_ModelicaStandardLibrary.txt
@@ -1,4 +1,4 @@
-Copyright (c) 1998-2020, Modelica Association and contributors
+Copyright (c) 1998-2024, Modelica Association and contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Modelica/Resources/Licenses/LICENSE_ModelicaStrings.txt
+++ b/Modelica/Resources/Licenses/LICENSE_ModelicaStrings.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2002-2020, Modelica Association and contributors
+Copyright (C) 2002-2024, Modelica Association and contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Modelica/StateGraph.mo
+++ b/Modelica/StateGraph.mo
@@ -2788,7 +2788,7 @@ are nearly always needed).
 </p>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>"), Icon(coordinateSystem(extent={{-100.0,-100.0},{100.0,100.0}}), graphics={
       Rectangle(

--- a/Modelica/Thermal/FluidHeatFlow/UsersGuide/Contact.mo
+++ b/Modelica/Thermal/FluidHeatFlow/UsersGuide/Contact.mo
@@ -21,7 +21,7 @@ email: <a href=\"mailto:dr.christian.kral@gmail.com\">dr.christian.kral@gmail.co
 <h4>Acknowledgements</h4>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>"));
 end Contact;

--- a/Modelica/Thermal/FluidHeatFlow/package.mo
+++ b/Modelica/Thermal/FluidHeatFlow/package.mo
@@ -36,7 +36,7 @@ Since mixing may occur, the outlet temperature may be different from the connect
 Outlet temperature is defined by variable T of the corresponding component.</li>
 </ul>
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>"), Icon(coordinateSystem(preserveAspectRatio = true, extent = {{-100,-100},{100,100}}), graphics={
       Polygon(

--- a/Modelica/Thermal/HeatTransfer/UsersGuide/Contact.mo
+++ b/Modelica/Thermal/HeatTransfer/UsersGuide/Contact.mo
@@ -14,7 +14,7 @@ class Contact "Contact"
   </dd>
 </dl>
 <p>
-Copyright &copy; 2001-2020, Modelica Association and contributors
+Copyright &copy; 2001-2024, Modelica Association and contributors
 </p>
 
 <p>

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -1890,7 +1890,7 @@ with package Units, have a look at:
 </p>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>", revisions="<html>
 <ul>

--- a/Modelica/Utilities/package.mo
+++ b/Modelica/Utilities/package.mo
@@ -211,7 +211,7 @@ The following main sublibraries are available:
 </ul>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 </html>"));
 end Utilities;

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -8537,7 +8537,6 @@ main version number is not changed.
 </p>
 
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_X_Y_0\">Version X.Y.0</a></td><td>Month D, 20YY</td></tr>
 <tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_4_1_0\">Version 4.1.0</a></td><td>March 15, 2024</td></tr>
 <tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_4_0_0\">Version 4.0.0</a></td><td>June 4, 2020</td></tr>
 <tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_2_3\">Version 3.2.3</a></td><td>January 23, 2019</td></tr>

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -1,5 +1,5 @@
 within ;
-package Modelica "Modelica Standard Library - Version 4.0.0"
+package Modelica "Modelica Standard Library - Version 4.1.0"
 extends Modelica.Icons.Package;
 
 package UsersGuide "User's Guide"
@@ -2379,15 +2379,15 @@ Modelica Standard Library and is not utilized by Modelica users.
 
 <h5>Maintenance branch</h5>
 <p>
-Name: \"maint/4.0.x\"
+Name: \"maint/4.1.x\"
 </p>
 
 <p>
-This branch contains the released Modelica Standard Library version (e.g., v4.0.0)
+This branch contains the released Modelica Standard Library version (e.g., v4.1.0)
 where all bug-fixes since this release date are included
-(also consecutive <code>BUGFIX</code> versions 4.0.1, 4.0.2, etc.,
+(also consecutive <code>BUGFIX</code> versions 4.1.1, 4.1.2, etc.,
 up to when a new <code>MINOR</code> or <code>MAJOR</code>  release becomes available;
-i.e., there will not be any further <code>BUGFIX</code> versions (i.e., 4.0.x) of a previous release).
+i.e., there will not be any further <code>BUGFIX</code> versions (i.e., 4.1.x) of a previous release).
 These bug-fixes might not yet be tested with all test cases or with
 other Modelica libraries. The goal is that a vendor may take this version at
 any time for a new release of its software, in order to incorporate the latest
@@ -8537,7 +8537,7 @@ main version number is not changed.
 </p>
 
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_X_Y_0\">Version X.Y.0</a></td><td>Month D, 20YY</td></tr>
+<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_X_Y_0\">Version 4.1.0</a></td><td>Mar 15, 2024</td></tr>
 <tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_4_0_0\">Version 4.0.0</a></td><td>June 4, 2020</td></tr>
 <tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_2_3\">Version 3.2.3</a></td><td>January 23, 2019</td></tr>
 <tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_2_2\">Version 3.2.2</a></td><td>April 3, 2016</td></tr>
@@ -9130,12 +9130,13 @@ end UsersGuide;
 
 annotation (
 preferredView="info",
-version="4.0.0",
-versionDate="2020-06-04",
-dateModified = "2020-06-04 11:00:00Z",
+version="4.1.0",
+versionDate="2024-03-15",
+dateModified = "2020-01-01 11:00:00Z",
 revisionId="$Format:%h %ci$",
-uses(Complex(version="4.0.0"), ModelicaServices(version="4.0.0")),
+uses(Complex(version="4.1.0"), ModelicaServices(version="4.1.0")),
 conversion(
+ noneFromVersion="4.0.0",
  from(version={"3.0", "3.0.1", "3.1", "3.2", "3.2.1", "3.2.2", "3.2.3"}, script="modelica://Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos")),
 Icon(coordinateSystem(extent={{-100.0,-100.0},{100.0,100.0}}), graphics={
   Polygon(

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -9132,7 +9132,7 @@ annotation (
 preferredView="info",
 version="4.1.0",
 versionDate="2024-03-15",
-dateModified = "2020-01-01 11:00:00Z",
+dateModified = "2024-04-15 11:00:00Z",
 revisionId="$Format:%h %ci$",
 uses(Complex(version="4.1.0"), ModelicaServices(version="4.1.0")),
 conversion(

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -8537,7 +8537,7 @@ main version number is not changed.
 </p>
 
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_X_Y_0\">Version 4.1.0</a></td><td>Mar 15, 2024</td></tr>
+<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_X_Y_0\">Version 4.1.0</a></td><td>March 15, 2024</td></tr>
 <tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_4_0_0\">Version 4.0.0</a></td><td>June 4, 2020</td></tr>
 <tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_2_3\">Version 3.2.3</a></td><td>January 23, 2019</td></tr>
 <tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_2_2\">Version 3.2.2</a></td><td>April 3, 2016</td></tr>

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -8537,6 +8537,7 @@ main version number is not changed.
 </p>
 
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
+<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_X_Y_0\">Version X.Y.0</a></td><td>Month D, 20YY</td></tr>
 <tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_4_1_0\">Version 4.1.0</a></td><td>March 15, 2024</td></tr>
 <tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_4_0_0\">Version 4.0.0</a></td><td>June 4, 2020</td></tr>
 <tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_2_3\">Version 3.2.3</a></td><td>January 23, 2019</td></tr>
@@ -9203,7 +9204,7 @@ and it has been tested with Modelica tools from different vendors.
 
 <p>
 <strong>Licensed by the Modelica Association under the 3-Clause BSD License</strong><br>
-Copyright &copy; 1998-2020, Modelica Association and <a href=\"modelica://Modelica.UsersGuide.Contact\">contributors</a>.
+Copyright &copy; 1998-2024, Modelica Association and <a href=\"modelica://Modelica.UsersGuide.Contact\">contributors</a>.
 </p>
 
 <p>

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -8537,7 +8537,7 @@ main version number is not changed.
 </p>
 
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
-<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_X_Y_0\">Version 4.1.0</a></td><td>March 15, 2024</td></tr>
+<tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_4_1_0\">Version 4.1.0</a></td><td>March 15, 2024</td></tr>
 <tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_4_0_0\">Version 4.0.0</a></td><td>June 4, 2020</td></tr>
 <tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_2_3\">Version 3.2.3</a></td><td>January 23, 2019</td></tr>
 <tr><td><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.Version_3_2_2\">Version 3.2.2</a></td><td>April 3, 2016</td></tr>

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -9131,7 +9131,7 @@ end UsersGuide;
 annotation (
 preferredView="info",
 version="4.1.0",
-versionDate="2024-03-15",
+versionDate="2024-01-12",
 dateModified = "2024-01-12 19:40:00Z",
 revisionId="$Format:%h %ci$",
 uses(Complex(version="4.1.0"), ModelicaServices(version="4.1.0")),

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -1,5 +1,5 @@
 within ;
-package Modelica "Modelica Standard Library - Version 4.1.0"
+package Modelica "Modelica Standard Library"
 extends Modelica.Icons.Package;
 
 package UsersGuide "User's Guide"

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -9132,7 +9132,7 @@ annotation (
 preferredView="info",
 version="4.1.0",
 versionDate="2024-03-15",
-dateModified = "2024-04-15 11:00:00Z",
+dateModified = "2024-03-15 11:00:00Z",
 revisionId="$Format:%h %ci$",
 uses(Complex(version="4.1.0"), ModelicaServices(version="4.1.0")),
 conversion(

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -9132,7 +9132,7 @@ annotation (
 preferredView="info",
 version="4.1.0",
 versionDate="2024-03-15",
-dateModified = "2024-03-15 11:00:00Z",
+dateModified = "2024-01-12 19:40:00Z",
 revisionId="$Format:%h %ci$",
 uses(Complex(version="4.1.0"), ModelicaServices(version="4.1.0")),
 conversion(

--- a/Modelica/readme.txt
+++ b/Modelica/readme.txt
@@ -2,7 +2,7 @@ All files in this directory ("Modelica") and in all subdirectories,
 especially all files that build package "Modelica" and the contents
 of the directory "Modelica/Resources" are licensed by the
 Modelica Association under the 3-Clause BSD License.
-Copyright © 1998-2020, Modelica Association and contributors
+Copyright © 1998-2024, Modelica Association and contributors
 
 These files are free software and the use is completely at your own risk;
 they can be redistributed and/or modified under the terms of the

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -7311,7 +7311,7 @@ annotation (
   DocumentationClass=true,
   version="4.1.0",
   versionDate="2024-03-15",
-  dateModified = "2024-01-01 11:00:00Z",
+  dateModified = "2024-01-12 19:40:00Z",
   revisionId="$Format:%h %ci$",
   Documentation(info="<html>
 <p>

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -7309,9 +7309,9 @@ end Icons;
 
 annotation (
   DocumentationClass=true,
-  version="4.0.0",
-  versionDate="2020-06-04",
-  dateModified = "2020-06-04 11:00:00Z",
+  version="4.1.0",
+  versionDate="2024-03-15",
+  dateModified = "2024-01-01 11:00:00Z",
   revisionId="$Format:%h %ci$",
   Documentation(info="<html>
 <p>
@@ -7323,7 +7323,7 @@ It is based on the
 </p>
 
 <p>
-Copyright &copy; 2003-2020, Modelica Association and contributors
+Copyright &copy; 2003-2024, Modelica Association and contributors
 </p>
 
 <p>

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -7310,7 +7310,7 @@ end Icons;
 annotation (
   DocumentationClass=true,
   version="4.1.0",
-  versionDate="2024-03-15",
+  versionDate="2024-01-12",
   dateModified = "2024-01-12 19:40:00Z",
   revisionId="$Format:%h %ci$",
   Documentation(info="<html>

--- a/ModelicaServices/package.mo
+++ b/ModelicaServices/package.mo
@@ -232,18 +232,19 @@ Specification (version &ge; 3.3).
 
   annotation (
     preferredView="info",
-    version="4.0.0",
-    versionDate="2020-06-04",
-    dateModified = "2020-06-04 11:00:00Z",
+    version="4.1.0",
+    versionDate="2024-03-15",
+    dateModified = "2024-01-01 11:00:00Z",
     revisionId="$Format:%h %ci$",
-    uses(Modelica(version="4.0.0")),
+    uses(Modelica(version="4.1.0")),
     conversion(
       noneFromVersion="1.0",
       noneFromVersion="1.1",
       noneFromVersion="1.2",
       noneFromVersion="3.2.1",
       noneFromVersion="3.2.2",
-      noneFromVersion="3.2.3"),
+      noneFromVersion="3.2.3",
+      noneFromVersion="4.0.0"),
     Documentation(info="<html>
 <p>
 This package contains a set of functions and models to be used in the
@@ -293,7 +294,7 @@ This ModelicaServices package provides only \"dummy\" models that do nothing.
 
 <p>
 <strong>Licensed by the Modelica Association under the 3-Clause BSD License</strong><br>
-Copyright &copy; 2009-2020, Modelica Association and contributors
+Copyright &copy; 2009-2024, Modelica Association and contributors
 </p>
 
 <p>

--- a/ModelicaServices/package.mo
+++ b/ModelicaServices/package.mo
@@ -233,7 +233,7 @@ Specification (version &ge; 3.3).
   annotation (
     preferredView="info",
     version="4.1.0",
-    versionDate="2024-03-15",
+    versionDate="2024-01-12",
     dateModified = "2024-01-01 11:00:00Z",
     revisionId="$Format:%h %ci$",
     uses(Modelica(version="4.1.0")),

--- a/ModelicaServices/package.mo
+++ b/ModelicaServices/package.mo
@@ -234,7 +234,7 @@ Specification (version &ge; 3.3).
     preferredView="info",
     version="4.1.0",
     versionDate="2024-01-12",
-    dateModified = "2024-01-01 11:00:00Z",
+    dateModified = "2024-01-12 19:40:00Z",
     revisionId="$Format:%h %ci$",
     uses(Modelica(version="4.1.0")),
     conversion(

--- a/ModelicaTest/package.mo
+++ b/ModelicaTest/package.mo
@@ -1,5 +1,5 @@
 within ;
-package ModelicaTest "Library to test components of package Modelica - Version 4.1.0"
+package ModelicaTest "Library to test components of package Modelica"
 extends Modelica.Icons.Package;
 
   import Modelica.Units.SI;

--- a/ModelicaTest/package.mo
+++ b/ModelicaTest/package.mo
@@ -53,7 +53,7 @@ end testAllFunctions;
   annotation (preferredView="info",
        version="4.1.0",
        versionDate="2024-01-12",
-       dateModified = "2024-01-01 11:00:00Z",
+       dateModified = "2024-01-12 19:40:00Z",
        revisionId="$Format:%h %ci$",
        uses(Modelica(version="4.1.0")),
     Documentation(info="<html>

--- a/ModelicaTest/package.mo
+++ b/ModelicaTest/package.mo
@@ -1,5 +1,5 @@
 within ;
-package ModelicaTest "Library to test components of package Modelica - Version 4.0.0"
+package ModelicaTest "Library to test components of package Modelica - Version 4.1.0"
 extends Modelica.Icons.Package;
 
   import Modelica.Units.SI;
@@ -51,11 +51,11 @@ algorithm
 end testAllFunctions;
 
   annotation (preferredView="info",
-       version="4.0.0",
-       versionDate="2020-06-04",
-       dateModified = "2020-06-04 11:00:00Z",
+       version="4.1.0",
+       versionDate="2024-03-15",
+       dateModified = "2024-01-01 11:00:00Z",
        revisionId="$Format:%h %ci$",
-       uses(Modelica(version="4.0.0")),
+       uses(Modelica(version="4.1.0")),
     Documentation(info="<html>
 <p>
 This library provides models and functions to test components of
@@ -84,7 +84,7 @@ way:
 </ul>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 
 <p>

--- a/ModelicaTest/package.mo
+++ b/ModelicaTest/package.mo
@@ -52,7 +52,7 @@ end testAllFunctions;
 
   annotation (preferredView="info",
        version="4.1.0",
-       versionDate="2024-03-15",
+       versionDate="2024-01-12",
        dateModified = "2024-01-01 11:00:00Z",
        revisionId="$Format:%h %ci$",
        uses(Modelica(version="4.1.0")),

--- a/ModelicaTestConversion4.mo
+++ b/ModelicaTestConversion4.mo
@@ -3212,7 +3212,7 @@ for conversion of Modelica libraries using MSL v3.x.y to MSL v4.0.0. These model
 </p>
 
 <p>
-Copyright &copy; 2019-2020, Modelica Association and contributors
+Copyright &copy; 2019-2024, Modelica Association and contributors
 </p>
 
 <p>

--- a/ModelicaTestOverdetermined.mo
+++ b/ModelicaTestOverdetermined.mo
@@ -608,11 +608,11 @@ The initial equations are consistent however and a tool shall reduce them approp
           fillColor={75,138,73},
           fillPattern=FillPattern.Solid)}),
        preferredView="info",
-       version="4.0.0",
-       versionDate="2020-06-04",
-       dateModified = "2020-06-04 11:00:00Z",
+       version="4.1.0",
+       versionDate="2024-03-15",
+       dateModified = "2024-01-01 11:00:00Z",
        revisionId="$Id::                                       $",
-       uses(Modelica(version="4.0.0")),
+       uses(Modelica(version="4.1.0")),
     Documentation(info="<html>
 <p>
 This library provides models and functions to test components of
@@ -627,7 +627,7 @@ fail during translation but give useful error messages.
 </p>
 
 <p>
-Copyright &copy; 1998-2020, Modelica Association and contributors
+Copyright &copy; 1998-2024, Modelica Association and contributors
 </p>
 
 <p>

--- a/ModelicaTestOverdetermined.mo
+++ b/ModelicaTestOverdetermined.mo
@@ -610,7 +610,7 @@ The initial equations are consistent however and a tool shall reduce them approp
        preferredView="info",
        version="4.1.0",
        versionDate="2024-01-12",
-       dateModified = "2024-01-01 11:00:00Z",
+       dateModified = "2024-01-12 19:40:00Z",
        revisionId="$Id::                                       $",
        uses(Modelica(version="4.1.0")),
     Documentation(info="<html>

--- a/ModelicaTestOverdetermined.mo
+++ b/ModelicaTestOverdetermined.mo
@@ -609,7 +609,7 @@ The initial equations are consistent however and a tool shall reduce them approp
           fillPattern=FillPattern.Solid)}),
        preferredView="info",
        version="4.1.0",
-       versionDate="2024-03-15",
+       versionDate="2024-01-12",
        dateModified = "2024-01-01 11:00:00Z",
        revisionId="$Id::                                       $",
        uses(Modelica(version="4.1.0")),

--- a/ObsoleteModelica4.mo
+++ b/ObsoleteModelica4.mo
@@ -2893,7 +2893,7 @@ that are recommended in the documentation of the respective model.
 
 <p>
 In most cases, this means that a model with the name
-\"ObsoleteModelica4.XXX\" should be renamed to \"Modelica.XXX\" (version 4.0.0)
+\"ObsoleteModelica4.XXX\" should be renamed to \"Modelica.XXX\"
 and then a manual adaptation is needed. For example, a reference to
 ObsoleteModelica4.Math.Matrices.LAPACK.dgeqpf
 should be replaced by

--- a/ObsoleteModelica4.mo
+++ b/ObsoleteModelica4.mo
@@ -2897,7 +2897,7 @@ In most cases, this means that a model with the name
 and then a manual adaptation is needed. For example, a reference to
 ObsoleteModelica4.Math.Matrices.LAPACK.dgeqpf
 should be replaced by
-Modelica.Math.Matrices.LAPACK.dgeqp3 (version >= 4.0.0).
+Modelica.Math.Matrices.LAPACK.dgeqp3.
 This usually requires some changes at the place where
 the class is used (besides the renaming of the underlying class).
 </p>

--- a/ObsoleteModelica4.mo
+++ b/ObsoleteModelica4.mo
@@ -2884,7 +2884,7 @@ Documentation(info="<html>
 <p>
 This package contains models and blocks from the Modelica Standard Library
 version 3.2.3 that are no longer available in version 4.0.0
-The conversion script for versions >= 4.0.0 changes references in existing
+The conversion script for version 4.0.0 changes references in existing
 user models automatically to the models and blocks of package
 ObsoleteModelica4. The user should <strong>manually</strong> replace all
 references to ObsoleteModelica4 in his/her models to the models

--- a/ObsoleteModelica4.mo
+++ b/ObsoleteModelica4.mo
@@ -2877,7 +2877,7 @@ Obsolete saliency cage model, see
   end Magnetic;
   annotation (uses(Modelica(version="4.1.0")),
               version="4.1.0",
-              versionDate="2024-03-15",
+              versionDate="2024-01-12",
               dateModified = "2024-01-01 11:00:00Z",
               revisionId="$Format:%h %ci$",
 Documentation(info="<html>

--- a/ObsoleteModelica4.mo
+++ b/ObsoleteModelica4.mo
@@ -2875,16 +2875,16 @@ Obsolete saliency cage model, see
       end BasicMachines;
     end FundamentalWave;
   end Magnetic;
-  annotation (uses(Modelica(version="4.0.0")),
-              version="4.0.0",
-              versionDate="2020-06-04",
-              dateModified = "2020-06-04 11:00:00Z",
+  annotation (uses(Modelica(version="4.1.0")),
+              version="4.1.0",
+              versionDate="2024-03-15",
+              dateModified = "2024-01-01 11:00:00Z",
               revisionId="$Format:%h %ci$",
 Documentation(info="<html>
 <p>
 This package contains models and blocks from the Modelica Standard Library
 version 3.2.3 that are no longer available in version 4.0.0
-The conversion script for version 4.0.0 changes references in existing
+The conversion script for versions >= 4.0.0 changes references in existing
 user models automatically to the models and blocks of package
 ObsoleteModelica4. The user should <strong>manually</strong> replace all
 references to ObsoleteModelica4 in his/her models to the models
@@ -2897,7 +2897,7 @@ In most cases, this means that a model with the name
 and then a manual adaptation is needed. For example, a reference to
 ObsoleteModelica4.Math.Matrices.LAPACK.dgeqpf
 should be replaced by
-Modelica.Math.Matrices.LAPACK.dgeqp3 (version 4.0.0).
+Modelica.Math.Matrices.LAPACK.dgeqp3 (version >= 4.0.0).
 This usually requires some changes at the place where
 the class is used (besides the renaming of the underlying class).
 </p>
@@ -2915,7 +2915,7 @@ marked in the icon layer with a red box.
 </p>
 
 <p>
-Copyright &copy; 2019-2020, Modelica Association and contributors
+Copyright &copy; 2019-2024, Modelica Association and contributors
 </p>
 
 <p>

--- a/ObsoleteModelica4.mo
+++ b/ObsoleteModelica4.mo
@@ -2878,7 +2878,7 @@ Obsolete saliency cage model, see
   annotation (uses(Modelica(version="4.1.0")),
               version="4.1.0",
               versionDate="2024-01-12",
-              dateModified = "2024-01-01 11:00:00Z",
+              dateModified = "2024-01-12 19:40:00Z",
               revisionId="$Format:%h %ci$",
 Documentation(info="<html>
 <p>


### PR DESCRIPTION
This PR updates all version and uses annotation to 4.1.0. It also updates copyright dates to 2024. Finally, it removes a spurious version annotation in a sub-package.