### PR TITLE
Add numerical tolerance to floating-point number comparison in ModelicaTest.Fluid.TestComponents.Machines.TestLinearPower

### DIFF
--- a/ModelicaTest/Fluid/TestComponents/Machines/TestLinearPower.mo
+++ b/ModelicaTest/Fluid/TestComponents/Machines/TestLinearPower.mo
@@ -4,6 +4,6 @@ model TestLinearPower
   Modelica.Units.SI.Power p;
 equation
   p = Modelica.Fluid.Machines.BaseClasses.PumpCharacteristics.linearPower(V_flow_nominal={1,2}, W_nominal={3,5}, V_flow=11);
-  assert(p >= 23 and p <= 23, "Error in linearPower");
+  assert(abs(p - 23) < 1e-9, "Error in linearPower");
 annotation(experiment(StopTime=1));
 end TestLinearPower;

--- a/ModelicaTest/Fluid/TestComponents/Machines/TestLinearPower.mo
+++ b/ModelicaTest/Fluid/TestComponents/Machines/TestLinearPower.mo
@@ -4,6 +4,6 @@ model TestLinearPower
   Modelica.Units.SI.Power p;
 equation
   p = Modelica.Fluid.Machines.BaseClasses.PumpCharacteristics.linearPower(V_flow_nominal={1,2}, W_nominal={3,5}, V_flow=11);
-  assert(abs(p - 23) < 1e-9, "Error in linearPower");
+  assert(Modelica.Math.isEqual(p, 23.0, 1e-9), "Error in linearPower");
 annotation(experiment(StopTime=1));
 end TestLinearPower;

--- a/ModelicaTest/Fluid/TestComponents/Pipes/DynamicPipeEnergyConservationCheck2.mo
+++ b/ModelicaTest/Fluid/TestComponents/Pipes/DynamicPipeEnergyConservationCheck2.mo
@@ -126,6 +126,7 @@ equation
   total_A_V_B_a = pipeA_V_B.H_flows[1] + pipeA_V_B.m_flows[1]*pipeA_V_B.flowModel.vs[1]^2/2;
   total_A_V_B_b = pipeA_V_B.H_flows[end] + pipeA_V_B.m_flows[end]*pipeA_V_B.flowModel.vs[end]^2/2;
   when terminal() then
+    assert(time > 495, "Steady state was not yet reached at StopTime");
     assert(Modelica.Math.isEqual(total_AV_B_a, total_AV_B_b, 1), "Energy not conserved!");
     assert(Modelica.Math.isEqual(total_A_VB_a, total_A_VB_b, 1), "Energy not conserved!");
     assert(Modelica.Math.isEqual(total_AV_VB_a, total_AV_VB_b, 1), "Energy not conserved!");

--- a/ModelicaTest/Fluid/TestComponents/Pipes/DynamicPipeEnergyConservationCheck2.mo
+++ b/ModelicaTest/Fluid/TestComponents/Pipes/DynamicPipeEnergyConservationCheck2.mo
@@ -125,10 +125,12 @@ equation
   total_AV_VB_b = pipeAV_VB.H_flows[end] + pipeAV_VB.m_flows[end]*pipeAV_VB.flowModel.vs[end]^2/2;
   total_A_V_B_a = pipeA_V_B.H_flows[1] + pipeA_V_B.m_flows[1]*pipeA_V_B.flowModel.vs[1]^2/2;
   total_A_V_B_b = pipeA_V_B.H_flows[end] + pipeA_V_B.m_flows[end]*pipeA_V_B.flowModel.vs[end]^2/2;
-  assert(time < 500 or Modelica.Math.isEqual(total_AV_B_a, total_AV_B_b, 1), "Energy not conserved!");
-  assert(time < 500 or Modelica.Math.isEqual(total_A_VB_a, total_A_VB_b, 1), "Energy not conserved!");
-  assert(time < 500 or Modelica.Math.isEqual(total_AV_VB_a, total_AV_VB_b, 1), "Energy not conserved!");
-  assert(time < 500 or Modelica.Math.isEqual(total_A_V_B_a, total_A_V_B_b, 1), "Energy not conserved!");
+  when terminal() then
+    assert(Modelica.Math.isEqual(total_AV_B_a, total_AV_B_b, 1), "Energy not conserved!");
+    assert(Modelica.Math.isEqual(total_A_VB_a, total_A_VB_b, 1), "Energy not conserved!");
+    assert(Modelica.Math.isEqual(total_AV_VB_a, total_AV_VB_b, 1), "Energy not conserved!");
+    assert(Modelica.Math.isEqual(total_A_V_B_a, total_A_V_B_b, 1), "Energy not conserved!");
+  end when;
   connect(boundary.ports[1], pipeAV_B.port_a)
     annotation (Line(points={{-20,50},{-10,50}}, color={0,127,255}));
   connect(pipeAV_B.port_b, boundary1.ports[1])


### PR DESCRIPTION
As discussed during the MAP-Lib meeting of 24/02/2025, the first issue in #4554 is fixed by allowing a bit of numerical tolerance. The second issue is addressed by explicitly calling assert() only at the end of the simulation, when the steady-state has been reached.