### PR TITLE
Partially revert 18320a6

### DIFF
--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -2562,7 +2562,7 @@ Short Overview:
 </p>
 <ul>
 <li>About <a href=\"modelica://Modelica/Resources/Documentation/Version-4.0.0/ResolvedGitHubIssues.html\">649 issues (including 432 pull requests)</a> have been addressed for this release.</li>
-<li>This version is based on the recent Modelica language standard version 3.6.</li>
+<li>This version is based on the recent Modelica language standard version 3.4.</li>
 <li>The library version (i.e., \"4.0.0\") follows semantic versioning using the convention <code>MAJOR.MINOR.BUGFIX</code>
 (see <a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.VersionManagement\">Version Management</a> for details)
  and was decoupled from the version of the utilized version of the Modelica language standard.</li>


### PR DESCRIPTION
MSL 4.0.0 never was based on MoLang 3.6. Reverting that change of 18320a68b295c9b0be7a5fade0420487ec0059dc.