### PR TITLE
Add License annotation to external functions

### DIFF
--- a/Modelica/Blocks/Tables.mo
+++ b/Modelica/Blocks/Tables.mo
@@ -1035,7 +1035,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real pre_nextTimeEvent "Pre-value of (scaled) next time event in table";
       output Real y "Interpolated value";
       external "C" y = ModelicaStandardTables_CombiTimeTable_getValue(tableID, icol, timeIn, nextTimeEvent, pre_nextTimeEvent)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
       annotation (derivative(
           noDerivative=nextTimeEvent,
           noDerivative=pre_nextTimeEvent) = getDerTimeTableValue);
@@ -1051,7 +1051,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real pre_nextTimeEvent "Pre-value of (scaled) next time event in table";
       output Real y "Interpolated value";
       external "C" y = ModelicaStandardTables_CombiTimeTable_getValue(tableID, icol, timeIn, nextTimeEvent, pre_nextTimeEvent)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end getTimeTableValueNoDer;
 
     pure function getTimeTableValueNoDer2
@@ -1064,7 +1064,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real pre_nextTimeEvent "Pre-value of (scaled) next time event in table";
       output Real y "Interpolated value";
       external "C" y = ModelicaStandardTables_CombiTimeTable_getValue(tableID, icol, timeIn, nextTimeEvent, pre_nextTimeEvent)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
       annotation (derivative(
           noDerivative=nextTimeEvent,
           noDerivative=pre_nextTimeEvent) = getDerTimeTableValueNoDer);
