### PR TITLE
MSL 4.1.0 Regressions: set FundamentalWave..SymmetricPolyphaseWinding.ZeroInductor.i0

### DIFF
--- a/Modelica/Magnetic/FundamentalWave/BasicMachines/Components/SymmetricPolyphaseWinding.mo
+++ b/Modelica/Magnetic/FundamentalWave/BasicMachines/Components/SymmetricPolyphaseWinding.mo
@@ -76,8 +76,8 @@ model SymmetricPolyphaseWinding
     final Lsigma=(1 - ratioCommonLeakage)*Lsigma)
                                             "Symmetric winding"
     annotation (Placement(transformation(extent={{-10,-20},{10,0}})));
-  Modelica.Electrical.Polyphase.Basic.ZeroInductor zeroInductor(final m=m, final Lzero=Lzero,
-    i0(nominal=10)) if mBase<>2 "Zero sequence inductance of winding"
+  Modelica.Electrical.Polyphase.Basic.ZeroInductor zeroInductor(final m=m, final Lzero=Lzero)
+    if mBase<>2 "Zero sequence inductance of winding"
     annotation (Placement(transformation(
         origin={-70,-30},
         extent={{10,-10},{-10,10}},

--- a/Modelica/Magnetic/FundamentalWave/BasicMachines/Components/SymmetricPolyphaseWinding.mo
+++ b/Modelica/Magnetic/FundamentalWave/BasicMachines/Components/SymmetricPolyphaseWinding.mo
@@ -76,8 +76,8 @@ model SymmetricPolyphaseWinding
     final Lsigma=(1 - ratioCommonLeakage)*Lsigma)
                                             "Symmetric winding"
     annotation (Placement(transformation(extent={{-10,-20},{10,0}})));
-  Modelica.Electrical.Polyphase.Basic.ZeroInductor zeroInductor(final m=m, final Lzero=Lzero) if
-       mBase<>2 "Zero sequence inductance of winding"
+  Modelica.Electrical.Polyphase.Basic.ZeroInductor zeroInductor(final m=m, final Lzero=Lzero,
+    i0(nominal=10)) if mBase<>2 "Zero sequence inductance of winding"
     annotation (Placement(transformation(
         origin={-70,-30},
         extent={{10,-10},{-10,10}},

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_YD.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_YD.mo
@@ -112,8 +112,9 @@ equation
       points={{40,20},{50,20}}));
   annotation (experiment(
       StopTime=2.5,
-      Interval=1E-4,
-      Tolerance=1e-06),                                 Documentation(
+      Interval=0.0001,
+      Tolerance=1e-06,
+      __Dymola_Algorithm="Dassl"),                      Documentation(
         info="<html>
 <p>At start time tStart three-phase voltage is supplied to the induction machine with squirrel cage,
 first star-connected, then delta-connected; the machine starts from standstill,

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_YD.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_YD.mo
@@ -37,7 +37,8 @@ model IMC_YD
     TsOperational=293.15,
     effectiveStatorTurns=aimcData.effectiveStatorTurns,
     alpha20r=aimcData.alpha20r,
-    TrOperational=293.15)
+    TrOperational=293.15,
+    stator(zeroInductor(i0(nominal=10))))
     annotation (Placement(transformation(extent={{20,10},{40,30}})));
   Modelica.Electrical.Machines.Sensors.CurrentQuasiRMSSensor currentQuasiRMSSensor
     annotation (Placement(transformation(

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_YD.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_YD.mo
@@ -113,8 +113,7 @@ equation
   annotation (experiment(
       StopTime=2.5,
       Interval=0.0001,
-      Tolerance=1e-06,
-      __Dymola_Algorithm="Dassl"),                      Documentation(
+      Tolerance=1e-06),                      Documentation(
         info="<html>
 <p>At start time tStart three-phase voltage is supplied to the induction machine with squirrel cage,
 first star-connected, then delta-connected; the machine starts from standstill,


### PR DESCRIPTION
Backport of #4486 from master to maint/4.1.x.