### PR TITLE
Fix building html tidy with CMake 4.0 (CI)

### DIFF
--- a/.github/workflows/checkCI.yml
+++ b/.github/workflows/checkCI.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           git clone --branch 5.8.0 --depth=1 https://github.com/htacg/tidy-html5.git
           pushd tidy-html5
-          cmake .
+          cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 .
           make
           sudo make install
           popd


### PR DESCRIPTION
@AHaumer @casella This should be merged and back-ported asap to no longer cause false-positive CI errors from PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build configuration to enforce improved compatibility and policy compliance within the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->