### PR TITLE
Utilize PressureSlope unit in Media consistently

### DIFF
--- a/Modelica/Media/Air/MoistAir.mo
+++ b/Modelica/Media/Air/MoistAir.mo
@@ -356,8 +356,8 @@ The ideal gas constant for moist air is computed from the gas phase composition.
 
     extends Modelica.Icons.Function;
     input SI.Temperature Tsat "Saturation temperature";
-    input Real dTsat(unit="K/s") "Saturation temperature derivative";
-    output Real psat_der(unit="Pa/s") "Saturation pressure derivative";
+    input SI.TemperatureSlope dTsat "Saturation temperature derivative";
+    output SI.PressureRate psat_der "Saturation pressure derivative";
   protected
     SI.Temperature Tcritical=647.096 "Critical temperature";
     SI.AbsolutePressure pcritical=22.064e6 "Critical pressure";
@@ -414,8 +414,8 @@ The ideal gas constant for moist air is computed from the gas phase composition.
 
     extends Modelica.Icons.Function;
     input SI.Temperature Tsat "Sublimation temperature";
-    input Real dTsat(unit="K/s") "Sublimation temperature derivative";
-    output Real psat_der(unit="Pa/s") "Sublimation pressure derivative";
+    input SI.TemperatureSlope dTsat "Sublimation temperature derivative";
+    output SI.PressureRate psat_der "Sublimation pressure derivative";
   protected
     SI.Temperature Ttriple=273.16 "Triple point temperature";
     SI.AbsolutePressure ptriple=611.657 "Triple point pressure";
@@ -458,9 +458,9 @@ Saturation pressure of water in the liquid and the solid region is computed usin
   function saturationPressure_der
     "Derivative function for 'saturationPressure'"
     extends Modelica.Icons.Function;
-    input Temperature Tsat "Saturation temperature";
-    input Real dTsat(unit="K/s") "Time derivative of saturation temperature";
-    output Real psat_der(unit="Pa/s") "Saturation pressure";
+    input SI.Temperature Tsat "Saturation temperature";
+    input SI.TemperatureSlope dTsat "Time derivative of saturation temperature";
+    output SI.PressureRate psat_der "Saturation pressure";
 
   algorithm
     /*psat := Utilities.spliceFunction(saturationPressureLiquid(Tsat),sublimationPressureIce(Tsat),Tsat-273.16,1.0);*/
@@ -801,8 +801,8 @@ Specific enthalpy of moist air is computed from pressure, temperature and compos
     input SI.Pressure p "Pressure";
     input SI.Temperature T "Temperature";
     input SI.MassFraction X[:] "Mass fractions of moist air";
-    input Real dp(unit="Pa/s") "Pressure derivative";
-    input Real dT(unit="K/s") "Temperature derivative";
+    input SI.PressureRate dp "Pressure derivative";
+    input SI.TemperatureSlope dT "Temperature derivative";
     input Real dX[:](each unit="1/s") "Composition derivative";
     output Real h_der(unit="J/(kg.s)") "Time derivative of specific enthalpy";
   protected
@@ -817,7 +817,7 @@ Specific enthalpy of moist air is computed from pressure, temperature and compos
     Real dX_air(unit="1/s") "Time derivative of dry air mass fraction";
     Real dX_liq(unit="1/s")
       "Time derivative of liquid/solid water mass fraction";
-    Real dps(unit="Pa/s") "Time derivative of saturation pressure";
+    SI.PressureRate dps "Time derivative of saturation pressure";
     Real dx_sat(unit="1/s")
       "Time derivative of absolute humidity per unit mass of dry air";
   algorithm
@@ -969,8 +969,8 @@ Specific internal energy is determined from pressure p, temperature T and compos
     input SI.Pressure p "Pressure";
     input SI.Temperature T "Temperature";
     input SI.MassFraction X[:] "Mass fractions of moist air";
-    input Real dp(unit="Pa/s") "Pressure derivative";
-    input Real dT(unit="K/s") "Temperature derivative";
+    input SI.PressureRate dp "Pressure derivative";
+    input SI.TemperatureSlope dT "Temperature derivative";
     input Real dX[:](each unit="1/s") "Mass fraction derivatives";
     output Real u_der(unit="J/(kg.s)") "Specific internal energy derivative";
   protected