@@ -1081,7 +1081,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real der_timeIn "Derivative of (scaled) time value";
       output Real der_y "Derivative of interpolated value";
       external "C" der_y = ModelicaStandardTables_CombiTimeTable_getDerValue(tableID, icol, timeIn, nextTimeEvent, pre_nextTimeEvent, der_timeIn)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
       annotation (derivative(
           order=2,
           noDerivative=nextTimeEvent,
@@ -1099,7 +1099,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real der_timeIn "Derivative of (scaled) time value";
       output Real der_y "Derivative of interpolated value";
       external "C" der_y = ModelicaStandardTables_CombiTimeTable_getDerValue(tableID, icol, timeIn, nextTimeEvent, pre_nextTimeEvent, der_timeIn)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end getDerTimeTableValueNoDer;
 
     pure function getDer2TimeTableValue
@@ -1114,7 +1114,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real der2_timeIn "Second derivative of (scaled) time value";
       output Real der2_y "Second derivative of interpolated value";
       external "C" der2_y = ModelicaStandardTables_CombiTimeTable_getDer2Value(tableID, icol, timeIn, nextTimeEvent, pre_nextTimeEvent, der_timeIn, der2_timeIn)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end getDer2TimeTableValue;
 
     pure function getTimeTableTmin
@@ -1123,7 +1123,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Modelica.Blocks.Types.ExternalCombiTimeTable tableID "External table object";
       output Real timeMin "Minimum abscissa value in table";
       external "C" timeMin = ModelicaStandardTables_CombiTimeTable_minimumTime(tableID)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end getTimeTableTmin;
 
     pure function getTimeTableTmax
@@ -1132,7 +1132,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Modelica.Blocks.Types.ExternalCombiTimeTable tableID "External table object";
       output Real timeMax "Maximum abscissa value in table";
       external "C" timeMax = ModelicaStandardTables_CombiTimeTable_maximumTime(tableID)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end getTimeTableTmax;
 
     pure function getNextTimeEvent
@@ -1142,7 +1142,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real timeIn "(Scaled) time value";
       output Real nextTimeEvent "(Scaled) next time event in table";
       external "C" nextTimeEvent = ModelicaStandardTables_CombiTimeTable_nextTimeEvent(tableID, timeIn)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end getNextTimeEvent;
 
     pure function getTable1DValue "Interpolate 1-dim. table defined by matrix"
@@ -1152,7 +1152,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real u "Abscissa value";
       output Real y "Interpolated value";
       external "C" y = ModelicaStandardTables_CombiTable1D_getValue(tableID, icol, u)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
       annotation (derivative = getDerTable1DValue);
     end getTable1DValue;
 
@@ -1164,7 +1164,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real u "Abscissa value";
       output Real y "Interpolated value";
       external "C" y = ModelicaStandardTables_CombiTable1D_getValue(tableID, icol, u)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end getTable1DValueNoDer;
 
     pure function getTable1DValueNoDer2
@@ -1175,7 +1175,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real u "Abscissa value";
       output Real y "Interpolated value";
       external "C" y = ModelicaStandardTables_CombiTable1D_getValue(tableID, icol, u)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
       annotation (derivative = getDerTable1DValueNoDer);
     end getTable1DValueNoDer2;
 
@@ -1188,7 +1188,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real der_u "Derivative of abscissa value";
       output Real der_y "Derivative of interpolated value";
       external "C" der_y = ModelicaStandardTables_CombiTable1D_getDerValue(tableID, icol, u, der_u)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
       annotation (derivative(order=2) = getDer2Table1DValue);
     end getDerTable1DValue;
 
@@ -1201,7 +1201,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real der_u "Derivative of abscissa value";
       output Real der_y "Derivative of interpolated value";
       external "C" der_y = ModelicaStandardTables_CombiTable1D_getDerValue(tableID, icol, u, der_u)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end getDerTable1DValueNoDer;
 
     pure function getDer2Table1DValue
@@ -1214,7 +1214,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real der2_u " Second derivative of abscissa value";
       output Real der2_y "Second derivative of interpolated value";
       external "C" der2_y = ModelicaStandardTables_CombiTable1D_getDer2Value(tableID, icol, u, der_u, der2_u)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end getDer2Table1DValue;
 
     pure function getTable1DAbscissaUmin
@@ -1223,7 +1223,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Modelica.Blocks.Types.ExternalCombiTable1D tableID "External table object";
       output Real uMin "Minimum abscissa value in table";
       external "C" uMin = ModelicaStandardTables_CombiTable1D_minimumAbscissa(tableID)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end getTable1DAbscissaUmin;
 
     pure function getTable1DAbscissaUmax
@@ -1232,7 +1232,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Modelica.Blocks.Types.ExternalCombiTable1D tableID "External table object";
       output Real uMax "Maximum abscissa value in table";
       external "C" uMax = ModelicaStandardTables_CombiTable1D_maximumAbscissa(tableID)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end getTable1DAbscissaUmax;
 
     pure function getTable2DValue "Interpolate 2-dim. table defined by matrix"
@@ -1242,7 +1242,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real u2 "Value of second independent variable";
       output Real y "Interpolated value";
       external "C" y = ModelicaStandardTables_CombiTable2D_getValue(tableID, u1, u2)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
       annotation (derivative = getDerTable2DValue);
     end getTable2DValue;
 
@@ -1254,7 +1254,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real u2 "Value of second independent variable";
       output Real y "Interpolated value";
       external "C" y = ModelicaStandardTables_CombiTable2D_getValue(tableID, u1, u2)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end getTable2DValueNoDer;
 
     pure function getTable2DValueNoDer2
@@ -1265,7 +1265,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real u2 "Value of second independent variable";
       output Real y "Interpolated value";
       external "C" y = ModelicaStandardTables_CombiTable2D_getValue(tableID, u1, u2)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
       annotation (derivative = getDerTable2DValueNoDer);
     end getTable2DValueNoDer2;
 
@@ -1279,7 +1279,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real der_u2 "Derivative of second independent variable";
       output Real der_y "Derivative of interpolated value";
       external "C" der_y = ModelicaStandardTables_CombiTable2D_getDerValue(tableID, u1, u2, der_u1, der_u2)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
       annotation (derivative(order=2) = getDer2Table2DValue);
     end getDerTable2DValue;
 
@@ -1293,7 +1293,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real der_u2 "Derivative of second independent variable";
       output Real der_y "Derivative of interpolated value";
       external "C" der_y = ModelicaStandardTables_CombiTable2D_getDerValue(tableID, u1, u2, der_u1, der_u2)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end getDerTable2DValueNoDer;
 
     pure function getDer2Table2DValue
@@ -1308,7 +1308,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Real der2_u2 "Second derivative of second independent variable";
       output Real der2_y "Second derivative of interpolated value";
       external "C" der2_y = ModelicaStandardTables_CombiTable2D_getDer2Value(tableID, u1, u2, der_u1, der_u2, der2_u1, der2_u2)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end getDer2Table2DValue;
 
     pure function getTable2DAbscissaUmin
@@ -1317,7 +1317,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Modelica.Blocks.Types.ExternalCombiTable2D tableID "External table object";
       output Real uMin[2] "Minimum abscissa value in table";
       external "C" ModelicaStandardTables_CombiTable2D_minimumAbscissa(tableID, uMin)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end getTable2DAbscissaUmin;
 
     pure function getTable2DAbscissaUmax
@@ -1326,7 +1326,7 @@ MATLAB is a registered trademark of The MathWorks, Inc.
       input Modelica.Blocks.Types.ExternalCombiTable2D tableID "External table object";
       output Real uMax[2] "Maximum abscissa value in table";
       external "C" ModelicaStandardTables_CombiTable2D_maximumAbscissa(tableID, uMax)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end getTable2DAbscissaUmax;
   end Internal;
   annotation (Documentation(info="<html>

--- a/Modelica/Blocks/Types.mo
+++ b/Modelica/Blocks/Types.mo
@@ -132,14 +132,14 @@ package Types
             timeEvents,
             verboseRead,
             delimiter,
-            nHeaderLines) annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+            nHeaderLines) annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end constructor;
 
     function destructor "Terminate 1-dim. table where first column is time"
       extends Modelica.Icons.Function;
       input ExternalCombiTimeTable externalCombiTimeTable;
     external "C" ModelicaStandardTables_CombiTimeTable_close(
-        externalCombiTimeTable) annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        externalCombiTimeTable) annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end destructor;
 
   end ExternalCombiTimeTable;
@@ -172,14 +172,14 @@ package Types
             extrapolation,
             verboseRead,
             delimiter,
-            nHeaderLines) annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+            nHeaderLines) annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end constructor;
 
     function destructor "Terminate 1-dim. table defined by matrix"
       extends Modelica.Icons.Function;
       input ExternalCombiTable1D externalCombiTable1D;
     external "C" ModelicaStandardTables_CombiTable1D_close(externalCombiTable1D)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end destructor;
 
   end ExternalCombiTable1D;
