### PR TITLE
Inertial stuck mode for friction models

### DIFF
--- a/Modelica/Mechanics/Rotational/Interfaces/PartialFriction.mo
+++ b/Modelica/Mechanics/Rotational/Interfaces/PartialFriction.mo
@@ -1,7 +1,6 @@
 within Modelica.Mechanics.Rotational.Interfaces;
 partial model PartialFriction "Partial model of Coulomb friction elements"
 
-  // parameter SI.AngularVelocity w_small=1 "Relative angular velocity near to zero (see model info text)";
   parameter SI.AngularVelocity w_small=1.0e10
     "Relative angular velocity near to zero if jumps due to a reinit(..) of the velocity can occur (set to low value only if such impulses can occur)"
     annotation (Dialog(tab="Advanced"));

--- a/Modelica/Mechanics/Rotational/Interfaces/PartialFriction.mo
+++ b/Modelica/Mechanics/Rotational/Interfaces/PartialFriction.mo
@@ -1,6 +1,9 @@
 within Modelica.Mechanics.Rotational.Interfaces;
 partial model PartialFriction "Partial model of Coulomb friction elements"
 
+  parameter Real J_inv_fixed(unit="kg-1.m-2")=0
+    "Virtual inverse moment of inertia in locked state to handle fix point iteration problems if the velocity is not selected as state"
+    annotation (Dialog(tab="Advanced"));
   parameter SI.AngularVelocity w_small=1.0e10
     "Relative angular velocity near to zero if jumps due to a reinit(..) of the velocity can occur (set to low value only if such impulses can occur)"
     annotation (Dialog(tab="Advanced"));
@@ -52,7 +55,7 @@ equation
   locked = not free and not (pre(mode) == Forward or startForward or pre(
     mode) == Backward or startBackward);
 
-  a_relfric/unitAngularAcceleration = if locked then 0 else if free then sa
+  a_relfric/unitAngularAcceleration = if locked then J_inv_fixed*sa*unitTorque else if free then sa
     else if startForward then sa - tau0_max/unitTorque
     else if startBackward then sa + tau0_max/unitTorque
     else if pre(mode) == Forward then sa - tau0_max/unitTorque

--- a/Modelica/Mechanics/Translational/Interfaces/PartialFriction.mo
+++ b/Modelica/Mechanics/Translational/Interfaces/PartialFriction.mo
@@ -2,6 +2,9 @@ within Modelica.Mechanics.Translational.Interfaces;
 partial model PartialFriction "Base model of Coulomb friction elements"
 
   //extends Translational.Interfaces.PartialRigid;
+  parameter Real m_inv_fixed(unit="kg-1")=0
+    "Virtual inverse mass in locked state to handle fix point iteration problems if the velocity is not selected as state"
+    annotation (Dialog(tab="Advanced"));
   parameter SI.Velocity v_small=1e-3
     "Relative velocity near to zero (see model info text)"
     annotation (Dialog(tab="Advanced"));
@@ -51,7 +54,7 @@ equation
   locked = not free and not (pre(mode) == Forward or startForward or pre(
     mode) == Backward or startBackward);
 
-  a_relfric/unitAcceleration = if locked then 0 else if free then sa
+  a_relfric/unitAcceleration = if locked then m_inv_fixed*sa*unitForce else if free then sa
     else if startForward then sa - f0_max/unitForce
     else if startBackward then sa + f0_max/unitForce
     else if pre(mode) == Forward then sa - f0_max/unitForce

--- a/ModelicaTest/Rotational.mo
+++ b/ModelicaTest/Rotational.mo
@@ -1670,6 +1670,44 @@ they were not deleted yet.")}));
     annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(coordinateSystem(preserveAspectRatio=false)));
   end TestFrictionPosition;
 