@@ -987,7 +987,7 @@ Specific internal energy is determined from pressure p, temperature T and compos
     Real dX_air(unit="1/s") "Time derivative of dry air mass fraction";
     Real dX_liq(unit="1/s")
       "Time derivative of liquid/solid water mass fraction";
-    Real dps(unit="Pa/s") "Time derivative of saturation pressure";
+    SI.PressureRate dps "Time derivative of saturation pressure";
     Real dx_sat(unit="1/s")
       "Time derivative of absolute humidity per unit mass of dry air";
     Real dR_gas(unit="J/(kg.K.s)") "Time derivative of ideal gas constant";
@@ -1344,8 +1344,8 @@ Specific entropy of moist air is computed from pressure, temperature and composi
     input SI.Pressure p "Pressure";
     input SI.Temperature T "Temperature";
     input SI.MassFraction X[:] "Mass fractions of moist air";
-    input Real dp(unit="Pa/s") "Derivative of pressure";
-    input Real dT(unit="K/s") "Derivative of temperature";
+    input SI.PressureRate dp "Derivative of pressure";
+    input SI.TemperatureSlope dT "Derivative of temperature";
     input Real dX[nX](each unit="1/s") "Derivative of mass fractions";
     output Real ds(unit="J/(kg.K.s)") "Specific entropy at p, T, X";
   protected

--- a/Modelica/Media/Air/MoistAir.mo
+++ b/Modelica/Media/Air/MoistAir.mo
@@ -357,7 +357,7 @@ The ideal gas constant for moist air is computed from the gas phase composition.
     extends Modelica.Icons.Function;
     input SI.Temperature Tsat "Saturation temperature";
     input SI.TemperatureSlope dTsat "Saturation temperature derivative";
-    output SI.PressureRate psat_der "Saturation pressure derivative";
+    output SI.PressureSlope psat_der "Saturation pressure derivative";
   protected
     SI.Temperature Tcritical=647.096 "Critical temperature";
     SI.AbsolutePressure pcritical=22.064e6 "Critical pressure";
@@ -415,7 +415,7 @@ The ideal gas constant for moist air is computed from the gas phase composition.
     extends Modelica.Icons.Function;
     input SI.Temperature Tsat "Sublimation temperature";
     input SI.TemperatureSlope dTsat "Sublimation temperature derivative";
-    output SI.PressureRate psat_der "Sublimation pressure derivative";
+    output SI.PressureSlope psat_der "Sublimation pressure derivative";
   protected
     SI.Temperature Ttriple=273.16 "Triple point temperature";
     SI.AbsolutePressure ptriple=611.657 "Triple point pressure";
@@ -460,7 +460,7 @@ Saturation pressure of water in the liquid and the solid region is computed usin
     extends Modelica.Icons.Function;
     input SI.Temperature Tsat "Saturation temperature";
     input SI.TemperatureSlope dTsat "Time derivative of saturation temperature";
-    output SI.PressureRate psat_der "Saturation pressure";
+    output SI.PressureSlope psat_der "Time derivative of saturation pressure";
 
   algorithm
     /*psat := Utilities.spliceFunction(saturationPressureLiquid(Tsat),sublimationPressureIce(Tsat),Tsat-273.16,1.0);*/
@@ -801,7 +801,7 @@ Specific enthalpy of moist air is computed from pressure, temperature and compos
     input SI.Pressure p "Pressure";
     input SI.Temperature T "Temperature";
     input SI.MassFraction X[:] "Mass fractions of moist air";
-    input SI.PressureRate dp "Pressure derivative";
+    input SI.PressureSlope dp "Pressure derivative";
     input SI.TemperatureSlope dT "Temperature derivative";
     input Real dX[:](each unit="1/s") "Composition derivative";
     output Real h_der(unit="J/(kg.s)") "Time derivative of specific enthalpy";
@@ -817,7 +817,7 @@ Specific enthalpy of moist air is computed from pressure, temperature and compos
     Real dX_air(unit="1/s") "Time derivative of dry air mass fraction";
     Real dX_liq(unit="1/s")
       "Time derivative of liquid/solid water mass fraction";
-    SI.PressureRate dps "Time derivative of saturation pressure";
+    SI.PressureSlope dps "Time derivative of saturation pressure";
     Real dx_sat(unit="1/s")
       "Time derivative of absolute humidity per unit mass of dry air";
   algorithm
