### PR TITLE
ImprovedOpAmpLimited

### DIFF
--- a/Modelica/Electrical/Analog/Examples/OpAmps/Adder.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Adder.mo
@@ -39,7 +39,6 @@ equation
     annotation (Line(points={{10,-10},{40,-10}}, color={0,0,255}));
   annotation (Documentation(info="<html>
 <p>This is an inverting adder.</p>
-<p>Note: <code>vOut</code> measure the negative output voltage.</p>
 </html>"),
     experiment(
       StartTime=0,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Adder.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Adder.mo
@@ -1,8 +1,8 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model Adder "Inverting adder"
   extends Modelica.Icons.Example;
-  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
+  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter SI.Frequency f=10 "Frequency of input voltage";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
   Modelica.Electrical.Analog.Sources.SineVoltage vIn1(V=Vin, f=f) annotation

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Adder.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Adder.mo
@@ -1,26 +1,26 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model Adder "Inverting adder"
   extends Modelica.Icons.Example;
-  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter SI.Frequency f=10 "Frequency of input voltage";
+  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
-  Sources.SineVoltage vIn1(V=Vin, f=f) annotation (Placement(
-        transformation(
+  Modelica.Electrical.Analog.Sources.SineVoltage vIn1(V=Vin, f=f) annotation
+    (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-60,0})));
-  Sources.ConstantVoltage vIn2(V=Vin) annotation (Placement(
-        transformation(
+  Modelica.Electrical.Analog.Sources.ConstantVoltage vIn2(V=Vin) annotation (
+      Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-40,-10})));
   Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(
         transformation(
-        extent={{10,10},{-10,-10}},
+        extent={{-10,10},{10,-10}},
         rotation=270,
         origin={40,0})));
-  OpAmpCircuits.Add add(p1_2(i(start=0)))
+  OpAmpCircuits.Add add
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
 equation
   connect(add.n1, ground.p)
@@ -33,9 +33,9 @@ equation
     annotation (Line(points={{-10,-20},{-40,-20}}, color={0,0,255}));
   connect(ground.p, vIn1.n)
     annotation (Line(points={{-10,-20},{-60,-20},{-60,-10}}, color={0,0,255}));
-  connect(add.p2, vOut.n)
+  connect(add.p2, vOut.p)
     annotation (Line(points={{10,10},{40,10}}, color={0,0,255}));
-  connect(add.n2, vOut.p)
+  connect(add.n2, vOut.n)
     annotation (Line(points={{10,-10},{40,-10}}, color={0,0,255}));
   annotation (Documentation(info="<html>
 <p>This is an inverting adder.</p>

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Comparator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Comparator.mo
@@ -1,15 +1,15 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model Comparator "Comparator"
   extends Modelica.Icons.Example;
-  parameter SI.Voltage Vps=+15 "Positive supply";
-  parameter SI.Voltage Vns=-15 "Negative supply";
-  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter SI.Frequency f=10 "Frequency of input voltage";
-  parameter SI.Voltage Vref=0 "Reference voltage";
+  parameter Modelica.Units.SI.Voltage Vps=+15 "Positive supply";
+  parameter Modelica.Units.SI.Voltage Vns=-15 "Negative supply";
+  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
+  parameter Modelica.Units.SI.Voltage Vref=0 "Reference voltage";
   parameter Real k=(Vref - Vns)/(Vps - Vns) "Calculated potentiometer ratio to reach Vref";
-  parameter SI.Resistance R=1000 "Resistance of potentiometer";
-  Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimited opAmp(Vps=Vps, Vns=
-        Vns) annotation (Placement(transformation(extent={{0,10},{20,-10}})));
+  parameter Modelica.Units.SI.Resistance R=1000 "Resistance of potentiometer";
+  Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp(Vps=Vps, Vns=Vns)
+    annotation (Placement(transformation(extent={{0,10},{20,-10}})));
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-100},{0,-80}})));
   Modelica.Electrical.Analog.Sources.TrapezoidVoltage vIn(

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Comparator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Comparator.mo
@@ -1,13 +1,13 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model Comparator "Comparator"
   extends Modelica.Icons.Example;
-  parameter Modelica.Units.SI.Voltage Vps=+15 "Positive supply";
-  parameter Modelica.Units.SI.Voltage Vns=-15 "Negative supply";
-  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
-  parameter Modelica.Units.SI.Voltage Vref=0 "Reference voltage";
+  parameter SI.Voltage Vps=+15 "Positive supply";
+  parameter SI.Voltage Vns=-15 "Negative supply";
+  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter SI.Frequency f=10 "Frequency of input voltage";
+  parameter SI.Voltage Vref=0 "Reference voltage";
   parameter Real k=(Vref - Vns)/(Vps - Vns) "Calculated potentiometer ratio to reach Vref";
-  parameter Modelica.Units.SI.Resistance R=1000 "Resistance of potentiometer";
+  parameter SI.Resistance R=1000 "Resistance of potentiometer";
   Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp(Vps=Vps, Vns=Vns)
     annotation (Placement(transformation(extent={{0,10},{20,-10}})));
   Modelica.Electrical.Analog.Basic.Ground ground

--- a/Modelica/Electrical/Analog/Examples/OpAmps/ControlCircuit.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/ControlCircuit.mo
@@ -1,60 +1,56 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model ControlCircuit "Control circuit"
   extends Modelica.Icons.Example;
-  parameter SI.Time T1=0.01 "Small time constant";
-  parameter SI.Time T2=0.01 "Large time constant";
-  parameter SI.Time Ti=T2 "Integral time constant";
+  parameter Modelica.Units.SI.Time T1=0.01 "Small time constant";
+  parameter Modelica.Units.SI.Time T2=0.01 "Large time constant";
+  parameter Modelica.Units.SI.Time Ti=T2 "Integral time constant";
   parameter Real kp=T2/(2*T1) "Proportional gain";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-100,-100},{-80,-80}})));
-  Sources.StepVoltage stepA(V=10, startTime=0.1) annotation (Placement(
-        transformation(
+  Modelica.Electrical.Analog.Sources.StepVoltage stepA(V=10, startTime=0.1)
+    annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-90,-62})));
-  OpAmpCircuits.Feedback feedbackA(p1(i(start=0)))
+  OpAmpCircuits.Feedback feedbackA(i1(start=0), i2(start=0))
     annotation (Placement(transformation(extent={{-70,-40},{-50,-20}})));
   OpAmpCircuits.PI PIA(
-    v2(fixed=true),
     k=kp,
     T=Ti,
-    opAmp(v_in(start=0)))
+    v(fixed=true))
     annotation (Placement(transformation(extent={{-40,-40},{-20,-20}})));
   OpAmpCircuits.FirstOrder firstOrder1A(
-    v2(fixed=true),
-    T=T1,
-    opAmp(v_in(start=0)))
+    T=T1, v(fixed=true))
     annotation (Placement(transformation(extent={{-10,-40},{10,-20}})));
-  OpAmpCircuits.Add addA(i1_2(start=0), r(i(start=0)))
+  OpAmpCircuits.Add addA(r(i(start=0)))
     annotation (Placement(transformation(extent={{30,-40},{50,-20}})));
-  Sources.StepVoltage step1A(V=1, startTime=0.5) annotation (Placement(
-        transformation(
+  Modelica.Electrical.Analog.Sources.StepVoltage step1A(V=1, startTime=0.5)
+    annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={20,-60})));
   OpAmpCircuits.FirstOrder firstOrder2A(
-    v2(fixed=true),
-    T=T2,
-    opAmp(v_in(start=0)))
+    T=T2, v(fixed=true))
     annotation (Placement(transformation(extent={{60,-40},{80,-20}})));
-  Blocks.Sources.Step stepB(height=10, startTime=0.1)
+  Modelica.Blocks.Sources.Step stepB(height=10, startTime=0.1)
     annotation (Placement(transformation(extent={{-100,60},{-80,80}})));
-  Blocks.Math.Feedback feedbackB
+  Modelica.Blocks.Math.Feedback feedbackB
     annotation (Placement(transformation(extent={{-70,60},{-50,80}})));
-  Blocks.Continuous.PI PIB(
+  Modelica.Blocks.Continuous.PI PIB(
     k=kp,
     T=Ti,
     initType=Modelica.Blocks.Types.Init.InitialOutput)
     annotation (Placement(transformation(extent={{-40,60},{-20,80}})));
-  Blocks.Continuous.FirstOrder firstOrder1B(T=T1, initType=Modelica.Blocks.Types.Init.InitialOutput)
+  Modelica.Blocks.Continuous.FirstOrder firstOrder1B(T=T1, initType=Modelica.Blocks.Types.Init.InitialOutput)
     annotation (Placement(transformation(extent={{-10,60},{10,80}})));
-  Blocks.Math.Add addB
+  Modelica.Blocks.Math.Add addB
     annotation (Placement(transformation(extent={{30,60},{50,80}})));
-  Blocks.Sources.Step step1B(height=1, startTime=0.5)
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}},
+  Modelica.Blocks.Sources.Step step1B(height=1, startTime=0.5) annotation (
+      Placement(transformation(
+        extent={{-10,-10},{10,10}},
         rotation=90,
         origin={20,30})));
-  Blocks.Continuous.FirstOrder firstOrder2B(T=T2, initType=Modelica.Blocks.Types.Init.InitialOutput)
+  Modelica.Blocks.Continuous.FirstOrder firstOrder2B(T=T2, initType=Modelica.Blocks.Types.Init.InitialOutput)
     annotation (Placement(transformation(extent={{60,60},{80,80}})));
 equation
   connect(stepA.n, ground.p)

--- a/Modelica/Electrical/Analog/Examples/OpAmps/ControlCircuit.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/ControlCircuit.mo
@@ -1,9 +1,9 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model ControlCircuit "Control circuit"
   extends Modelica.Icons.Example;
-  parameter Modelica.Units.SI.Time T1=0.01 "Small time constant";
-  parameter Modelica.Units.SI.Time T2=0.01 "Large time constant";
-  parameter Modelica.Units.SI.Time Ti=T2 "Integral time constant";
+  parameter SI.Time T1=0.01 "Small time constant";
+  parameter SI.Time T2=0.01 "Large time constant";
+  parameter SI.Time Ti=T2 "Integral time constant";
   parameter Real kp=T2/(2*T1) "Proportional gain";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-100,-100},{-80,-80}})));

--- a/Modelica/Electrical/Analog/Examples/OpAmps/DifferentialAmplifier.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/DifferentialAmplifier.mo
@@ -1,10 +1,9 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model DifferentialAmplifier "Differential amplifier"
   extends Modelica.Icons.Example;