+  model TestFrictionPositionInertial
+    extends Modelica.Icons.Example;
+
+    Modelica.Mechanics.Rotational.Sources.Position position(exact=true)
+      annotation (Placement(transformation(extent={{-10,30},{10,50}})));
+
+    Modelica.Blocks.Sources.Cosine cosine(
+      amplitude=0.1,
+      f=1,
+      phase=0,
+      continuous=true,
+      offset=0.5,
+      startTime=0.1) annotation (Placement(transformation(extent={{-70,30},{-50,50}})));
+
+    Modelica.Mechanics.Rotational.Components.BearingFriction bearingFriction(
+      tau_pos=[0,5; 100,5],
+      peak=1.001) annotation (Placement(transformation(extent={{46,30},{66,50}})));
+    Modelica.Mechanics.Rotational.Sources.Position position1(exact=true)
+      annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+    Modelica.Blocks.Sources.Cosine cosine1(
+      amplitude=0.3,
+      f=1,
+      phase=3.1415926535898,
+      continuous=true,
+      offset=0.5,
+      startTime=0.1) annotation (Placement(transformation(extent={{-70,-10},{-50,10}})));
+    Modelica.Mechanics.Rotational.Components.BearingFriction bearingFriction2(
+      tau_pos=[0,5; 100,5],
+      peak=1.001) annotation (Placement(transformation(extent={{46,-10},{66,10}})));
+  equation
+
+    connect(cosine.y, position.phi_ref) annotation (Line(points={{-49,40},{-12,40}}, color={0,0,127}));
+    connect(position.flange, bearingFriction.flange_a) annotation (Line(points={{10,40},{48,40},{48,40},{46,40}}, color={0,0,0}));
+    connect(cosine1.y, position1.phi_ref) annotation (Line(points={{-49,0},{-12,0}}, color={0,0,127}));
+    connect(position1.flange, bearingFriction2.flange_a) annotation (Line(points={{10,0},{46,0}}, color={0,0,0}));
+    annotation (Placement(transformation(extent={{46,-10},{66,10}})));
+  end TestFrictionPositionInertial;
+
   model TestBraking
     extends Modelica.Icons.Example;
     Modelica.Mechanics.Rotational.Components.Inertia inertia1(

--- a/ModelicaTest/Rotational.mo
+++ b/ModelicaTest/Rotational.mo
@@ -1686,7 +1686,8 @@ they were not deleted yet.")}));
 
     Modelica.Mechanics.Rotational.Components.BearingFriction bearingFriction(
       tau_pos=[0,5; 100,5],
-      peak=1.001) annotation (Placement(transformation(extent={{46,30},{66,50}})));
+      peak=1.001,
+      J_inv_fixed=1e-15) annotation (Placement(transformation(extent={{46,30},{66,50}})));
     Modelica.Mechanics.Rotational.Sources.Position position1(exact=true)
       annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
     Modelica.Blocks.Sources.Cosine cosine1(
@@ -1698,7 +1699,8 @@ they were not deleted yet.")}));
       startTime=0.1) annotation (Placement(transformation(extent={{-70,-10},{-50,10}})));
     Modelica.Mechanics.Rotational.Components.BearingFriction bearingFriction2(
       tau_pos=[0,5; 100,5],
-      peak=1.001) annotation (Placement(transformation(extent={{46,-10},{66,10}})));
+      peak=1.001,
+      J_inv_fixed=1e-15) annotation (Placement(transformation(extent={{46,-10},{66,10}})));
   equation
 
     connect(cosine.y, position.phi_ref) annotation (Line(points={{-49,40},{-12,40}}, color={0,0,127}));

--- a/ModelicaTest/Rotational.mo
+++ b/ModelicaTest/Rotational.mo
@@ -1626,7 +1626,6 @@ they were not deleted yet.")}));
   model TestFrictionPosition
     extends Modelica.Icons.Example;
 
-    parameter Real fric=155.9218;
     Modelica.Mechanics.Rotational.Sources.Position    position(exact=true)
       annotation (Placement(transformation(extent={{-10,30},{10,50}})));
 

