### PR TITLE
Fix regression introduced by #4306 by using public alias variables for initial equations in all examples using OLine

### DIFF
--- a/Modelica/Electrical/Analog/Examples/Lines/CompareLineTrunks.mo
+++ b/Modelica/Electrical/Analog/Examples/Lines/CompareLineTrunks.mo
@@ -88,14 +88,14 @@ model CompareLineTrunks "Compares oLine and tLine splitting lines into trunks"
         extent={{-10,-10},{10,10}},
         rotation=-90)));
 initial equation
-  oLine1.C.v=zeros(segsPerTrunk);
-  oLine1.L.i=zeros(segsPerTrunk + 1);
-  oLine2.C.v=zeros(segsPerTrunk);
-  oLine2.L.i=zeros(segsPerTrunk + 1);
-  oLine3.C.v=zeros(segsPerTrunk);
-  oLine3.L.i=zeros(segsPerTrunk + 1);
-  oLine4.C.v=zeros(segsPerTrunk);
-  oLine4.L.i=zeros(segsPerTrunk + 1);
+  oLine1.v=zeros(segsPerTrunk);
+  oLine1.i=zeros(segsPerTrunk + 1);
+  oLine2.v=zeros(segsPerTrunk);
+  oLine2.i=zeros(segsPerTrunk + 1);
+  oLine3.v=zeros(segsPerTrunk);
+  oLine3.i=zeros(segsPerTrunk + 1);
+  oLine4.v=zeros(segsPerTrunk);
+  oLine4.i=zeros(segsPerTrunk + 1);
 equation
   connect(srcLump.v, ramp.y)
     annotation (Line(points={{-52,30},{-60,30},{-60,0},{-67,0}},

--- a/Modelica/Electrical/Analog/Examples/Lines/SmoothStep.mo
+++ b/Modelica/Electrical/Analog/Examples/Lines/SmoothStep.mo
@@ -89,12 +89,12 @@ model SmoothStep "Compares oLine and tLine behaviour"
   Modelica.Electrical.Analog.Basic.Ground groundT
     annotation (Placement(transformation(extent={{-10,-70},{10,-50}})));
 initial equation
-  oLine1.C.v=zeros(N1);
-  oLine1.L.i=zeros(N1 + 1);
-  oLine5.C.v=zeros(N5);
-  oLine5.L.i=zeros(N5 + 1);
-  oLine50.C.v=zeros(N50);
-  oLine50.L.i=zeros(N50 + 1);
+  oLine1.v=zeros(N1);
+  oLine1.i=zeros(N1 + 1);
+  oLine5.v=zeros(N5);
+  oLine5.i=zeros(N5 + 1);
+  oLine50.v=zeros(N50);
+  oLine50.i=zeros(N50 + 1);
 equation
   connect(groundS.p, sourceV.n) annotation (Line(
       points={{-50,-50},{-50,-40}},


### PR DESCRIPTION
Backport of #4422 from master to main/4.1.x.

Resolves #4383