### PR TITLE
Reintroduce Arrow as a visualization shape

### DIFF
--- a/Modelica/Mechanics/MultiBody/Visualizers/FixedFrame.mo
+++ b/Modelica/Mechanics/MultiBody/Visualizers/FixedFrame.mo
@@ -11,8 +11,8 @@ model FixedFrame
     annotation (Dialog(group="if animation = true", enable=animation));
   input SI.Distance diameter=length/world.defaultFrameDiameterFraction
     "Diameter of axes arrows" annotation (Dialog(group="if animation = true", enable=animation));
-  input Types.Color color_x=Modelica.Mechanics.MultiBody.Types.Defaults.
-      FrameColor "Color of x-arrow"
+  input Types.Color color_x=Modelica.Mechanics.MultiBody.Types.Defaults.FrameColor
+    "Color of x-arrow"
     annotation (Dialog(colorSelector=true,group="if animation = true", enable=animation));
   input Types.Color color_y=color_x "Color of y-arrow"
     annotation (Dialog(colorSelector=true,group="if animation = true", enable=animation));
@@ -26,38 +26,23 @@ protected
   parameter Boolean showLabels2= world.enableAnimation and animation and showLabels;
 
   // Parameters to define axes
-  SI.Length headLength=min(length, diameter*Types.Defaults.FrameHeadLengthFraction);
+  SI.Length headLength=diameter*Types.Defaults.FrameHeadLengthFraction;
   SI.Length headWidth=diameter*Types.Defaults.FrameHeadWidthFraction;
-  SI.Length lineLength=max(0, length - headLength);
-  SI.Length lineWidth=diameter;
 
   // Parameters to define axes labels
-  SI.Length scaledLabel=Modelica.Mechanics.MultiBody.Types.Defaults.FrameLabelHeightFraction*diameter;
+  SI.Length scaledLabel=diameter*Types.Defaults.FrameLabelHeightFraction;
   SI.Length labelStart=1.05*length;
 
   // x-axis
-  Visualizers.Advanced.Shape x_arrowLine(
-    shapeType="cylinder",
-    length=lineLength,
-    width=lineWidth,
-    height=lineWidth,
-    lengthDirection={1,0,0},
-    widthDirection={0,1,0},
-    color=color_x,
-    specularCoefficient=specularCoefficient,
+  Visualizers.Advanced.Arrow x_arrow(
+    R=frame_a.R,
     r=frame_a.r_0,
-    R=frame_a.R) if animation2;
-  Visualizers.Advanced.Shape x_arrowHead(
-    shapeType="cone",
-    length=headLength,
-    width=headWidth,
-    height=headWidth,
-    lengthDirection={1,0,0},
-    widthDirection={0,1,0},
+    r_head=length*{1,0,0},
+    diameter=diameter,
+    headDiameter=headWidth,
+    headLength=headLength,
     color=color_x,
-    specularCoefficient=specularCoefficient,
-    r=frame_a.r_0 + Frames.resolve1(frame_a.R, {lineLength,0,0}),
-    R=frame_a.R) if animation2;
+    specularCoefficient=specularCoefficient) if animation2;
   Visualizers.Internal.Lines x_label(
     lines=scaledLabel*{[0,0; 1,1],[0,1; 1,0]},
     diameter=diameter,
@@ -70,28 +55,15 @@ protected
     R=frame_a.R) if showLabels2;
 
   // y-axis
-  Visualizers.Advanced.Shape y_arrowLine(
-    shapeType="cylinder",
-    length=lineLength,
-    width=lineWidth,
-    height=lineWidth,
-    lengthDirection={0,1,0},
-    widthDirection={1,0,0},
-    color=color_y,
-    specularCoefficient=specularCoefficient,
+  Visualizers.Advanced.Arrow y_arrow(
+    R=frame_a.R,
     r=frame_a.r_0,
-    R=frame_a.R) if animation2;
-  Visualizers.Advanced.Shape y_arrowHead(
-    shapeType="cone",
-    length=headLength,
-    width=headWidth,
-    height=headWidth,
-    lengthDirection={0,1,0},
-    widthDirection={1,0,0},
+    r_head=length*{0,1,0},
+    diameter=diameter,
+    headDiameter=headWidth,
+    headLength=headLength,
     color=color_y,
-    specularCoefficient=specularCoefficient,
-    r=frame_a.r_0 + Frames.resolve1(frame_a.R, {0,lineLength,0}),
-    R=frame_a.R) if animation2;
+    specularCoefficient=specularCoefficient) if animation2;
   Visualizers.Internal.Lines y_label(
     lines=scaledLabel*{[0,0; 1,1.5],[0,1.5; 0.5,0.75]},
     diameter=diameter,
@@ -104,28 +76,15 @@ protected
     R=frame_a.R) if showLabels2;
 
   // z-axis
