### PR TITLE
Make propagation final of lifted parameter 'c' in Spring

### DIFF
--- a/Modelica/Mechanics/MultiBody/Forces/Spring.mo
+++ b/Modelica/Mechanics/MultiBody/Forces/Spring.mo
@@ -75,7 +75,7 @@ model Spring "Linear translational spring with optional mass"
     fixedRotationAtFrame_b=fixedRotationAtFrame_b) annotation (Placement(transformation(extent={{-20,-20},{20,20}})));
   Modelica.Mechanics.Translational.Components.Spring spring(
      s_rel0=s_unstretched,
-     c=c) annotation (Placement(transformation(extent={{-8,40},{12,60}})));
+     final c=c) annotation (Placement(transformation(extent={{-8,40},{12,60}})));
 
 equation
   // Results


### PR DESCRIPTION
Fixes #3707.

As there wasn't any arguments agains making the propagation of `c` final in #3707, I suggest that we go with this solution.

One could argue that there are more parameters whose propagation should be final, but I'm starting with this one which is sufficient to fix the issue.