-  parameter
-    Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits.DifferentialAmplifierData
-    data "Parameters for source, OpAmp and measurement"
-     annotation (Placement(transformation(extent={{50,10},{70,30}})));
+  parameter OpAmps.OpAmpCircuits.DifferentialAmplifierData data
+    "Parameters for source, OpAmp and measurement"
+    annotation (Placement(transformation(extent={{50,10},{70,30}})));
   Modelica.Electrical.Analog.Sources.SineVoltage sourceVoltage1(
     V=sqrt(2/3)*data.VSource,
     phase=1.0471975511966,
@@ -33,7 +32,7 @@ model DifferentialAmplifier "Differential amplifier"
   Modelica.Electrical.Analog.Basic.Resistor resistorGround(R=data.RGround,
     i(start=0, fixed=false))
     annotation (Placement(transformation(extent={{-60,-70},{-40,-50}})));
-  Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimited opAmp(
+  Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp(
     V0=data.V0,
     useSupply=true,
     Vps=+data.VSupply,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Differentiator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Differentiator.mo
@@ -40,8 +40,7 @@ equation
   connect(der_.n2, vOut.n)
     annotation (Line(points={{10,-10},{40,-10}}, color={0,0,255}));
   annotation (Documentation(info="<html>
-<p>This is a (inverting) differentiating amplifier. Resistance R can be chosen, capacitance C is defined by the desired time constant resp. frequency.</p>
-<p>Note: <code>vOut</code> measure the negative output voltage.</p>
+<p>This is a (inverting) differentiating amplifier. Resistance R can be chosen, capacitance C is defined by the desired time constant resp. frequency.</p
 </html>"),
     experiment(
       StartTime=0,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Differentiator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Differentiator.mo
@@ -1,11 +1,11 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model Differentiator "Differentiating amplifier"
   extends Modelica.Icons.Example;
-  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter SI.Frequency f=10 "Frequency of input voltage";
+  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
-  Sources.TrapezoidVoltage vIn(
+  Modelica.Electrical.Analog.Sources.TrapezoidVoltage vIn(
     V=2*Vin,
     rising=0.2/f,
     width=0.3/f,
@@ -13,8 +13,7 @@ model Differentiator "Differentiating amplifier"
     period=1/f,
     nperiod=-1,
     offset=-Vin,
-    startTime=-(vIn.rising + vIn.width/2))
-    annotation (Placement(
+    startTime=-(vIn.rising + vIn.width/2)) annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Differentiator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Differentiator.mo
@@ -1,8 +1,8 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model Differentiator "Differentiating amplifier"
   extends Modelica.Icons.Example;
-  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
+  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter SI.Frequency f=10 "Frequency of input voltage";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
   Modelica.Electrical.Analog.Sources.TrapezoidVoltage vIn(

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Differentiator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Differentiator.mo
@@ -40,7 +40,7 @@ equation
   connect(der_.n2, vOut.n)
     annotation (Line(points={{10,-10},{40,-10}}, color={0,0,255}));
   annotation (Documentation(info="<html>
-<p>This is a (inverting) differentiating amplifier. Resistance R can be chosen, capacitance C is defined by the desired time constant resp. frequency.</p
+<p>This is a (inverting) differentiating amplifier. Resistance R can be chosen, capacitance C is defined by the desired time constant resp. frequency.</p>
 </html>"),
     experiment(
       StartTime=0,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/HighPass.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/HighPass.mo
@@ -2,9 +2,9 @@ within Modelica.Electrical.Analog.Examples.OpAmps;
 model HighPass "High-pass filter"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter SI.Frequency f=10 "Frequency of input voltage";
-  parameter SI.Frequency fG=f/10 "Limiting frequency";
+  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
+  parameter Modelica.Units.SI.Frequency fG=f/10 "Limiting frequency";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
   Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(
@@ -15,7 +15,7 @@ model HighPass "High-pass filter"
   OpAmpCircuits.Derivative derivative(T=1/(2*pi*fG),
     v(fixed=true))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
-  Sources.TrapezoidVoltage vIn(
+  Modelica.Electrical.Analog.Sources.TrapezoidVoltage vIn(
     V=Vin,
     rising=0.2/f,
     width=0.3/f,
@@ -23,8 +23,7 @@ model HighPass "High-pass filter"
     period=1/f,
     nperiod=-1,
     offset=0,
-    startTime=-(vIn.rising + vIn.width/2))
-    annotation (Placement(
+    startTime=-(vIn.rising + vIn.width/2)) annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/HighPass.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/HighPass.mo
@@ -42,7 +42,6 @@ equation
   annotation (Documentation(info="<html>
 <p>This is a (inverting) high pass filter. Resistance R1 can be chosen, resistance R2 is defined by the desired amplification k, capacitance C is defined by the desired cut-off frequency.</p>
 <p>The example is taken from: U. Tietze and C. Schenk, Halbleiter-Schaltungstechnik (German), 11th edition, Springer 1999, Chapter 13.3</p>
-<p>Note: <code>vOut</code> measure the negative output voltage.</p>
 </html>"),
     experiment(
       StartTime=0,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/HighPass.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/HighPass.mo
@@ -2,9 +2,9 @@ within Modelica.Electrical.Analog.Examples.OpAmps;
 model HighPass "High-pass filter"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
-  parameter Modelica.Units.SI.Frequency fG=f/10 "Limiting frequency";
+  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter SI.Frequency f=10 "Frequency of input voltage";
+  parameter SI.Frequency fG=f/10 "Limiting frequency";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
   Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Integrator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Integrator.mo
@@ -1,8 +1,8 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model Integrator "Integrating amplifier"
   extends Modelica.Icons.Example;
-  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter SI.Frequency f=10 "Frequency of input voltage";
+  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
   Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(
@@ -15,7 +15,7 @@ model Integrator "Integrating amplifier"
     f=f,
     v(fixed=true))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
-  Sources.TrapezoidVoltage vIn(
+  Modelica.Electrical.Analog.Sources.TrapezoidVoltage vIn(
     V=2*Vin,
     rising=0.2/f,
     width=0.3/f,
@@ -23,8 +23,7 @@ model Integrator "Integrating amplifier"
     period=1/f,
     nperiod=-1,
     offset=-Vin,
-    startTime=-(vIn.rising + vIn.width/2))
-    annotation (Placement(
+    startTime=-(vIn.rising + vIn.width/2)) annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Integrator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Integrator.mo
@@ -1,8 +1,8 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model Integrator "Integrating amplifier"
   extends Modelica.Icons.Example;
-  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
+  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter SI.Frequency f=10 "Frequency of input voltage";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
   Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Integrator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Integrator.mo
@@ -41,7 +41,6 @@ equation
     annotation (Line(points={{-40,-10},{-10,-10}}, color={0,0,255}));
   annotation (Documentation(info="<html>
 <p>This is an (inverting) integrating amplifier. Resistance R can be chosen, capacitance C is defined by the desired time constant resp. frequency.</p>
-<p>Note: <code>vOut</code> measure the negative output voltage.</p>
 </html>"),
     experiment(
       StartTime=0,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/InvertingAmplifier.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/InvertingAmplifier.mo
@@ -39,7 +39,6 @@ equation
   annotation (
     Documentation(info="<html>
 <p>This is an inverting amplifier.</p>
-<p>Note: <code>vOut</code> measure the negative output voltage.</p>
 </html>"),
     experiment(
       StartTime=0,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/InvertingAmplifier.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/InvertingAmplifier.mo
@@ -1,8 +1,8 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model InvertingAmplifier "Inverting amplifier"
   extends Modelica.Icons.Example;
-  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
+  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter SI.Frequency f=10 "Frequency of input voltage";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
   Modelica.Electrical.Analog.Sources.TrapezoidVoltage vIn(

--- a/Modelica/Electrical/Analog/Examples/OpAmps/InvertingAmplifier.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/InvertingAmplifier.mo
@@ -1,8 +1,8 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model InvertingAmplifier "Inverting amplifier"
   extends Modelica.Icons.Example;
-  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter SI.Frequency f=10 "Frequency of input voltage";
+  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
   Modelica.Electrical.Analog.Sources.TrapezoidVoltage vIn(
@@ -20,7 +20,7 @@ model InvertingAmplifier "Inverting amplifier"
         origin={-40,0})));
   Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(
         transformation(
-        extent={{10,10},{-10,-10}},
+        extent={{-10,10},{10,-10}},
         rotation=270,
         origin={40,0})));
   OpAmpCircuits.Gain gain(k=2)
@@ -32,10 +32,10 @@ equation
     annotation (Line(points={{-10,-10},{-10,-20}}, color={0,0,255}));
   connect(gain.n1, vIn.n)
     annotation (Line(points={{-10,-10},{-40,-10}}, color={0,0,255}));
-  connect(gain.p2, vOut.n)
-    annotation (Line(points={{10,10},{40,10}}, color={0,0,255}));
-  connect(gain.n2, vOut.p)
+  connect(gain.n2, vOut.n)
     annotation (Line(points={{10,-10},{40,-10}}, color={0,0,255}));
+  connect(gain.p2, vOut.p)
+    annotation (Line(points={{10,10},{40,10}}, color={0,0,255}));
   annotation (
     Documentation(info="<html>
 <p>This is an inverting amplifier.</p>

--- a/Modelica/Electrical/Analog/Examples/OpAmps/InvertingSchmittTrigger.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/InvertingSchmittTrigger.mo
@@ -1,14 +1,14 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model InvertingSchmittTrigger "Inverting Schmitt trigger with hysteresis"
   extends Modelica.Icons.Example;
-  parameter Modelica.Units.SI.Voltage Vps=+15 "Positive supply";
-  parameter Modelica.Units.SI.Voltage Vns=-15 "Negative supply";
-  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
-  parameter Modelica.Units.SI.Voltage vHys=1 "(Positive) hysteresis voltage";
+  parameter SI.Voltage Vps=+15 "Positive supply";
+  parameter SI.Voltage Vns=-15 "Negative supply";
+  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter SI.Frequency f=10 "Frequency of input voltage";
+  parameter SI.Voltage vHys=1 "(Positive) hysteresis voltage";
   parameter Real k=vHys/Vps "Auxiliary calculated parameter to be used in R2 calculation";
-  parameter Modelica.Units.SI.Resistance R1=1000 "Arbitrary resistance";
-  parameter Modelica.Units.SI.Resistance R2=(1 - k)/k*R1
+  parameter SI.Resistance R1=1000 "Arbitrary resistance";
+  parameter SI.Resistance R2=(1 - k)/k*R1
     "Calculated resistance to reach hysteresis voltage";
   Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp(Vps=Vps, Vns=Vns)
     annotation (Placement(transformation(extent={{0,-10},{20,10}})));

--- a/Modelica/Electrical/Analog/Examples/OpAmps/InvertingSchmittTrigger.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/InvertingSchmittTrigger.mo
@@ -1,18 +1,16 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model InvertingSchmittTrigger "Inverting Schmitt trigger with hysteresis"
   extends Modelica.Icons.Example;
-  parameter SI.Voltage Vps=+15 "Positive supply";
-  parameter SI.Voltage Vns=-15 "Negative supply";
-  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter SI.Frequency f=10 "Frequency of input voltage";
-  parameter SI.Voltage vHys=1 "(Positive) hysteresis voltage";
+  parameter Modelica.Units.SI.Voltage Vps=+15 "Positive supply";
+  parameter Modelica.Units.SI.Voltage Vns=-15 "Negative supply";
+  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
+  parameter Modelica.Units.SI.Voltage vHys=1 "(Positive) hysteresis voltage";
   parameter Real k=vHys/Vps "Auxiliary calculated parameter to be used in R2 calculation";
-  parameter SI.Resistance R1=1000 "Arbitrary resistance";
-  parameter SI.Resistance R2=(1 - k)/k*R1 "Calculated resistance to reach hysteresis voltage";
-  Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimited opAmp(
-    Vps=Vps,
-    Vns=Vns,
-    out(i(start=0)))
+  parameter Modelica.Units.SI.Resistance R1=1000 "Arbitrary resistance";
+  parameter Modelica.Units.SI.Resistance R2=(1 - k)/k*R1
+    "Calculated resistance to reach hysteresis voltage";
+  Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp(Vps=Vps, Vns=Vns)
     annotation (Placement(transformation(extent={{0,-10},{20,10}})));
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-100},{0,-80}})));

--- a/Modelica/Electrical/Analog/Examples/OpAmps/LCOscillator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/LCOscillator.mo
@@ -2,20 +2,23 @@ within Modelica.Electrical.Analog.Examples.OpAmps;
 model LCOscillator "LC oscillator"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter SI.Voltage VAmp=10 "Amplitude of output";
-  parameter SI.Frequency f=1000 "Desired frequency";
+  parameter Modelica.Units.SI.Voltage VAmp=10 "Amplitude of output";
+  parameter Modelica.Units.SI.Frequency f=1000 "Desired frequency";
   parameter Real A=1.001 "Amplification constant: A > 1 amplification, A = 1 pure sinusoidal oscillation, A < 0 damping";
-  parameter SI.Inductance L=0.001 "Arbitrary inductance > 0";
-  parameter SI.Capacitance C=1/((2*pi*f)^2*L) "Calculated capacitance to reach frequency f";
-  parameter SI.Resistance R=10000.0 "Damping resistance";
-  parameter SI.Resistance R1=10000.0 "Arbitrary high resistance";
-  parameter SI.Resistance R2=(A - 1)*R1 "Calculated resistance to reach amplification A";
+  parameter Modelica.Units.SI.Inductance L=0.001 "Arbitrary inductance > 0";
+  parameter Modelica.Units.SI.Capacitance C=1/((2*pi*f)^2*L)
+    "Calculated capacitance to reach frequency f";
+  parameter Modelica.Units.SI.Resistance R=10000.0 "Damping resistance";
+  parameter Modelica.Units.SI.Resistance R1=10000.0
+    "Arbitrary high resistance";
+  parameter Modelica.Units.SI.Resistance R2=(A - 1)*R1
+    "Calculated resistance to reach amplification A";
   parameter Real gamma=(1 - A)/(2*R*C) "Calculated characteristical parameter";
   Modelica.Electrical.Analog.Basic.Ground ground annotation (Placement(
         transformation(
         origin={20,-50},
         extent={{-10,-10},{10,10}})));
-  Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimited opAmp
+  Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp
     annotation (Placement(transformation(extent={{-50,10},{-30,-10}})));
   Modelica.Electrical.Analog.Basic.Resistor r(R=R)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));

--- a/Modelica/Electrical/Analog/Examples/OpAmps/LCOscillator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/LCOscillator.mo
@@ -2,16 +2,16 @@ within Modelica.Electrical.Analog.Examples.OpAmps;
 model LCOscillator "LC oscillator"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Modelica.Units.SI.Voltage VAmp=10 "Amplitude of output";
-  parameter Modelica.Units.SI.Frequency f=1000 "Desired frequency";
+  parameter SI.Voltage VAmp=10 "Amplitude of output";
+  parameter SI.Frequency f=1000 "Desired frequency";
   parameter Real A=1.001 "Amplification constant: A > 1 amplification, A = 1 pure sinusoidal oscillation, A < 0 damping";
-  parameter Modelica.Units.SI.Inductance L=0.001 "Arbitrary inductance > 0";
-  parameter Modelica.Units.SI.Capacitance C=1/((2*pi*f)^2*L)
+  parameter SI.Inductance L=0.001 "Arbitrary inductance > 0";
+  parameter SI.Capacitance C=1/((2*pi*f)^2*L)
     "Calculated capacitance to reach frequency f";
-  parameter Modelica.Units.SI.Resistance R=10000.0 "Damping resistance";
-  parameter Modelica.Units.SI.Resistance R1=10000.0
+  parameter SI.Resistance R=10000.0 "Damping resistance";
+  parameter SI.Resistance R1=10000.0
     "Arbitrary high resistance";
-  parameter Modelica.Units.SI.Resistance R2=(A - 1)*R1
+  parameter SI.Resistance R2=(A - 1)*R1
     "Calculated resistance to reach amplification A";
   parameter Real gamma=(1 - A)/(2*R*C) "Calculated characteristical parameter";
   Modelica.Electrical.Analog.Basic.Ground ground annotation (Placement(

--- a/Modelica/Electrical/Analog/Examples/OpAmps/LowPass.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/LowPass.mo
@@ -2,9 +2,9 @@ within Modelica.Electrical.Analog.Examples.OpAmps;
 model LowPass "Low-pass filter"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter SI.Frequency f=10 "Frequency of input voltage";
-  parameter SI.Frequency fG=f/10 "Limiting frequency";
+  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
+  parameter Modelica.Units.SI.Frequency fG=f/10 "Limiting frequency";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
   Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(
@@ -15,7 +15,7 @@ model LowPass "Low-pass filter"
   OpAmpCircuits.FirstOrder firstOrder(
     T=1/(2*pi*fG), v(fixed=true))
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
-  Sources.TrapezoidVoltage vIn(
+  Modelica.Electrical.Analog.Sources.TrapezoidVoltage vIn(
     V=Vin,
     rising=0.2/f,
     width=0.3/f,
@@ -23,8 +23,7 @@ model LowPass "Low-pass filter"
     period=1/f,
     nperiod=-1,
     offset=0,
-    startTime=-(vIn.rising + vIn.width/2))
-    annotation (Placement(
+    startTime=-(vIn.rising + vIn.width/2)) annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/LowPass.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/LowPass.mo
@@ -2,9 +2,9 @@ within Modelica.Electrical.Analog.Examples.OpAmps;
 model LowPass "Low-pass filter"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
-  parameter Modelica.Units.SI.Frequency fG=f/10 "Limiting frequency";
+  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter SI.Frequency f=10 "Frequency of input voltage";
+  parameter SI.Frequency fG=f/10 "Limiting frequency";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
   Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(

--- a/Modelica/Electrical/Analog/Examples/OpAmps/LowPass.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/LowPass.mo
@@ -42,7 +42,6 @@ equation
   annotation (Documentation(info="<html>
 <p>This is a (inverting) low pass filter. Resistance R1 can be chosen, resistance R2 is defined by the desired amplification k, capacitance C is defined by the desired cut-off frequency.</p>
 <p>The example is taken from: U. Tietze and C. Schenk, Halbleiter-Schaltungstechnik (German), 11th edition, Springer 1999, Chapter 13.3</p>
-<p>Note: <code>vOut</code> measure the negative output voltage.</p>
 </html>"),
     experiment(
       StartTime=0,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/MeasureRiseTime.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/MeasureRiseTime.mo
@@ -1,0 +1,58 @@
+within Modelica.Electrical.Analog.Examples.OpAmps;
+model MeasureRiseTime "Measure riseTime as voltageFollower"
+  extends Modelica.Icons.Example;
+  parameter SI.Voltage Vps=+15 "Positive supply";
+  parameter SI.Voltage Vns=-15 "Negative supply";
+  parameter SI.Voltage Vin=10 "Amplitude of input voltage";
+  parameter Real V0=15000 "No-load amplification of opAmp";
+  parameter SI.Time Tr=1e-3 "Rise time (unrealistic low for visibility)";
+  parameter SI.Time Tau=V0/log(9)*Tr "Time constant of firstOrder";
+  discrete SI.Time t10(start=0) "Time when output reaches 10% Vin";
+  discrete SI.Time t90(start=0) "Time when output reaches 90% Vin";
+  SI.Time riseTime=t90-t10 "Measured rise time";
+  Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp(
+    V0=V0,                                                    Vps=Vps, Vns=Vns,
+    useFirstOrder=true,
+    Tau=Tau)
+    annotation (Placement(transformation(extent={{0,-10},{20,10}})));
+  Modelica.Electrical.Analog.Basic.Ground ground
+    annotation (Placement(transformation(extent={{-20,-60},{0,-40}})));
+  Sources.StepVoltage                                 vIn(
+    V=Vin,
+    offset=0,
+    startTime=1e-3)                        annotation (Placement(
+        transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-10,-20})));
+  Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(
+        transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=270,
+        origin={30,-20})));
+equation
+  when vOut.v>=0.10*Vin then
+    t10=time;
+  end when;
+  when vOut.v>=0.90*Vin then
+    t90=time;
+  end when;
+  connect(ground.p, vIn.n) annotation (Line(
+      points={{-10,-40},{-10,-30}},           color={0,0,255}));
+  connect(opAmp.out, vOut.p) annotation (Line(
+      points={{20,0},{30,0},{30,-10}}, color={0,0,255}));
+  connect(ground.p, vOut.n) annotation (Line(
+      points={{-10,-40},{30,-40},{30,-30}}, color={0,0,255}));
+  connect(opAmp.out, opAmp.in_n) annotation (Line(
+      points={{20,0},{30,0},{30,20},{-10,20},{-10,6},{0,6}}, color={0,0,255}));
+  connect(vIn.p, opAmp.in_p)
+    annotation (Line(points={{-10,-10},{-10,-6},{0,-6}}, color={0,0,255}));
+  annotation (Documentation(info="<html>
+<p>This is a voltage follower. Rise time is measured between the time instances when output reaches 10&#037; and 90&#037; of input step.</p>
+</html>"),
+    experiment(
+      StartTime=0,
+      StopTime=5e-3,
+      Interval=1e-7,
+      Tolerance=1e-006));
+end MeasureRiseTime;

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Multivibrator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Multivibrator.mo
@@ -63,7 +63,7 @@ equation
   annotation (Documentation(info="<html>
 <p>This is a Multivibrator with Schmitt trigger according to:</p>
 <p>U. Tietze and C. Schenk, Halbleiter-Schaltungstechnik (German), 11th edition, Springer 1999, Chapter 6.5.3</p>
-<p>As the initialization system has two solutions, one with the op amp output at the lower saturation limit, and the other one with the two voltage inputs very close to each other, the <code>homotopyType</code> parameter is set to get the solver to converge to the former one, which is the required solution.</p>
+<p>As the initialization system has two solutions, the required solution is choosen by proper initialization of the opAmp at the LowerLimit.</p>
 </html>"),
     experiment(
       StartTime=0,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Multivibrator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Multivibrator.mo
@@ -14,6 +14,7 @@ model Multivibrator "Multivibrator with Schmitt trigger"
   Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp(
     Vps=Vps,
     Vns=Vns,
+    useFirstOrder=true,
     initOpAmp=Modelica.Electrical.Analog.Types.InitOpAmp.LowerLimit)
     annotation (Placement(transformation(extent={{0,-10},{20,10}})));
   Modelica.Electrical.Analog.Basic.Ground ground
@@ -68,6 +69,6 @@ equation
     experiment(
       StartTime=0,
       StopTime=1,
-      Tolerance=1e-006,
-      Interval=0.001));
+      Interval=0.001,
+      Tolerance=1e-006));
 end Multivibrator;

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Multivibrator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Multivibrator.mo
@@ -1,18 +1,21 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model Multivibrator "Multivibrator with Schmitt trigger"
   extends Modelica.Icons.Example;
-  parameter SI.Voltage Vps=+15 "Positive supply";
-  parameter SI.Voltage Vns=-15 "Negative supply";
-  parameter SI.Frequency f=10 "Desired frequency";
-  parameter SI.Resistance R1=1000 "Resistance 1 for adjusting the Schmitt trigger voltage level";
-  parameter SI.Resistance R2=1000 "Resistance 2 for adjusting the Schmitt trigger voltage level";
-  parameter SI.Resistance R=1000 "Arbitrary resistance";
-  parameter SI.Capacitance C=1/f/(2*R*log(1 + 2*R1/R2)) "Calculated capacitance to reach the desired frequency f";
-  Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimited opAmp(
+  parameter Modelica.Units.SI.Voltage Vps=+15 "Positive supply";
+  parameter Modelica.Units.SI.Voltage Vns=-15 "Negative supply";
+  parameter Modelica.Units.SI.Frequency f=10 "Desired frequency";
+  parameter Modelica.Units.SI.Resistance R1=1000
+    "Resistance 1 for adjusting the Schmitt trigger voltage level";
+  parameter Modelica.Units.SI.Resistance R2=1000
+    "Resistance 2 for adjusting the Schmitt trigger voltage level";
+  parameter Modelica.Units.SI.Resistance R=1000 "Arbitrary resistance";
+  parameter Modelica.Units.SI.Capacitance C=1/f/(2*R*log(1 + 2*R1/R2))
+    "Calculated capacitance to reach the desired frequency f";
+  Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp(
     Vps=Vps,
     Vns=Vns,
-    homotopyType = Modelica.Blocks.Types.LimiterHomotopy.LowerLimit,
-    strict = true) annotation (Placement(transformation(extent={{0,-10},{20,10}})));
+    initOpAmp=Modelica.Electrical.Analog.Types.InitOpAmp.LowerLimit)
+    annotation (Placement(transformation(extent={{0,-10},{20,10}})));
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-80},{0,-60}})));
   Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Multivibrator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Multivibrator.mo
@@ -1,15 +1,15 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model Multivibrator "Multivibrator with Schmitt trigger"
   extends Modelica.Icons.Example;
-  parameter Modelica.Units.SI.Voltage Vps=+15 "Positive supply";
-  parameter Modelica.Units.SI.Voltage Vns=-15 "Negative supply";
-  parameter Modelica.Units.SI.Frequency f=10 "Desired frequency";
-  parameter Modelica.Units.SI.Resistance R1=1000
+  parameter SI.Voltage Vps=+15 "Positive supply";
+  parameter SI.Voltage Vns=-15 "Negative supply";
+  parameter SI.Frequency f=10 "Desired frequency";
+  parameter SI.Resistance R1=1000
     "Resistance 1 for adjusting the Schmitt trigger voltage level";
-  parameter Modelica.Units.SI.Resistance R2=1000
+  parameter SI.Resistance R2=1000
     "Resistance 2 for adjusting the Schmitt trigger voltage level";
-  parameter Modelica.Units.SI.Resistance R=1000 "Arbitrary resistance";
-  parameter Modelica.Units.SI.Capacitance C=1/f/(2*R*log(1 + 2*R1/R2))
+  parameter SI.Resistance R=1000 "Arbitrary resistance";
+  parameter SI.Capacitance C=1/f/(2*R*log(1 + 2*R1/R2))
     "Calculated capacitance to reach the desired frequency f";
   Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp(
     Vps=Vps,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/NonInvertingAmplifier.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/NonInvertingAmplifier.mo
@@ -1,8 +1,8 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model NonInvertingAmplifier "Non-inverting amplifier"
   extends Modelica.Icons.Example;
-  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter SI.Frequency f=10 "Frequency of input voltage";
+  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
   Modelica.Electrical.Analog.Sources.TrapezoidVoltage vIn(

--- a/Modelica/Electrical/Analog/Examples/OpAmps/NonInvertingAmplifier.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/NonInvertingAmplifier.mo
@@ -1,8 +1,8 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model NonInvertingAmplifier "Non-inverting amplifier"
   extends Modelica.Icons.Example;
-  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
+  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter SI.Frequency f=10 "Frequency of input voltage";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
   Modelica.Electrical.Analog.Sources.TrapezoidVoltage vIn(

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Add.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Add.mo
@@ -1,17 +1,17 @@
 within Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits;
 model Add "Adding operational amplifier circuit"
   extends PartialOpAmp;
-  Modelica.Units.SI.Voltage v1_2=p1_2.v - n1.v
+  SI.Voltage v1_2=p1_2.v - n1.v
     "Voltage drop of port 1_2 (= p1_2.v - n1.v)";
-  Modelica.Units.SI.Current i1_2(start=0)=p1_2.i
+  SI.Current i1_2(start=0)=p1_2.i
     "Current flowing from pos. to neg. pin of port 1_2";
   parameter Real k1(final min=0)=1 "Weight of input 1";
   parameter Real k2(final min=0)=1 "Weight of input 2";
-  parameter Modelica.Units.SI.Resistance R=1000
+  parameter SI.Resistance R=1000
     "Resistance at output of OpAmp";
-  parameter Modelica.Units.SI.Resistance R1=R/k1
+  parameter SI.Resistance R1=R/k1
     "Calculated resistance to reach desired weight 1";
-  parameter Modelica.Units.SI.Resistance R2=R/k2
+  parameter SI.Resistance R2=R/k2
     "Calculated resistance to reach desired weight 2";
   Modelica.Electrical.Analog.Basic.Resistor r1(final R=R1) annotation (
       Placement(transformation(extent={{-10,-10},{10,10}}, origin={-40,70})));

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Add.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Add.mo
@@ -1,26 +1,31 @@
 within Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits;
 model Add "Adding operational amplifier circuit"
   extends PartialOpAmp;
-  SI.Voltage v1_2=p1_2.v - n1.v "Voltage drop of port 1_2 (= p1_2.v - n1.v)";
-  SI.Current i1_2=p1_2.i "Current flowing from pos. to neg. pin of port 1_2";
+  Modelica.Units.SI.Voltage v1_2=p1_2.v - n1.v
+    "Voltage drop of port 1_2 (= p1_2.v - n1.v)";
+  Modelica.Units.SI.Current i1_2(start=0)=p1_2.i
+    "Current flowing from pos. to neg. pin of port 1_2";
   parameter Real k1(final min=0)=1 "Weight of input 1";
   parameter Real k2(final min=0)=1 "Weight of input 2";
-  parameter SI.Resistance R=1000 "Resistance at output of OpAmp";
-  parameter SI.Resistance R1=R/k1 "Calculated resistance to reach desired weight 1";
-  parameter SI.Resistance R2=R/k2 "Calculated resistance to reach desired weight 2";
-  Basic.Resistor  r1(final R=R1)
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}},
-        origin={-40,70})));
-  Basic.Resistor  r2(final R=R2)
-    annotation (Placement(transformation(extent={{10,-10},{-10,10}},
+  parameter Modelica.Units.SI.Resistance R=1000
+    "Resistance at output of OpAmp";
+  parameter Modelica.Units.SI.Resistance R1=R/k1
+    "Calculated resistance to reach desired weight 1";
+  parameter Modelica.Units.SI.Resistance R2=R/k2
+    "Calculated resistance to reach desired weight 2";
+  Modelica.Electrical.Analog.Basic.Resistor r1(final R=R1) annotation (
+      Placement(transformation(extent={{-10,-10},{10,10}}, origin={-40,70})));
+  Modelica.Electrical.Analog.Basic.Resistor r2(final R=R2) annotation (
+      Placement(transformation(
+        extent={{10,-10},{-10,10}},
         rotation=180,
         origin={-40,30})));
-  Interfaces.PositivePin p1_2 "Positive electrical pin 1.2" annotation (
-      Placement(transformation(extent={{-110,-10},{-90,10}}),
-        iconTransformation(extent={{-110,-10},{-90,10}})));
-  Basic.Resistor r(final R=R) annotation (Placement(transformation(
-        extent={{10,-10},{-10,10}},
-        origin={20,30})));
+  Modelica.Electrical.Analog.Interfaces.PositivePin p1_2
+    "Positive electrical pin 1.2" annotation (Placement(transformation(
+          extent={{-110,-10},{-90,10}}), iconTransformation(extent={{-110,-10},
+            {-90,10}})));
+  Modelica.Electrical.Analog.Basic.Resistor r(final R=R) annotation (
+      Placement(transformation(extent={{10,-10},{-10,10}}, origin={20,30})));
 equation
   connect(n1, n2)
     annotation (Line(points={{-100,-100},{100,-100}}, color={0,0,255}));

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Buffer.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Buffer.mo
@@ -2,9 +2,9 @@ within Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits;
 model Buffer "Non inverting operational amplifier circuit"
   extends PartialOpAmp;
   parameter Real k(final min=0)=1 "Desired amplification";
-  parameter Modelica.Units.SI.Resistance R1=1000
+  parameter SI.Resistance R1=1000
     "Resistance at negative pin(s)";
-  parameter Modelica.Units.SI.Resistance R2=(k - 1)*R1
+  parameter SI.Resistance R2=(k - 1)*R1
     "Calculated resistance to reach desired amplification k";
   Modelica.Electrical.Analog.Basic.Resistor r1(final R=R1) annotation (
       Placement(transformation(

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Buffer.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Buffer.mo
@@ -2,14 +2,18 @@ within Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits;
 model Buffer "Non inverting operational amplifier circuit"
   extends PartialOpAmp;
   parameter Real k(final min=0)=1 "Desired amplification";
-  parameter SI.Resistance R1=1000 "Resistance at negative pin(s)";
-  parameter SI.Resistance R2=(k - 1)*R1 "Calculated resistance to reach desired amplification k";
-  Basic.Resistor                            r1(final R=R1)
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}},
+  parameter Modelica.Units.SI.Resistance R1=1000
+    "Resistance at negative pin(s)";
+  parameter Modelica.Units.SI.Resistance R2=(k - 1)*R1
+    "Calculated resistance to reach desired amplification k";
+  Modelica.Electrical.Analog.Basic.Resistor r1(final R=R1) annotation (
+      Placement(transformation(
+        extent={{-10,-10},{10,10}},
         rotation=270,
         origin={10,-70})));
-  Basic.Resistor                            r2(final R=R2)
-    annotation (Placement(transformation(extent={{10,-10},{-10,10}},
+  Modelica.Electrical.Analog.Basic.Resistor r2(final R=R2) annotation (
+      Placement(transformation(
+        extent={{10,-10},{-10,10}},
         rotation=90,
         origin={10,-30})));
 equation

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Der.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Der.mo
@@ -3,12 +3,12 @@ model Der "Differentiating operational amplifier circuit"
   extends PartialOpAmp;
   import Modelica.Constants.pi;
   parameter Real k(final min=0)=1 "Desired amplification at frequency f";
-  parameter Modelica.Units.SI.Frequency f "Frequency";
-  parameter Modelica.Units.SI.Resistance R=1000
+  parameter SI.Frequency f "Frequency";
+  parameter SI.Resistance R=1000
     "Resistance at output of OpAmp";
-  parameter Modelica.Units.SI.Capacitance C=k/(2*pi*f*R)
+  parameter SI.Capacitance C=k/(2*pi*f*R)
     "Calculated capacitance to reach desired amplification k";
-  Modelica.Units.SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
+  SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
   Modelica.Electrical.Analog.Basic.Capacitor c(final C=C)
     annotation (Placement(transformation(extent={{-50,20},{-30,40}})));
   Modelica.Electrical.Analog.Basic.Resistor r(final R=R)

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Der.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Der.mo
@@ -3,13 +3,15 @@ model Der "Differentiating operational amplifier circuit"
   extends PartialOpAmp;
   import Modelica.Constants.pi;
   parameter Real k(final min=0)=1 "Desired amplification at frequency f";
-  parameter SI.Frequency f "Frequency";
-  parameter SI.Resistance R=1000 "Resistance at output of OpAmp";
-  parameter SI.Capacitance C=k/(2*pi*f*R) "Calculated capacitance to reach desired amplification k";
-  SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
-  Basic.Capacitor                            c(final C=C)
+  parameter Modelica.Units.SI.Frequency f "Frequency";
+  parameter Modelica.Units.SI.Resistance R=1000
+    "Resistance at output of OpAmp";
+  parameter Modelica.Units.SI.Capacitance C=k/(2*pi*f*R)
+    "Calculated capacitance to reach desired amplification k";
+  Modelica.Units.SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
+  Modelica.Electrical.Analog.Basic.Capacitor c(final C=C)
     annotation (Placement(transformation(extent={{-50,20},{-30,40}})));
-  Basic.Resistor                            r(final R=R)
+  Modelica.Electrical.Analog.Basic.Resistor r(final R=R)
     annotation (Placement(transformation(extent={{30,20},{10,40}})));
 equation
   connect(n1, n2)

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Derivative.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Derivative.mo
@@ -3,14 +3,14 @@ model Derivative "Lowpass filter operational amplifier circuit"
   extends PartialOpAmp;
   import Modelica.Constants.pi;
   parameter Real k(final min=0)=1 "Desired amplification";
-  parameter Modelica.Units.SI.Resistance R1=1000
+  parameter SI.Resistance R1=1000
     "Resistance at negative input of OpAmp";
-  parameter Modelica.Units.SI.Resistance R2=k*R1
+  parameter SI.Resistance R2=k*R1
     "Calculated resistance to reach k";
-  parameter Modelica.Units.SI.Time T "Time constant";
-  parameter Modelica.Units.SI.Capacitance C=T/R1
+  parameter SI.Time T "Time constant";
+  parameter SI.Capacitance C=T/R1
     "Calculated capacitance to reach T";
-  Modelica.Units.SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
+  SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
   Modelica.Electrical.Analog.Basic.Resistor r1(R=R1)
     annotation (Placement(transformation(extent={{-50,20},{-30,40}})));
   Modelica.Electrical.Analog.Basic.Resistor r2(R=R2)

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Derivative.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Derivative.mo
@@ -3,16 +3,19 @@ model Derivative "Lowpass filter operational amplifier circuit"
   extends PartialOpAmp;
   import Modelica.Constants.pi;
   parameter Real k(final min=0)=1 "Desired amplification";
-  parameter SI.Resistance R1=1000 "Resistance at negative input of OpAmp";
-  parameter SI.Resistance R2=k*R1 "Calculated resistance to reach k";
-  parameter SI.Time T "Time constant";
-  parameter SI.Capacitance C=T/R1 "Calculated capacitance to reach T";
-  SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
-  Basic.Resistor                            r1(R=R1)
+  parameter Modelica.Units.SI.Resistance R1=1000
+    "Resistance at negative input of OpAmp";
+  parameter Modelica.Units.SI.Resistance R2=k*R1
+    "Calculated resistance to reach k";
+  parameter Modelica.Units.SI.Time T "Time constant";
+  parameter Modelica.Units.SI.Capacitance C=T/R1
+    "Calculated capacitance to reach T";
+  Modelica.Units.SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
+  Modelica.Electrical.Analog.Basic.Resistor r1(R=R1)
     annotation (Placement(transformation(extent={{-50,20},{-30,40}})));
-  Basic.Resistor                            r2(R=R2)
+  Modelica.Electrical.Analog.Basic.Resistor r2(R=R2)
     annotation (Placement(transformation(extent={{30,20},{10,40}})));
-  Basic.Capacitor                            c(C=C)
+  Modelica.Electrical.Analog.Basic.Capacitor c(C=C)
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
 equation
   connect(n1, n2)

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/DifferentialAmplifierData.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/DifferentialAmplifierData.mo
@@ -1,30 +1,31 @@
 within Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits;
 record DifferentialAmplifierData "Data record for differential amplifier"
   extends Modelica.Icons.Record;
-  parameter SI.Voltage VSource=400 "Source RMS voltage line-to-line"
-    annotation(Dialog(group="Source"));
-  parameter SI.Frequency fSource=50 "Source frequency"
-    annotation(Dialog(group="Source"));
-  parameter SI.Resistance RLoad=10 "Load resistance of source"
-    annotation(Dialog(group="Source"));
-  parameter SI.Resistance RGround=100e3 "Resistance of ground connection"
-    annotation(Dialog(group="Source"));
+  parameter Modelica.Units.SI.Voltage VSource=400
+    "Source RMS voltage line-to-line" annotation (Dialog(group="Source"));
+  parameter Modelica.Units.SI.Frequency fSource=50 "Source frequency"
+    annotation (Dialog(group="Source"));
+  parameter Modelica.Units.SI.Resistance RLoad=10
+    "Load resistance of source" annotation (Dialog(group="Source"));
+  parameter Modelica.Units.SI.Resistance RGround=100e3
+    "Resistance of ground connection" annotation (Dialog(group="Source"));
   parameter Real V0=10e3 "No-load differential amplification"
     annotation(Dialog(group="OpAmp"));
-  parameter SI.Voltage VSupply=15 "Supply voltage"
-    annotation(Dialog(group="OpAmp"));
+  parameter Modelica.Units.SI.Voltage VSupply=15 "Supply voltage"
+    annotation (Dialog(group="OpAmp"));
   parameter Real k=100 "Attenuation factor"
     annotation(Dialog(group="OpAmp"));
-  parameter SI.Resistance R1=100e3 "Resistor 1"
-    annotation(Dialog(group="OpAmp"));
-  parameter SI.Resistance R2=R1 "Resistor 2"
-    annotation(Dialog(group="OpAmp"));
-  parameter SI.Resistance R3=R1/k "Resistor 3"
-    annotation(Dialog(group="OpAmp"));
-  parameter SI.Resistance R4=R3 "Resistor 4"
-    annotation(Dialog(group="OpAmp"));
-  parameter SI.Resistance RInstrument=100e3 "Input resistance of instrument"
-    annotation(Dialog(group="Measurement"));
+  parameter Modelica.Units.SI.Resistance R1=100e3 "Resistor 1"
+    annotation (Dialog(group="OpAmp"));
+  parameter Modelica.Units.SI.Resistance R2=R1 "Resistor 2"
+    annotation (Dialog(group="OpAmp"));
+  parameter Modelica.Units.SI.Resistance R3=R1/k "Resistor 3"
+    annotation (Dialog(group="OpAmp"));
+  parameter Modelica.Units.SI.Resistance R4=R3 "Resistor 4"
+    annotation (Dialog(group="OpAmp"));
+  parameter Modelica.Units.SI.Resistance RInstrument=100e3
+    "Input resistance of instrument"
+    annotation (Dialog(group="Measurement"));
   annotation (defaultComponentPrefixes="parameter", defaultComponentName="data",
     Documentation(info="<html>
 <p>

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/DifferentialAmplifierData.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/DifferentialAmplifierData.mo
@@ -1,29 +1,29 @@
 within Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits;
 record DifferentialAmplifierData "Data record for differential amplifier"
   extends Modelica.Icons.Record;
-  parameter Modelica.Units.SI.Voltage VSource=400
+  parameter SI.Voltage VSource=400
     "Source RMS voltage line-to-line" annotation (Dialog(group="Source"));
-  parameter Modelica.Units.SI.Frequency fSource=50 "Source frequency"
+  parameter SI.Frequency fSource=50 "Source frequency"
     annotation (Dialog(group="Source"));
-  parameter Modelica.Units.SI.Resistance RLoad=10
+  parameter SI.Resistance RLoad=10
     "Load resistance of source" annotation (Dialog(group="Source"));
-  parameter Modelica.Units.SI.Resistance RGround=100e3
+  parameter SI.Resistance RGround=100e3
     "Resistance of ground connection" annotation (Dialog(group="Source"));
   parameter Real V0=10e3 "No-load differential amplification"
     annotation(Dialog(group="OpAmp"));
-  parameter Modelica.Units.SI.Voltage VSupply=15 "Supply voltage"
+  parameter SI.Voltage VSupply=15 "Supply voltage"
     annotation (Dialog(group="OpAmp"));
   parameter Real k=100 "Attenuation factor"
     annotation(Dialog(group="OpAmp"));
-  parameter Modelica.Units.SI.Resistance R1=100e3 "Resistor 1"
+  parameter SI.Resistance R1=100e3 "Resistor 1"
     annotation (Dialog(group="OpAmp"));
-  parameter Modelica.Units.SI.Resistance R2=R1 "Resistor 2"
+  parameter SI.Resistance R2=R1 "Resistor 2"
     annotation (Dialog(group="OpAmp"));
-  parameter Modelica.Units.SI.Resistance R3=R1/k "Resistor 3"
+  parameter SI.Resistance R3=R1/k "Resistor 3"
     annotation (Dialog(group="OpAmp"));
-  parameter Modelica.Units.SI.Resistance R4=R3 "Resistor 4"
+  parameter SI.Resistance R4=R3 "Resistor 4"
     annotation (Dialog(group="OpAmp"));
-  parameter Modelica.Units.SI.Resistance RInstrument=100e3
+  parameter SI.Resistance RInstrument=100e3
     "Input resistance of instrument"
     annotation (Dialog(group="Measurement"));
   annotation (defaultComponentPrefixes="parameter", defaultComponentName="data",

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Feedback.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Feedback.mo
@@ -1,14 +1,14 @@
 within Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits;
 model Feedback "Subtracting operational amplifier circuit"
   extends PartialOpAmp;
-  Modelica.Units.SI.Voltage v1_2=p1_2.v - n1.v
+  SI.Voltage v1_2=p1_2.v - n1.v
     "Voltage drop of port 1_2 (= p1_2.v - n1.v)";
-  Modelica.Units.SI.Current i1_2(start=0)=p1_2.i
+  SI.Current i1_2(start=0)=p1_2.i
     "Current flowing from pos. to neg. pin of port 1_2";
   parameter Real k(final min=0)=1 "Desired amplification";
-  parameter Modelica.Units.SI.Resistance R1=1000
+  parameter SI.Resistance R1=1000
     "Resistance at inputs of OpAmp";
-  parameter Modelica.Units.SI.Resistance R3=R1/k
+  parameter SI.Resistance R3=R1/k
     "Calculated resistance to reach desired amplification k";
   Modelica.Electrical.Analog.Basic.Resistor r1(final R=R1) annotation (
       Placement(transformation(extent={{-10,-10},{10,10}}, origin={-40,70})));

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Feedback.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Feedback.mo
@@ -1,26 +1,31 @@
 within Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits;
 model Feedback "Subtracting operational amplifier circuit"
   extends PartialOpAmp;
-  SI.Voltage v1_2=p1_2.v - n1.v "Voltage drop of port 1_2 (= p1_2.v - n1.v)";
-  SI.Current i1_2=p1_2.i "Current flowing from pos. to neg. pin of port 1_2";
+  Modelica.Units.SI.Voltage v1_2=p1_2.v - n1.v
+    "Voltage drop of port 1_2 (= p1_2.v - n1.v)";
+  Modelica.Units.SI.Current i1_2(start=0)=p1_2.i
+    "Current flowing from pos. to neg. pin of port 1_2";
   parameter Real k(final min=0)=1 "Desired amplification";
-  parameter SI.Resistance R1=1000 "Resistance at inputs of OpAmp";
-  parameter SI.Resistance R3=R1/k "Calculated resistance to reach desired amplification k";
-  Basic.Resistor                            r1(final R=R1)
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}},
-        origin={-40,70})));
-  Basic.Resistor                            r2(final R=R1)
-    annotation (Placement(transformation(extent={{10,-10},{-10,10}},
+  parameter Modelica.Units.SI.Resistance R1=1000
+    "Resistance at inputs of OpAmp";
+  parameter Modelica.Units.SI.Resistance R3=R1/k
+    "Calculated resistance to reach desired amplification k";
+  Modelica.Electrical.Analog.Basic.Resistor r1(final R=R1) annotation (
+      Placement(transformation(extent={{-10,-10},{10,10}}, origin={-40,70})));
+  Modelica.Electrical.Analog.Basic.Resistor r2(final R=R1) annotation (
+      Placement(transformation(
+        extent={{10,-10},{-10,10}},
         rotation=180,
         origin={-40,-70})));
-  Interfaces.PositivePin p1_2 "Positive electrical pin 1.2" annotation (
-      Placement(transformation(extent={{-110,-10},{-90,10}}),
-        iconTransformation(extent={{-110,-10},{-90,10}})));
-  Basic.Resistor                            r3(final R=R3)
-    annotation (Placement(transformation(extent={{10,-10},{-10,10}},
-        origin={20,70})));
-  Basic.Resistor                            r4(final R=R3)
-    annotation (Placement(transformation(extent={{10,-10},{-10,10}},
+  Modelica.Electrical.Analog.Interfaces.PositivePin p1_2
+    "Positive electrical pin 1.2" annotation (Placement(transformation(
+          extent={{-110,-10},{-90,10}}), iconTransformation(extent={{-110,-10},
+            {-90,10}})));
+  Modelica.Electrical.Analog.Basic.Resistor r3(final R=R3) annotation (
+      Placement(transformation(extent={{10,-10},{-10,10}}, origin={20,70})));
+  Modelica.Electrical.Analog.Basic.Resistor r4(final R=R3) annotation (
+      Placement(transformation(
+        extent={{10,-10},{-10,10}},
         rotation=180,
         origin={20,-70})));
 equation

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/FirstOrder.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/FirstOrder.mo
@@ -3,14 +3,14 @@ model FirstOrder "Lowpass filter operational amplifier circuit"
   extends PartialOpAmp;
   import Modelica.Constants.pi;
   parameter Real k(final min=0)=1 "Desired amplification";
-  parameter Modelica.Units.SI.Resistance R1=1000
+  parameter SI.Resistance R1=1000
     "Resistance at negative input of OpAmp";
-  parameter Modelica.Units.SI.Resistance R2=k*R1
+  parameter SI.Resistance R2=k*R1
     "Calculated resistance to reach k";
-  parameter Modelica.Units.SI.Time T "Time constant";
-  parameter Modelica.Units.SI.Capacitance C=T/R2
+  parameter SI.Time T "Time constant";
+  parameter SI.Capacitance C=T/R2
     "Calculated capacitance to reach T";
-  Modelica.Units.SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
+  SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
   Modelica.Electrical.Analog.Basic.Resistor r1(R=R1)
     annotation (Placement(transformation(extent={{-50,20},{-30,40}})));
   Modelica.Electrical.Analog.Basic.Resistor r2(R=R2)

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/FirstOrder.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/FirstOrder.mo
@@ -1,18 +1,21 @@
 within Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits;
 model FirstOrder "Lowpass filter operational amplifier circuit"
-  extends PartialOpAmp(v2(start=0));
+  extends PartialOpAmp;
   import Modelica.Constants.pi;
   parameter Real k(final min=0)=1 "Desired amplification";
-  parameter SI.Resistance R1=1000 "Resistance at negative input of OpAmp";
-  parameter SI.Resistance R2=k*R1 "Calculated resistance to reach k";
-  parameter SI.Time T "Time constant";
-  parameter SI.Capacitance C=T/R2 "Calculated capacitance to reach T";
-  SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
-  Basic.Resistor                            r1(R=R1)
+  parameter Modelica.Units.SI.Resistance R1=1000
+    "Resistance at negative input of OpAmp";
+  parameter Modelica.Units.SI.Resistance R2=k*R1
+    "Calculated resistance to reach k";
+  parameter Modelica.Units.SI.Time T "Time constant";
+  parameter Modelica.Units.SI.Capacitance C=T/R2
+    "Calculated capacitance to reach T";
+  Modelica.Units.SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
+  Modelica.Electrical.Analog.Basic.Resistor r1(R=R1)
     annotation (Placement(transformation(extent={{-50,20},{-30,40}})));
-  Basic.Resistor                            r2(R=R2)
+  Modelica.Electrical.Analog.Basic.Resistor r2(R=R2)
     annotation (Placement(transformation(extent={{30,20},{10,40}})));
-  Basic.Capacitor                            c(C=C)
+  Modelica.Electrical.Analog.Basic.Capacitor c(C=C)
     annotation (Placement(transformation(extent={{30,40},{10,60}})));
 equation
   connect(n1, n2)

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Gain.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Gain.mo
@@ -2,11 +2,13 @@ within Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits;
 model Gain "Inverting operational amplifier circuit"
   extends PartialOpAmp;
   parameter Real k(final min=0)=1 "Desired amplification";
-  parameter SI.Resistance R1=1000 "Resistance at negative input of OpAmp";
-  parameter SI.Resistance R2=k*R1 "Calculated resistance to reach desired amplification k";
-  Basic.Resistor                            r1(final R=R1)
+  parameter Modelica.Units.SI.Resistance R1=1000
+    "Resistance at negative input of OpAmp";
+  parameter Modelica.Units.SI.Resistance R2=k*R1
+    "Calculated resistance to reach desired amplification k";
+  Modelica.Electrical.Analog.Basic.Resistor r1(final R=R1)
     annotation (Placement(transformation(extent={{-50,20},{-30,40}})));
-  Basic.Resistor                            r2(final R=R2)
+  Modelica.Electrical.Analog.Basic.Resistor r2(final R=R2)
     annotation (Placement(transformation(extent={{30,20},{10,40}})));
 equation
   connect(opAmp.out, r2.p)

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Gain.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Gain.mo
@@ -2,9 +2,9 @@ within Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits;
 model Gain "Inverting operational amplifier circuit"
   extends PartialOpAmp;
   parameter Real k(final min=0)=1 "Desired amplification";
-  parameter Modelica.Units.SI.Resistance R1=1000
+  parameter SI.Resistance R1=1000
     "Resistance at negative input of OpAmp";
-  parameter Modelica.Units.SI.Resistance R2=k*R1
+  parameter SI.Resistance R2=k*R1
     "Calculated resistance to reach desired amplification k";
   Modelica.Electrical.Analog.Basic.Resistor r1(final R=R1)
     annotation (Placement(transformation(extent={{-50,20},{-30,40}})));

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Integrator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Integrator.mo
@@ -1,15 +1,17 @@
 within Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits;
 model Integrator "Integrating operational amplifier circuit"
-  extends PartialOpAmp(v2(start=0));
+  extends PartialOpAmp;
   import Modelica.Constants.pi;
   parameter Real k(final min=0)=1 "Desired amplification at frequency f";
-  parameter SI.Frequency f "Frequency";
-  parameter SI.Resistance R=1000 "Resistance at negative input of OpAmp";
-  parameter SI.Capacitance C=1/k/(2*pi*f*R) "Calculated capacitance to reach desired amplification k";
-  SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
-  Basic.Capacitor  c(final C=C)
+  parameter Modelica.Units.SI.Frequency f "Frequency";
+  parameter Modelica.Units.SI.Resistance R=1000
+    "Resistance at negative input of OpAmp";
+  parameter Modelica.Units.SI.Capacitance C=1/k/(2*pi*f*R)
+    "Calculated capacitance to reach desired amplification k";
+  Modelica.Units.SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
+  Modelica.Electrical.Analog.Basic.Capacitor c(final C=C)
     annotation (Placement(transformation(extent={{30,20},{10,40}})));
-  Basic.Resistor r(final R=R)
+  Modelica.Electrical.Analog.Basic.Resistor r(final R=R)
     annotation (Placement(transformation(extent={{-50,20},{-30,40}})));
 equation
   connect(n1, n2)

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Integrator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/Integrator.mo
@@ -3,12 +3,12 @@ model Integrator "Integrating operational amplifier circuit"
   extends PartialOpAmp;
   import Modelica.Constants.pi;
   parameter Real k(final min=0)=1 "Desired amplification at frequency f";
-  parameter Modelica.Units.SI.Frequency f "Frequency";
-  parameter Modelica.Units.SI.Resistance R=1000
+  parameter SI.Frequency f "Frequency";
+  parameter SI.Resistance R=1000
     "Resistance at negative input of OpAmp";
-  parameter Modelica.Units.SI.Capacitance C=1/k/(2*pi*f*R)
+  parameter SI.Capacitance C=1/k/(2*pi*f*R)
     "Calculated capacitance to reach desired amplification k";
-  Modelica.Units.SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
+  SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
   Modelica.Electrical.Analog.Basic.Capacitor c(final C=C)
     annotation (Placement(transformation(extent={{30,20},{10,40}})));
   Modelica.Electrical.Analog.Basic.Resistor r(final R=R)

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/PI.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/PI.mo
@@ -3,14 +3,14 @@ model PI "PI controller operational amplifier circuit"
   extends PartialOpAmp;
   import Modelica.Constants.pi;
   parameter Real k(final min=0)=1 "Desired amplification";
-  parameter Modelica.Units.SI.Resistance R1=1000
+  parameter SI.Resistance R1=1000
     "Resistance at negative input of OpAmp";
-  parameter Modelica.Units.SI.Resistance R2=k*R1
+  parameter SI.Resistance R2=k*R1
     "Calculated resistance to reach k";
-  parameter Modelica.Units.SI.Time T "Time constant";
-  parameter Modelica.Units.SI.Capacitance C=T/k/R1
+  parameter SI.Time T "Time constant";
+  parameter SI.Capacitance C=T/k/R1
     "Calculated capacitance to reach T";
-  Modelica.Units.SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
+  SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
   Modelica.Electrical.Analog.Basic.Resistor r1(R=R1)
     annotation (Placement(transformation(extent={{-50,20},{-30,40}})));
   Modelica.Electrical.Analog.Basic.Resistor r2(R=R2)

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/PI.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/PI.mo
@@ -1,17 +1,21 @@
 within Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits;
 model PI "PI controller operational amplifier circuit"
-  extends PartialOpAmp(v2(start=0));
+  extends PartialOpAmp;
   import Modelica.Constants.pi;
   parameter Real k(final min=0)=1 "Desired amplification";
-  parameter SI.Resistance R1=1000 "Resistance at negative input of OpAmp";
-  parameter SI.Resistance R2=k*R1 "Calculated resistance to reach k";
-  parameter SI.Time T "Time constant";
-  parameter SI.Capacitance C=T/k/R1 "Calculated capacitance to reach T";
-  Basic.Resistor                            r1(R=R1)
+  parameter Modelica.Units.SI.Resistance R1=1000
+    "Resistance at negative input of OpAmp";
+  parameter Modelica.Units.SI.Resistance R2=k*R1
+    "Calculated resistance to reach k";
+  parameter Modelica.Units.SI.Time T "Time constant";
+  parameter Modelica.Units.SI.Capacitance C=T/k/R1
+    "Calculated capacitance to reach T";
+  Modelica.Units.SI.Voltage v(start=0)=c.v "Capacitor voltage = state";
+  Modelica.Electrical.Analog.Basic.Resistor r1(R=R1)
     annotation (Placement(transformation(extent={{-50,20},{-30,40}})));
-  Basic.Resistor                            r2(R=R2)
+  Modelica.Electrical.Analog.Basic.Resistor r2(R=R2)
     annotation (Placement(transformation(extent={{30,20},{10,40}})));
-  Basic.Capacitor                            c(C=C)
+  Modelica.Electrical.Analog.Basic.Capacitor c(C=C)
     annotation (Placement(transformation(extent={{60,20},{40,40}})));
 equation
   connect(n1, n2)

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/PartialOpAmp.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/PartialOpAmp.mo
@@ -2,15 +2,14 @@ within Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits;
 partial model PartialOpAmp
   "Partial circuit of operational amplifiers"
   extends Modelica.Electrical.Analog.Interfaces.FourPin;
-  parameter SI.Voltage Vps=+15 "Positive supply";
-  parameter SI.Voltage Vns=-15 "Negative supply";
+  parameter Modelica.Units.SI.Voltage Vps=+15 "Positive supply";
+  parameter Modelica.Units.SI.Voltage Vns=-15 "Negative supply";
   parameter Real V0=15000.0 "No-load amplification";
-  Ideal.IdealizedOpAmpLimited opAmp(
+  Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp(
     V0=V0,
     final useSupply=false,
     final Vps=Vps,
-    final Vns=Vns,
-    out(i(start=0, fixed=false)))
+    final Vns=Vns)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false), graphics={
         Text(

--- a/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/PartialOpAmp.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/OpAmpCircuits/PartialOpAmp.mo
@@ -2,8 +2,8 @@ within Modelica.Electrical.Analog.Examples.OpAmps.OpAmpCircuits;
 partial model PartialOpAmp
   "Partial circuit of operational amplifiers"
   extends Modelica.Electrical.Analog.Interfaces.FourPin;
-  parameter Modelica.Units.SI.Voltage Vps=+15 "Positive supply";
-  parameter Modelica.Units.SI.Voltage Vns=-15 "Negative supply";
+  parameter SI.Voltage Vps=+15 "Positive supply";
+  parameter SI.Voltage Vns=-15 "Negative supply";
   parameter Real V0=15000.0 "No-load amplification";
   Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp(
     V0=V0,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/SchmittTrigger.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/SchmittTrigger.mo
@@ -1,14 +1,14 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model SchmittTrigger "Schmitt trigger with hysteresis"
   extends Modelica.Icons.Example;
-  parameter Modelica.Units.SI.Voltage Vps=+15 "Positive supply";
-  parameter Modelica.Units.SI.Voltage Vns=-15 "Negative supply";
-  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
-  parameter Modelica.Units.SI.Voltage vHys=1 "(Positive) hysteresis voltage";
+  parameter SI.Voltage Vps=+15 "Positive supply";
+  parameter SI.Voltage Vns=-15 "Negative supply";
+  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter SI.Frequency f=10 "Frequency of input voltage";
+  parameter SI.Voltage vHys=1 "(Positive) hysteresis voltage";
   parameter Real k=vHys/Vps "Auxiliary calculated parameter to be used in R2 calculation";
-  parameter Modelica.Units.SI.Resistance R1=1000 "Arbitrary resistance";
-  parameter Modelica.Units.SI.Resistance R2=R1/k
+  parameter SI.Resistance R1=1000 "Arbitrary resistance";
+  parameter SI.Resistance R2=R1/k
     "Calculated resistance to reach hysteresis voltage";
   Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp(Vps=Vps, Vns=Vns)
     annotation (Placement(transformation(extent={{0,10},{20,-10}})));

--- a/Modelica/Electrical/Analog/Examples/OpAmps/SchmittTrigger.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/SchmittTrigger.mo
@@ -1,18 +1,16 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model SchmittTrigger "Schmitt trigger with hysteresis"
   extends Modelica.Icons.Example;
-  parameter SI.Voltage Vps=+15 "Positive supply";
-  parameter SI.Voltage Vns=-15 "Negative supply";
-  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter SI.Frequency f=10 "Frequency of input voltage";
-  parameter SI.Voltage vHys=1 "(Positive) hysteresis voltage";
+  parameter Modelica.Units.SI.Voltage Vps=+15 "Positive supply";
+  parameter Modelica.Units.SI.Voltage Vns=-15 "Negative supply";
+  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
+  parameter Modelica.Units.SI.Voltage vHys=1 "(Positive) hysteresis voltage";
   parameter Real k=vHys/Vps "Auxiliary calculated parameter to be used in R2 calculation";
-  parameter SI.Resistance R1=1000 "Arbitrary resistance";
-  parameter SI.Resistance R2=R1/k "Calculated resistance to reach hysteresis voltage";
-  Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimited opAmp(
-    Vps=Vps,
-    Vns=Vns,
-    out(i(start=0)))
+  parameter Modelica.Units.SI.Resistance R1=1000 "Arbitrary resistance";
+  parameter Modelica.Units.SI.Resistance R2=R1/k
+    "Calculated resistance to reach hysteresis voltage";
+  Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp(Vps=Vps, Vns=Vns)
     annotation (Placement(transformation(extent={{0,10},{20,-10}})));
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-100},{0,-80}})));

--- a/Modelica/Electrical/Analog/Examples/OpAmps/SignalGenerator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/SignalGenerator.mo
@@ -2,17 +2,17 @@ within Modelica.Electrical.Analog.Examples.OpAmps;
 model SignalGenerator "Rectangle-Triangle generator"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter Modelica.Units.SI.Voltage Vps=+15 "Positive supply";
-  parameter Modelica.Units.SI.Voltage Vns=-Vps "Negative supply";
-  parameter Modelica.Units.SI.Voltage VAmp=10 "Desired amplitude of output";
-  parameter Modelica.Units.SI.Resistance R1=1000
+  parameter SI.Voltage Vps=+15 "Positive supply";
+  parameter SI.Voltage Vns=-Vps "Negative supply";
+  parameter SI.Voltage VAmp=10 "Desired amplitude of output";
+  parameter SI.Resistance R1=1000
     "Arbitrary resistance for Schmitt trigger part";
-  parameter Modelica.Units.SI.Resistance R2=R1*Vps/VAmp
+  parameter SI.Resistance R2=R1*Vps/VAmp
     "Calculated resistance for Schmitt trigger to reach VAmp";
-  parameter Modelica.Units.SI.Frequency f=10 "Desired frequency";
-  parameter Modelica.Units.SI.Resistance R=1000
+  parameter SI.Frequency f=10 "Desired frequency";
+  parameter SI.Resistance R=1000
     "Arbitrary resistance of integrator part";
-  parameter Modelica.Units.SI.Capacitance C=Vps/VAmp/(4*f*R)
+  parameter SI.Capacitance C=Vps/VAmp/(4*f*R)
     "Calculated capacitance of integrator part to reach f";
   Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp1(
     Vps=Vps,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/SignalGenerator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/SignalGenerator.mo
@@ -2,19 +2,22 @@ within Modelica.Electrical.Analog.Examples.OpAmps;
 model SignalGenerator "Rectangle-Triangle generator"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
-  parameter SI.Voltage Vps=+15 "Positive supply";
-  parameter SI.Voltage Vns=-Vps "Negative supply";
-  parameter SI.Voltage VAmp=10 "Desired amplitude of output";
-  parameter SI.Resistance R1=1000 "Arbitrary resistance for Schmitt trigger part";
-  parameter SI.Resistance R2=R1*Vps/VAmp "Calculated resistance for Schmitt trigger to reach VAmp";
-  parameter SI.Frequency f=10 "Desired frequency";
-  parameter SI.Resistance R=1000 "Arbitrary resistance of integrator part";
-  parameter SI.Capacitance C=Vps/VAmp/(4*f*R) "Calculated capacitance of integrator part to reach f";
-  Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimited opAmp1(
+  parameter Modelica.Units.SI.Voltage Vps=+15 "Positive supply";
+  parameter Modelica.Units.SI.Voltage Vns=-Vps "Negative supply";
+  parameter Modelica.Units.SI.Voltage VAmp=10 "Desired amplitude of output";
+  parameter Modelica.Units.SI.Resistance R1=1000
+    "Arbitrary resistance for Schmitt trigger part";
+  parameter Modelica.Units.SI.Resistance R2=R1*Vps/VAmp
+    "Calculated resistance for Schmitt trigger to reach VAmp";
+  parameter Modelica.Units.SI.Frequency f=10 "Desired frequency";
+  parameter Modelica.Units.SI.Resistance R=1000
+    "Arbitrary resistance of integrator part";
+  parameter Modelica.Units.SI.Capacitance C=Vps/VAmp/(4*f*R)
+    "Calculated capacitance of integrator part to reach f";
+  Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp1(
     Vps=Vps,
     Vns=Vns,
-    strict=false,
-    homotopyType=Modelica.Blocks.Types.LimiterHomotopy.LowerLimit)
+    initOpAmp=Modelica.Electrical.Analog.Types.InitOpAmp.LowerLimit)
     annotation (Placement(transformation(extent={{-60,10},{-40,-10}})));
   Modelica.Electrical.Analog.Basic.Resistor r2(R=R2, i(start=Vps/R2))
     annotation (Placement(transformation(
@@ -27,11 +30,7 @@ model SignalGenerator "Rectangle-Triangle generator"
         origin={-50,50})));
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-10,-60},{10,-40}})));
-  Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimited opAmp2(
-    Vps=Vps,
-    Vns=Vns,
-    v_in(start=0),
-    strict=false)
+  Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp2(Vps=Vps, Vns=Vns)
     annotation (Placement(transformation(extent={{30,-10},{50,10}})));
   Modelica.Electrical.Analog.Basic.Capacitor c(C=C, v(fixed=true, start=0))
     annotation (Placement(transformation(extent={{50,20},{30,40}})));

--- a/Modelica/Electrical/Analog/Examples/OpAmps/SignalGenerator.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/SignalGenerator.mo
@@ -17,6 +17,7 @@ model SignalGenerator "Rectangle-Triangle generator"
   Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp1(
     Vps=Vps,
     Vns=Vns,
+    useFirstOrder=true,
     initOpAmp=Modelica.Electrical.Analog.Types.InitOpAmp.LowerLimit)
     annotation (Placement(transformation(extent={{-60,10},{-40,-10}})));
   Modelica.Electrical.Analog.Basic.Resistor r2(R=R2, i(start=Vps/R2))

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Subtracter.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Subtracter.mo
@@ -1,8 +1,8 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model Subtracter "Inverting subtracter"
   extends Modelica.Icons.Example;
-  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
+  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter SI.Frequency f=10 "Frequency of input voltage";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
   Modelica.Electrical.Analog.Sources.SineVoltage vIn1(V=Vin, f=f) annotation

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Subtracter.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Subtracter.mo
@@ -39,7 +39,6 @@ equation
     annotation (Line(points={{10,-10},{40,-10}}, color={0,0,255}));
   annotation (Documentation(info="<html>
 <p>This is an inverting subtracter.</p>
-<p>Note: <code>vOut</code> measure the negative output voltage.</p>
 </html>"),
     experiment(
       StartTime=0,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/Subtracter.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/Subtracter.mo
@@ -1,26 +1,26 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model Subtracter "Inverting subtracter"
   extends Modelica.Icons.Example;
-  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter SI.Frequency f=10 "Frequency of input voltage";
+  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
-  Sources.SineVoltage vIn1(V=Vin, f=f) annotation (Placement(
-        transformation(
+  Modelica.Electrical.Analog.Sources.SineVoltage vIn1(V=Vin, f=f) annotation
+    (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-60,0})));
-  Sources.ConstantVoltage vIn2(V=Vin) annotation (Placement(
-        transformation(
+  Modelica.Electrical.Analog.Sources.ConstantVoltage vIn2(V=Vin) annotation (
+      Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-40,-10})));
   Modelica.Electrical.Analog.Sensors.VoltageSensor vOut annotation (Placement(
         transformation(
-        extent={{10,10},{-10,-10}},
+        extent={{-10,10},{10,-10}},
         rotation=270,
         origin={40,0})));
-  OpAmpCircuits.Feedback feedback(p1_2(i(start=0)))
+  OpAmpCircuits.Feedback feedback
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
 equation
   connect(feedback.n1, ground.p)
@@ -33,9 +33,9 @@ equation
     annotation (Line(points={{-10,-20},{-40,-20}}, color={0,0,255}));
   connect(ground.p, vIn1.n)
     annotation (Line(points={{-10,-20},{-60,-20},{-60,-10}}, color={0,0,255}));
-  connect(feedback.p2, vOut.n)
+  connect(feedback.p2, vOut.p)
     annotation (Line(points={{10,10},{40,10}}, color={0,0,255}));
-  connect(feedback.n2, vOut.p)
+  connect(feedback.n2, vOut.n)
     annotation (Line(points={{10,-10},{40,-10}}, color={0,0,255}));
   annotation (Documentation(info="<html>
 <p>This is an inverting subtracter.</p>

--- a/Modelica/Electrical/Analog/Examples/OpAmps/VoltageFollower.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/VoltageFollower.mo
@@ -1,17 +1,14 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model VoltageFollower "Reproduce input voltage"
   extends Modelica.Icons.Example;
-  parameter SI.Voltage Vps=+15 "Positive supply";
-  parameter SI.Voltage Vns=-15 "Negative supply";
-  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter SI.Frequency f=10 "Frequency of input voltage";
-  parameter SI.Resistance Ri=1
+  parameter Modelica.Units.SI.Voltage Vps=+15 "Positive supply";
+  parameter Modelica.Units.SI.Voltage Vns=-15 "Negative supply";
+  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
+  parameter Modelica.Units.SI.Resistance Ri=1
     "Inner resistance of input voltage source";
-  parameter SI.Resistance Rl=1 "Load resistance";
-  Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimited opAmp(
-    Vps=Vps,
-    Vns=Vns,
-    v_in(start=0))
+  parameter Modelica.Units.SI.Resistance Rl=1 "Load resistance";
+  Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp(Vps=Vps, Vns=Vns)
     annotation (Placement(transformation(extent={{0,-10},{20,10}})));
   Modelica.Electrical.Analog.Basic.Ground ground
     annotation (Placement(transformation(extent={{-20,-100},{0,-80}})));

--- a/Modelica/Electrical/Analog/Examples/OpAmps/VoltageFollower.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/VoltageFollower.mo
@@ -1,13 +1,13 @@
 within Modelica.Electrical.Analog.Examples.OpAmps;
 model VoltageFollower "Reproduce input voltage"
   extends Modelica.Icons.Example;
-  parameter Modelica.Units.SI.Voltage Vps=+15 "Positive supply";
-  parameter Modelica.Units.SI.Voltage Vns=-15 "Negative supply";
-  parameter Modelica.Units.SI.Voltage Vin=5 "Amplitude of input voltage";
-  parameter Modelica.Units.SI.Frequency f=10 "Frequency of input voltage";
-  parameter Modelica.Units.SI.Resistance Ri=1
+  parameter SI.Voltage Vps=+15 "Positive supply";
+  parameter SI.Voltage Vns=-15 "Negative supply";
+  parameter SI.Voltage Vin=5 "Amplitude of input voltage";
+  parameter SI.Frequency f=10 "Frequency of input voltage";
+  parameter SI.Resistance Ri=1
     "Inner resistance of input voltage source";
-  parameter Modelica.Units.SI.Resistance Rl=1 "Load resistance";
+  parameter SI.Resistance Rl=1 "Load resistance";
   Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited opAmp(Vps=Vps, Vns=Vns)
     annotation (Placement(transformation(extent={{0,-10},{20,10}})));
   Modelica.Electrical.Analog.Basic.Ground ground

--- a/Modelica/Electrical/Analog/Examples/OpAmps/package.order
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/package.order
@@ -12,7 +12,7 @@ VoltageFollower
 Comparator
 InvertingSchmittTrigger
 SchmittTrigger
+LCOscillator
 Multivibrator
 SignalGenerator
-LCOscillator
 OpAmpCircuits

--- a/Modelica/Electrical/Analog/Examples/OpAmps/package.order
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/package.order
@@ -1,6 +1,5 @@
 NonInvertingAmplifier
 InvertingAmplifier
-DifferentialAmplifier
 Adder
 Subtracter
 Differentiator
@@ -8,6 +7,8 @@ Integrator
 LowPass
 HighPass
 ControlCircuit
+MeasureRiseTime
+DifferentialAmplifier
 VoltageFollower
 Comparator
 InvertingSchmittTrigger

--- a/Modelica/Electrical/Analog/Examples/package.order
+++ b/Modelica/Electrical/Analog/Examples/package.order
@@ -31,6 +31,6 @@ ParallelResonance
 DemonstrateLightning
 DemoPowerSupply
 DemoPowerSupplyWithBuffer
-Lines
 OpAmps
+Lines
 Utilities

--- a/Modelica/Electrical/Analog/Ideal/IdealizedOpAmpLimited.mo
+++ b/Modelica/Electrical/Analog/Ideal/IdealizedOpAmpLimited.mo
@@ -1,5 +1,6 @@
 within Modelica.Electrical.Analog.Ideal;
 model IdealizedOpAmpLimited "Idealized operational amplifier with limitation"
+  extends Modelica.Icons.ObsoleteModel;
   parameter Real V0=15000.0 "No-load amplification";
   parameter Boolean useSupply=false
     "Use supply pins (otherwise constant supply)" annotation (Evaluate=true);
@@ -64,7 +65,8 @@ equation
                        simplified=simplifiedExpr);
     end if;
   end if;
-  annotation (defaultComponentName="opAmp",
+  annotation (obsolete = "Please use Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited instead of this model",
+    defaultComponentName="opAmp",
     Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
             100}}), graphics={
         Line(points={{60,0},{90,0}}, color={0,0,255}),

--- a/Modelica/Electrical/Analog/Ideal/ImprovedOpAmpLimited.mo
+++ b/Modelica/Electrical/Analog/Ideal/ImprovedOpAmpLimited.mo
@@ -1,28 +1,28 @@
 within Modelica.Electrical.Analog.Ideal;
 model ImprovedOpAmpLimited "Improved operational amplifier with limitation"
   parameter Real V0=15000.0 "No-load amplification";
-  parameter Modelica.Units.SI.Time Tr=1e-5 "Rise time 10%-90% of output voltage";
+  parameter SI.Time Tr=1e-5 "Rise time 10%-90% of output voltage";
   parameter Boolean useSupply=false
     "Use supply pins (otherwise constant supply)" annotation (Evaluate=true);
-  parameter Modelica.Units.SI.Voltage Vps=+15 "Positive supply voltage"
+  parameter SI.Voltage Vps=+15 "Positive supply voltage"
     annotation (Dialog(enable=not useSupply));
-  parameter Modelica.Units.SI.Voltage Vns=-15 "Negative supply voltage"
+  parameter SI.Voltage Vns=-15 "Negative supply voltage"
     annotation (Dialog(enable=not useSupply));
   parameter Modelica.Electrical.Analog.Types.InitOpAmp initOpAmp=Modelica.Electrical.Analog.Types.InitOpAmp.Linear
     "Initialization of rise time fristOrder"
     annotation (Evaluate=true, Dialog(group="Initialization"));
   Boolean satPos=v_int>=vps "Indicates positive Saturation";
   Boolean satNeg=v_int<=vns "Indicates negative Saturation";
-  Modelica.Units.SI.Voltage vps "Positive supply voltage";
-  Modelica.Units.SI.Voltage vns "Negative supply voltage";
-  Modelica.Units.SI.Voltage v_in(start=0)=in_p.v - in_n.v "Input voltage difference";
-  Modelica.Units.SI.Voltage v_int "Intermediate voltage";
-  Modelica.Units.SI.Voltage v_out=out.v "Output voltage to ground";
-  Modelica.Units.SI.Current i_out(start=0)=out.i "Output current into OpAmp";
-  Modelica.Units.SI.Power p_in=in_p.v*in_p.i + in_n.v*in_n.i "Input power";
-  Modelica.Units.SI.Power p_out=out.v*out.i "Output power";
-  Modelica.Units.SI.Power p_s=-(p_in + p_out) "Supply power";
-  Modelica.Units.SI.Current i_s=p_s/(vps - vns) "Supply current";
+  SI.Voltage vps "Positive supply voltage";
+  SI.Voltage vns "Negative supply voltage";
+  SI.Voltage v_in(start=0)=in_p.v - in_n.v "Input voltage difference";
+  SI.Voltage v_int "Intermediate voltage";
+  SI.Voltage v_out=out.v "Output voltage to ground";
+  SI.Current i_out(start=0)=out.i "Output current into OpAmp";
+  SI.Power p_in=in_p.v*in_p.i + in_n.v*in_n.i "Input power";
+  SI.Power p_out=out.v*out.i "Output power";
+  SI.Power p_s=-(p_in + p_out) "Supply power";
+  SI.Current i_s=p_s/(vps - vns) "Supply current";
   Modelica.Electrical.Analog.Interfaces.PositivePin in_p
     "Positive pin of the input port" annotation (Placement(transformation(
           extent={{-90,-70},{-110,-50}})));

--- a/Modelica/Electrical/Analog/Ideal/ImprovedOpAmpLimited.mo
+++ b/Modelica/Electrical/Analog/Ideal/ImprovedOpAmpLimited.mo
@@ -1,0 +1,110 @@
+within Modelica.Electrical.Analog.Ideal;
+model ImprovedOpAmpLimited "Improved operational amplifier with limitation"
+  parameter Real V0=15000.0 "No-load amplification";
+  parameter Modelica.Units.SI.Time Tr=1e-5 "Rise time 10%-90% of output voltage";
+  parameter Boolean useSupply=false
+    "Use supply pins (otherwise constant supply)" annotation (Evaluate=true);
+  parameter Modelica.Units.SI.Voltage Vps=+15 "Positive supply voltage"
+    annotation (Dialog(enable=not useSupply));
+  parameter Modelica.Units.SI.Voltage Vns=-15 "Negative supply voltage"
+    annotation (Dialog(enable=not useSupply));
+  parameter Modelica.Electrical.Analog.Types.InitOpAmp initOpAmp=Modelica.Electrical.Analog.Types.InitOpAmp.Linear
+    "Initialization of rise time fristOrder"
+    annotation (Evaluate=true, Dialog(group="Initialization"));
+  Boolean satPos=v_int>=vps "Indicates positive Saturation";
+  Boolean satNeg=v_int<=vns "Indicates negative Saturation";
+  Modelica.Units.SI.Voltage vps "Positive supply voltage";
+  Modelica.Units.SI.Voltage vns "Negative supply voltage";
+  Modelica.Units.SI.Voltage v_in(start=0)=in_p.v - in_n.v "Input voltage difference";
+  Modelica.Units.SI.Voltage v_int "Intermediate voltage";
+  Modelica.Units.SI.Voltage v_out=out.v "Output voltage to ground";
+  Modelica.Units.SI.Current i_out(start=0)=out.i "Output current into OpAmp";
+  Modelica.Units.SI.Power p_in=in_p.v*in_p.i + in_n.v*in_n.i "Input power";
+  Modelica.Units.SI.Power p_out=out.v*out.i "Output power";
+  Modelica.Units.SI.Power p_s=-(p_in + p_out) "Supply power";
+  Modelica.Units.SI.Current i_s=p_s/(vps - vns) "Supply current";
+  Modelica.Electrical.Analog.Interfaces.PositivePin in_p
+    "Positive pin of the input port" annotation (Placement(transformation(
+          extent={{-90,-70},{-110,-50}})));
+  Modelica.Electrical.Analog.Interfaces.NegativePin in_n
+    "Negative pin of the input port" annotation (Placement(transformation(
+          extent={{-110,50},{-90,70}})));
+  Modelica.Electrical.Analog.Interfaces.PositivePin out
+    "Pin of the output port" annotation (Placement(transformation(extent={{
+            110,-10},{90,10}}), iconTransformation(extent={{110,-10},
+            {90,10}})));
+  //optional supply pins
+  Modelica.Electrical.Analog.Interfaces.PositivePin s_p(final i=+i_s, final v=vps)
+    if useSupply "Optional positive supply pin" annotation (Placement(
+        transformation(extent={{10,90},{-10,110}})));
+  Modelica.Electrical.Analog.Interfaces.NegativePin s_n(final i=-i_s, final v=vns)
+    if useSupply "Optional negative supply pin" annotation (Placement(
+        transformation(extent={{-10,-110},{10,-90}})));
+initial equation
+  if initOpAmp == Modelica.Electrical.Analog.Types.InitOpAmp.UpperLimit then
+    v_int=vps;
+  elseif initOpAmp == Modelica.Electrical.Analog.Types.InitOpAmp.LowerLimit
+       then
+    v_int=vns;
+  else
+    v_int=V0*v_in;
+  end if;
+equation
+  if not useSupply then
+    vps = Vps;
+    vns = Vns;
+  end if;
+  assert(vps > vns, "Supply voltages are not consistent: vps <= vns");
+  //input currents
+  in_p.i = 0;
+  in_n.i = 0;
+  //firstOrder to model Rise time
+  der(v_int) = (V0*v_in - v_int)/(Tr/log(9));
+  //saturation of output: satPos and satNeg trigger events
+  v_out = smooth(0, min(vps, max(vns, v_int)));
+  annotation (defaultComponentName="opAmp",
+    Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
+            100}}), graphics={
+        Line(points={{60,0},{90,0}}, color={0,0,255}),
+        Text(
+          extent={{-150,150},{150,110}},
+          textString="%name",
+          textColor={0,0,255}),
+        Line(points={{60,0},{90,0}}, color={0,0,255}),
+        Polygon(
+          points={{70,0},{-70,80},{-70,-80},{70,0}},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,255}),
+        Line(points={{-100,60},{-70,60}}, color={0,0,255}),
+        Line(points={{-100,-60},{-70,-60}}, color={0,0,255}),
+        Line(points={{-60,50},{-40,50}}, color={0,0,255}),
+        Line(points={{-50,-40},{-50,-60}}, color={0,0,255}),
+        Line(points={{-60,-50},{-40,-50}}, color={0,0,255}),
+        Line(points={{0,40},{0,100}}, color={0,0,255}, visible=useSupply),
+        Line(points={{0,-100},{0,-40}}, color={0,0,255}, visible=useSupply)}),
+    Documentation(info="<html>
+<p>Idealized operational amplifier with saturation:</p>
+<ul>
+<li>Input currents are zero.</li>
+<li>No-load amplification is high (but not infinite).</li>
+<li>Rise time of output from 10&#037; to 90&#037; (at input step) is low (but not zero).</li>
+<li>Output voltage is limited between positive and negative supply.</li>
+</ul>
+<p>Supply voltage is either defined by parameter Vps and Vns or by (optional) pins s_p and s_n.<br>
+In the first case the necessary power is drawn from an implicit internal supply, in the second case from the external supply.</p>
+<p>
+The differential input voltage <code>v_in</code> is treated by a firstOrder with gain <code>V0</code> and time constant <code>Tr/log(9)</code> to meet the rise time.<br>
+If this intermediate voltage <code>v_int</code> gets higher than positive supply, Boolean <code>satPos</code> inidicates that.<br>
+If this intermediate voltage <code>v_int</code> gets lower  than negative supply, Boolean <code>satNeg</code> inidicates that.<br>
+Then <code>v_int</code> is limited between positive supply and negative supply to achieve output voltage <code>v_out</code>.
+</p>
+<p>
+It is essential to initialize intermediate voltage <code>v_int</code> correctly.<br>
+As a default, default initialization (<strong>Linear</strong>) is sufficient: <code>v_int = V0*v_in</code>.<br>
+However, in some cases the initialization has more than one solution and it is desired to set 
+<code>v_int</code> at the positive supply (<strong>UpperLimit</strong>) or 
+<code>v_int</code> at the negative supply (<strong>LowerLimit</strong>).
+</p>
+</html>"));
+end ImprovedOpAmpLimited;

--- a/Modelica/Electrical/Analog/Ideal/ImprovedOpAmpLimited.mo
+++ b/Modelica/Electrical/Analog/Ideal/ImprovedOpAmpLimited.mo
@@ -7,15 +7,16 @@ model ImprovedOpAmpLimited "Improved operational amplifier with limitation"
     annotation (Dialog(enable=not useSupply));
   parameter SI.Voltage Vns=-15 "Negative supply voltage"
     annotation (Dialog(enable=not useSupply));
-  parameter Boolean useFirstOrder=false "use firstOrder rise of output voltage?"
+  parameter Boolean useFirstOrder=false "Use firstOrder rise of output voltage"
     annotation(Evaluate=true, Dialog(tab="Advanced"));
   parameter SI.Time Tau=1e-5 "Time constant of firstOrder rise of output voltage"
     annotation(Evaluate=true, Dialog(tab="Advanced", enable=useFirstOrder));
   parameter Modelica.Electrical.Analog.Types.InitOpAmp initOpAmp=Modelica.Electrical.Analog.Types.InitOpAmp.Linear
     "Initialization of firstOrder rise of output voltage"
     annotation (Evaluate=true, Dialog(tab="Advanced", enable=useFirstOrder));
-  Boolean satPos=v_int>=vps "Indicates positive Saturation";
-  Boolean satNeg=v_int<=vns "Indicates negative Saturation";
+  //Indicate saturation and provide events without being involved in limitation
+  Boolean satPos=v_int>=vps "Positive Saturation";
+  Boolean satNeg=v_int<=vns "Negative Saturation";
   SI.Voltage vps "Positive supply voltage";
   SI.Voltage vns "Negative supply voltage";
   SI.Voltage v_in(start=0)=in_p.v - in_n.v "Input voltage difference";
@@ -101,9 +102,9 @@ equation
 <p>Supply voltage is either defined by parameter <code>Vps</code> and <code>Vns</code> or by (optional) pins <code>s_p</code> and <code>s_n</code>.<br>
 In the first case the necessary power is drawn from an implicit internal supply, in the second case from the external supply.</p>
 <p>
-For most applications it is sufficient ot use default settings <code>Advanced.useFirstOrder=false</code>. 
+For most applications it is sufficient ot use default settings <code>useFirstOrder=false</code> (default on the Advanced-tab).
 In this case the intermediate voltage <code>v_int</code> is simply <code>V0*v_in</code>.<br>
-In some applications it might be necessary to set <code>Advanced.useFirstOrder=true</code> 
+In some applications it might be necessary to set <code>useFirstOrder=true</code> 
 to let the intermediate voltage <code>v_int</code> rise according to a firstOrder with time constant <code>Tau</code>. 
 In that case the time constant <code>Tau</code> should fit to the dynamics of the input signal.
 </p>
@@ -118,7 +119,7 @@ Intermediate voltage <code>v_int</code> is limited between positive supply and n
 it is unlikely that it is necessary to change the start values and / or to declare them as fixed.
 </p>
 <p>
-If it is necessary to use <code>Advanced.useFirstOrder=true</code>, it is essential to initialize intermediate voltage <code>v_int</code> correctly.<br>
+If it is necessary to use <code>useFirstOrder=true</code>, it is essential to initialize intermediate voltage <code>v_int</code> correctly.<br>
 As a default, default initialization (<strong>Linear</strong>) is sufficient: <code>v_int = V0*v_in</code>.<br>
 However, in some cases the initialization has more than one solution and it is desired to set 
 <code>v_int</code> at the positive supply (<strong>UpperLimit</strong>) or 

--- a/Modelica/Electrical/Analog/Ideal/package.order
+++ b/Modelica/Electrical/Analog/Ideal/package.order
@@ -9,6 +9,7 @@ IdealOpAmp
 IdealOpAmp3Pin
 IdealOpAmpLimited
 IdealizedOpAmpLimited
+ImprovedOpAmpLimited
 IdealTransformer
 Idle
 Short

--- a/Modelica/Electrical/Analog/Types/InitOpAmp.mo
+++ b/Modelica/Electrical/Analog/Types/InitOpAmp.mo
@@ -3,4 +3,4 @@ type InitOpAmp = enumeration(
     Linear "Initialization of firstOrder linearly dependent on input",
     UpperLimit "Initialization of firstOrder at positive supply",
     LowerLimit "Initialization of firstOrder at negative supply")
-  "Enumeration defining initialization of the IdealizedOpAmpLimited" annotation (Evaluate=true);
+  "Enumeration defining initialization of the ImprovedOpAmpLimited" annotation (Evaluate=true);

--- a/Modelica/Electrical/Analog/Types/InitOpAmp.mo
+++ b/Modelica/Electrical/Analog/Types/InitOpAmp.mo
@@ -1,0 +1,6 @@
+within Modelica.Electrical.Analog.Types;
+type InitOpAmp = enumeration(
+    Linear "Initialization of firstOrder linearly dependent on input",
+    UpperLimit "Initialization of firstOrder at positive supply",
+    LowerLimit "Initialization of firstOrder at negative supply")
+  "Enumeration defining initialization of the IdealizedOpAmpLimited" annotation (Evaluate=true);

--- a/Modelica/Electrical/Analog/Types/package.order
+++ b/Modelica/Electrical/Analog/Types/package.order
@@ -1,1 +1,2 @@
 ImpulseApproximation
+InitOpAmp

--- a/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/OpAmps/DifferentialAmplifier/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/OpAmps/DifferentialAmplifier/comparisonSignals.txt
@@ -1,3 +1,4 @@
 time
+gain.y
 opAmp.v_out
 rootMeanSquare.mean.x

--- a/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/OpAmps/MeasureRiseTime/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/OpAmps/MeasureRiseTime/comparisonSignals.txt
@@ -1,0 +1,3 @@
+time
+vOut.v
+riseTime


### PR DESCRIPTION
This PR replaces #4485 which will be closed but we still can look up the discussions.
The following explanation could be used for future release notes:
Modelica.Electrical.Analog.Ideal.IdealizedOpAmpLimited has been declared as deprecated since some of the results (Modelica.Electrical.Analog.Examples.OpAmps) could not be compared between different tools, because the usage of noEvent() and smooth() for saturation prevented exact events in switching applications. 
As a replacement Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited has been implemented, thoroughly tested with different tools and used in the above mentioned examples. Saturation has been designed simpler, events are triggered by two Boolean variables that indicate saturation. Additionally a firstOrder models rise time of the OpAmp. Initialization is now without homopotopy acting on the result of the firstOrder (before saturation acts on the output).