### PR TITLE
Classify Modelica not as Motoko for GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -47,3 +47,5 @@ Modelica/Resources/Images/Magnetic/FluxTubes/Shapes/HollowCylinder.vsdx export-i
 Modelica/Resources/Images/Magnetic/FluxTubes/Shapes/Toroid.vsdx export-ignore
 Modelica/Resources/Reference export-ignore
 ModelicaTest/Resources/Reference export-ignore
+
+*.mo linguist-language=Modelica


### PR DESCRIPTION
Before

![grafik](https://github.com/user-attachments/assets/2881b3d1-3cf5-4558-afd0-fa4f14312c38)

After

![grafik](https://github.com/user-attachments/assets/28d99843-2689-4c53-8660-fc43b904aeff)
