### PR TITLE
Update documentation according to changes in the Modelica Specification

### DIFF
--- a/Modelica/Utilities/Files.mo
+++ b/Modelica/Utilities/Files.mo
@@ -714,7 +714,7 @@ this might require copying the resource to a temporary folder and referencing th
 
 <p>
 The implementation of this function is tool specific. However, at least Modelica URIs
-(see \"Chapter 13.5 External Resources\" of the Modelica Specification),
+(see <a href=\"https://specification.modelica.org/maint/3.6/packages.html#external-resources\">Section&nbsp;13.5 <em>External Resources</em> of the Modelica&nbsp;3.6 specification</a>),
 as well as absolute local file path names are supported.
 </p>
 

--- a/Modelica/Utilities/Files.mo
+++ b/Modelica/Utilities/Files.mo
@@ -714,7 +714,7 @@ this might require copying the resource to a temporary folder and referencing th
 
 <p>
 The implementation of this function is tool specific. However, at least Modelica URIs
-(see \"chapter 13.2.3 External Resources\" of the Modelica Specification),
+(see \"Chapter 13.5 External Resources\" of the Modelica Specification),
 as well as absolute local file path names are supported.
 </p>
 


### PR DESCRIPTION
Currently, Modelica.Utilities.Files.loadResource's documentation indicates: "(see "chapter 13.2.3 External Resources" of the Modelica Specification)" However, in the Modelica Specification, this has been moved to a new sub-section: [link](https://specification.modelica.org/master/packages.html#external-resources)