### PR TITLE
comparisonSignals of PowerConverters

### DIFF
--- a/Modelica/Resources/Reference/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_DC_Drive/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_DC_Drive/comparisonSignals.txt
@@ -4,11 +4,7 @@ dcpm.inertiaRotor.w
 inductor.i
 meanCurrent.y
 meanVoltage.y
-hbridge.dc_n1.v
-hbridge.dc_n1.i
-hbridge.dc_p1.v
-hbridge.dc_p1.i
-hbridge.dc_n2.v
-hbridge.dc_n2.i
-hbridge.dc_p2.v
-hbridge.dc_p2.i
+hbridge.vDC1
+hbridge.iDC1
+hbridge.vDC2
+hbridge.iDC2

--- a/Modelica/Resources/Reference/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_R/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_R/comparisonSignals.txt
@@ -1,11 +1,7 @@
 time
 meanCurrent.y
 meanVoltage.y
-hbridge.dc_n1.v
-hbridge.dc_n1.i
-hbridge.dc_p1.v
-hbridge.dc_p1.i
-hbridge.dc_n2.v
-hbridge.dc_n2.i
-hbridge.dc_p2.v
-hbridge.dc_p2.i
+hbridge.vDC1
+hbridge.iDC1
+hbridge.vDC2
+hbridge.iDC2

--- a/Modelica/Resources/Reference/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_RL/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_RL/comparisonSignals.txt
@@ -2,11 +2,7 @@ time
 inductor.i
 meanCurrent.y
 meanVoltage.y
-hbridge.dc_n1.v
-hbridge.dc_n1.i
-hbridge.dc_p1.v
-hbridge.dc_p1.i
-hbridge.dc_n2.v
-hbridge.dc_n2.i
-hbridge.dc_p2.v
-hbridge.dc_p2.i
+hbridge.vDC1
+hbridge.iDC1
+hbridge.vDC2
+hbridge.iDC2


### PR DESCRIPTION
improve comparisonSignals.txt of Modelica.Electrical.PowerConverters.Examples.DCDC.HBridge.*
It doesn't make sense to compare potential and current of positive and negative pin on both sides, better compare voltage and current on both sides. This ensures better regression testing in the future.
@arunkumar-narasimhan this should be back-ported to 4.1.x and 4.0.x - thanks!