--- a/ModelicaTest/Rotational.mo
+++ b/ModelicaTest/Rotational.mo
@@ -1655,7 +1655,7 @@ they were not deleted yet.")}));
     Modelica.Blocks.Sources.Sine sine2(
       amplitude=0.3,
       f=1,
-      phase=0.78539816339745,
+      phase=2.3561944901923,
       offset=0.5) annotation (Placement(transformation(extent={{-70,-10},{-50,10}})));
     Modelica.Mechanics.Rotational.Components.BearingFriction    bearingFriction2(tau_pos=[0,5; 100,5], peak=1.001)
       annotation (Placement(transformation(extent={{46,-10},{66,10}})));

--- a/ModelicaTest/Translational.mo
+++ b/ModelicaTest/Translational.mo
@@ -359,7 +359,7 @@ extends Modelica.Icons.ExamplesPackage;
     Modelica.Blocks.Sources.Sine sine2(
       amplitude=0.3,
       f=1,
-      phase=0.78539816339745,
+      phase=2.3561944901923,
       offset=0.5) annotation (Placement(transformation(extent={{-70,-10},{-50,10}})));
     Modelica.Mechanics.Translational.Components.SupportFriction supportFriction2(f_pos=
           Modelica.Mechanics.Translational.Examples.Utilities.GenerateStribeckFrictionTable(

--- a/ModelicaTest/Translational.mo
+++ b/ModelicaTest/Translational.mo
@@ -405,7 +405,8 @@ extends Modelica.Icons.ExamplesPackage;
           1,
           12,
           50),
-      peak=1.001) annotation (Placement(transformation(extent={{46,30},{66,50}})));
+      peak=1.001,
+      m_inv_fixed=1e-15) annotation (Placement(transformation(extent={{46,30},{66,50}})));
     Modelica.Mechanics.Translational.Sources.Speed speed1(exact=true)
       annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
     Modelica.Blocks.Sources.Cosine cosine1(
@@ -423,7 +424,8 @@ extends Modelica.Icons.ExamplesPackage;
           1,
           12,
           50),
-      peak=1.001) annotation (Placement(transformation(extent={{46,-10},{66,10}})));
+      peak=1.001,
+      m_inv_fixed=1e-15) annotation (Placement(transformation(extent={{46,-10},{66,10}})));
   equation
 
     connect(speed.flange, supportFriction.flange_a) annotation (Line(points={{10,40},{46,40}}, color={0,127,0}));

--- a/ModelicaTest/Translational.mo
+++ b/ModelicaTest/Translational.mo
@@ -382,4 +382,54 @@ extends Modelica.Icons.ExamplesPackage;
     connect(position1.flange, supportFriction2.flange_a) annotation (Line(points={{10,0},{46,0}}, color={0,127,0}));
     annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(coordinateSystem(preserveAspectRatio=false)));
   end TestFrictionPosition;
