### PR TITLE
Remove useless and numerically critical error signals from MoistAir tests

### DIFF
--- a/ModelicaTest/Resources/Reference/ModelicaTest/Media/TestAllProperties/IncompleteMedia/ReferenceMoistAir/comparisonSignals.txt
+++ b/ModelicaTest/Resources/Reference/ModelicaTest/Media/TestAllProperties/IncompleteMedia/ReferenceMoistAir/comparisonSignals.txt
@@ -21,8 +21,4 @@ a
 MM
 h2
 d2
-err_T
-err_d
-err_u
 s_is
-err_h_is

--- a/ModelicaTest/Resources/Reference/ModelicaTest/Media/TestAllProperties/MoistAir/comparisonSignals.txt
+++ b/ModelicaTest/Resources/Reference/ModelicaTest/Media/TestAllProperties/MoistAir/comparisonSignals.txt
@@ -28,9 +28,5 @@ dddX[2]
 MM
 h2
 d2
-err_T
-err_d
-err_u
 s_is
-err_h_is
 eps


### PR DESCRIPTION
Backport of #4430  