### PR TITLE
Fix MSVC warning on strdup

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaMatIO.c
+++ b/Modelica/Resources/C-Sources/ModelicaMatIO.c
@@ -3327,7 +3327,7 @@ Mat_GetDir(mat_t *mat, size_t *n)
                         }
                         if ( NULL != dir ) {
                             mat->dir = dir;
-                            mat->dir[mat->num_datasets++] = strdup(matvar->name);
+                            mat->dir[mat->num_datasets++] = Mat_strdup(matvar->name);
                         } else {
                             Mat_Critical("Couldn't allocate memory for the directory");
                             break;


### PR DESCRIPTION
Follow-up of #4222. I missed that one location. (Only detected when playing with #4265.) Sorry for the extra review.