### PR TITLE
Issue3931 use vector in forces and sensors

### DIFF
--- a/Modelica/Mechanics/MultiBody/Forces/Force.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/Force.mo
@@ -34,13 +34,13 @@ model Force
     annotation (Dialog(group="if animation = true", enable=animation));
 
 protected
-  Visualizers.Advanced.Arrow forceArrow(
+  Visualizers.Advanced.Vector forceArrow(
     color=forceColor,
     specularCoefficient=specularCoefficient,
     quantity=Modelica.Mechanics.MultiBody.Types.VectorQuantity.Force,
     R=frame_b.R,
     r=frame_b.r_0,
-    r_head=-frame_b.f,
+    coordinates=-frame_b.f,
     headAtOrigin=true) if world.enableAnimation and animation;
   Visualizers.Advanced.Shape connectionLine(
     shapeType="cylinder",

--- a/Modelica/Mechanics/MultiBody/Forces/ForceAndTorque.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/ForceAndTorque.mo
@@ -47,22 +47,23 @@ model ForceAndTorque
     annotation (Dialog(group="if animation = true", enable=animation));
 
 protected
-  Visualizers.Advanced.Arrow forceArrow(
+  Visualizers.Advanced.Vector forceArrow(
     color=forceColor,
     specularCoefficient=specularCoefficient,
     quantity=Modelica.Mechanics.MultiBody.Types.VectorQuantity.Force,
     R=frame_b.R,
     r=frame_b.r_0,
     headAtOrigin=true,
-    r_head=-frame_b.f) if world.enableAnimation and animation;
-  Visualizers.Advanced.DoubleArrow torqueArrow(
+    coordinates=-frame_b.f) if world.enableAnimation and animation;
+  Visualizers.Advanced.Vector torqueArrow(
     color=torqueColor,
     specularCoefficient=specularCoefficient,
     quantity=Modelica.Mechanics.MultiBody.Types.VectorQuantity.Torque,
     R=frame_b.R,
     r=frame_b.r_0,
     headAtOrigin=true,
-    r_head=-frame_b.t) if world.enableAnimation and animation;
+    twoHeadedArrow=true,
+    coordinates=-frame_b.t) if world.enableAnimation and animation;
   Visualizers.Advanced.Shape connectionLine(
     shapeType="cylinder",
     lengthDirection = to_unit1(basicForce.r_0),

--- a/Modelica/Mechanics/MultiBody/Forces/Torque.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/Torque.mo
@@ -35,14 +35,15 @@ model Torque
     annotation (Dialog(group="if animation = true", enable=animation));
 
 protected
-  Visualizers.Advanced.DoubleArrow torqueArrow(
+  Visualizers.Advanced.Vector torqueArrow(
     color=torqueColor,
     specularCoefficient=specularCoefficient,
     R=frame_b.R,
     r=frame_b.r_0,
     quantity=Modelica.Mechanics.MultiBody.Types.VectorQuantity.Torque,
     headAtOrigin=true,
-    r_head=-frame_b.t) if world.enableAnimation and animation;
+    twoHeadedArrow=true,
+    coordinates=-frame_b.t) if world.enableAnimation and animation;
   Visualizers.Advanced.Shape connectionLine(
     shapeType="cylinder",
     lengthDirection = to_unit1(basicTorque.r_0),

--- a/Modelica/Mechanics/MultiBody/Forces/WorldForce.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/WorldForce.mo
@@ -25,14 +25,14 @@ model WorldForce
     annotation (Dialog(group="if animation = true", enable=animation));
 
 protected
-  Visualizers.Advanced.Arrow arrow(
+  Visualizers.Advanced.Vector arrow(
     color=color,
     specularCoefficient=specularCoefficient,
     R=frame_b.R,
     r=frame_b.r_0,
     headAtOrigin=true,
     quantity=Modelica.Mechanics.MultiBody.Types.VectorQuantity.Force,
-    r_head=-frame_b.f) if world.enableAnimation and animation;
+    coordinates=-frame_b.f) if world.enableAnimation and animation;
 
 public
   Internal.BasicWorldForce basicWorldForce(resolveInFrame=resolveInFrame)

--- a/Modelica/Mechanics/MultiBody/Forces/WorldForceAndTorque.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/WorldForceAndTorque.mo
@@ -34,21 +34,22 @@ model WorldForceAndTorque
     annotation (Dialog(group="if animation = true", enable=animation));
 
 protected
-  Visualizers.Advanced.Arrow forceArrow(
+  Visualizers.Advanced.Vector forceArrow(
     color=forceColor,
     specularCoefficient=specularCoefficient,
     quantity=Modelica.Mechanics.MultiBody.Types.VectorQuantity.Force,
     R=frame_b.R,
     r=frame_b.r_0,
-    r_head=-frame_b.f,
+    coordinates=-frame_b.f,
     headAtOrigin=true) if world.enableAnimation and animation;
-  Visualizers.Advanced.DoubleArrow torqueArrow(
+  Visualizers.Advanced.Vector torqueArrow(
     color=torqueColor,
     specularCoefficient=specularCoefficient,
     quantity=Modelica.Mechanics.MultiBody.Types.VectorQuantity.Torque,
     R=frame_b.R,
     r=frame_b.r_0,
-    r_head=-frame_b.t,
+    coordinates=-frame_b.t,
+    twoHeadedArrow=true,
     headAtOrigin=true) if world.enableAnimation and animation;
 public
   Internal.BasicWorldForce basicWorldForce(resolveInFrame=resolveInFrame)

--- a/Modelica/Mechanics/MultiBody/Forces/WorldTorque.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/WorldTorque.mo
@@ -26,14 +26,15 @@ model WorldTorque
     annotation (Dialog(group="if animation = true", enable=animation));
 
 protected
-  Visualizers.Advanced.DoubleArrow arrow(
+  Visualizers.Advanced.Vector arrow(
     color=color,
     specularCoefficient=specularCoefficient,
     R=frame_b.R,
     r=frame_b.r_0,
     quantity=Modelica.Mechanics.MultiBody.Types.VectorQuantity.Torque,
     headAtOrigin=true,
-    r_head=-frame_b.t) if world.enableAnimation and animation;
+    twoHeadedArrow=true,
+    coordinates=-frame_b.t) if world.enableAnimation and animation;
 public
   Internal.BasicWorldTorque basicWorldTorque(resolveInFrame=resolveInFrame)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));

--- a/Modelica/Mechanics/MultiBody/Joints/FreeMotion.mo
+++ b/Modelica/Mechanics/MultiBody/Joints/FreeMotion.mo
@@ -64,10 +64,11 @@ model FreeMotion
     "Orientation object from frame_a to frame_b at initial time";
 
 protected
-  Visualizers.Advanced.Arrow arrow(
-    r_head=r_rel_a,
+  Visualizers.Advanced.Vector arrow(
+    coordinates=r_rel_a,
     color=arrowColor,
     specularCoefficient=specularCoefficient,
+    quantity=Types.VectorQuantity.RelativePosition,
     r=frame_a.r_0,
     R=frame_a.R) if world.enableAnimation and animation;
 

--- a/Modelica/Mechanics/MultiBody/Sensors/AbsoluteSensor.mo
+++ b/Modelica/Mechanics/MultiBody/Sensors/AbsoluteSensor.mo
@@ -136,10 +136,11 @@ protected
 protected
   outer Modelica.Mechanics.MultiBody.World world;
 
-  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow arrow(
-    r_head=frame_a.r_0,
+  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Vector arrow(
+    coordinates=frame_a.r_0,
+    quantity=Types.VectorQuantity.RelativePosition,
     color=arrowColor,
-    specularCoefficient) if world.enableAnimation and animation;
+    specularCoefficient=specularCoefficient) if world.enableAnimation and animation;
 
 protected
   AbsoluteVelocity absoluteVelocity(resolveInFrame=Modelica.Mechanics.MultiBody.Types.ResolveInFrameA.world) if get_a

--- a/Modelica/Mechanics/MultiBody/Sensors/CutForce.mo
+++ b/Modelica/Mechanics/MultiBody/Sensors/CutForce.mo
@@ -23,14 +23,14 @@ model CutForce "Measure cut force vector"
   extends Modelica.Mechanics.MultiBody.Sensors.Internal.PartialCutForceSensor;
 
 protected
-  Visualizers.Advanced.Arrow forceArrow(
+  Visualizers.Advanced.Vector forceArrow(
     color=forceColor,
     specularCoefficient=specularCoefficient,
     R=frame_b.R,
     r=frame_b.r_0,
     headAtOrigin=true,
     quantity=Modelica.Mechanics.MultiBody.Types.VectorQuantity.Force,
-    r_head=-frame_a.f*(if positiveSign then +1 else -1)) if world.enableAnimation and animation;
+    coordinates=-frame_a.f*(if positiveSign then +1 else -1)) if world.enableAnimation and animation;
 
   Internal.BasicCutForce cutForce(resolveInFrame=resolveInFrame, positiveSign=
         positiveSign)

--- a/Modelica/Mechanics/MultiBody/Sensors/CutForceAndTorque.mo
+++ b/Modelica/Mechanics/MultiBody/Sensors/CutForceAndTorque.mo
@@ -38,22 +38,23 @@ model CutForceAndTorque "Measure cut force and cut torque vector"
 
 protected
   parameter Integer csign=if positiveSign then +1 else -1;
-  Visualizers.Advanced.Arrow forceArrow(
+  Visualizers.Advanced.Vector forceArrow(
     color=forceColor,
     specularCoefficient=specularCoefficient,
     R=frame_b.R,
     r=frame_b.r_0,
     headAtOrigin=true,
     quantity=Modelica.Mechanics.MultiBody.Types.VectorQuantity.Force,
-    r_head=-frame_a.f*csign) if world.enableAnimation and animation;
-  Visualizers.Advanced.DoubleArrow torqueArrow(
+    coordinates=-frame_a.f*csign) if world.enableAnimation and animation;
+  Visualizers.Advanced.Vector torqueArrow(
     color=torqueColor,
     specularCoefficient=specularCoefficient,
     quantity=Modelica.Mechanics.MultiBody.Types.VectorQuantity.Torque,
     R=frame_b.R,
     r=frame_b.r_0,
     headAtOrigin=true,
-    r_head=-frame_a.t*csign) if world.enableAnimation and animation;
+    twoHeadedArrow=true,
+    coordinates=-frame_a.t*csign) if world.enableAnimation and animation;
   Internal.BasicCutForce cutForce(resolveInFrame=resolveInFrame, positiveSign=
         positiveSign)
     annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));

--- a/Modelica/Mechanics/MultiBody/Sensors/CutTorque.mo
+++ b/Modelica/Mechanics/MultiBody/Sensors/CutTorque.mo
@@ -24,14 +24,15 @@ model CutTorque "Measure cut torque vector"
   extends Modelica.Mechanics.MultiBody.Sensors.Internal.PartialCutForceSensor;
 
 protected
-  Visualizers.Advanced.DoubleArrow torqueArrow(
+  Visualizers.Advanced.Vector torqueArrow(
     color=torqueColor,
     specularCoefficient=specularCoefficient,
     quantity=Modelica.Mechanics.MultiBody.Types.VectorQuantity.Torque,
     R=frame_b.R,
     r=frame_b.r_0,
     headAtOrigin=true,
-    r_head=-frame_a.t*(if positiveSign then +1 else -1)) if world.enableAnimation and animation;
+    twoHeadedArrow=true,
+    coordinates=-frame_a.t*(if positiveSign then +1 else -1)) if world.enableAnimation and animation;
   Internal.BasicCutTorque cutTorque(resolveInFrame=resolveInFrame, positiveSign=
        positiveSign)
     annotation (Placement(transformation(extent={{-62,-10},{-42,10}})));

--- a/Modelica/Mechanics/MultiBody/Sensors/Distance.mo
+++ b/Modelica/Mechanics/MultiBody/Sensors/Distance.mo
@@ -26,9 +26,10 @@ model Distance
     "Prevent zero-division if distance between frame_a and frame_b is zero"
     annotation (Dialog(tab="Advanced"));
 protected
-  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow arrow(
+  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Vector arrow(
     r=frame_a.r_0,
-    r_head=frame_b.r_0 - frame_a.r_0,
+    coordinates=frame_b.r_0 - frame_a.r_0,
+    quantity=Types.VectorQuantity.RelativePosition,
     color=arrowColor,
     specularCoefficient=specularCoefficient) if world.enableAnimation and animation;
 

--- a/Modelica/Mechanics/MultiBody/Sensors/RelativeSensor.mo
+++ b/Modelica/Mechanics/MultiBody/Sensors/RelativeSensor.mo
@@ -136,11 +136,12 @@ protected
 protected
   outer Modelica.Mechanics.MultiBody.World world;
 
-  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow arrow(
+  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Vector arrow(
     r=frame_a.r_0,
-    r_head=frame_b.r_0 - frame_a.r_0,
+    coordinates=frame_b.r_0 - frame_a.r_0,
+    quantity=Types.VectorQuantity.RelativePosition,
     color=arrowColor,
-    specularCoefficient) if world.enableAnimation and animation;
+    specularCoefficient=specularCoefficient) if world.enableAnimation and animation;
 equation
   connect(relativePosition.frame_a, frame_a) annotation (Line(
       points={{-80,0},{-100,0}},
@@ -211,7 +212,7 @@ equation
       color={95,95,95},
       pattern=LinePattern.Dot));
   connect(frame_resolve, relativePosition.frame_resolve) annotation (Line(
-      points={{100,80},{50,80},{50,20},{-30,20},{-30,8.1},{-60,8.1}},
+      points={{100,80},{50,80},{50,20},{-30,20},{-30,8},{-60,8}},
       color={95,95,95},
       pattern=LinePattern.Dot));
   connect(frame_resolve, zeroForce3.frame_a) annotation (Line(
@@ -220,7 +221,7 @@ equation
       pattern=LinePattern.Dot));
   connect(relativeAngularVelocity.frame_resolve, frame_resolve) annotation (
       Line(
-      points={{70,-21.9},{70,-21.9},{70,20},{50,20},{50,80},{100,80}},
+      points={{70,-22},{70,-22},{70,20},{50,20},{50,80},{100,80}},
       color={95,95,95},
       pattern=LinePattern.Dot));
   connect(der2.y, transformVector_a_rel.r_in) annotation (Line(


### PR DESCRIPTION
Refs #3931 

Visualizer `Vector` is used for visualization of Forces', Joints' and Sensors' components from `Mechanics.MultiBody`, Peviously, `Arrow` and/or `DoubleArrow` was used.