### PR TITLE
Attempt to fix #4559 by increasing RonDiode and GoffDiode

### DIFF
--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_Braking.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_Braking.mo
@@ -149,13 +149,13 @@ equation
   connect(starM.pin_n, grounding.p)
     annotation (Line(points={{-70,-10},{-70,5},{-70,20}}, color={0,0,255}));
   annotation (experiment(StopTime=0.8, Interval=1E-4, Tolerance=1e-06), Documentation(
-        info="<html>
+        info= "<html>
 <p>
 A synchronous machine with permanent magnets starts braking from nominal speed by feeding a diode bridge,
 which in turn feeds a braking resistor.
 Since induced voltage is reduced proportional to falling speed, the braking resistance is set proportional
 to speed to achieve constant current and torque.</p>
 
-<p>Default machine parameters are used</p>
+<p>Default machine parameters are used. The RonDiode and GoffDiode parameters of the diode bridge are both increased to 1e-4 to avoid numerical issues when the variable resistor voltage gets close to zero.</p>
 </html>"));
 end SMPM_Braking;

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_Braking.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_Braking.mo
@@ -69,7 +69,7 @@ model SMPM_Braking
         origin={-10,0},
         extent={{-10,-10},{10,10}},
         rotation=270)));
-  Modelica.Electrical.PowerConverters.ACDC.DiodeBridge2mPulse diodeBridge2mPulse(m=m)
+  Modelica.Electrical.PowerConverters.ACDC.DiodeBridge2mPulse diodeBridge2mPulse(m = m, RonDiode = 1e-4, GoffDiode = 1e-4)
     annotation (Placement(transformation(
         extent={{-10,10},{10,-10}},
         rotation=90,


### PR DESCRIPTION
This attempts to fix #4559 by making the system less brutally nonlinear when approaching zero voltage and current on the load towards the end of the transient.