### PR TITLE
Make parameter propagation in SingularTransformer final

### DIFF
--- a/ModelicaTest/Electrical/SingularTransformer.mo
+++ b/ModelicaTest/Electrical/SingularTransformer.mo
@@ -24,9 +24,9 @@ model SingularTransformer
   Modelica.Electrical.Analog.Basic.Ground ground2 annotation (Placement(
         transformation(extent={{68,0},{88,20}})));
   Modelica.Electrical.Analog.Basic.Transformer basicTransformer(
-    L1=L,
-    L2=L,
-    M=L,
+    final L1=L,
+    final L2=L,
+    final M=L,
     i1(fixed=true)) annotation (Placement(transformation(extent={{-10,32},{10,52}})));
 equation
   connect(sineVoltage1.n, ground1.p)


### PR DESCRIPTION
When refining the logic for parameter evaluation in System Modeler, we encountered the need to see that these parameter propagations are final.

Without it, there is a differential equation with parametric coefficients that causes incomplete index reduction since the coefficients are zero for the given parameter values.

The change is similar to #4407, where the conversation shows that making parameter propagation final isn't a controversial change.
