### PR TITLE
Avoid the tank to ever become completely empty - fixes #4526

### DIFF
--- a/Modelica/Fluid/Vessels.mo
+++ b/Modelica/Fluid/Vessels.mo
@@ -307,7 +307,7 @@ of the modeller. Increase nPorts to add an additional port.
         end for;
         // Check for correct solution
         assert(fluidLevel <= fluidLevel_max, "Vessel is overflowing (fluidLevel > fluidLevel_max = " + String(fluidLevel) + ")");
-        assert(fluidLevel > 0, "Fluid level (= " + String(fluidLevel) + ") is too small, the tank cannot be completely empty otherwise the energy balance equation becomes singular.");
+        assert(fluidLevel > 0, "Fluid level is too small, the tank cannot be completely empty otherwise the energy balance equation becomes singular.");
 
         // Boundary conditions
 

--- a/Modelica/Fluid/Vessels.mo
+++ b/Modelica/Fluid/Vessels.mo
@@ -307,7 +307,7 @@ of the modeller. Increase nPorts to add an additional port.
         end for;
         // Check for correct solution
         assert(fluidLevel <= fluidLevel_max, "Vessel is overflowing (fluidLevel > fluidLevel_max = " + String(fluidLevel) + ")");
-        assert(fluidLevel > 1e-6*fluidLevel_max, "Fluid level (= " + String(fluidLevel) + ") is too small, the tank cannot be completely empty otherwise the energy balance equation becomes singular.");
+        assert(fluidLevel > 0, "Fluid level (= " + String(fluidLevel) + ") is too small, the tank cannot be completely empty otherwise the energy balance equation becomes singular.");
 
         // Boundary conditions
 

--- a/Modelica/Fluid/Vessels.mo
+++ b/Modelica/Fluid/Vessels.mo
@@ -307,7 +307,7 @@ of the modeller. Increase nPorts to add an additional port.
         end for;
         // Check for correct solution
         assert(fluidLevel <= fluidLevel_max, "Vessel is overflowing (fluidLevel > fluidLevel_max = " + String(fluidLevel) + ")");
-        assert(fluidLevel > -1e-6*fluidLevel_max, "Fluid level (= " + String(fluidLevel) + ") is below zero meaning that the solution failed.");
+        assert(fluidLevel > 1e-6*fluidLevel_max, "Fluid level (= " + String(fluidLevel) + ") is too small, the tank cannot be completely empty otherwise the energy balance equation becomes singular.");
 
         // Boundary conditions
 

--- a/ModelicaTest/Fluid/TestComponents/Vessels/TestSimpleTank.mo
+++ b/ModelicaTest/Fluid/TestComponents/Vessels/TestSimpleTank.mo
@@ -10,10 +10,10 @@ model TestSimpleTank
     height=1,
     nPorts=2,
     portsData={Modelica.Fluid.Vessels.BaseClasses.VesselPortsData(diameter=0.1,
-        height=0),Modelica.Fluid.Vessels.BaseClasses.VesselPortsData(diameter=
+        height=0.001),Modelica.Fluid.Vessels.BaseClasses.VesselPortsData(diameter=
         0.1, height=1)},
     crossArea=1,
-    level_start=0)
+    level_start=0.001)
     annotation (Placement(transformation(extent={{0,0},{40,40}})));
 
   inner Modelica.Fluid.System system(energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial)


### PR DESCRIPTION
This fixes #4526 by:

- adding an assert that prevents the tank to ever become completely empty, a condition in which the energy balance equation becomes singular
- putting the height of the bottom port 1 mm above the bottom of the tank, to avoid it getting completely empty
- initializing the tank level at 1 mm, not 0, which is singular and no longer allowed.

With the following prescribed incoming flow (which is unchanged w.r.t. MSL 4.0.0)
![immagine](https://github.com/user-attachments/assets/d7f5efac-9651-4cd5-acde-40804ecf1ba2)
OMC can now simulate the system successfully and produces the following transient for the level
![immagine](https://github.com/user-attachments/assets/345342d8-e03d-4780-bb53-412e4ad86b49)

As expected, the tank starts near empty at 1 mm level and the check-valve behaviour on the bottom port prevents the fluid from going down the drain. When providing 40 kg/s of incoming flow rate ,which is more than the out-going pipe can drain, the level goes up; however, when that flow rate is reduced to 10 kg/s, the level goes down, until it settles to a value very close to the level of the outlet port, which swallows the incoming flow while keeping the level constant. When the flow rate is reduced to zero, the level settles down to 1 mm, i.e., the port level. And so on and so forth...

As expected, since the tank fluid is initialized at ambient temperature and the fed fluid is also at ambient temperature, the fluid temperature is always well defined and always equal to ambient temperature, i.e., 20 degC
![immagine](https://github.com/user-attachments/assets/7089fd23-7f39-4b5d-ac08-ac1a9bcc8fa8)