@@ -969,7 +969,7 @@ Specific internal energy is determined from pressure p, temperature T and compos
     input SI.Pressure p "Pressure";
     input SI.Temperature T "Temperature";
     input SI.MassFraction X[:] "Mass fractions of moist air";
-    input SI.PressureRate dp "Pressure derivative";
+    input SI.PressureSlope dp "Pressure derivative";
     input SI.TemperatureSlope dT "Temperature derivative";
     input Real dX[:](each unit="1/s") "Mass fraction derivatives";
     output Real u_der(unit="J/(kg.s)") "Specific internal energy derivative";
@@ -987,7 +987,7 @@ Specific internal energy is determined from pressure p, temperature T and compos
     Real dX_air(unit="1/s") "Time derivative of dry air mass fraction";
     Real dX_liq(unit="1/s")
       "Time derivative of liquid/solid water mass fraction";
-    SI.PressureRate dps "Time derivative of saturation pressure";
+    SI.PressureSlope dps "Time derivative of saturation pressure";
     Real dx_sat(unit="1/s")
       "Time derivative of absolute humidity per unit mass of dry air";
     Real dR_gas(unit="J/(kg.K.s)") "Time derivative of ideal gas constant";
@@ -1344,7 +1344,7 @@ Specific entropy of moist air is computed from pressure, temperature and composi
     input SI.Pressure p "Pressure";
     input SI.Temperature T "Temperature";
     input SI.MassFraction X[:] "Mass fractions of moist air";
-    input SI.PressureRate dp "Derivative of pressure";
+    input SI.PressureSlope dp "Derivative of pressure";
     input SI.TemperatureSlope dT "Derivative of temperature";
     input Real dX[nX](each unit="1/s") "Derivative of mass fractions";
     output Real ds(unit="J/(kg.K.s)") "Specific entropy at p, T, X";

--- a/Modelica/Media/Water/IF97_Utilities.mo
+++ b/Modelica/Media/Water/IF97_Utilities.mo
@@ -3113,7 +3113,7 @@ email: hubertus@modelon.se
       function tsat_der "Derivative function for tsat"
         extends Modelica.Icons.Function;
         input SI.Pressure p "Pressure";
-        input SI.PressureRate der_p "Pressure derivative";
+        input SI.PressureSlope der_p "Pressure derivative";
         output SI.TemperatureSlope der_tsat "Temperature derivative";
       protected
         Real dtp;
@@ -3202,7 +3202,7 @@ email: hubertus@modelon.se
         extends Modelica.Icons.Function;
         input SI.Temperature T "Temperature (K)";
         input SI.TemperatureSlope der_T "Temperature derivative";
-        output SI.PressureRate der_psat "Pressure";
+        output SI.PressureSlope der_psat "Pressure derivative";
       protected
         Real dpt;
       algorithm

--- a/Modelica/Media/Water/IF97_Utilities.mo
+++ b/Modelica/Media/Water/IF97_Utilities.mo
@@ -3113,8 +3113,8 @@ email: hubertus@modelon.se
       function tsat_der "Derivative function for tsat"
         extends Modelica.Icons.Function;
         input SI.Pressure p "Pressure";
-        input Real der_p(unit="Pa/s") "Pressure derivative";
-        output Real der_tsat(unit="K/s") "Temperature derivative";
+        input SI.PressureRate der_p "Pressure derivative";
+        output SI.TemperatureSlope der_tsat "Temperature derivative";
       protected
         Real dtp;
       algorithm
@@ -3201,8 +3201,8 @@ email: hubertus@modelon.se
       function psat_der "Derivative function for psat"
         extends Modelica.Icons.Function;
         input SI.Temperature T "Temperature (K)";
-        input Real der_T(unit="K/s") "Temperature derivative";
-        output Real der_psat(unit="Pa/s") "Pressure";
+        input SI.TemperatureSlope der_T "Temperature derivative";
+        output SI.PressureRate der_psat "Pressure";
       protected
         Real dpt;
       algorithm

--- a/Modelica/Media/package.mo
+++ b/Modelica/Media/package.mo
@@ -2149,7 +2149,7 @@ package Examples
   model SimpleLiquidWater "Example for Water.SimpleLiquidWater medium model"
     extends Modelica.Icons.Example;
 
