### PR TITLE
Update Continuous.mo

### DIFF
--- a/Modelica/Blocks/Continuous.mo
+++ b/Modelica/Blocks/Continuous.mo
@@ -21,7 +21,7 @@ package Continuous "Library of continuous control blocks with internal states"
         Dialog(group="Initialization"));
     parameter Real y_start=0 "Initial or guess value of output (= state)"
       annotation (Dialog(group="Initialization"));
-    extends Interfaces.SISO;
+    extends Interfaces.SISO(y(start = if initType == Init.SteadyState then y_start), fixed = if initType == Init.SteadyState then false else true);
     Modelica.Blocks.Interfaces.BooleanInput reset if use_reset "Optional connector of reset signal" annotation(Placement(
       transformation(
         extent={{-20,-20},{20,20}},
@@ -144,7 +144,7 @@ port has a rising edge.
       annotation (Dialog(group="Initialization"));
     parameter Boolean strict=false "= true, if strict limits with noEvent(..)"
       annotation (Evaluate=true, choices(checkBox=true), Dialog(tab="Advanced"));
-    extends Interfaces.SISO;
+    extends Interfaces.SISO(y(start = if initType == Init.SteadyState then y_start), fixed = if initType == Init.SteadyState then false else true);
     Modelica.Blocks.Interfaces.BooleanInput reset if use_reset "Optional connector of reset signal" annotation(Placement(
       transformation(
         extent={{-20,-20},{20,20}},


### PR DESCRIPTION
Better suggestion to fix init issue for Integrators in Modelica.Blocks.Continuous. WARNING: @MartinOtter, I currently don't have a setup to test this immediately, so this is UNTESTED. Please test before committing. It would be nice to have a test when this is in a loop with a non-linear plant + steady-state initialization.