### PR TITLE
Revise CTest configuration

### DIFF
--- a/Modelica/Resources/BuildProjects/CMake/options.cmake
+++ b/Modelica/Resources/BuildProjects/CMake/options.cmake
@@ -21,3 +21,11 @@ option(
 
 # Option whether to install ModelicaExternalC
 option(MODELICA_INSTALL_EXTC "Install ModelicaExternalC library" OFF)
+
+# Option to enable testsuite
+option(MODELICA_BUILD_TESTING "Build testing" ON)
+
+set(BUILD_TESTING OFF)
+if(MODELICA_BUILD_TESTING)
+  set(BUILD_TESTING ON)
+endif()

--- a/Modelica/Resources/BuildProjects/CMake/test.cmake
+++ b/Modelica/Resources/BuildProjects/CMake/test.cmake
@@ -1,9 +1,8 @@
-include(CTest)
-
-if(BUILD_TESTING)
+if(MODELICA_BUILD_TESTING)
   set(MODELICA_TEST_DIR_AUX "${MODELICA_RESOURCES_DIR}/../../.CI/Test")
   get_filename_component(MODELICA_TEST_DIR "${MODELICA_TEST_DIR_AUX}" ABSOLUTE)
   if(EXISTS "${MODELICA_TEST_DIR}")
+    enable_testing()
     set(MODELICA_TESTS
       FileSystem
       ModelicaStrings
@@ -14,32 +13,34 @@ if(BUILD_TESTING)
       TablesFromTxtFile
       TablesNoUsertab
     )
-    foreach(TEST ${MODELICA_TESTS})
-      add_executable(Test${TEST} "${MODELICA_TEST_DIR}/${TEST}.c")
-      target_link_libraries(Test${TEST}
+    foreach(test_file ${MODELICA_TESTS})
+      set(TEST_EXECUTABLE Test${test_file})
+      add_executable(${TEST_EXECUTABLE} "${MODELICA_TEST_DIR}/${test_file}.c")
+      target_link_libraries(${TEST_EXECUTABLE}
         ModelicaExternalC
         ModelicaStandardTables
         ModelicaIO
         ModelicaMatIO
       )
       if(MODELICA_BUILD_ZLIB)
-        target_link_libraries(Test${TEST} zlib)
+        target_link_libraries(${TEST_EXECUTABLE} zlib)
       else()
-        target_link_libraries(Test${TEST} z)
+        target_link_libraries(${TEST_EXECUTABLE} z)
       endif()
       if(UNIX)
-        target_link_libraries(Test${TEST} m)
+        target_link_libraries(${TEST_EXECUTABLE} m)
       endif()
+      set_target_properties(${TEST_EXECUTABLE} PROPERTIES FOLDER "Test")
       add_test(
-        NAME Test${TEST}
-        COMMAND Test${TEST}
+        NAME ${TEST_EXECUTABLE}
+        COMMAND ${TEST_EXECUTABLE}
         WORKING_DIRECTORY "${MODELICA_TEST_DIR}"
       )
     endforeach()
   else()
     message(WARNING
       " Testsuite not found in \"${MODELICA_TEST_DIR}\"."
-      " Set BUILD_TESTING to OFF to silence this warning."
+      " Set MODELICA_BUILD_TESTING to OFF to silence this warning."
     )
   endif()
 endif()

--- a/Modelica/Resources/CMakeLists.txt
+++ b/Modelica/Resources/CMakeLists.txt
@@ -9,6 +9,8 @@ endif()
 
 project(Modelica_Standard_Library_Tables C)
 
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
 include(BuildProjects/CMake/Modelica_platform.cmake)
 include(BuildProjects/CMake/Modelica_utilities.cmake)
 


### PR DESCRIPTION
* `include(CTest)` dependency is not required and considered controversial because it introduces extra build targets. Instead `enable_testing()` is good enough. I read about it [here](https://discourse.cmake.org/t/is-there-any-reason-to-prefer-include-ctest-or-enable-testing-over-the-other/1905) and [here](https://gitlab.kitware.com/cmake/cmake/-/issues/21730) from the CMake experts, for example.
* Introduce `MODELICA_BUILD_TESTING:BOOL=ON` as a dedicated option to build the tests. 
* Add folder property globally and additionally to test targets to achieve better structuring in VS.