### PR TITLE
Add extra variables for easier check.

### DIFF
--- a/ModelicaTest/Tables/CombiTable1Ds.mo
+++ b/ModelicaTest/Tables/CombiTable1Ds.mo
@@ -13,14 +13,26 @@ package CombiTable1Ds "Test models for Modelica.Blocks.Tables.CombiTable1Ds"
   partial model TestDer
     extends Test;
     Modelica.Blocks.Continuous.Der d_t_new annotation(Placement(transformation(extent={{0,0},{20,20}})));
+    Real integrated "Integral that should equal d_t_new.u";
+    parameter Real factor1=1 "To prevent symbolic simplification" annotation(Evaluate=false);
+  initial equation
+    integrated=d_t_new.u;
   equation
+    der(integrated)=factor1*d_t_new.y;
     connect(t_new.y[1], d_t_new.u) annotation(Line(points={{-19,10},{-2,10}}, color={0,0,127}));
   end TestDer;
 
   partial model TestDer2
     extends TestDer;
     Modelica.Blocks.Continuous.Der d2_t_new annotation(Placement(transformation(extent={{40,0},{60,20}})));
+    Real integrated2 "Integral that should equal d_t_new.u";
+    Real der_integrated2;
+  initial equation
+    integrated2=d_t_new.u;
+    der_integrated2=d2_t_new.u;
   equation
+    der(integrated2)=factor1*der_integrated2;
+    der(der_integrated2)=factor1*d2_t_new.y;
     connect(d_t_new.y, d2_t_new.u) annotation(Line(points={{21,10},{26,10},{33,10},{38,10}}, color={0,0,127}));
   end TestDer2;
 

--- a/ModelicaTest/Tables/CombiTable1Dv.mo
+++ b/ModelicaTest/Tables/CombiTable1Dv.mo
@@ -13,14 +13,26 @@ package CombiTable1Dv "Test models for Modelica.Blocks.Tables.CombiTable1Dv"
   partial model TestDer
     extends Test;
     Modelica.Blocks.Continuous.Der d_t_new annotation(Placement(transformation(extent={{0,0},{20,20}})));
+    Real integrated "Integral that should equal d_t_new.u";
+    parameter Real factor1=1 "To prevent symbolic simplification" annotation(Evaluate=false);
+  initial equation
+    integrated=d_t_new.u;
   equation
+    der(integrated)=factor1*d_t_new.y;
     connect(t_new.y[1], d_t_new.u) annotation(Line(points={{-19,10},{-2,10}}, color={0,0,127}));
   end TestDer;
 
   partial model TestDer2
     extends TestDer;
     Modelica.Blocks.Continuous.Der d2_t_new annotation(Placement(transformation(extent={{40,0},{60,20}})));
+    Real integrated2 "Integral that should equal d_t_new.u";
+    Real der_integrated2;
+  initial equation
+    integrated2=d_t_new.u;
+    der_integrated2=d2_t_new.u;
   equation
+    der(integrated2)=factor1*der_integrated2;
+    der(der_integrated2)=factor1*d2_t_new.y;
     connect(d_t_new.y, d2_t_new.u) annotation(Line(points={{21,10},{26,10},{33,10},{38,10}}, color={0,0,127}));
   end TestDer2;
 

--- a/ModelicaTest/Tables/CombiTable2Ds.mo
+++ b/ModelicaTest/Tables/CombiTable2Ds.mo
@@ -10,14 +10,26 @@ package CombiTable2Ds "Test models for Modelica.Blocks.Tables.CombiTable2Ds"
   partial model TestDer
     extends Test;
     Modelica.Blocks.Continuous.Der d_t_new annotation(Placement(transformation(extent={{0,0},{20,20}})));
+    Real integrated "Integral that should equal d_t_new.u";
+    parameter Real factor1=1 "To prevent symbolic simplification" annotation(Evaluate=false);
+  initial equation
+    integrated=d_t_new.u;
   equation
+    der(integrated)=factor1*d_t_new.y;
     connect(t_new.y, d_t_new.u) annotation(Line(points={{-19,10},{-2,10}}, color={0,0,127}));
   end TestDer;
 
   partial model TestDer2
     extends TestDer;
     Modelica.Blocks.Continuous.Der d2_t_new annotation(Placement(transformation(extent={{40,0},{60,20}})));
