### PR TITLE
It does not make sense to restrict a temperature difference to be >=0

### DIFF
--- a/Modelica/Fluid/Sensors.mo
+++ b/Modelica/Fluid/Sensors.mo
@@ -696,7 +696,7 @@ through the sensor is allowed.
     extends Sensors.BaseClasses.PartialRelativeSensor;
 
     Modelica.Blocks.Interfaces.RealOutput T_rel(final quantity="ThermodynamicTemperature",
-                                                final unit = "K", displayUnit = "degC", min=0)
+                                                final unit = "K", displayUnit = "degC")
       "Relative temperature signal" annotation (Placement(
           transformation(
           origin={0,-90},


### PR DESCRIPTION
Found when investigating https://github.com/modelica/ModelicaSpecification/pull/3645
I assume the min=0 is just copy-paste from the Absolute-variant, and no-one tested this.

We might add `annotation(absoluteValue=false)` if we want to be clear for this one.

