### PR TITLE
Document how UnitDelay currently works.

### DIFF
--- a/Modelica/Blocks/Discrete.mo
+++ b/Modelica/Blocks/Discrete.mo
@@ -131,8 +131,11 @@ y = --- * u
 </pre></blockquote>
 <p>
 that is, the output signal y is the input signal u of the
-previous sample instant. Before the second sample instant,
+previous sample instant. Before the first sample instant,
 the output y is identical to parameter yStart.
+
+<strong>The block assumes that the input is sampled.</strong>
+If the input is continuous it will only sample and not create a delay.
 </p>
 
 </html>"), Icon(


### PR DESCRIPTION
The current description of UnitDelay has two issues:
- It is plain wrong regarding "second"
- It doesn't document the strong restriction that UnitDelay only works for sampled inputs, this is also the issue in #4451

An alternative is to just correct the model as described in #4451; the downside is that it is not backwards compatible and it introduces additional states.


