### PR TITLE
MassFlowSource_T and MassFlowSource_h only work if there are at least one port

### DIFF
--- a/Modelica/Fluid/Sources.mo
+++ b/Modelica/Fluid/Sources.mo
@@ -415,7 +415,7 @@ with exception of boundary pressure, do not have an effect.
   model MassFlowSource_T
     "Ideal flow source that produces a prescribed mass flow with prescribed temperature, mass fraction and trace substances"
     import Modelica.Media.Interfaces.Choices.IndependentVariables;
-    extends Sources.BaseClasses.PartialFlowSource;
+    extends Sources.BaseClasses.PartialFlowSource(nPorts(min=1));
     parameter Boolean use_m_flow_in = false
       "Get the mass flow rate from the input connector"
       annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
@@ -562,7 +562,7 @@ with exception of boundary flow rate, do not have an effect.
   model MassFlowSource_h
     "Ideal flow source that produces a prescribed mass flow with prescribed specific enthalpy, mass fraction and trace substances"
     import Modelica.Media.Interfaces.Choices.IndependentVariables;
-    extends Sources.BaseClasses.PartialFlowSource;
+    extends Sources.BaseClasses.PartialFlowSource(nPorts(min=1));
     parameter Boolean use_m_flow_in = false
       "Get the mass flow rate from the input connector"
       annotation(Evaluate=true, HideResult=true, choices(checkBox=true));


### PR DESCRIPTION
The two models Modelica.Fluid.Sources.MassFlowSource_T and Modelica.Fluid.Sources.MassFlowSource_h only work if there is at least one port - since they set a mass-flow and you cannot have a mass-flow without  ports.

Due to the design of connectorSizing we should clearly not change the default value, but I instead propose to add a min-value.

The reason for this change is two-fold:
- Avoid false positives when checking the library; as the default configuration _shouldn't_ work.
- When (mis)using these components the error can be detected early.