### PR TITLE
Redesign ChuaCircuit and add ChuaDiode

### DIFF
--- a/Modelica/Electrical/Analog/Examples/ChuaCircuit.mo
+++ b/Modelica/Electrical/Analog/Examples/ChuaCircuit.mo
@@ -1,58 +1,94 @@
 within Modelica.Electrical.Analog.Examples;
-model ChuaCircuit "Chua's circuit, ns, V, A"
+model ChuaCircuit "Chua's circuit"
   extends Modelica.Icons.Example;
-
-  Modelica.Electrical.Analog.Basic.Inductor L(L=18, i(start=0, fixed=true)) annotation (Placement(transformation(
-        origin={-75,38},
-        extent={{-25,-25},{25,25}},
+  parameter Modelica.Units.SI.Resistance R=1900 "Try R={1850,1800,1750}";
+  SI.Voltage v1(start=+2.764331, fixed=true)=c1.v "Result: c1.v";
+  SI.Voltage v2(start=+0.744123, fixed=true)=c2.v "Result: c2.v";
+  Modelica.Electrical.Analog.Basic.Inductor inductor(i(fixed=true, start=0), L=18e-3)
+    annotation (Placement(transformation(
+        origin={-70,20},
+        extent={{-20,-20},{20,20}},
         rotation=270)));
-  Modelica.Electrical.Analog.Basic.Resistor Ro(R=12.5e-3) annotation (Placement(transformation(
-        origin={-75,-17},
-        extent={{-25,-25},{25,25}},
+  Modelica.Electrical.Analog.Basic.Resistor rL(R=14) annotation (Placement(transformation(
+        origin={-70,-40},
+        extent={{-20,-20},{20,20}},
         rotation=270)));
-  Modelica.Electrical.Analog.Basic.Conductor G(G=0.565) annotation (Placement(transformation(extent={{-25,38},
-            {25,88}})));
-  Modelica.Electrical.Analog.Basic.Capacitor C1(C=10, v(start=4, fixed=true)) annotation (Placement(transformation(
-        origin={25,3},
-        extent={{-25,-25},{25,25}},
+  Modelica.Electrical.Analog.Basic.Resistor resistor(R=R)    annotation (
+      Placement(transformation(
+        extent={{-20,-20},{20,20}},
+        rotation=0,
+        origin={0,40})));
+  Modelica.Electrical.Analog.Basic.Capacitor c1(C=10e-9)
+    annotation (Placement(transformation(
+        origin={20,-10},
+        extent={{-20,-20},{20,20}},
         rotation=270)));
-  Modelica.Electrical.Analog.Basic.Capacitor C2(C=100, v(start=0, fixed=true)) annotation (Placement(transformation(
-        origin={-25,3},
-        extent={{-25,-25},{25,25}},
+  Modelica.Electrical.Analog.Basic.Capacitor c2(C=100e-9)
+    annotation (Placement(transformation(
+        origin={-20,-10},
+        extent={{-20,-20},{20,20}},
         rotation=270)));
-  Modelica.Electrical.Analog.Examples.Utilities.NonlinearResistor Nr(
-    Ga(min=-1) = -0.757576,
-    Gb(min=-1) = -0.409091,
-    Ve=1) annotation (Placement(transformation(
-        origin={75,3},
-        extent={{-25,-25},{25,25}},
+  Modelica.Electrical.Analog.Examples.Utilities.NonlinearResistor chuasDiode(
+    Ga(min=-1) = -757.7576e-6,
+    Gb(min=-1) = -409.0909e-6,
+    Ve=1)     annotation (Placement(transformation(
+        origin={70,-10},
+        extent={{-20,-20},{20,20}},
         rotation=270)));
-  Modelica.Electrical.Analog.Basic.Ground Gnd annotation (Placement(transformation(extent={{-25,-112},{25,
-            -62}})));
+  Modelica.Electrical.Analog.Basic.Ground Gnd annotation (Placement(transformation(extent={{-20,
+            -100},{20,-60}})));
 equation
-  connect(L.n, Ro.p) annotation (Line(points={{-75,13},{-75,8}}));
-  connect(C2.p, G.p) annotation (Line(
-      points={{-25,28},{-25,45.5},{-25,45.5},{-25,63}}, color={0,0,255}));
-  connect(L.p, G.p) annotation (Line(
-      points={{-75,63},{-25,63}}, color={0,0,255}));
-  connect(G.n, Nr.p) annotation (Line(
-      points={{25,63},{75,63},{75,28}}, color={0,0,255}));
-  connect(C1.p, G.n) annotation (Line(
-      points={{25,28},{25,45.5},{25,45.5},{25,63}}, color={0,0,255}));
-  connect(Ro.n, Gnd.p) annotation (Line(
-      points={{-75,-42},{-75,-62},{0,-62}}, color={0,0,255}));
-  connect(C2.n, Gnd.p) annotation (Line(
-      points={{-25,-22},{-24,-22},{-24,-62},{0,-62}}, color={0,0,255}));
-  connect(Gnd.p, C1.n) annotation (Line(
-      points={{0,-62},{25,-62},{25,-22}}, color={0,0,255}));
-  connect(Gnd.p, Nr.n) annotation (Line(
-      points={{0,-62},{75,-62},{75,-22}}, color={0,0,255}));
+  connect(inductor.n, rL.p) annotation (Line(points={{-70,0},{-70,-20}}));
+  connect(c2.p, resistor.p)
+    annotation (Line(points={{-20,10},{-20,40}}, color={0,0,255}));
+  connect(inductor.p, resistor.p)
+    annotation (Line(points={{-70,40},{-20,40}}, color={0,0,255}));
+  connect(resistor.n, chuasDiode.p)
+    annotation (Line(points={{20,40},{70,40},{70,10}}, color={0,0,255}));
+  connect(c1.p, resistor.n)
+    annotation (Line(points={{20,10},{20,40}}, color={0,0,255}));
+  connect(rL.n, Gnd.p) annotation (Line(
+      points={{-70,-60},{0,-60}},           color={0,0,255}));
+  connect(c2.n, Gnd.p) annotation (Line(
+      points={{-20,-30},{-20,-60},{0,-60}},           color={0,0,255}));
+  connect(Gnd.p,c1. n) annotation (Line(
+      points={{0,-60},{20,-60},{20,-30}}, color={0,0,255}));
+  connect(Gnd.p, chuasDiode.n)
+    annotation (Line(points={{0,-60},{70,-60},{70,-30}}, color={0,0,255}));
   annotation (
+    experiment(
+      StopTime=0.1,
+      Interval=1e-06,
+      Tolerance=1e-06),
+    Diagram(coordinateSystem(preserveAspectRatio=true,  extent={{-100,-100},{
+            100,100}}), graphics={Text(
+          extent={{-100,90},{100,60}},
+          textColor={0,0,255},
+          textString="Path to chaos: R = 
+{1850, 1800, 1750} Ohm
+Plot v2 vs. v1")}),
     Documentation(info="<html>
-<p>Chua&#39;s circuit is the most simple nonlinear circuit which shows chaotic behaviour. The circuit consists of linear basic elements (capacitors, resistor, conductor, inductor), and one nonlinear element, which is called Chua&#39;s diode. The chaotic behaviour is simulated.</p>
-<p>The simulation end time should be set to 5e4. To get the chaotic behaviour please plot C1.v. Choose C2.v as the independent variable .</p>
+<p>This is a remake of the original implementation using realistic parameters for the components.</p>
+<p>Chua&#39;s circuit is the most simple nonlinear circuit which shows chaotic behaviour. The circuit consists of linear basic elements (capacitors, resistor, conductor, inductor), and one nonlinear element, which is called Chua&#39;s diode. </p>
+<p>It is possible to implement the nonlinear Chua&#39;s diode with two circuits called <a href=\"modelica://Modelica.Electrical.Analog.Examples.ChuaDiode\">NIC</a> 
+(negative impedance converter) using each an operational amplifier.</p>
+<p>
+The default paremeterization shows periodic behaviour at least after initial transients have vanished.<br>
+In the periodic region two attractors exist: Try initialization for v1 and v2 with exact negative values.<br>
+To investigate the path to chaos set (one after the other) R = {1900, 1850, 1800, 1750} Ohm and plot v2 vs. v1 as independent variable.<br>
+</p>
 <p><strong>Reference:</strong></p>
-<p>Kennedy, M.P.: Three Steps to Chaos - Part I: Evolution. IEEE Transactions on CAS I 40 (1993)10, 640-656</p>
+<ul>
+<li>Leon O. Chua, Chai Wah Wu, Anshan Huang and Guo-Qun Zhong: 
+    A Universal Circuit for Studying and Generating Chaos - Part I: Routes to Chaos. 
+    IEEE Transactions on Circuits and Systems, Vol. 40 (1993) 10, 732-744</li>
+<li>Michael Peter Kennedy: 
+    Three Steps to Chaos - Part I: Evolution. 
+    IEEE Transactions on Circuits and Systems, Vol. 40 (1993)10, 640-656</li>
+<li>Guo-Qun Zhong and F. Ayrom: 
+    Periodicity and Chaos in Chua&#39;s Circuit. 
+    IEEE Transactions on Circuits and Systems, Vol. 32 (1985) 5, 501-503</li>
+</ul>
 </html>",
    revisions="<html>
 <dl>
@@ -60,7 +96,7 @@ equation
 <strong>Main Authors:</strong>
 </dt>
 <dd>
-Christoph Clau&szlig;
+    Christoph Clau&szlig;
     &lt;<a href=\"mailto:christoph@clauss-it.com\">christoph@clauss-it.com</a>&gt;<br>
     Andr&eacute; Schneider
     &lt;<a href=\"mailto:Andre.Schneider@eas.iis.fraunhofer.de\">Andre.Schneider@eas.iis.fraunhofer.de</a>&gt;<br>
@@ -69,9 +105,15 @@ Christoph Clau&szlig;
     Zeunerstra&szlig;e 38<br>
     D-01069 Dresden<br>
 </dd>
+<dt>
+<strong>Revision 2025:</strong>
+</dt>
+<dd>
+    Prof. Anton Haumer
+    &lt;<a href=\"mailto:anton.haumer@oth-regensburg.de\">anton.haumer@oth-regensburg.de</a>&gt;<br>
+    Estbavarian Technical University of Applied Sciences Regensburg<br>
+    D-93053 Regensburg, Germany<br>
+</dd>
 </dl>
-</html>"),
-    experiment(StopTime=5e4, Interval=1),
-    Diagram(coordinateSystem(preserveAspectRatio=true,  extent={{-100,-100},{
-            100,100}})));
+</html>"));
 end ChuaCircuit;

--- a/Modelica/Electrical/Analog/Examples/ChuaDiode.mo
+++ b/Modelica/Electrical/Analog/Examples/ChuaDiode.mo
@@ -1,0 +1,131 @@
+within Modelica.Electrical.Analog.Examples;
+model ChuaDiode "Demonstrate Chuas Diode"
+  extends Modelica.Icons.Example;
+  parameter SI.Voltage Vs=7.66667 "Supply voltage";
+  //NIC1+2
+  parameter SI.Resistance R1=220 "Pos. and neg. feedback resistance of NIC1";
+  parameter SI.Resistance Rg1=2200 "Resistance to ground of NIC1";
+  parameter SI.Resistance R2=22000 "Pos. and neg. feedback resistance of NIC2";
+  parameter SI.Resistance Rg2=3300 "Resistance to ground of NIC2";
+  //Results for NIC1+2
+  parameter SI.Voltage VLim1=Vs*Rg1/(Rg1 + R1) "NIC1: Left and right corner voltage";
+  parameter SI.Conductance gPos1=1/R1 "NIC1: Positive differential conductance";
+  parameter SI.Conductance gNeg1=-1/Rg1 "NIC1: Negative (inner) conductance";
+  parameter SI.Voltage VLim2=Vs*Rg2/(Rg2 + R2) "NIC2: Left and right corner voltage";
+  parameter SI.Conductance gPos2=1/R2 "NIC2: Positive differential conductance";
+  parameter SI.Conductance gNeg2=-1/Rg2 "NIC2: Negative (inner) conductance";
+  //Results for Chuas Diode
+  parameter SI.Conductance Ga=gNeg1 + gNeg2 "CHUA: Inner slope";
+  parameter SI.Voltage Ve=min(VLim1, VLim2) "CHUA: Inner limit";
+  parameter SI.Conductance Gb=if VLim1<VLim2 then gPos1 + gNeg2 else gNeg1 + gPos2
+    "CHUA: Intermediate slope";
+  parameter SI.Voltage Vp=max(VLim1, VLim2) "CHUA: Outer limit";
+  parameter SI.Conductance Gc=gPos1 + gPos2 "CHUA: Outer slope";
+  Modelica.Electrical.Analog.Basic.Resistor rPos1(R=R1) annotation (Placement(
+        transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=0,
+        origin={-70,40})));
+  Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited
+                       opAmp1(Vps=+Vs, Vns=-Vs) annotation (Placement(
+        transformation(
+        extent={{10,10},{-10,-10}},
+        rotation=0,
+        origin={-70,10})));
+  Modelica.Electrical.Analog.Basic.Resistor rNeg1(R=R1) annotation (Placement(
+        transformation(extent={{-80,-10},{-60,-30}}, rotation=0)));
+  Modelica.Electrical.Analog.Basic.Resistor rg1(R=Rg1, i(start=0))
+                                                       annotation (Placement(
+        transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-60,-40})));
+  Modelica.Electrical.Analog.Basic.Resistor rPos2(R=R2) annotation (Placement(
+        transformation(
+        extent={{10,-10},{-10,10}},
+        rotation=0,
+        origin={-30,40})));
+  Modelica.Electrical.Analog.Ideal.ImprovedOpAmpLimited
+                       opAmp2(Vps=+Vs, Vns=-Vs) annotation (Placement(
+        transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=0,
+        origin={-30,10})));
+  Modelica.Electrical.Analog.Basic.Resistor rNeg2(R=R2) annotation (Placement(
+        transformation(extent={{-20,-10},{-40,-30}}, rotation=0)));
+  Modelica.Electrical.Analog.Basic.Resistor rg2(R=Rg2, i(start=0))
+                                                       annotation (Placement(
+        transformation(
+        extent={{-10,10},{10,-10}},
+        rotation=270,
+        origin={-40,-40})));
+  Modelica.Electrical.Analog.Basic.Ground ground
+    annotation (Placement(transformation(extent={{-10,-80},{10,-60}})));
+  Modelica.Electrical.Analog.Sources.SineVoltage source(V=8,    f=10)
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}}, rotation=270)));
+  Modelica.Electrical.Analog.Sensors.CurrentSensor currentSensorA
+    annotation (Placement(transformation(extent={{-20,70},{-40,50}})));
+  Modelica.Electrical.Analog.Sensors.CurrentSensor currentSensorB
+    annotation (Placement(transformation(extent={{20,70},{40,50}})));
+  Modelica.Electrical.Analog.Examples.Utilities.NonlinearResistor chuasDiode(
+    Ga(min=-1) = Ga,
+    Gb(min=-1) = Gb,
+    Ve=Ve)    annotation (Placement(transformation(
+        origin={50,0},
+        extent={{-10,-10},{10,10}},
+        rotation=270)));
+equation
+  connect(opAmp1.in_n, rNeg1.n)
+    annotation (Line(points={{-60,4},{-60,-20}},  color={0,0,255}));
+  connect(opAmp1.out, rNeg1.p)
+    annotation (Line(points={{-80,10},{-80,-20}},color={0,0,255}));
+  connect(opAmp1.out, rPos1.p)
+    annotation (Line(points={{-80,10},{-80,40}},color={0,0,255}));
+  connect(opAmp1.in_p, rPos1.n)
+    annotation (Line(points={{-60,16},{-60,40}},color={0,0,255}));
+  connect(rNeg1.n, rg1.p)
+    annotation (Line(points={{-60,-20},{-60,-30}}, color={0,0,255}));
+  connect(opAmp2.out, rNeg2.p)
+    annotation (Line(points={{-20,10},{-20,-20}},color={0,0,255}));
+  connect(opAmp2.in_n, rNeg2.n)
+    annotation (Line(points={{-40,4},{-40,-20}},  color={0,0,255}));
+  connect(rPos2.n, opAmp2.in_p)
+    annotation (Line(points={{-40,40},{-40,16}},color={0,0,255}));
+  connect(rNeg2.n, rg2.p)
+    annotation (Line(points={{-40,-20},{-40,-30}}, color={0,0,255}));
+  connect(rPos2.p, opAmp2.out)
+    annotation (Line(points={{-20,40},{-20,10}},color={0,0,255}));
+  connect(source.n, ground.p)
+    annotation (Line(points={{0,-10},{0,-60}}, color={0,0,255}));
+  connect(rg1.n, ground.p)
+    annotation (Line(points={{-60,-50},{-50,-50},{-50,-60},{0,-60}},
+                                                           color={0,0,255}));
+  connect(ground.p, rg2.n)
+    annotation (Line(points={{0,-60},{-50,-60},{-50,-50},{-40,-50}},
+                                                           color={0,0,255}));
+  connect(currentSensorA.p, source.p)
+    annotation (Line(points={{-20,60},{0,60},{0,10}}, color={0,0,255}));
+  connect(currentSensorA.n, rPos2.n) annotation (Line(points={{-40,60},{-50,60},
+          {-50,40},{-40,40}},          color={0,0,255}));
+  connect(rPos1.n, rPos2.n) annotation (Line(points={{-60,40},{-40,40}},
+                     color={0,0,255}));
+  connect(source.p, currentSensorB.p)
+    annotation (Line(points={{0,10},{0,60},{20,60}}, color={0,0,255}));
+  connect(currentSensorB.n, chuasDiode.p)
+    annotation (Line(points={{40,60},{50,60},{50,10}}, color={0,0,255}));
+  connect(ground.p, chuasDiode.n)
+    annotation (Line(points={{0,-60},{50,-60},{50,-10}}, color={0,0,255}));
+  annotation (experiment(
+      StopTime=1.0,
+      Interval=0.001,
+      Tolerance=1e-06), Documentation(info="<html>
+<p>
+This example demonstrates how <a href=\"modelica://Modelica.Electrical.Analog.Examples.ChuaCircuit\">Chua&#39;s diode</a> can be implemented two OpAmp-circuits called NIC
+(negative impedance converter) using each an operational amplifier. The relations between the parameters of the OpAmp-circuit and the 
+ideal <a href=\"modelica://Modelica.Electrical.Analog.Examples.Utilities.NonlinearResistor\">nonlinear resistor</a> can be seen from the parameter calculations in the text layer.
+</p>
+<p>Plot <code>currentSensorA.i</code> and <code>currentSensorB.i</code> versus <code>source.v</code> to inspect the characteristic.</p>
+<p><strong>Note:</strong><br>
+The implementation using 2 NICs shows an outer positive slope which is not present in the ideal nonlinear resistor.</p>
+</html>"));
+end ChuaDiode;

--- a/Modelica/Electrical/Analog/Examples/package.order
+++ b/Modelica/Electrical/Analog/Examples/package.order
@@ -4,6 +4,7 @@ CauerLowPassSC
 CharacteristicIdealDiodes
 CharacteristicThyristors
 ChuaCircuit
+ChuaDiode
 DifferenceAmplifier
 HeatingMOSInverter
 HeatingNPN_NORGate

--- a/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/ChuaCircuit/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/ChuaCircuit/comparisonSignals.txt
@@ -1,4 +1,4 @@
 time
-C1.v
-C2.v
-L.i
+v1
+v2
+inductor.i

--- a/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/ChuaDiode/comparisonSignals.txt
+++ b/Modelica/Resources/Reference/Modelica/Electrical/Analog/Examples/ChuaDiode/comparisonSignals.txt
@@ -1,0 +1,3 @@
+time
+currentSensorA.i
+currentSensorB.i


### PR DESCRIPTION
I wanted to redesign the parameterization of Chua's Circuit to realistic values (mH instead of H, nF instead of F) and explain how the nonlinear resistor called Chua's diode can be implemented using two OpAmp circuits called negative impedance converter.
With Chua's circuit you may see that changing initialization switches between two attractors.
Furthermore, changing a resistance you may see the path to chaos. 
Before we start a discussion about perodicity and chaos: Please have a look at the references. 
Default parameterization delivers periodic results. 
Results obtained with Dymola, Open Modelica and Wolfram System Modeler are (nearly) the same:
![ChuaCircuitv1](https://github.com/user-attachments/assets/8a89d6a3-2ed9-4c5d-8cf4-98ac9ddd8c52)
![ChuaCircuitv2](https://github.com/user-attachments/assets/f4705944-fb44-440e-bdf3-ca48ba514b94)
