### PR TITLE
Only force CMAKE_INSTALL_PREFIX if the user didn't specify it.

### DIFF
--- a/Modelica/Resources/CMakeLists.txt
+++ b/Modelica/Resources/CMakeLists.txt
@@ -17,6 +17,7 @@ set(MODELICA_UTILITIES_INCLUDE_DIR "${MODELICA_RESOURCES_DIR}/C-Sources")
 include(BuildProjects/CMake/Modelica_platform.cmake)
 include(BuildProjects/CMake/Modelica_utilities.cmake)
 
+# Do not override CMAKE_INSTALL_PREFIX if it was set by the user. CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT is automatically provided by cmake.
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(
     CMAKE_INSTALL_PREFIX "${MODELICA_RESOURCES_DIR}"

--- a/Modelica/Resources/CMakeLists.txt
+++ b/Modelica/Resources/CMakeLists.txt
@@ -17,11 +17,13 @@ set(MODELICA_UTILITIES_INCLUDE_DIR "${MODELICA_RESOURCES_DIR}/C-Sources")
 include(BuildProjects/CMake/Modelica_platform.cmake)
 include(BuildProjects/CMake/Modelica_utilities.cmake)
 
-set(
-  CMAKE_INSTALL_PREFIX "${MODELICA_RESOURCES_DIR}"
-  CACHE PATH
-  "Library installation prefix path (don't change)" FORCE
-)
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(
+    CMAKE_INSTALL_PREFIX "${MODELICA_RESOURCES_DIR}"
+    CACHE PATH
+    "Library installation prefix path (don't change)" FORCE
+  )
+endif()
 
 get_modelica_platform_name_with_compiler_version(MODELICA_PLATFORM_NAME)
 set(


### PR DESCRIPTION
Forcing an override of `CMAKE_INSTALL_PREFIX` is not friendly, since users might expect to set it themselves when they run cmake.

We have a real-world use case where we do set this ourselves when running cmake. We build the libraries on each platform separately, setting `CMAKE_INSTALL_PREFIX` to a nice place outside of the source. Only afterwards do we combine all of the results from each platform and put them in the final location.