@@ -209,14 +209,14 @@ package Types
             extrapolation,
             verboseRead,
             delimiter,
-            nHeaderLines) annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+            nHeaderLines) annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end constructor;
 
     function destructor "Terminate 2-dim. table defined by matrix"
       extends Modelica.Icons.Function;
       input ExternalCombiTable2D externalCombiTable2D;
     external "C" ModelicaStandardTables_CombiTable2D_close(externalCombiTable2D)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     end destructor;
 
   end ExternalCombiTable2D;

--- a/Modelica/Math/FastFourierTransform.mo
+++ b/Modelica/Math/FastFourierTransform.mo
@@ -642,7 +642,7 @@ See detailed example model:
     protected
       Real work[3*size(u,1) + 2*(div(size(u,1),2)+1)];
       external "C" info = ModelicaFFT_kiss_fftr(u, size(u,1), work, size(work,1), amplitudes, phases)
-                   annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaFFT.h\"", Library="ModelicaExternalC");
+                   annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaFFT.h\"", Library="ModelicaExternalC", License="modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaKissFFT.txt");
       annotation (Documentation(revisions="<html>
 <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
 <tr><th>Date</th> <th align=\"left\">Description</th></tr>

--- a/Modelica/Math/Random.mo
+++ b/Modelica/Math/Random.mo
@@ -222,7 +222,7 @@ and the returned state is the one from the last iteration.
         output Integer stateOut[nState]
           "The new internal states of the random number generator";
         external "C" ModelicaRandom_xorshift64star(stateIn, stateOut, result)
-          annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaRandom.h\"", Library="ModelicaExternalC");
+          annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaRandom.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaKissFFT.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt"});
         annotation(Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -395,7 +395,7 @@ random number generator is used to fill the internal state vector with 64 bit ra
         output Integer stateOut[nState]
           "The new internal states of the random number generator";
         external "C" ModelicaRandom_xorshift128plus(stateIn, stateOut, result)
-          annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaRandom.h\"", Library="ModelicaExternalC");
+          annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaRandom.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaKissFFT.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt"});
         annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -572,7 +572,7 @@ random number generator is used to fill the internal state vector with 64 bit ra
         output Integer stateOut[nState]
           "The new internal states of the random number generator";
         external "C" ModelicaRandom_xorshift1024star(stateIn, stateOut, result)
-          annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaRandom.h\"", Library="ModelicaExternalC");
+          annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaRandom.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaKissFFT.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt"});
         annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -935,7 +935,7 @@ If the same localSeed, globalSeed, nState is given, the same state vector is ret
       extends Modelica.Icons.Function;
       output Integer seed "Automatically generated seed";
 