-    constant SI.PressureRate pressureRate = 1e5/10;
+    constant SI.PressureSlope pressureRate = 1e5/10;
     parameter SI.Volume V=1 "Volume";
     parameter SI.EnthalpyFlowRate H_flow_ext=1.e6
       "Constant enthalpy flow rate into the volume";
@@ -2220,11 +2220,11 @@ package Examples
     Real der_T;
   protected
     parameter SI.AbsolutePressure p01 = 100000.0 "state.p at time 0";
-    parameter SI.PressureRate pRate1 = 0 "state.p rate of change";
+    parameter SI.PressureSlope pRate1 = 0 "state.p rate of change";
     parameter SI.Temperature T01 = 200 "state.T at time 0";
     parameter SI.TemperatureSlope Trate1 = 1000 "state.T rate of change";
     parameter SI.AbsolutePressure p02 = 2.0e5 "state2.p at time 0";
-    parameter SI.PressureRate pRate2 = 0 "state2.p rate of change";
+    parameter SI.PressureSlope pRate2 = 0 "state2.p rate of change";
     parameter SI.Temperature T02 = 500 "state2.T at time 0";
     parameter SI.TemperatureSlope Trate2 = 0 "state2.T rate of change";
 
@@ -2408,11 +2408,11 @@ is given to compare the approximation.
   protected
     constant SI.Time unitTime=1;
     parameter SI.AbsolutePressure p01 = 1.e5 "state1.p at time 0";
-    parameter SI.PressureRate pRate1 = 1.e5 "state1.p rate of change";
+    parameter SI.PressureSlope pRate1 = 1.e5 "state1.p rate of change";
     parameter SI.Temperature T01 = 300 "state1.T at time 0";
     parameter SI.TemperatureSlope Trate1 = 10 "state1.T rate of change";
     parameter SI.AbsolutePressure p02 = 1.e5 "state2.p at time 0";
-    parameter SI.PressureRate pRate2 = 1.e5/2 "state2.p rate of change";
+    parameter SI.PressureSlope pRate2 = 1.e5/2 "state2.p rate of change";
     parameter SI.Temperature T02 = 340 "state2.T at time 0";
     parameter SI.TemperatureSlope Trate2 = -20 "state2.T rate of change";
   equation
@@ -2614,7 +2614,7 @@ It must be noted that the relationship of both axis variables is not right-angle
       ExtendedProperties medium(p(start=2000.0, fixed=true), h(start=8.0e5,
             fixed=true));
       parameter Real dh(unit="J/(kg.s)", displayUnit="kJ/(kg.s)") = 80000.0 "Derivative of specific enthalpy of medium";
-      parameter SI.PressureRate dp = 1.0e6 "Derivative of pressure of medium";
+      parameter SI.PressureSlope dp = 1.0e6 "Derivative of pressure of medium";
     equation
       der(medium.p) = dp;
       der(medium.h) = dh;
@@ -2717,11 +2717,11 @@ points, e.g., when an isentropic reference state is computed.
     protected
       constant SI.Time unitTime=1;
       parameter SI.AbsolutePressure p01 = 1.e5 "state1.p at time 0";
-      parameter SI.PressureRate pRate1 = 1.e5 "state1.p rate of change";
+      parameter SI.PressureSlope pRate1 = 1.e5 "state1.p rate of change";
       parameter SI.Temperature T01 = 300 "state1.T at time 0";
       parameter SI.TemperatureSlope Trate1 = 10 "state1.T rate of change";
       parameter SI.AbsolutePressure p02 = 1.e5 "state2.p at time 0";
-      parameter SI.PressureRate pRate2 = 1.e5/2 "state2.p rate of change";
+      parameter SI.PressureSlope pRate2 = 1.e5/2 "state2.p rate of change";
       parameter SI.Temperature T02 = 340 "state2.T at time 0";
       parameter SI.TemperatureSlope Trate2 = -20 "state2.T rate of change";
     equation

--- a/Modelica/Media/package.mo
+++ b/Modelica/Media/package.mo
@@ -2220,11 +2220,11 @@ package Examples
     Real der_T;
   protected
     parameter SI.AbsolutePressure p01 = 100000.0 "state.p at time 0";