+    Real integrated2 "Integral that should equal d_t_new.u";
+    Real der_integrated2;
+  initial equation
+    integrated2=d_t_new.u;
+    der_integrated2=d2_t_new.u;
   equation
+    der(integrated2)=factor1*der_integrated2;
+    der(der_integrated2)=factor1*d2_t_new.y;
     connect(d_t_new.y, d2_t_new.u) annotation(Line(points={{21,10},{26,10},{33,10},{38,10}}, color={0,0,127}));
   end TestDer2;
 

--- a/ModelicaTest/Tables/CombiTable2Dv.mo
+++ b/ModelicaTest/Tables/CombiTable2Dv.mo
@@ -10,14 +10,26 @@ package CombiTable2Dv "Test models for Modelica.Blocks.Tables.CombiTable2Dv"
   partial model TestDer
     extends Test;
     Modelica.Blocks.Continuous.Der d_t_new annotation(Placement(transformation(extent={{0,0},{20,20}})));
+    Real integrated "Integral that should equal d_t_new.u";
+    parameter Real factor1=1 "To prevent symbolic simplification" annotation(Evaluate=false);
+  initial equation
+    integrated=d_t_new.u;
   equation
+    der(integrated)=factor1*d_t_new.y;
     connect(t_new.y[1], d_t_new.u) annotation(Line(points={{-19,10},{-2,10}}, color={0,0,127}));
   end TestDer;
 
   partial model TestDer2
     extends TestDer;
     Modelica.Blocks.Continuous.Der d2_t_new annotation(Placement(transformation(extent={{40,0},{60,20}})));
+    Real integrated2 "Integral that should equal d_t_new.u";
+    Real der_integrated2;
+  initial equation
+    integrated2=d_t_new.u;
+    der_integrated2=d2_t_new.u;
   equation
+    der(integrated2)=factor1*der_integrated2;
+    der(der_integrated2)=factor1*d2_t_new.y;
     connect(d_t_new.y, d2_t_new.u) annotation(Line(points={{21,10},{26,10},{33,10},{38,10}}, color={0,0,127}));
   end TestDer2;
 

--- a/ModelicaTest/Tables/CombiTimeTable.mo
+++ b/ModelicaTest/Tables/CombiTimeTable.mo
@@ -10,14 +10,26 @@ package CombiTimeTable "Test models for Modelica.Blocks.Sources.CombiTimeTable"
   partial model TestDer
     extends Test;
     Modelica.Blocks.Continuous.Der d_t_new annotation(Placement(transformation(extent={{0,0},{20,20}})));
+    Real integrated "Integral that should equal d_t_new.u";
+    parameter Real factor1=1 "To prevent symbolic simplification" annotation(Evaluate=false);
+  initial equation
+    integrated=d_t_new.u;
   equation
+    der(integrated)=factor1*d_t_new.y;
     connect(t_new.y[1], d_t_new.u) annotation(Line(points={{-19,10},{-2,10}}, color={0,0,127}));
   end TestDer;
 
   partial model TestDer2
     extends TestDer;
     Modelica.Blocks.Continuous.Der d2_t_new annotation(Placement(transformation(extent={{40,0},{60,20}})));
+    Real integrated2 "Integral that should equal d_t_new.u";
+    Real der_integrated2;
+  initial equation
+    integrated2=d_t_new.u;
+    der_integrated2=d2_t_new.u;
   equation
+    der(integrated2)=factor1*der_integrated2;
+    der(der_integrated2)=factor1*d2_t_new.y;
     connect(d_t_new.y, d2_t_new.u) annotation(Line(points={{21,10},{26,10},{33,10},{38,10}}, color={0,0,127}));
   end TestDer2;
 


### PR DESCRIPTION
In order to check the derivative-approximation a simple possibility is to just integrate it and see that it is roughly the same as the original. It doesn't replace the reference results, but it helps in analyzing potential errors.

As an example simulate `ModelicaTest.Tables.CombiTable1Ds.Test34` and plot `d_t_new.u`, `integrated`, `integrated2`. They should all be almost identical to each other. The parameter with `Evaluate=false` is added so that tools don't have the amazing idea of seeing through the differentiation combined with integration. There is no need to have references for these variables.

Possible extensions:
- assert for equality (a bit complicated due to double integration)
- turn it into a block
  -  so that we don't mix graphics and text
   - and it can be re-use for derivative test-models not extending from those base-classes
- figure-annotations