-      external "C" seed = ModelicaRandom_automaticGlobalSeed(0.0) annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaRandom.h\"", Library="ModelicaExternalC");
+      external "C" seed = ModelicaRandom_automaticGlobalSeed(0.0) annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaRandom.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaKissFFT.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt"});
      annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -1073,7 +1073,7 @@ path is provided.
         input Integer[33] rngState "The initial state";
         input Integer id;
         external "C" ModelicaRandom_setInternalState_xorshift1024star(rngState, size(rngState,1), id)
-          annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaRandom.h\"", Library="ModelicaExternalC");
+          annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaRandom.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaKissFFT.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt"});
       end setInternalState;
 
     algorithm
@@ -1153,7 +1153,7 @@ random number generator to fill the internal state vector with 64 bit random num
       output Real y
         "A random number with a uniform distribution on the interval (0,1]";
       external "C" y = ModelicaRandom_impureRandom_xorshift1024star(id)
-        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaRandom.h\"", Library="ModelicaExternalC");
+        annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaRandom.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaKissFFT.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt"});
       annotation(Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>

--- a/Modelica/Utilities/Files.mo
+++ b/Modelica/Utilities/Files.mo
@@ -569,7 +569,7 @@ impure function fullPathName "Get full path name of file or directory name"
   extends Modelica.Icons.Function;
   input String name "Absolute or relative file or directory name";
   output String fullName "Full path of 'name'";
-external "C" fullName = ModelicaInternal_fullPathName(name) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+external "C" fullName = ModelicaInternal_fullPathName(name) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
   annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -658,7 +658,7 @@ impure function temporaryFileName
     "Return arbitrary name of a file that does not exist and is in a directory where access rights allow to write to this file (useful for temporary output of files)"
   extends Modelica.Icons.Function;
   output String fileName "Full path name of temporary file";
-  external "C" fileName=ModelicaInternal_temporaryFileName() annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+  external "C" fileName=ModelicaInternal_temporaryFileName() annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
   annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>

--- a/Modelica/Utilities/Internal.mo
+++ b/Modelica/Utilities/Internal.mo
@@ -162,33 +162,33 @@ package FileSystem
   impure function mkdir "Make directory (POSIX: 'mkdir')"
     extends Modelica.Icons.Function;
     input String directoryName "Make a new directory";
-  external "C" ModelicaInternal_mkdir(directoryName) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+  external "C" ModelicaInternal_mkdir(directoryName) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
   end mkdir;
 
   impure function rmdir "Remove empty directory (POSIX function 'rmdir')"
     extends Modelica.Icons.Function;
     input String directoryName "Empty directory to be removed";
-  external "C" ModelicaInternal_rmdir(directoryName) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+  external "C" ModelicaInternal_rmdir(directoryName) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
   end rmdir;
 
   impure function stat "Inquire file information (POSIX function 'stat')"
     extends Modelica.Icons.Function;
     input String name "Name of file, directory, pipe etc.";
     output Types.FileType fileType "Type of file";
-  external "C" fileType = ModelicaInternal_stat(name) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+  external "C" fileType = ModelicaInternal_stat(name) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
   end stat;
 
   impure function rename "Rename existing file or directory (C function 'rename')"
     extends Modelica.Icons.Function;
     input String oldName "Current name";
     input String newName "New name";
-  external "C" ModelicaInternal_rename(oldName, newName) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+  external "C" ModelicaInternal_rename(oldName, newName) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
   end rename;
 
   impure function removeFile "Remove existing file (C function 'remove')"
     extends Modelica.Icons.Function;
     input String fileName "File to be removed";
-  external "C" ModelicaInternal_removeFile(fileName) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+  external "C" ModelicaInternal_removeFile(fileName) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
   end removeFile;
 
   impure function copyFile
@@ -196,7 +196,7 @@ package FileSystem
     extends Modelica.Icons.Function;
     input String fromName "Name of file to be copied";
     input String toName "Name of copy of file";
-  external "C" ModelicaInternal_copyFile(fromName, toName) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+  external "C" ModelicaInternal_copyFile(fromName, toName) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
   end copyFile;
 
   impure function readDirectory
@@ -208,7 +208,7 @@ package FileSystem
         "Number of names that are returned (inquire with getNumberOfFiles)";
     output String names[nNames]
         "All file and directory names in any order from the desired directory";
-    external "C" ModelicaInternal_readDirectory(directory,nNames,names) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+    external "C" ModelicaInternal_readDirectory(directory,nNames,names) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
   end readDirectory;
 
 impure function getNumberOfFiles
@@ -217,7 +217,7 @@ impure function getNumberOfFiles
   input String directory "Directory name";
   output Integer result
         "Number of files and directories present in 'directory'";
-  external "C" result = ModelicaInternal_getNumberOfFiles(directory) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+  external "C" result = ModelicaInternal_getNumberOfFiles(directory) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
 end getNumberOfFiles;
 
   annotation (

--- a/Modelica/Utilities/Streams.mo
+++ b/Modelica/Utilities/Streams.mo
@@ -6,7 +6,7 @@ package Streams "Read from files and write to files"
     extends Modelica.Icons.Function;
     input String string="" "String to be printed";
     input String fileName="" "File where to print (empty string is the terminal)" annotation(Dialog(saveSelector(filter="Text files (*.txt)", caption="Text file to store the output of print(..)")));
-  external "C" ModelicaInternal_print(string, fileName) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+  external "C" ModelicaInternal_print(string, fileName) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
     annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -44,7 +44,7 @@ Streams.print(\"x = \" + String(y), \"mytestfile.txt\");
     extends Modelica.Icons.Function;
     input String fileName "Name of the file that shall be read" annotation(Dialog(loadSelector(filter="Text files (*.txt)", caption="Open text file for reading")));
     output String stringVector[countLines(fileName)] "Content of file";
-  external "C" ModelicaInternal_readFile(fileName,stringVector,size(stringVector,1)) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+  external "C" ModelicaInternal_readFile(fileName,stringVector,size(stringVector,1)) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
     annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -66,7 +66,7 @@ Note, a fileName can be defined as URI by using the helper function
     input Integer lineNumber(min=1) "Number of line to read";
     output String string "Line of text";
     output Boolean endOfFile "If true, end-of-file was reached when trying to read line";
-  external "C" string=  ModelicaInternal_readLine(fileName,lineNumber,endOfFile) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+  external "C" string=  ModelicaInternal_readLine(fileName,lineNumber,endOfFile) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
     annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -91,7 +91,7 @@ and endOfFile=true. Otherwise endOfFile=false.
     extends Modelica.Icons.Function;
     input String fileName "Name of the file that shall be read" annotation(Dialog(loadSelector(filter="Text files (*.txt)", caption="Open text file for counting lines")));
     output Integer numberOfLines "Number of lines in file";
-  external "C" numberOfLines=  ModelicaInternal_countLines(fileName) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+  external "C" numberOfLines=  ModelicaInternal_countLines(fileName) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
     annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -140,7 +140,7 @@ Streams.error(\"x (= \" + String(x) + \")\\nhas to be in the range 0 .. 1\");
   impure function close "Close file"
     extends Modelica.Icons.Function;
     input String fileName "Name of the file that shall be closed" annotation(Dialog(loadSelector(filter="Text files (*.txt)", caption="Close text file")));
-  external "C" ModelicaStreams_closeFile(fileName) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+  external "C" ModelicaStreams_closeFile(fileName) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
     annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -159,7 +159,7 @@ Close file if it is open. Ignore call if file is already closed or does not exis
     input String matrixName "Name / identifier of the 2D Real array on the file";
     output Integer dim[2] "Number of rows and columns of the 2D Real array";
   external "C" ModelicaIO_readMatrixSizes(fileName, matrixName, dim)
-    annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaIO.h\"", Library={"ModelicaIO", "ModelicaMatIO", "zlib"});
+    annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaIO.h\"", Library={"ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     annotation(Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -196,7 +196,7 @@ See <a href=\"modelica://Modelica.Utilities.Examples.ReadRealMatrixFromFile\">Ex
     input Boolean verboseRead = true "= true: Print info message; = false: No info message";
     output Real matrix[nrow, ncol] "2D Real array";
   external "C" ModelicaIO_readRealMatrix(fileName, matrixName, matrix, size(matrix, 1), size(matrix, 2), verboseRead)
-    annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaIO.h\"", Library={"ModelicaIO", "ModelicaMatIO", "zlib"});
+    annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaIO.h\"", Library={"ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     annotation(Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -238,7 +238,7 @@ See <a href=\"modelica://Modelica.Utilities.Examples.ReadRealMatrixFromFile\">Ex
                          choice="7" "MATLAB v7 MAT file"));
     output Boolean success "true if successful";
   external "C" success = ModelicaIO_writeRealMatrix(fileName, matrixName, matrix, size(matrix, 1), size(matrix, 2), append, format)
-    annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaIO.h\"", Library={"ModelicaIO", "ModelicaMatIO", "zlib"});
+    annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaIO.h\"", Library={"ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
     annotation(Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>

--- a/Modelica/Utilities/Strings.mo
+++ b/Modelica/Utilities/Strings.mo
@@ -6,7 +6,7 @@ package Strings "Operations on strings"
     extends Modelica.Icons.Function;
     input String string;
     output Integer result "Number of characters of string";
-  external "C" result = ModelicaStrings_length(string) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC");
+  external "C" result = ModelicaStrings_length(string) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStrings.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_APHashFunction.txt"});
     annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -27,7 +27,7 @@ Returns the number of characters of \"string\".
     input Integer endIndex "Character position of substring end";
     output String result
       "String containing substring string[startIndex:endIndex]";
-  external "C" result = ModelicaStrings_substring(string,startIndex,endIndex) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC");
+  external "C" result = ModelicaStrings_substring(string,startIndex,endIndex) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStrings.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_APHashFunction.txt"});
     annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -91,7 +91,7 @@ defined by the optional argument \"string\".
     input String string2;
     input Boolean caseSensitive=true "= false, if case of letters is ignored";
     output Modelica.Utilities.Types.Compare result "Result of comparison";
-  external "C" result = ModelicaStrings_compare(string1, string2, caseSensitive) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC");
+  external "C" result = ModelicaStrings_compare(string1, string2, caseSensitive) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStrings.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_APHashFunction.txt"});
     annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -524,7 +524,7 @@ s2 = Strings.sort(s1);
     input String string "The string to create a hash from";
     output Integer hash "The hash value of string";
     external "C" hash=  ModelicaStrings_hashString(string)
-       annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC");
+       annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStrings.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_APHashFunction.txt"});
     annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -1100,7 +1100,7 @@ part of the string is printed.
       output Integer nextIndex
         "Index after the found token (success=true) or index at which scanning failed (success=false)";
       output Real number "Value of Real number";
-      external "C" ModelicaStrings_scanReal(string, startIndex, unsigned, nextIndex, number) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC");
+      external "C" ModelicaStrings_scanReal(string, startIndex, unsigned, nextIndex, number) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStrings.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_APHashFunction.txt"});
       annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -1147,7 +1147,7 @@ shall not start with '+' or '-'. The default of \"unsigned\" is <strong>false</s
       output Integer nextIndex
         "Index after the found token (success=true) or index at which scanning failed (success=false)";
       output Integer number "Value of Integer number";
-      external "C" ModelicaStrings_scanInteger(string, startIndex, unsigned, nextIndex, number) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC");
+      external "C" ModelicaStrings_scanInteger(string, startIndex, unsigned, nextIndex, number) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStrings.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_APHashFunction.txt"});
       annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -1191,7 +1191,7 @@ shall not start with '+' or '-'. The default of \"unsigned\" is <strong>false</s
       output Integer nextIndex
         "Index after the found token (success=true) or index at which scanning failed (success=false)";
       output String string2 "Value of String token";
-      external "C" ModelicaStrings_scanString(string, startIndex, nextIndex, string2) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC");
+      external "C" ModelicaStrings_scanString(string, startIndex, nextIndex, string2) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStrings.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_APHashFunction.txt"});
       annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -1225,7 +1225,7 @@ the second output argument is an empty string.
       output Integer nextIndex
         "Index after the found token (success=true) or index at which scanning failed (success=false)";
       output String identifier "Value of identifier token";
-      external "C" ModelicaStrings_scanIdentifier(string, startIndex, nextIndex, identifier) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC");
+      external "C" ModelicaStrings_scanIdentifier(string, startIndex, nextIndex, identifier) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStrings.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_APHashFunction.txt"});
 
       annotation (Documentation(info="<html>
 <h4>Syntax</h4>
@@ -1259,7 +1259,7 @@ the second output argument is an empty string.
       input String string;
       input Integer startIndex(min=1)=1;
       output Integer nextIndex;
-      external "C" nextIndex = ModelicaStrings_skipWhiteSpace(string, startIndex) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC");
+      external "C" nextIndex = ModelicaStrings_skipWhiteSpace(string, startIndex) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStrings.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStrings.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_APHashFunction.txt"});
       annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>

--- a/Modelica/Utilities/System.mo
+++ b/Modelica/Utilities/System.mo
@@ -6,7 +6,7 @@ impure function getWorkDirectory "Get full path name of work directory"
   extends Modelica.Icons.Function;
   output String directory "Full path name of work directory";
 // POSIX function "getcwd"
-  external "C" directory = ModelicaInternal_getcwd(0) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+  external "C" directory = ModelicaInternal_getcwd(0) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
     annotation (Documentation(info="<html>
 
 </html>"));
@@ -16,7 +16,7 @@ impure function setWorkDirectory "Set work directory"
   extends Modelica.Icons.Function;
   input String directory "New work directory";
 // POSIX function "chdir"
-external "C" ModelicaInternal_chdir(directory) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+external "C" ModelicaInternal_chdir(directory) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
     annotation (Documentation(info="<html>
 
 </html>"));
@@ -31,7 +31,7 @@ impure function getEnvironmentVariable "Get content of environment variable"
       "Content of environment variable (empty, if not existent)";
   output Boolean exist
       "= true, if environment variable exists; = false, if it does not exist";
-  external "C" ModelicaInternal_getenv(name, convertToSlash, content, exist) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+  external "C" ModelicaInternal_getenv(name, convertToSlash, content, exist) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
     annotation (Documentation(info="<html>
 
 </html>"));
@@ -43,7 +43,7 @@ impure function setEnvironmentVariable "Set content of local environment variabl
   input String content "Value of the environment variable";
   input Boolean convertFromSlash =  false
       "True, if '/' in environment variable shall be changed to native directory separators";
-external "C" ModelicaInternal_setenv(name, content, convertFromSlash) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+external "C" ModelicaInternal_setenv(name, content, convertFromSlash) annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
     annotation (Documentation(info="<html>
 
 </html>"));
@@ -59,7 +59,7 @@ end setEnvironmentVariable;
     output Integer mon "Month";
     output Integer year "Year";
     external "C" ModelicaInternal_getTime(ms,sec,min,hour,day,mon,year)
-      annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+      annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
     annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>
@@ -131,7 +131,7 @@ All returned values are of type Integer and have the following meaning:
   impure function getPid "Retrieve the current process id"
     extends Modelica.Icons.Function;
     output Integer pid "Process ID";
-    external "C" pid = ModelicaInternal_getpid() annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC");
+    external "C" pid = ModelicaInternal_getpid() annotation(IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaInternal.h\"", Library="ModelicaExternalC", License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaInternal.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_win32_dirent.txt"});
     annotation (Documentation(info="<html>
 <h4>Syntax</h4>
 <blockquote><pre>

--- a/ObsoleteModelica4.mo
+++ b/ObsoleteModelica4.mo
@@ -218,7 +218,7 @@ for signal buses, see example
           input Boolean verboseRead = true
             "= true: Print info message; = false: No info message";
           external "C" readSuccess = ModelicaStandardTables_CombiTimeTable_read(tableID, forceRead, verboseRead)
-            annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+            annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
           annotation(__ModelicaAssociation_Impure=true);
         end readTimeTableData;
 
@@ -232,7 +232,7 @@ for signal buses, see example
             "= true: Print info message; = false: No info message";
           output Real readSuccess "Table read success";
           external "C" readSuccess = ModelicaStandardTables_CombiTable1D_read(tableID, forceRead, verboseRead)
-            annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+            annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
           annotation(__ModelicaAssociation_Impure=true);
         end readTable1DData;
 
@@ -246,7 +246,7 @@ for signal buses, see example
             "= true: Print info message; = false: No info message";
           output Real readSuccess "Table read success";
           external "C" readSuccess = ModelicaStandardTables_CombiTable2D_read(tableID, forceRead, verboseRead)
-            annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"});
+            annotation (IncludeDirectory="modelica://Modelica/Resources/C-Sources", Include="#include \"ModelicaStandardTables.h\"", Library={"ModelicaStandardTables", "ModelicaIO", "ModelicaMatIO", "zlib"}, License={"modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaStandardTables.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaIO.txt", "modelica:/Modelica/Resources/Licenses/LICENSE_ModelicaMatIO.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_zlib.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_uthash.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_stdint_msvc.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_portable-snippets.txt", "modelica:/Modelica/Resources/Licenses/Third-party/LICENSE_c99-snprintf.txt"});
           annotation(__ModelicaAssociation_Impure=true);
         end readTable2DData;
       end Internal;


### PR DESCRIPTION
This PR comes along with #4411 (after merging Mo-2900) and makes the license texts of the external functions/objects explicit such that FMU exporting tools no longer need to distribute all files of `modelica:/Modelica/Resources/Licenses/` along with the FMU, but only the actually used license texts.

Edit: Dependency on lapack (and the corresponding license texts) still is an exception since it is not seen as MSL dependency, but as tool requirement (see #2849).

Edit 2: Needs to be aligned with #4240.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added explicit license information to external C function annotations across multiple packages, enhancing metadata about third-party and internal library usage.
  - No changes to function signatures, logic, or user-facing behavior; only license references were added for greater transparency regarding external dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->