### PR TITLE
Use nthRoot as proposed for Modelica 3.7.

### DIFF
--- a/Modelica/Fluid/Vessels.mo
+++ b/Modelica/Fluid/Vessels.mo
@@ -9,8 +9,8 @@ package Vessels "Devices for storing fluid"
       // Mass and energy balance, ports
       extends Modelica.Fluid.Vessels.BaseClasses.PartialLumpedVessel(
         final fluidVolume = V,
-        vesselArea = pi*(3/4*V)^(2/3),
-        heatTransfer(surfaceAreas={4*pi*(3/4*V/pi)^(2/3)}));
+        vesselArea = pi*nthRoot(3/4*V, 3)^2,
+        heatTransfer(surfaceAreas={4*pi*nthRoot(3/4*V/pi, 3)^2}));
 
       parameter SI.Volume V "Volume";
 


### PR DESCRIPTION
Note that there are some other uses that were deliberately not updated here:
- Modelica.Fluid.Dissipation.HeatTransfer.General.kc_approxForcedConvection_KC
- Modelica.Fluid.Dissipation.HeatTransfer.Channel.kc_evenGapLaminar_KC
- Modelica.Fluid.Dissipation.HeatTransfer.HelicalPipe.kc_laminar_KC
- Modelica.Fluid.Dissipation.HeatTransfer.Plate.kc_laminar_KC
- Modelica.Fluid.Pipes.BaseClasses.HeatTransfer.LocalPipeFlowHeatTransfer
- Modelica.Media.IdealGases.Common.MixtureGasNasa.mixtureViscosityChung
- Modelica.Fluid.Dissipation.Utilities.Functions.PressureLoss.TwoPhase.SlipRatio

However, if done it must be after switching to sqrt.

I believe Modelica.Media.IdealGases.Common.MixtureGasNasa.mixtureViscosityChung should be updated, but I don't know about the rest. However, the units seems to be weird in that one (Ångström?) so I'm not proposing it.

Note that many of them use dimensionless numbers and thus there is no unit-issue. There are also other rational exponents, I'm even less sure about them.

Closes #4370