### PR TITLE
Add test model ModelicaTest.Media.TestOnly.R134a_setState_pTX_high_T

### DIFF
--- a/ModelicaTest/Media.mo
+++ b/ModelicaTest/Media.mo
@@ -934,7 +934,7 @@ is given to compare the approximation.
       annotation (experiment(StopTime=1));
     end MoistAir;
 
-    model R134a_setState_pTX "Test setState_pTX() of R134a"
+    model R134a_setState_pTX "Test setState_pTX() of R134a at constant room temperature"
       extends Modelica.Icons.Example;
       replaceable package Medium = Modelica.Media.R134a.R134a_ph "Medium model";
       SI.Temperature T = 273.15 + 25;
@@ -949,6 +949,11 @@ is given to compare the approximation.
       SI.ThermalConductivity k = Medium.thermalConductivity(state);
       annotation (experiment(StopTime=1));
     end R134a_setState_pTX;
+
+    model R134a_setState_pTX_high_T "Test setState_pTX() of R134a at constant high temperature"
+      extends R134a_setState_pTX(T=400);
+      annotation (experiment(StopTime=1));
+    end R134a_setState_pTX_high_T;
 
     model R134a_setState_phX "Test setState_phX() of R134a"
       extends Modelica.Icons.Example;

--- a/ModelicaTest/Resources/Reference/ModelicaTest/Media/TestOnly/R134a_setState_pTX_high_T/comparisonSignals.txt
+++ b/ModelicaTest/Resources/Reference/ModelicaTest/Media/TestOnly/R134a_setState_pTX_high_T/comparisonSignals.txt
@@ -1,0 +1,6 @@
+time
+h
+rho
+mu
+cp
+k


### PR DESCRIPTION
This is a test model for the regression of MSL v4.1.0-alpha.1 to v4.1.0-beta.2 reported by #4598.

Here is the expected reference result (obtained by reverting f1574e8116fd5e4d72c5cbae4176f29e1dc3445f): [R134a_setState_pTX_high_T.csv.zip](https://github.com/user-attachments/files/19346593/R134a_setState_pTX_high_T.csv.zip)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced test models now clearly differentiate between standard room-temperature conditions and a high-temperature (400 K) scenario.
	- Added a reference data file containing key signals for thermodynamic property comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->