### PR TITLE
Set unit instead of having it in description

### DIFF
--- a/Modelica/ComplexBlocks/ComplexMath/Bode.mo
+++ b/Modelica/ComplexBlocks/ComplexMath/Bode.mo
@@ -25,7 +25,7 @@ block Bode "Calculate quantities to plot Bode diagram"
         extent={{-10,10},{10,-10}},
         rotation=270,
         origin={0,-20})));
-  Blocks.Interfaces.RealOutput dB_y(unit="dB") "Log10 of absolute value of ratio u / divisor in dB" annotation (Placement(transformation(
+  Blocks.Interfaces.RealOutput dB_y(unit="dB") "Log10 of absolute value of ratio u / divisor" annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={0,-110}), iconTransformation(

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/SeriesBode.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/SeriesBode.mo
@@ -2,7 +2,7 @@ within Modelica.Electrical.QuasiStatic.SinglePhase.Examples;
 model SeriesBode "Series circuit with Bode analysis"
   extends Modelica.Icons.Example;
   output Real abs_y = bode.abs_y "Magnitude of voltage ratio";
-  output SI.AmplitudeLevelDifference dB_y = bode.dB_y "Log10 of magnitude of voltage ratio in dB";
+  output SI.AmplitudeLevelDifference dB_y = bode.dB_y "Log10 of magnitude of voltage ratio";
   output SI.Angle arg_y = bode.arg_y "Angle of voltage ratio";
   Modelica.Blocks.Sources.LogFrequencySweep frequencySweep(
     duration=1,

--- a/Modelica/StateGraph.mo
+++ b/Modelica/StateGraph.mo
@@ -1535,9 +1535,9 @@ buttons:
                        annotation (Placement(transformation(extent={{55,-50},{
                   65,-40}})));
       Real level(start=0,fixed=true) "Tank level in % of max height";
-      parameter Modelica.Units.SI.Area A=1 "Ground area of tank";
-      parameter Modelica.Units.SI.Area a=0.2 "Area of drain hole";
-      parameter Modelica.Units.SI.Height hmax=1 "Max height of tank";
+      parameter SI.Area A=1 "Ground area of tank";
+      parameter SI.Area a=0.2 "Area of drain hole";
+      parameter SI.Height hmax=1 "Max height of tank";
       constant Real g=Modelica.Constants.g_n;
     equation
       der(level) = (inflow1.Fi - outflow1.Fo)/(hmax*A);

--- a/Modelica/StateGraph.mo
+++ b/Modelica/StateGraph.mo
@@ -1535,9 +1535,9 @@ buttons:
                        annotation (Placement(transformation(extent={{55,-50},{
                   65,-40}})));
       Real level(start=0,fixed=true) "Tank level in % of max height";
-      parameter Real A=1 "Ground area of tank in m^2";
-      parameter Real a=0.2 "Area of drain hole in m^2";
-      parameter Real hmax=1 "Max height of tank in m";
+      parameter Real A(unit="m2")=1 "Ground area of tank";
+      parameter Real a(unit="m2")=0.2 "Area of drain hole";
+      parameter Real hmax(unit="m")=1 "Max height of tank";
       constant Real g=Modelica.Constants.g_n;
     equation
       der(level) = (inflow1.Fi - outflow1.Fo)/(hmax*A);

--- a/Modelica/StateGraph.mo
+++ b/Modelica/StateGraph.mo
@@ -1535,9 +1535,9 @@ buttons:
                        annotation (Placement(transformation(extent={{55,-50},{
                   65,-40}})));
       Real level(start=0,fixed=true) "Tank level in % of max height";
-      parameter Real A(unit="m2")=1 "Ground area of tank";
-      parameter Real a(unit="m2")=0.2 "Area of drain hole";
-      parameter Real hmax(unit="m")=1 "Max height of tank";
+      parameter Modelica.Units.SI.Area A=1 "Ground area of tank";
+      parameter Modelica.Units.SI.Area a=0.2 "Area of drain hole";
+      parameter Modelica.Units.SI.Height hmax=1 "Max height of tank";
       constant Real g=Modelica.Constants.g_n;
     equation
       der(level) = (inflow1.Fi - outflow1.Fo)/(hmax*A);


### PR DESCRIPTION
Closes #4076 
Only that StateGraph model and two uses of "in dB" were changed.
In addition to these changes the only other cases were in Modelica.Units.Conversions - cases such as the following:

```
function to_degC "Convert from kelvin to degree Celsius"
  extends Modelica.Units.Icons.Conversion;
  input SI.Temperature Kelvin "Value in kelvin";
  output Modelica.Units.NonSI.Temperature_degC Celsius "Value in degree Celsius";
```

I **didn't** update them, because:
- It seemed a bit tedious
- Without the unit the documentation would be kind of meaningless. "You send in a value and get out a value!"

It may be possible to reformulate it in a good way without the redundant unit but I don't know exactly how, and I don't view it as important.