### PR TITLE
Minor documentation error for Modelica.Math.log

### DIFF
--- a/Modelica/Math/package.mo
+++ b/Modelica/Math/package.mo
@@ -11599,7 +11599,7 @@ algorithm
           textString="log")}),
     Documentation(info="<html>
 <p>
-This function returns y = log(10) (the natural logarithm of u),
+This function returns y = log(u) (the natural logarithm of u),
 with u &gt; 0:
 </p>
 


### PR DESCRIPTION
It should obviously be `log(u)` not `log(10)` in the documentation.