### PR TITLE
Updated Version 4.1.0 release date for the record in ReleaseNotes.mo

### DIFF
--- a/Modelica/UsersGuide/ReleaseNotes.mo
+++ b/Modelica/UsersGuide/ReleaseNotes.mo
@@ -126,7 +126,7 @@ more of the following changes.
 </html>"));
 end VersionManagement;
 
-class Version_4_1_0 "Version 4.1.0 (April 17, 2025)"
+class Version_4_1_0 "Version 4.1.0 (May 23, 2025)"
   extends Modelica.Icons.ReleaseNotes;
 
   annotation (Documentation(info="<html>


### PR DESCRIPTION
Updated release date for 4.1.0 in the Release Notes record on master. No need to update the other dates, which will have to be changed anyway when releasing either 4.1.1 or 4.2.0.