### PR TITLE
Fixed illegal ModelicaTest.Media.TestOnly.WaterIF97_dewEnthalpy

### DIFF
--- a/ModelicaTest/Media.mo
+++ b/ModelicaTest/Media.mo
@@ -952,7 +952,7 @@ is given to compare the approximation.
 
     model WaterIF97_dewEnthalpy "Test dewEnthalpy of WaterIF97"
       extends Modelica.Icons.Example;
-      replaceable package Medium = Modelica.Media.Water.WaterIF97_fixedregion "Medium model";
+      replaceable package Medium = Modelica.Media.Water.StandardWater "Medium model";
       SI.Temperature T = 273.15 + 25;
       parameter SI.AbsolutePressure p0 = 10e5 "p at time 0";
       parameter SI.PressureSlope pRate = 20e5 "p's rate of change";


### PR DESCRIPTION
ModelicaTest.Media.TestOnly.WaterIF97_dewEnthalpy used the partial medium Modelica.Media.Water.WaterIF97_fixedregion, which is not allowed by the MLS, so it is not valid Modelica code.

This PR replaces the medium model with the non-partial package Modelica.Media.Water.StandardWater