### PR TITLE
Remove redundant text in celsius to kelvin icon

### DIFF
--- a/Modelica/Thermal/HeatTransfer/Celsius/ToKelvin.mo
+++ b/Modelica/Thermal/HeatTransfer/Celsius/ToKelvin.mo
@@ -11,14 +11,6 @@ equation
     Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{
             100,100}}), graphics={
         Text(
-          extent={{54,-88},{114,-148}},
-          textColor={64,64,64},
-          textString="degC"),
-        Text(
-          extent={{194,-88},{254,-148}},
-          textColor={64,64,64},
-          textString="K"),
-        Text(
           extent={{-100,60},{-40,0}},
           textColor={64,64,64},
           textString="degC"),


### PR DESCRIPTION
Backport of #4466 to maint/4.1.x