### PR TITLE
resolves #4306

### DIFF
--- a/Modelica/Electrical/Analog/Examples/Lines/LightningSegmentedTransmissionLine.mo
+++ b/Modelica/Electrical/Analog/Examples/Lines/LightningSegmentedTransmissionLine.mo
@@ -44,12 +44,12 @@ model LightningSegmentedTransmissionLine
     startTime=0.02)                   annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=90,
-        origin={10,10})));
+        origin={0,10})));
 initial equation
-  line1.C.v=zeros(N);
-  line1.L.i=zeros(N + 1);
-  line2.C.v=zeros(N);
-  line2.L[2:N + 1].i=zeros(N);
+  line1.v=zeros(N);
+  line1.i=zeros(N + 1);
+  line2.v=zeros(N);
+  line2.i[2:N + 1]=zeros(N);
 equation
   connect(line1.p1, source.p)
     annotation (Line(points={{-40,20},{-60,20}}, color={0,0,255}));
@@ -59,9 +59,12 @@ equation
           -10},{0,-10}}, color={0,0,255}));
   connect(ground.p, load.n)
     annotation (Line(points={{0,-10},{60,-10},{60,0}}, color={0,0,255}));
-  connect(line1.p2, lightningImpulseCurrent.n) annotation (Line(points={{-20,20},{10,20}}, color={0,0,255}));
-  connect(lightningImpulseCurrent.n, line2.p1) annotation (Line(points={{10,20},{20,20}}, color={0,0,255}));
-  connect(ground.p, lightningImpulseCurrent.p) annotation (Line(points={{0,-10},{10,-10},{10,0}}, color={0,0,255}));
+  connect(line1.p2, lightningImpulseCurrent.n) annotation (Line(points={{-20,20},
+          {0,20}},                                                                         color={0,0,255}));
+  connect(lightningImpulseCurrent.n, line2.p1) annotation (Line(points={{0,20},{
+          20,20}},                                                                        color={0,0,255}));
+  connect(ground.p, lightningImpulseCurrent.p) annotation (Line(points={{0,-10},
+          {0,0}},                                                                                 color={0,0,255}));
   connect(ground.p, line1.p3)
     annotation (Line(points={{0,-10},{-30,-10},{-30,10}}, color={0,0,255}));
   connect(ground.p, line2.p3)
@@ -69,7 +72,7 @@ equation
   annotation (
     experiment(
       StopTime=0.025,
-      Interval=1e-07,
+      Interval=1e-06,
       Tolerance=1e-06),
     Documentation(info="<html>
 <p>

--- a/Modelica/Electrical/Analog/Lines/OLine.mo
+++ b/Modelica/Electrical/Analog/Lines/OLine.mo
@@ -46,6 +46,15 @@ model OLine "Lossy Transmission Line"
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if useHeatPort
     annotation (Placement(transformation(extent={{-110,-110},{-90,-90}}),
         iconTransformation(extent={{-110,-110},{-90,-90}})));
+  output SI.Voltage v[N]=G.v "Voltages at the connections of the elements";
+  output SI.Current i[N+1]=R.i "Currents at the connections of the elements";
+  /* 
+  The components R[N+1], L[N+1], C[N] and G[N] have been protected in the previous release(s)
+  to avoid excessive size of simulation results.
+  Voltages and currents at the connections are now mirrored to alias variables
+  to be able to initialize and to track travelling waves along the line.
+  */
+protected
   Modelica.Electrical.Analog.Basic.Resistor R[N + 1](
     R=rm,
     T_ref=fill(T_ref, N + 1),
@@ -60,7 +69,6 @@ model OLine "Lossy Transmission Line"
     alpha=fill(alpha_G, N),
     useHeatPort=fill(useHeatPort, N),
     T=fill(T, N));
-protected
   parameter SI.Resistance rm[N + 1]=
   {if i==1 or i==N + 1 then r*length/(N*2) else r*length/N for i in 1:N+1};
   parameter SI.Inductance lm[N + 1]=

--- a/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/Lines/LightningSegmentedTransmissionLine/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/Lines/LightningSegmentedTransmissionLine/comparisonSignals.txt
@@ -1,4 +1,4 @@
 time
 source.i
-load.v
 load.i
+lightningImpulseCurrent.v


### PR DESCRIPTION
... i.e. excessive size of the simulation result. 
1. The elements R[N+1], L[N+1], G[N] and C[N] are protected again, but voltages v[N] and currents i[N+1] are mirrored to to alias variables to be able to initialize and to track traveling waves along the line.
2. The output interval of the example has been relaxed to 1e-6,
3. The comparisonSignals,txt has been updated: It doesn't make sense to compare both current and voltage at the load resistor, but the voltage in the middle of the line is useful.
