### PR TITLE
Remove parameter keyword in functions

### DIFF
--- a/Modelica/Electrical/Machines/SpacePhasors/Functions/FromSpacePhasor.mo
+++ b/Modelica/Electrical/Machines/SpacePhasors/Functions/FromSpacePhasor.mo
@@ -8,9 +8,9 @@ function FromSpacePhasor
   input Integer m "Number of phases";
   output Real y[m] "Polyphase output";
 protected
-  parameter SI.Angle phi[m]=
+  SI.Angle phi[m]=
       Modelica.Electrical.Polyphase.Functions.symmetricOrientation(m);
-  parameter Real InverseTransformation[m, 2]={{+cos(-phi[k]),-sin(-phi[k])}
+  Real InverseTransformation[m, 2]={{+cos(-phi[k]),-sin(-phi[k])}
       for k in 1:m};
 
 algorithm

--- a/Modelica/Electrical/Machines/SpacePhasors/Functions/ToSpacePhasor.mo
+++ b/Modelica/Electrical/Machines/SpacePhasors/Functions/ToSpacePhasor.mo
@@ -7,10 +7,10 @@ function ToSpacePhasor
   output Real y[2] "Space phasor";
   output Real y0 "Zero sequence component (of voltage or current)";
 protected
-  parameter Integer m=size(x, 1) "Number of phases" annotation(Evaluate=true);
-  parameter SI.Angle phi[m]=
+  Integer m=size(x, 1) "Number of phases" annotation(Evaluate=true);
+  SI.Angle phi[m]=
       Modelica.Electrical.Polyphase.Functions.symmetricOrientation(m);
-  parameter Real TransformationMatrix[2, m]=2/m*{+cos(+phi),+sin(+phi)};
+  Real TransformationMatrix[2, m]=2/m*{+cos(+phi),+sin(+phi)};
 algorithm
   y := TransformationMatrix*x;
   y0 := 1/m*sum(x);

--- a/Modelica/Electrical/Polyphase/Functions/factorY2D.mo
+++ b/Modelica/Electrical/Polyphase/Functions/factorY2D.mo
@@ -7,7 +7,7 @@ function factorY2D "Calculates factor Y voltage to polygon (delta) voltage"
   input Integer kPolygon=1 "Alternative of polygon";
   output Real y "Factor Y to D";
 protected
-  parameter Integer mBasic=integer(m/numberOfSymmetricBaseSystems(m));
+  Integer mBasic=integer(m/numberOfSymmetricBaseSystems(m));
 algorithm
   if mBasic==2 then
     y := sqrt(2);

--- a/Modelica/Electrical/Polyphase/Functions/factorY2DC.mo
+++ b/Modelica/Electrical/Polyphase/Functions/factorY2DC.mo
@@ -6,7 +6,7 @@ function factorY2DC "Calculates factor of DC-voltage from RMS Y-voltage"
   input Integer m=3 "Number of phases";
   output Real y "Factor Yrms to DC";
 protected
-  parameter Integer mBasic=integer(m/numberOfSymmetricBaseSystems(m));
+  Integer mBasic=integer(m/numberOfSymmetricBaseSystems(m));
 algorithm
   if mBasic==2 then
     y := 4/pi;


### PR DESCRIPTION
Note that these "parameters" were bound to non-parameter expressions, and that doesn't make sense.