### PR TITLE
Consider shiftTime for verbose extrapolation in CombiTimeTable

### DIFF
--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -1684,11 +1684,11 @@ parameter Real table[:, <strong>2</strong>]=[0, 0; 1, 1; 2, 4];
     if verboseExtrapolation and (
       extrapolation == Modelica.Blocks.Types.Extrapolation.LastTwoPoints or
       extrapolation == Modelica.Blocks.Types.Extrapolation.HoldLastPoint) then
-      assert(noEvent(time >= t_min), "
+      assert(noEvent(time >= t_min + shiftTime), "
 Extrapolation warning: Time (=" + String(time) + ") must be greater or equal
 than the minimum abscissa value t_min (=" + String(t_min) + ") defined in the table.
 ", level=AssertionLevel.warning);
-      assert(noEvent(time <= t_max), "
+      assert(noEvent(time <= t_max + shiftTime), "
 Extrapolation warning: Time (=" + String(time) + ") must be less or equal
 than the maximum abscissa value t_max (=" + String(t_max) + ") defined in the table.
 ", level=AssertionLevel.warning);

--- a/Modelica/Blocks/Sources.mo
+++ b/Modelica/Blocks/Sources.mo
@@ -1685,12 +1685,12 @@ parameter Real table[:, <strong>2</strong>]=[0, 0; 1, 1; 2, 4];
       extrapolation == Modelica.Blocks.Types.Extrapolation.LastTwoPoints or
       extrapolation == Modelica.Blocks.Types.Extrapolation.HoldLastPoint) then
       assert(noEvent(time >= t_min + shiftTime), "
-Extrapolation warning: Time (=" + String(time) + ") must be greater or equal
-than the minimum abscissa value t_min (=" + String(t_min) + ") defined in the table.
+Extrapolation warning: Time must be greater or equal
+than the shifted minimum abscissa value defined in the table.
 ", level=AssertionLevel.warning);
       assert(noEvent(time <= t_max + shiftTime), "
-Extrapolation warning: Time (=" + String(time) + ") must be less or equal
-than the maximum abscissa value t_max (=" + String(t_max) + ") defined in the table.
+Extrapolation warning: Time must be less or equal
+than the shifted maximum abscissa value defined in the table.
 ", level=AssertionLevel.warning);
     end if;
 

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.c
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.c
@@ -1167,13 +1167,11 @@ double ModelicaStandardTables_CombiTimeTable_getValue(void* _tableID, int iCol,
                             break;
 
                         case NO_EXTRAPOLATION:
-                            ModelicaFormatError("Extrapolation error: Time "
-                                "(=%lf) must be %s or equal\nthan the %s abscissa "
-                                "value %s (=%lf) defined in the table.\n", tOld,
+                            ModelicaFormatError("Extrapolation error: Time must be "
+                                "%s or equal\nthan the shifted %s abscissa "
+                                "value defined in the table.\n",
                                 (extrapolate == LEFT) ? "greater" : "less",
-                                (extrapolate == LEFT) ? "minimum" : "maximum",
-                                (extrapolate == LEFT) ? "t_min" : "t_max",
-                                (extrapolate == LEFT) ? tMin : tMax);
+                                (extrapolate == LEFT) ? "minimum" : "maximum");
                             return y;
 
                         case PERIODIC:
@@ -1425,13 +1423,11 @@ double ModelicaStandardTables_CombiTimeTable_getDerValue(void* _tableID, int iCo
                             break;
 
                         case NO_EXTRAPOLATION:
-                            ModelicaFormatError("Extrapolation error: Time "
-                                "(=%lf) must be %s or equal\nthan the %s abscissa "
-                                "value %s (=%lf) defined in the table.\n", tOld,
+                            ModelicaFormatError("Extrapolation error: Time must be "
+                                "%s or equal\nthan the shifted %s abscissa "
+                                "value defined in the table.\n",
                                 (extrapolate == LEFT) ? "greater" : "less",
-                                (extrapolate == LEFT) ? "minimum" : "maximum",
-                                (extrapolate == LEFT) ? "t_min" : "t_max",
-                                (extrapolate == LEFT) ? tMin : tMax);
+                                (extrapolate == LEFT) ? "minimum" : "maximum");
                             return der_y;
 
                         case PERIODIC:
@@ -1685,13 +1681,11 @@ double ModelicaStandardTables_CombiTimeTable_getDer2Value(void* _tableID, int iC
                             break;
 
                         case NO_EXTRAPOLATION:
-                            ModelicaFormatError("Extrapolation error: Time "
-                                "(=%lf) must be %s or equal\nthan the %s abscissa "
-                                "value %s (=%lf) defined in the table.\n", tOld,
+                            ModelicaFormatError("Extrapolation error: Time must be "
+                                "%s or equal\nthan the shifted %s abscissa "
+                                "value defined in the table.\n",
                                 (extrapolate == LEFT) ? "greater" : "less",
-                                (extrapolate == LEFT) ? "minimum" : "maximum",
-                                (extrapolate == LEFT) ? "t_min" : "t_max",
-                                (extrapolate == LEFT) ? tMin : tMax);
+                                (extrapolate == LEFT) ? "minimum" : "maximum");
                             return der2_y;
 
                         case PERIODIC:


### PR DESCRIPTION
The time table data is relative to the shiftTime parameter, which should also be considered for the verbose extrapolation warning.

It's already correct (in the C code) for `extrapolation=Modelica.Blocks.Types.Extrapolation.NoExtrapolation`, i.e., if extrapolation triggers an error.

Of course, the warning or error message, respectively, could still be improved to also mention the shiftTime (if non-zero), if desired.