### PR TITLE
Obsolete Line Models

### DIFF
--- a/Modelica/Electrical/Analog/Lines/TLine1.mo
+++ b/Modelica/Electrical/Analog/Lines/TLine1.mo
@@ -15,7 +15,7 @@ equation
   i2 = (v2 - er)/Z0;
   es = 2*delay(v2, TD) - delay(er, TD);
   er = 2*delay(v1, TD) - delay(es, TD);
-  annotation (obsolete = "Please use Modelica.Electrical.Lines.TLine instead of this model",
+  annotation (obsolete = "Please use Modelica.Electrical.Analog.Lines.TLine instead of this model",
     defaultComponentName="line",
     Documentation(info="<html>
 <p>Lossless transmission line with characteristic impedance Z0 and transmission delay TD The lossless transmission line TLine1 is a two Port. Both port branches consist of a resistor with characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay TD. For further details see [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>]. The model parameters can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;) and TD = sqrt(L&#39;*C&#39;)*length_of_line. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero.</p>

--- a/Modelica/Electrical/Analog/Lines/TLine1.mo
+++ b/Modelica/Electrical/Analog/Lines/TLine1.mo
@@ -15,7 +15,8 @@ equation
   i2 = (v2 - er)/Z0;
   es = 2*delay(v2, TD) - delay(er, TD);
   er = 2*delay(v1, TD) - delay(es, TD);
-  annotation (defaultComponentName="line",
+  annotation (obsolete = "Please use Modelica.Electrical.Lines.TLine instead of this model",
+    defaultComponentName="line",
     Documentation(info="<html>
 <p>Lossless transmission line with characteristic impedance Z0 and transmission delay TD The lossless transmission line TLine1 is a two Port. Both port branches consist of a resistor with characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay TD. For further details see [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>]. The model parameters can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;) and TD = sqrt(L&#39;*C&#39;)*length_of_line. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero.</p>
 

--- a/Modelica/Electrical/Analog/Lines/TLine2.mo
+++ b/Modelica/Electrical/Analog/Lines/TLine2.mo
@@ -19,7 +19,7 @@ equation
   i2 = (v2 - er)/Z0;
   es = 2*delay(v2, TD) - delay(er, TD);
   er = 2*delay(v1, TD) - delay(es, TD);
-  annotation (obsolete = "Please use Modelica.Electrical.Lines.TLine instead of this model",
+  annotation (obsolete = "Please use Modelica.Electrical.Analog.Lines.TLine instead of this model",
     defaultComponentName="line",
     Documentation(info="<html>
 <p>Lossless transmission line with characteristic impedance Z0, frequency F and normalized length NL The lossless transmission line TLine2 is a two Port. Both port branches consist of a resistor with the value of the characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay. For further details see [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>]. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero. The characteristic impedance Z0 can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;). The normalized length NL is equal to the length of the line divided by the wavelength corresponding to the frequency F, i. e. the transmission delay TD is the quotient of NL and F.</p>

--- a/Modelica/Electrical/Analog/Lines/TLine2.mo
+++ b/Modelica/Electrical/Analog/Lines/TLine2.mo
@@ -19,7 +19,8 @@ equation
   i2 = (v2 - er)/Z0;
   es = 2*delay(v2, TD) - delay(er, TD);
   er = 2*delay(v1, TD) - delay(es, TD);
-  annotation (defaultComponentName="line",
+  annotation (obsolete = "Please use Modelica.Electrical.Lines.TLine instead of this model",
+    defaultComponentName="line",
     Documentation(info="<html>
 <p>Lossless transmission line with characteristic impedance Z0, frequency F and normalized length NL The lossless transmission line TLine2 is a two Port. Both port branches consist of a resistor with the value of the characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay. For further details see [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>]. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero. The characteristic impedance Z0 can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;). The normalized length NL is equal to the length of the line divided by the wavelength corresponding to the frequency F, i. e. the transmission delay TD is the quotient of NL and F.</p>
 <p><strong>References:</strong>

--- a/Modelica/Electrical/Analog/Lines/TLine3.mo
+++ b/Modelica/Electrical/Analog/Lines/TLine3.mo
@@ -16,7 +16,8 @@ equation
   i2 = (v2 - er)/Z0;
   es = 2*delay(v2, TD) - delay(er, TD);
   er = 2*delay(v1, TD) - delay(es, TD);
-  annotation (defaultComponentName="line",
+  annotation (obsolete = "Please use Modelica.Electrical.Lines.TLine instead of this model",
+    defaultComponentName="line",
     Documentation(info="<html>
 <p>Lossless transmission line with characteristic impedance Z0 and frequency F The lossless transmission line TLine3 is a two Port. Both port branches consist of a resistor with value of the characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay. For further details see [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>]. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero. The characteristic impedance Z0 can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;). The length of the line is equal to a quarter of the wavelength corresponding to the frequency F, i. e. the transmission delay is the quotient of 4 and F. In this case, the characteristic impedance is called natural impedance.</p>
 <p><strong>References:</strong>

--- a/Modelica/Electrical/Analog/Lines/TLine3.mo
+++ b/Modelica/Electrical/Analog/Lines/TLine3.mo
@@ -16,7 +16,7 @@ equation
   i2 = (v2 - er)/Z0;
   es = 2*delay(v2, TD) - delay(er, TD);
   er = 2*delay(v1, TD) - delay(es, TD);
-  annotation (obsolete = "Please use Modelica.Electrical.Lines.TLine instead of this model",
+  annotation (obsolete = "Please use Modelica.Electrical.Analog.Lines.TLine instead of this model",
     defaultComponentName="line",
     Documentation(info="<html>
 <p>Lossless transmission line with characteristic impedance Z0 and frequency F The lossless transmission line TLine3 is a two Port. Both port branches consist of a resistor with value of the characteristic impedance Z0 and a controlled voltage source that takes into consideration the transmission delay. For further details see [<a href=\"modelica://Modelica.Electrical.Analog.UsersGuide.References\">Branin1967</a>]. Resistance R&#39; and conductance C&#39; per meter are assumed to be zero. The characteristic impedance Z0 can be derived from inductance and capacitance per length (L&#39; resp. C&#39;), i. e. Z0 = sqrt(L&#39;/C&#39;). The length of the line is equal to a quarter of the wavelength corresponding to the frequency F, i. e. the transmission delay is the quotient of 4 and F. In this case, the characteristic impedance is called natural impedance.</p>


### PR DESCRIPTION
Added obsolete annotation (fixes #4609)
Once reviews are done and the PR is merged: @Esther-Devakirubai please backport to 4.1.x!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated deprecation messages for several legacy electrical line components, advising users to transition to the new, recommended alternative.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->