### PR TITLE
Added comparison signals for HBridge_TrianglePWM_RL, same as HBridge_RL

### DIFF
--- a/Modelica/Resources/Reference/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_TrianglePWM_RL/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_TrianglePWM_RL/comparisonSignals.txt
@@ -1,0 +1,8 @@
+time
+inductor.i
+meanCurrent.y
+meanVoltage.y
+hbridge.vDC1
+hbridge.iDC1
+hbridge.vDC2
+hbridge.iDC2


### PR DESCRIPTION
As required by [#4349](https://github.com/modelica/ModelicaStandardLibrary/issues/4349#issuecomment-2112892849).

@AHaumer the new model is very similar to HBridge_RL, so I just copied the comparisonSignals.txt of that model. Feel free to add more variables by committing to this PR, if you find this appropriate.

Once accepted, this needs to be back-ported to maint/4.1.0.