-    parameter Real pRate1(unit = "Pa/s") = 0 "state.p rate of change";
+    parameter SI.PressureRate pRate1 = 0 "state.p rate of change";
     parameter SI.Temperature T01 = 200 "state.T at time 0";
     parameter SI.TemperatureSlope Trate1 = 1000 "state.T rate of change";
     parameter SI.AbsolutePressure p02 = 2.0e5 "state2.p at time 0";
-    parameter Real pRate2(unit = "Pa/s") = 0 "state2.p rate of change";
+    parameter SI.PressureRate pRate2 = 0 "state2.p rate of change";
     parameter SI.Temperature T02 = 500 "state2.T at time 0";
     parameter SI.TemperatureSlope Trate2 = 0 "state2.T rate of change";
 
@@ -2408,11 +2408,11 @@ is given to compare the approximation.
   protected
     constant SI.Time unitTime=1;
     parameter SI.AbsolutePressure p01 = 1.e5 "state1.p at time 0";
-    parameter Real pRate1(unit = "Pa/s") = 1.e5 "state1.p rate of change";
+    parameter SI.PressureRate pRate1 = 1.e5 "state1.p rate of change";
     parameter SI.Temperature T01 = 300 "state1.T at time 0";
     parameter SI.TemperatureSlope Trate1 = 10 "state1.T rate of change";
     parameter SI.AbsolutePressure p02 = 1.e5 "state2.p at time 0";
-    parameter Real pRate2(unit = "Pa/s") = 1.e5/2 "state2.p rate of change";
+    parameter SI.PressureRate pRate2 = 1.e5/2 "state2.p rate of change";
     parameter SI.Temperature T02 = 340 "state2.T at time 0";
     parameter SI.TemperatureSlope Trate2 = -20 "state2.T rate of change";
   equation
@@ -2613,8 +2613,8 @@ It must be noted that the relationship of both axis variables is not right-angle
       extends Modelica.Icons.Example;
       ExtendedProperties medium(p(start=2000.0, fixed=true), h(start=8.0e5,
             fixed=true));
-      parameter Real dh(unit="J/(kg.s)", displayUnit="kJ/(kg.s)")=80000.0 "Derivative of specific enthalpy of medium";
-      parameter Real dp(unit="Pa/s", displayUnit="bar/s")=1.0e6 "Derivative of pressure of medium";
+      parameter Real dh(unit="J/(kg.s)", displayUnit="kJ/(kg.s)") = 80000.0 "Derivative of specific enthalpy of medium";
+      parameter SI.PressureRate dp = 1.0e6 "Derivative of pressure of medium";
     equation
       der(medium.p) = dp;
       der(medium.h) = dh;
@@ -2717,11 +2717,11 @@ points, e.g., when an isentropic reference state is computed.
     protected
       constant SI.Time unitTime=1;
       parameter SI.AbsolutePressure p01 = 1.e5 "state1.p at time 0";
-      parameter Real pRate1(unit = "Pa/s") = 1.e5 "state1.p rate of change";
+      parameter SI.PressureRate pRate1 = 1.e5 "state1.p rate of change";
       parameter SI.Temperature T01 = 300 "state1.T at time 0";
       parameter SI.TemperatureSlope Trate1 = 10 "state1.T rate of change";
       parameter SI.AbsolutePressure p02 = 1.e5 "state2.p at time 0";
-      parameter Real pRate2(unit = "Pa/s") = 1.e5/2 "state2.p rate of change";
+      parameter SI.PressureRate pRate2 = 1.e5/2 "state2.p rate of change";
       parameter SI.Temperature T02 = 340 "state2.T at time 0";
       parameter SI.TemperatureSlope Trate2 = -20 "state2.T rate of change";
     equation

--- a/Modelica/Units.mo
+++ b/Modelica/Units.mo
@@ -342,8 +342,8 @@ end UsersGuide;
         displayUnit="bar");
     type AbsolutePressure = Pressure (min=0.0, nominal = 1e5);
     type PressureDifference = Pressure;
-    type PressureRate = Real (
-        final quantity="PressureRate",
+    type PressureSlope = Real (
+        final quantity="PressureSlope",
         final unit="Pa/s",
         displayUnit="bar/s");
     type BulkModulus = AbsolutePressure;


### PR DESCRIPTION
This is a follow-up of the recently merged PRs #4115 (adding unit "Pa/s") and #4103 (introducing a new type PressureRate with unit "Pa/s").