### PR TITLE
Proper unit for gamma. It is computed as the square root of something.

### DIFF
--- a/Modelica/Electrical/Spice3.mo
+++ b/Modelica/Electrical/Spice3.mo
@@ -6528,7 +6528,7 @@ This function mosfetRenameParametersDev assigns the external (given by the user)
          SI.Voltage m_phi(                 start = 0.6)
           "PHI, Surface potential";
          Real m_phiIsGiven "Phi IsGivenValue";
-         SI.Voltage m_gamma(               start = 0.0)
+         Real m_gamma(final unit="V(1/2)",               start = 0.0)
           "GAMMA, Bulk threshold parameter";
          Real m_gammaIsGiven "Gamma IsGivenValue";
          SI.InversePotential m_lambda "Channel-length modulation";


### PR DESCRIPTION
Closes #4369
To confirm I just binged "gamma spice Bulk threshold parameter" and found: https://www.seas.upenn.edu/~jan/spice/spice.MOSparamlist.html
which contains the same unit for gamma.
And the copilot said: "Its units are Volts^(1/2)."