+
+  model TestFrictionPositionInertial
+    extends Modelica.Icons.Example;
+
+    Modelica.Mechanics.Translational.Sources.Speed speed(exact=true)
+      annotation (Placement(transformation(extent={{-10,30},{10,50}})));
+
+    Modelica.Blocks.Sources.Cosine cosine(
+      amplitude=0.1,
+      f=1,
+      phase=0,
+      continuous=true,
+      offset=0.5,
+      startTime=0.1) annotation (Placement(transformation(extent={{-70,30},{-50,50}})));
+
+    Modelica.Mechanics.Translational.Components.SupportFriction supportFriction(
+      f_pos=Modelica.Mechanics.Translational.Examples.Utilities.GenerateStribeckFrictionTable(
+          1,
+          5,
+          10,
+          1,
+          12,
+          50),
+      peak=1.001) annotation (Placement(transformation(extent={{46,30},{66,50}})));
+    Modelica.Mechanics.Translational.Sources.Speed speed1(exact=true)
+      annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+    Modelica.Blocks.Sources.Cosine cosine1(
+      amplitude=0.3,
+      f=1,
+      phase=3.1415926535898,
+      continuous=true,
+      offset=0.5,
+      startTime=0.1) annotation (Placement(transformation(extent={{-70,-10},{-50,10}})));
+    Modelica.Mechanics.Translational.Components.SupportFriction supportFriction2(
+      f_pos=Modelica.Mechanics.Translational.Examples.Utilities.GenerateStribeckFrictionTable(
+          1,
+          5,
+          10,
+          1,
+          12,
+          50),
+      peak=1.001) annotation (Placement(transformation(extent={{46,-10},{66,10}})));
+  equation
+
+    connect(speed.flange, supportFriction.flange_a) annotation (Line(points={{10,40},{46,40}}, color={0,127,0}));
+    connect(speed1.flange, supportFriction2.flange_a) annotation (Line(points={{10,0},{46,0}}, color={0,127,0}));
+    connect(cosine.y, speed.v_ref) annotation (Line(points={{-49,40},{-12,40},{-12,40}}, color={0,0,127}));
+    connect(cosine1.y, speed1.v_ref) annotation (Line(points={{-49,0},{-12,0}}, color={0,0,127}));
+    annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(coordinateSystem(preserveAspectRatio=false)));
+  end TestFrictionPositionInertial;
 end Translational;

--- a/ModelicaTest/Translational.mo
+++ b/ModelicaTest/Translational.mo
@@ -317,7 +317,6 @@ extends Modelica.Icons.ExamplesPackage;
   model TestFrictionPosition
     extends Modelica.Icons.Example;
 
-    parameter Real fric=155.9218;
     Modelica.Mechanics.Translational.Sources.Position position(exact=true)
       annotation (Placement(transformation(extent={{-10,30},{10,50}})));
 


### PR DESCRIPTION
The current implementation of the friction models require the velocity to be selected as state. This is not the case for all model configurations (e. g. a MultiBody crankshaft connected to a translational bearing). The problem can be reduced to this exemplary model:

![image](https://github.com/modelica/ModelicaStandardLibrary/assets/30152720/cb60bb30-01ef-43a8-afc2-1c905696425e)

This can be solved by introducing an inertial stuck mode as described in the documentation of this PR:

> If the velocity of the friction element is not selected as state (e. g. if connected to MultiBody elements like a crancshaft), the fix point iteration will not be able to solve the set of equations when leaving the stuck mode. In this case the acceleration is overdetermined by the external constrait a <> 0 and the stuck mode equation a = 0. Now that we already became comfortable with a non-zero but extremly small velocity in stuck mode, we can introduce another assumption: When locked, the block is fixed to a extremely huge mass. This means it can move in stuck mode, but then implies a huge friction force. These high values will not enter the integrator, because they only act during fix point iteration and directly lead to leaving the stuck mode. For better parametrization not the mass (or the moment of inertia in rotational case) but rather the inverse mass m_inv_fixed will be the input parameter. By default it is set to zero and implies exactly the same behaviour as the set of equations above. At fix point iteration problems it can be set to a small value (e. g. 1e-15) meaning a huge mass. This results in a slightly modified set of equations:

```
// part of mixed system of equations
startFor  = pre(mode) == Stuck and sa >  1;
startBack = pre(mode) == Stuck and sa < -1;
        a = der(v);
        a = if pre(mode) == Forward  or startFor  then  sa - 1    elseif
               pre(mode) == Backward or startBack then  sa + 1    else m_inv*f;
        f = if pre(mode) == Forward or startFor   then  f0 + f1*v elseif
               pre(mode) == Backward or startBack then -f0 + f1*v else f0*sa;

// state machine to determine configuration
mode = if (pre(mode) == Forward  or startFor)  and v>0 then Forward  elseif
          (pre(mode) == Backward or startBack) and v<0 then Backward else Stuck;
```


