### PR TITLE
Fix ComplexImpedance ctor call Modelica.Electrical.QuasiStatic.SinglePhase.Examples.MultipleResonance

### DIFF
--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/MultipleResonance.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/MultipleResonance.mo
@@ -2,12 +2,11 @@ within Modelica.Electrical.QuasiStatic.SinglePhase.Examples;
 model MultipleResonance
   "Demonstrates series and parallel resonance using a transformer"
   extends Icons.Example;
-  import Modelica.ComplexMath.j;
   import Modelica.Constants.small;
   parameter Modelica.Units.SI.Voltage V=0.5 "Source rms voltage";
   parameter Modelica.Units.SI.Frequency fLo=5.e6 "Lower source frequency";
   parameter Modelica.Units.SI.Frequency fUp=15e6 "Upper source frequency";
-  parameter Modelica.Units.SI.ComplexImpedance Zi=Modelica.Units.SI.ComplexImpedance(100 +j*0) "Source inner impedance";
+  parameter Modelica.Units.SI.ComplexImpedance Zi=Modelica.Units.SI.ComplexImpedance(100) "Source inner impedance";
   parameter Modelica.Units.SI.Inductance L1=30e-6 "Transformer primary inductance";
   parameter Modelica.Units.SI.Inductance L2=1.e-6 "Transformer secondary inductance";
   parameter Real k(min=small, max=1)=0.95 "Transformer coupling factor";


### PR DESCRIPTION
Fix for 1f8e25f101dc6563cdac408ed7051429c3a7c388 as suggested by https://github.com/modelica/ModelicaStandardLibrary/pull/4351#issuecomment-2007628804.