### PR TITLE
Resolve #4336

### DIFF
--- a/Modelica/Magnetic/FluxTubes/Examples/MovingCoilActuator/ArmatureStroke.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/MovingCoilActuator/ArmatureStroke.mo
@@ -67,7 +67,10 @@ equation
           Text( extent={{-98,90},{-30,80}},
                 textColor={0,0,255},
                 textString="after a voltage step at t=0")}),
-    experiment(StopTime=0.05, Tolerance=1e-007),
+    experiment(
+      StopTime=0.05,
+      Interval=1e-05,
+      Tolerance=1e-07),
     Documentation(info="<html>
 <p>
 Have a look at <a href=\"modelica://Modelica.Magnetic.FluxTubes.Examples.MovingCoilActuator.Components.ConstantActuator\">ConstantActuator</a> and at <a href=\"modelica://Modelica.Magnetic.FluxTubes.Examples.MovingCoilActuator.Components.PermeanceActuator\">PermeanceActuator</a>

--- a/Modelica/Magnetic/FluxTubes/Examples/MovingCoilActuator/ForceCurrentBehaviour.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/MovingCoilActuator/ForceCurrentBehaviour.mo
@@ -77,7 +77,10 @@ equation
           Text( extent={{-98,88},{2,78}},
                 textColor={0,0,255},
                 textString="with armature blocked at mid-position")}),
-    experiment(StopTime=6, Tolerance=1e-007),
+    experiment(
+      StopTime=6,
+      Interval=0.0001,
+      Tolerance=1e-07),
     Documentation(info="<html>
 <p>
 Have a look at <a href=\"modelica://Modelica.Magnetic.FluxTubes.Examples.MovingCoilActuator.Components.ConstantActuator\">ConstantActuator</a> and at <a href=\"modelica://Modelica.Magnetic.FluxTubes.Examples.MovingCoilActuator.Components.PermeanceActuator\">PermeanceActuator</a> for an explanation of both converter models.<br>

--- a/Modelica/Magnetic/FluxTubes/Examples/MovingCoilActuator/ForceStrokeBehaviour.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/MovingCoilActuator/ForceStrokeBehaviour.mo
@@ -51,6 +51,7 @@ equation
   annotation (experiment(
       StartTime=-4,
       StopTime=4,
+      Interval=0.0001,
       Tolerance=1e-007), Documentation(info="<html>
 <p>
 Have a look at <a href=\"modelica://Modelica.Magnetic.FluxTubes.Examples.MovingCoilActuator.Components.ConstantActuator\">ConstantActuator</a> and at <a href=\"modelica://Modelica.Magnetic.FluxTubes.Examples.MovingCoilActuator.Components.PermeanceActuator\">PermeanceActuator</a> for an explanation of both converter models.<br>

--- a/Modelica/Resources/Reference/Modelica/Magnetic/FluxTubes/Examples/MovingCoilActuator/ForceCurrentBehaviour/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Magnetic/FluxTubes/Examples/MovingCoilActuator/ForceCurrentBehaviour/comparisonSignals.txt
@@ -2,4 +2,3 @@ time
 cActuator.flange.f
 pmActuator.flange.f
 pmActuator.coil.Phi
-pmActuator.coil.L_stat


### PR DESCRIPTION
- remove ill-defined pmActuator.coil.L_stat from comparisonSignals.txt for Modelica.Magnetic.FluxTubes.Examples.MovingCoilActuator.ForceCurrentBehaviour
- define output interval for all 3 examples Modelica.Magnetic.FluxTubes.Examples.MovingCoilActuator