### PR TITLE
Revert "Merge pull request #4255 from modelica/revert-4129-fix-friction"

### DIFF
--- a/Modelica/Mechanics/Rotational/Interfaces/PartialFriction.mo
+++ b/Modelica/Mechanics/Rotational/Interfaces/PartialFriction.mo
@@ -54,9 +54,9 @@ equation
     mode) == Backward or startBackward);
 
   a_relfric/unitAngularAcceleration = if locked then 0 else if free then sa
-     else if startForward then sa - tau0_max/unitTorque else if
-    startBackward then sa + tau0_max/unitTorque else if pre(mode) ==
-    Forward then sa - tau0_max/unitTorque else sa + tau0_max/unitTorque;
+    else if startForward then sa - tau0_max/unitTorque
+    else if startBackward then sa + tau0_max/unitTorque
+    else sa - sign(w_relfric)*tau0_max/unitTorque;
 
   /* Friction torque "tau" has to be defined in a subclass. Example for possible
      realization of a clutch utilizing interpolation by ExternalCombiTable1D see:

--- a/Modelica/Mechanics/Translational/Interfaces/PartialFriction.mo
+++ b/Modelica/Mechanics/Translational/Interfaces/PartialFriction.mo
@@ -51,10 +51,10 @@ equation
   locked = not free and not (pre(mode) == Forward or startForward or pre(
     mode) == Backward or startBackward);
 
-  a_relfric/unitAcceleration = if locked then 0 else if free then sa else
-    if startForward then sa - f0_max/unitForce else if startBackward then
-    sa + f0_max/unitForce else if pre(mode) == Forward then sa - f0_max/
-    unitForce else sa + f0_max/unitForce;
+  a_relfric/unitAcceleration = if locked then 0 else if free then sa
+    else if startForward then sa - f0_max/unitForce
+    else if startBackward then sa + f0_max/unitForce
+    else sa - sign(v_relfric)*f0_max/unitForce;
 
   /* Friction force "f" has to be defined in a subclass. Example for possible
      realization of a brake utilizing interpolation by ExternalCombiTable1D see:

--- a/ModelicaTest/Rotational.mo
+++ b/ModelicaTest/Rotational.mo
@@ -1623,6 +1623,54 @@ they were not deleted yet.")}));
     annotation (experiment(StopTime=1.1));
   end TestFriction;
 
+  model TestFrictionPosition
+    extends Modelica.Icons.Example;
+
+    parameter Real fric=155.9218;
+    Modelica.Mechanics.Rotational.Sources.Position    position(exact=true)
+      annotation (Placement(transformation(extent={{-10,30},{10,50}})));
+
+    Modelica.Blocks.Sources.Sine sine(
+      amplitude=0.1,
+      f=1,
+      phase=0.78539816339745,
+      offset=0.5) annotation (Placement(transformation(extent={{-70,30},{-50,50}})));
+
+    Modelica.Mechanics.Rotational.Components.BearingFriction    bearingFriction(tau_pos=[0,5; 100,5],
+               peak=1.001)
+      annotation (Placement(transformation(extent={{46,30},{66,50}})));
+    Modelica.Mechanics.Rotational.Sources.Torque      torque
+      annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
+    Modelica.Blocks.Sources.Sine sine1(
+      amplitude=25,
+      f=1,
+      phase=0.78539816339745,
+      offset=0.5) annotation (Placement(transformation(extent={{-70,-50},{-50,-30}})));
+    Modelica.Mechanics.Rotational.Components.BearingFriction    bearingFriction1(tau_pos=[0,5; 100,5], peak=1.001)
+      annotation (Placement(transformation(extent={{46,-50},{66,-30}})));
+    Modelica.Mechanics.Rotational.Components.Inertia inertia(J=1, w(start=-2, fixed=true))
+      annotation (Placement(transformation(extent={{74,-50},{94,-30}})));
+    Modelica.Mechanics.Rotational.Sources.Position    position1(exact=true)
+      annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+    Modelica.Blocks.Sources.Sine sine2(
+      amplitude=0.3,
+      f=1,
+      phase=0.78539816339745,
+      offset=0.5) annotation (Placement(transformation(extent={{-70,-10},{-50,10}})));
+    Modelica.Mechanics.Rotational.Components.BearingFriction    bearingFriction2(tau_pos=[0,5; 100,5], peak=1.001)
+      annotation (Placement(transformation(extent={{46,-10},{66,10}})));
+  equation
+
+    connect(sine.y, position.phi_ref) annotation (Line(points={{-49,40},{-12,40}}, color={0,0,127}));
+    connect(position.flange, bearingFriction.flange_a) annotation (Line(points={{10,40},{48,40},{48,40},{46,40}}, color={0,0,0}));
+    connect(sine1.y, torque.tau) annotation (Line(points={{-49,-40},{-12,-40}}, color={0,0,127}));
+    connect(torque.flange, bearingFriction1.flange_a) annotation (Line(points={{10,-40},{46,-40}}, color={0,0,0}));
+    connect(bearingFriction1.flange_b, inertia.flange_a) annotation (Line(points={{66,-40},{74,-40}}, color={0,0,0}));
+    connect(sine2.y, position1.phi_ref) annotation (Line(points={{-49,0},{-12,0}}, color={0,0,127}));
+    connect(position1.flange, bearingFriction2.flange_a) annotation (Line(points={{10,0},{46,0}}, color={0,0,0}));
+    annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(coordinateSystem(preserveAspectRatio=false)));
+  end TestFrictionPosition;
+
   model TestBraking
     extends Modelica.Icons.Example;
     Modelica.Mechanics.Rotational.Components.Inertia inertia1(

--- a/ModelicaTest/Translational.mo
+++ b/ModelicaTest/Translational.mo
@@ -313,4 +313,74 @@ extends Modelica.Icons.ExamplesPackage;
     annotation (
       experiment(StopTime=2));
   end Vehicles;
+
+  model TestFrictionPosition
+    extends Modelica.Icons.Example;
+
+    parameter Real fric=155.9218;
+    Modelica.Mechanics.Translational.Sources.Position position(exact=true)
+      annotation (Placement(transformation(extent={{-10,30},{10,50}})));
+
+    Modelica.Blocks.Sources.Sine sine(
+      amplitude=0.1,
+      f=1,
+      phase=0.78539816339745,
+      offset=0.5) annotation (Placement(transformation(extent={{-70,30},{-50,50}})));
+
+    Modelica.Mechanics.Translational.Components.SupportFriction supportFriction(f_pos=
+          Modelica.Mechanics.Translational.Examples.Utilities.GenerateStribeckFrictionTable(
+          1,
+          5,
+          10,
+          1,
+          12,
+          50), peak=1.001)
+      annotation (Placement(transformation(extent={{46,30},{66,50}})));
+    Modelica.Mechanics.Translational.Sources.Force    force
+      annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
+    Modelica.Blocks.Sources.Sine sine1(
+      amplitude=25,
+      f=1,
+      phase=0.78539816339745,
+      offset=0.5) annotation (Placement(transformation(extent={{-70,-50},{-50,-30}})));
+    Modelica.Mechanics.Translational.Components.SupportFriction supportFriction1(f_pos=
+          Modelica.Mechanics.Translational.Examples.Utilities.GenerateStribeckFrictionTable(
+            1,
+            5,
+            10,
+            1,
+            12,
+            50), peak=1.001)
+      annotation (Placement(transformation(extent={{46,-50},{66,-30}})));
+    Modelica.Mechanics.Translational.Components.Mass mass(m=1, v(start=-2, fixed=true))
+      annotation (Placement(transformation(extent={{74,-50},{94,-30}})));
+    Modelica.Mechanics.Translational.Sources.Position position1(exact=true)
+      annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+    Modelica.Blocks.Sources.Sine sine2(
+      amplitude=0.3,
+      f=1,
+      phase=0.78539816339745,
+      offset=0.5) annotation (Placement(transformation(extent={{-70,-10},{-50,10}})));
+    Modelica.Mechanics.Translational.Components.SupportFriction supportFriction2(f_pos=
+          Modelica.Mechanics.Translational.Examples.Utilities.GenerateStribeckFrictionTable(
+            1,
+            5,
+            10,
+            1,
+            12,
+            50), peak=1.001)
+      annotation (Placement(transformation(extent={{46,-10},{66,10}})));
+  equation
+    connect(sine.y, position.s_ref) annotation (Line(points={{-49,40},{-12,40}},
+                                                                               color={0,0,127}));
+
+    connect(position.flange, supportFriction.flange_a) annotation (Line(points={{10,40},{46,40}},
+                                                                                                color={0,127,0}));
+    connect(force.flange, supportFriction1.flange_a) annotation (Line(points={{10,-40},{46,-40}}, color={0,127,0}));
+    connect(supportFriction1.flange_b, mass.flange_a) annotation (Line(points={{66,-40},{74,-40}}, color={0,127,0}));
+    connect(sine1.y, force.f) annotation (Line(points={{-49,-40},{-12,-40}}, color={0,0,127}));
+    connect(sine2.y, position1.s_ref) annotation (Line(points={{-49,0},{-12,0}}, color={0,0,127}));
+    connect(position1.flange, supportFriction2.flange_a) annotation (Line(points={{10,0},{46,0}}, color={0,127,0}));
+    annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(coordinateSystem(preserveAspectRatio=false)));
+  end TestFrictionPosition;
 end Translational;


### PR DESCRIPTION
The fix from #4129 has been accidentally reverted by #4255 without being the reason for the compiling errors.

The compilation errors should be fixed by recompilation of the binaries as discussed in #3911, #4178 and #4250.