-  Visualizers.Advanced.Shape z_arrowLine(
-    shapeType="cylinder",
-    length=lineLength,
-    width=lineWidth,
-    height=lineWidth,
-    lengthDirection={0,0,1},
-    widthDirection={0,1,0},
-    color=color_z,
-    specularCoefficient=specularCoefficient,
+  Visualizers.Advanced.Arrow z_arrow(
+    R=frame_a.R,
     r=frame_a.r_0,
-    R=frame_a.R) if animation2;
-  Visualizers.Advanced.Shape z_arrowHead(
-    shapeType="cone",
-    length=headLength,
-    width=headWidth,
-    height=headWidth,
-    lengthDirection={0,0,1},
-    widthDirection={0,1,0},
+    r_head=length*{0,0,1},
+    diameter=diameter,
+    headDiameter=headWidth,
+    headLength=headLength,
     color=color_z,
-    specularCoefficient=specularCoefficient,
-    r=frame_a.r_0 + Frames.resolve1(frame_a.R, {0,0,lineLength}),
-    R=frame_a.R) if animation2;
+    specularCoefficient=specularCoefficient) if animation2;
   Visualizers.Internal.Lines z_label(
     lines=scaledLabel*{[0,0; 1,0],[0,1; 1,1],[0,1; 1,0]},
     diameter=diameter,

--- a/Modelica/Mechanics/MultiBody/package.mo
+++ b/Modelica/Mechanics/MultiBody/package.mo
@@ -174,37 +174,20 @@ protected
       axisShowLabels then 1 else 0;
 
   // Parameters to define axes
-  parameter SI.Length headLength=min(axisLength, axisDiameter*Types.Defaults.
-      FrameHeadLengthFraction);
-  parameter SI.Length headWidth=axisDiameter*Types.Defaults.
-      FrameHeadWidthFraction;
-  parameter SI.Length lineLength=max(0, axisLength - headLength);
-  parameter SI.Length lineWidth=axisDiameter;
+  parameter SI.Length headLength=axisDiameter*Types.Defaults.FrameHeadLengthFraction;
+  parameter SI.Length headWidth=axisDiameter*Types.Defaults.FrameHeadWidthFraction;
 
   // Parameters to define axes labels
-  parameter SI.Length scaledLabel=Modelica.Mechanics.MultiBody.Types.Defaults.FrameLabelHeightFraction*
-      axisDiameter;
+  parameter SI.Length scaledLabel=axisDiameter*Types.Defaults.FrameLabelHeightFraction;
   parameter SI.Length labelStart=1.05*axisLength;
 
   // x-axis
-  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Shape x_arrowLine(
-    shapeType="cylinder",
-    length=lineLength,
-    width=lineWidth,
-    height=lineWidth,
-    lengthDirection={1,0,0},
-    widthDirection={0,1,0},
+  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow x_arrow(
+    r_head=axisLength*{1,0,0},
+    diameter=axisDiameter,
+    headDiameter=headWidth,
+    headLength=headLength,
     color=axisColor_x,
-    specularCoefficient=0) if enableAnimation and animateWorld;
-  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Shape x_arrowHead(
-    shapeType="cone",
-    length=headLength,
-    width=headWidth,
-    height=headWidth,
-    lengthDirection={1,0,0},
-    widthDirection={0,1,0},
-    color=axisColor_x,
-    r={lineLength,0,0},
     specularCoefficient=0) if enableAnimation and animateWorld;
   Modelica.Mechanics.MultiBody.Visualizers.Internal.Lines x_label(
     lines=scaledLabel*{[0, 0; 1, 1],[0, 1; 1, 0]},
@@ -216,24 +199,12 @@ protected
     specularCoefficient=0) if enableAnimation and animateWorld and axisShowLabels;
 
   // y-axis
-  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Shape y_arrowLine(
-    shapeType="cylinder",
-    length=lineLength,
-    width=lineWidth,
-    height=lineWidth,
-    lengthDirection={0,1,0},
-    widthDirection={1,0,0},
+  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow y_arrow(
+    r_head=axisLength*{0,1,0},
+    diameter=axisDiameter,
+    headDiameter=headWidth,
+    headLength=headLength,
     color=axisColor_y,
-    specularCoefficient=0) if enableAnimation and animateWorld;
-  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Shape y_arrowHead(
-    shapeType="cone",
-    length=headLength,
-    width=headWidth,
-    height=headWidth,
-    lengthDirection={0,1,0},
-    widthDirection={1,0,0},
-    color=axisColor_y,
-    r={0,lineLength,0},
     specularCoefficient=0) if enableAnimation and animateWorld;
   Modelica.Mechanics.MultiBody.Visualizers.Internal.Lines y_label(
     lines=scaledLabel*{[0, 0; 1, 1.5],[0, 1.5; 0.5, 0.75]},
@@ -245,24 +216,12 @@ protected
     specularCoefficient=0) if enableAnimation and animateWorld and axisShowLabels;
 
   // z-axis
-  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Shape z_arrowLine(
-    shapeType="cylinder",
-    length=lineLength,
-    width=lineWidth,
-    height=lineWidth,
-    lengthDirection={0,0,1},
-    widthDirection={0,1,0},
+  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow z_arrow(
+    r_head=axisLength*{0,0,1},
+    diameter=axisDiameter,
+    headDiameter=headWidth,
+    headLength=headLength,
     color=axisColor_z,
-    specularCoefficient=0) if enableAnimation and animateWorld;
-  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Shape z_arrowHead(
-    shapeType="cone",
-    length=headLength,
-    width=headWidth,
-    height=headWidth,
-    lengthDirection={0,0,1},
-    widthDirection={0,1,0},
-    color=axisColor_z,
-    r={0,0,lineLength},
     specularCoefficient=0) if enableAnimation and animateWorld;
   Modelica.Mechanics.MultiBody.Visualizers.Internal.Lines z_label(
     lines=scaledLabel*{[0, 0; 1, 0],[0, 1; 1, 1],[0, 1; 1, 0]},
@@ -274,30 +233,14 @@ protected
     specularCoefficient=0) if enableAnimation and animateWorld and axisShowLabels;
 
   // Uniform gravity visualization
-  parameter SI.Length gravityHeadLength=min(gravityArrowLength,
-      gravityArrowDiameter*Types.Defaults.ArrowHeadLengthFraction);
+  parameter SI.Length gravityheadLength=gravityArrowDiameter*Types.Defaults.ArrowHeadLengthFraction;
   parameter SI.Length gravityHeadWidth=gravityArrowDiameter*Types.Defaults.ArrowHeadWidthFraction;
-  parameter SI.Length gravityLineLength=max(0, gravityArrowLength - gravityHeadLength);
-  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Shape gravityArrowLine(
-    shapeType="cylinder",
-    length=gravityLineLength,
-    width=gravityArrowDiameter,
-    height=gravityArrowDiameter,
-    lengthDirection=n,
-    widthDirection={0,1,0},
+  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow gravityArrow(
+    r_head=gravityArrowLength*n,
+    diameter=gravityArrowDiameter,
+    headDiameter=gravityHeadWidth,
+    headLength=gravityheadLength,
     color=gravityArrowColor,
-    r_shape=gravityArrowTail,
-    specularCoefficient=0) if enableAnimation and animateGravity and gravityType == GravityTypes.UniformGravity;
-  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Shape gravityArrowHead(
-    shapeType="cone",
-    length=gravityHeadLength,
-    width=gravityHeadWidth,
-    height=gravityHeadWidth,
-    lengthDirection=n,
-    widthDirection={0,1,0},
-    color=gravityArrowColor,
-    r_shape=gravityArrowTail + Modelica.Math.Vectors.normalize(
-                                                n)*gravityLineLength,
     specularCoefficient=0) if enableAnimation and animateGravity and gravityType == GravityTypes.UniformGravity;
 
   // Point gravity visualization


### PR DESCRIPTION
Reintroduce `Arrow` as a common visualization object, similar to a box or a sphere. In the MultiBody, the `Arrow` is now used for visualization of axes of coordinate system in 
- `MultiBody.Visualizers.FixedFrame`
- `MultiBody.World`

To better understand the idea, see also https://github.com/modelica/ModelicaStandardLibrary/issues/3931#issuecomment-1594362054

This PR bases on #4248 and is, thus, a draft only. It shall be rebased, checked and changed to a full PR after merging that other PR. 

Note: I didn't change `DoubleArrow` since I consider this being an obsolete model.