### PR TITLE
CMake: Set GCC version specific subfolder for MinGW

### DIFF
--- a/Modelica/Resources/BuildProjects/CMake/Modelica_platform.cmake
+++ b/Modelica/Resources/BuildProjects/CMake/Modelica_platform.cmake
@@ -79,15 +79,8 @@ function(get_modelica_platform_name_with_compiler_version var)
     elseif(MSVC_VERSION GREATER_EQUAL 1950 AND MSVC_VERSION LESS 1960)
       set(PLATFORM_PATH_SUFFIX "${PLATFORM_PATH_SUFFIX}/vs2026")
     elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-      execute_process(
-        COMMAND ${CMAKE_C_COMPILER} -dumpversion
-        OUTPUT_VARIABLE GCC_VERSION
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-      )
-      if(GCC_VERSION)
-        string(REPLACE "." "" GCC_VERSION_NO_DOTS "${GCC_VERSION}")
-        set(PLATFORM_PATH_SUFFIX "${PLATFORM_PATH_SUFFIX}/gcc${GCC_VERSION_NO_DOTS}")
-      endif()
+      string(REPLACE "." "" GCC_VERSION_NO_DOTS "${CMAKE_C_COMPILER_VERSION}")
+      set(PLATFORM_PATH_SUFFIX "${PLATFORM_PATH_SUFFIX}/gcc${GCC_VERSION_NO_DOTS}")
     endif()
   endif()
 


### PR DESCRIPTION
GCC x.y.z will create a subfolder gccxyz.