### PR TITLE
Remove redundant text in celsius to kelvin icon

### DIFF
--- a/Modelica/Thermal/HeatTransfer/Celsius/ToKelvin.mo
+++ b/Modelica/Thermal/HeatTransfer/Celsius/ToKelvin.mo
@@ -11,14 +11,6 @@ equation
     Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{
             100,100}}), graphics={
         Text(
-          extent={{54,-88},{114,-148}},
-          textColor={64,64,64},
-          textString="degC"),
-        Text(
-          extent={{194,-88},{254,-148}},
-          textColor={64,64,64},
-          textString="K"),
-        Text(
           extent={{-100,60},{-40,0}},
           textColor={64,64,64},
           textString="degC"),


### PR DESCRIPTION
Removed highlighted text.
![image](https://github.com/user-attachments/assets/8d3b7eee-428d-4f38-9a72-839f030bd97d)
