### PR TITLE
Add starting point for figures in Electrical Machines, PowerConvertes, QuasiStatic

### DIFF
--- a/Modelica/Electrical/Machines/Examples/DCMachines/DCEE_Start.mo
+++ b/Modelica/Electrical/Machines/Examples/DCMachines/DCEE_Start.mo
@@ -104,5 +104,29 @@ Simulate for 2 seconds and plot (versus time):
 <li>dcee.ie: excitation current</li>
 </ul>
 Default machine parameters of model <em>DC_ElectricalExcited</em> are used.
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "89773",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = dcee.ia, legend = "Armature current"),
+                Curve(y = dcee.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = dcee.tauElectrical, legend = "Motor torque")
+              },
+              x = Axis(min = 0, max = 1.2)
+            ),
+            Plot(
+              curves = {
+                Curve(y = dcee.ie, legend = "Field excitation current")
+              },
+              x = Axis(min = 0, max = 1.2)
+            )
+          }
+        )
+      }
+    ));
 end DCEE_Start;

--- a/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Cooling.mo
+++ b/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Cooling.mo
@@ -196,5 +196,22 @@ Default machine parameters are used, but:
 <li>Armature reference temperature is set to 80 degC.</li>
 <li>Nominal armature temperature is set to 80 degC.</li>
 </ul>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Temperatures",
+          identifier = "01776",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = armature.T, legend = "Armature temperature"),
+                Curve(y = core.T, legend = "Core temperature"),
+                Curve(y = cooling.T, legend = "Cooling temperature")
+              }
+            )
+          }
+        )
+      }
+    ));
 end DCPM_Cooling;

--- a/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_QuasiStatic.mo
+++ b/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_QuasiStatic.mo
@@ -112,5 +112,29 @@ Simulate for 2 seconds and plot (versus time):
 <li>dcpm2.wMechanical: motor's speed of quasi-static model</li>
 <li>dcpm2.tauElectrical: motor's torque of quasi-static model</li>
 </ul>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "bbe59",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = dcpm1.ia, legend = "Armature current of transient model"),
+                Curve(y = dcpm1.wMechanical, legend = "Motor angular velocity of rotor against stator of transient model"),
+                Curve(y = dcpm1.tauElectrical, legend = "Motor torque of transient model")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = dcpm2.ia, legend = "Armature current of quasistatic model"),
+                Curve(y = dcpm2.wMechanical, legend = "Motor angular velocity of rotor against stator of quasistatic model"),
+                Curve(y = dcpm2.tauElectrical, legend = "Motor torque of quasistatic model")
+              }
+            )
+          }
+        )
+      }
+    ));
 end DCPM_QuasiStatic;

--- a/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Start.mo
+++ b/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Start.mo
@@ -78,5 +78,22 @@ Simulate for 2 seconds and plot (versus time):
 <li>dcpm.tauElectrical: motor's torque</li>
 </ul>
 Default machine parameters of model <em>DC_PermanentMagnet</em> are used.
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "9246c",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = dcpm.ia, legend = "Armature current"),
+                Curve(y = dcpm.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = dcpm.tauElectrical, legend = "Motor torque")
+              }
+            )
+          }
+        )
+      }
+    ));
 end DCPM_Start;

--- a/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Temperature.mo
+++ b/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_Temperature.mo
@@ -106,5 +106,22 @@ Default machine parameters are used, but:
 </ul>
 So the machine is at the beginning in cold condition, ending in warm condition
 (with the same armature resistance as the unmodified machine).
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "e423c",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = dcpm.ia, legend = "Armature current"),
+                Curve(y = dcpm.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = dcpm.tauElectrical, legend = "Motor torque")
+              }
+            )
+          }
+        )
+      }
+    ));
 end DCPM_Temperature;

--- a/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_withLosses.mo
+++ b/Modelica/Electrical/Machines/Examples/DCMachines/DCPM_withLosses.mo
@@ -160,5 +160,25 @@ Anton Haumer, Christian Kral, Hansj&ouml;rg Kapeller, Thomas B&auml;uml, Johanne
 <a href=\"https://2009.international.conference.modelica.org/proceedings/pages/papers/0103/0103_FI.pdf\">
 The AdvancedMachines Library: Loss Models for Electric Machines</a><br>
 Modelica 2009, 7<sup>th</sup> International Modelica Conference
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "0c174",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = dcpm1.ia, legend = "Armature current of dcpm1"),
+                Curve(y = dcpm2.ia, legend = "Armature current of dcpm2"),
+                Curve(y = dcpm1.wMechanical, legend = "Motor angular velocity of rotor against stator of dcpm1"),
+                Curve(y = dcpm2.wMechanical, legend = "Motor angular velocity of rotor against stator of dcpm2"),
+                Curve(y = dcpm1.tauElectrical, legend = "Motor torque of dcpm1"),
+                Curve(y = dcpm2.tauElectrical, legend = "Motor torque of dcpm2")
+              }
+            )
+          }
+        )
+      }
+    ));
 end DCPM_withLosses;

--- a/Modelica/Electrical/Machines/Examples/DCMachines/DCSE_SinglePhase.mo
+++ b/Modelica/Electrical/Machines/Examples/DCMachines/DCSE_SinglePhase.mo
@@ -99,5 +99,22 @@ Default machine parameters of model <em>DC_SeriesExcited</em> are used.<br>
 <strong>Note:</strong><br>
 Since both the field and the armature current are sinusoidal, the waveform of the torque is the square of sine.
 Due to the additional inductive voltage drops, output of the motor is lower, compared to the same motor (DCSE_Start) at DC voltage.
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "04168",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = dcse.ia, legend = "Armature current"),
+                Curve(y = dcse.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = dcse.tauElectrical, legend = "Motor torque")
+              }
+            )
+          }
+        )
+      }
+    ));
 end DCSE_SinglePhase;

--- a/Modelica/Electrical/Machines/Examples/DCMachines/DCSE_Start.mo
+++ b/Modelica/Electrical/Machines/Examples/DCMachines/DCSE_Start.mo
@@ -95,5 +95,22 @@ Simulate for 2 seconds and plot (versus time):
 <li>dcse.tauElectrical: motor's torque</li>
 </ul>
 Default machine parameters of model <em>DC_SeriesExcited</em> are used.
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "e556f",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = dcse.ia, legend = "Armature current"),
+                Curve(y = dcse.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = dcse.tauElectrical, legend = "Motor torque")
+              }
+            )
+          }
+        )
+      }
+    ));
 end DCSE_Start;

--- a/Modelica/Electrical/Machines/Examples/InductionMachines/IMC_Conveyor.mo
+++ b/Modelica/Electrical/Machines/Examples/InductionMachines/IMC_Conveyor.mo
@@ -122,5 +122,22 @@ The mechanical load is a constant torque like a conveyor (with regularization ar
 </ul>
 
 <p>Default machine parameters are used.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "695b3",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentQuasiRMSSensor.I, legend = "Stator current RMS"),
+                Curve(y = aimc.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = aimc.tauElectrical, legend = "Motor torque")
+              }
+            )
+          }
+        )
+      }
+    ));
 end IMC_Conveyor;

--- a/Modelica/Electrical/Machines/Examples/InductionMachines/IMC_DOL.mo
+++ b/Modelica/Electrical/Machines/Examples/InductionMachines/IMC_DOL.mo
@@ -116,5 +116,22 @@ finally reaching nominal speed.</p>
 <li>aimc.tauElectrical: motor's torque</li>
 </ul>
 <p>Default machine parameters are used.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "36dc2",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentQuasiRMSSensor.I, legend = "Stator current RMS"),
+                Curve(y = aimc.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = aimc.tauElectrical, legend = "Motor torque")
+              }
+            )
+          }
+        )
+      }
+    ));
 end IMC_DOL;

--- a/Modelica/Electrical/Machines/Examples/InductionMachines/IMC_Inverter.mo
+++ b/Modelica/Electrical/Machines/Examples/InductionMachines/IMC_Inverter.mo
@@ -118,5 +118,22 @@ and accelerating inertias.<br>At time tStep a load step is applied.</p>
 </ul>
 
 <p>Default machine parameters are used.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "c51c3",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentQuasiRMSSensor.I, legend = "Stator current RMS"),
+                Curve(y = aimc.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = aimc.tauElectrical, legend = "Motor torque")
+              }
+            )
+          }
+        )
+      }
+    ));
 end IMC_Inverter;

--- a/Modelica/Electrical/Machines/Examples/InductionMachines/IMC_Transformer.mo
+++ b/Modelica/Electrical/Machines/Examples/InductionMachines/IMC_Transformer.mo
@@ -190,5 +190,22 @@ at start time tStart2 the machine is fed directly from the voltage source, final
 </ul>
 
 <p>Default machine parameters are used.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "8efd2",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentQuasiRMSSensor.I, legend = "Stator current RMS"),
+                Curve(y = aimc.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = aimc.tauElectrical, legend = "Motor torque")
+              }
+            )
+          }
+        )
+      }
+    ));
 end IMC_Transformer;

--- a/Modelica/Electrical/Machines/Examples/InductionMachines/IMC_YD.mo
+++ b/Modelica/Electrical/Machines/Examples/InductionMachines/IMC_YD.mo
@@ -122,5 +122,22 @@ load torque quadratic dependent on speed, finally reaching nominal speed.</p>
 </ul>
 
 <p>Default machine parameters are used.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "9f2b3",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentQuasiRMSSensor.I, legend = "Stator current RMS"),
+                Curve(y = aimc.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = aimc.tauElectrical, legend = "Motor torque")
+              }
+            )
+          }
+        )
+      }
+    ));
 end IMC_YD;

--- a/Modelica/Electrical/Machines/Examples/InductionMachines/IMC_withLosses.mo
+++ b/Modelica/Electrical/Machines/Examples/InductionMachines/IMC_withLosses.mo
@@ -245,7 +245,59 @@ Anton Haumer, Christian Kral, Hansj&ouml;rg Kapeller, Thomas B&auml;uml, Johanne
 <a href=\"https://2009.international.conference.modelica.org/proceedings/pages/papers/0103/0103_FI.pdf\">
 The AdvancedMachines Library: Loss Models for Electric Machines</a><br>
 Modelica 2009, 7<sup>th</sup> International Modelica Conference</p>
-</html>"),
+</html>",
+      figures = {
+        Figure(
+          title = "Current",
+          identifier = "a1d88",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = Pmech, y = I_sim, legend = "Simulated current vs. Mechanical losses"),
+                Curve(x = Pmech, y = I_meas, legend = "Measured current vs. Mechanical losses")
+              }
+            )
+          }
+        ),
+        Figure(
+          title = "Speed",
+          identifier = "996d3",
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = Pmech, y = w_sim, legend = "Simulated angular velocity vs. Mechanical losses"),
+                Curve(x = Pmech, y = w_meas, legend = "Measured angular velocity vs. Mechanical losses")
+              }
+            )
+          }
+        ),
+        Figure(
+          title = "Power factor",
+          identifier = "2104a",
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = Pmech, y = pf_sim, legend = "Simulated power factor vs. Mechanical losses"),
+                Curve(x = Pmech, y = pf_meas, legend = "Measured power factor vs. Mechanical losses")
+              }
+            )
+          }
+        ),
+        Figure(
+          title = "Efficiency",
+          identifier = "9e6d4",
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = Pmech, y = eff_sim, legend = "Simulated efficiency vs. Mechanical losses"),
+                Curve(x = Pmech, y = eff_meas, legend = "Measured efficiency vs. Mechanical losses")
+              }
+            )
+          }
+        )
+      }
+    ),
     Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
             {100,100}}), graphics={Text(
                 extent={{-72,100},{68,80}},

--- a/Modelica/Electrical/Machines/Examples/InductionMachines/IMS_Start.mo
+++ b/Modelica/Electrical/Machines/Examples/InductionMachines/IMS_Start.mo
@@ -135,5 +135,22 @@ using a starting resistance. At time tStart2 external rotor resistance is shorte
 </ul>
 
 <p>Default machine parameters are used.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "d52d0",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentQuasiRMSSensor.I, legend = "Stator current RMS"),
+                Curve(y = aims.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = aims.tauElectrical, legend = "Motor torque")
+              }
+            )
+          }
+        )
+      }
+    ));
 end IMS_Start;

--- a/Modelica/Electrical/Machines/Examples/SynchronousMachines/SMEE_Generator.mo
+++ b/Modelica/Electrical/Machines/Examples/SynchronousMachines/SMEE_Generator.mo
@@ -173,5 +173,34 @@ rotor angle is very slowly increased. This allows to see several characteristics
 </ul>
 
 <p>Default machine parameters are used.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Power vs. rotor displacement angle",
+          identifier = "48c9a",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = rotorDisplacementAngle.rotorDisplacementAngle, y = electricalPowerSensor.P, legend = "Electric power sensor P vs. rotor displacement angle"),
+                Curve(x = rotorDisplacementAngle.rotorDisplacementAngle, y = electricalPowerSensor.Q, legend = "Electric power sensor Q vs. rotor displacement angle"),
+                Curve(x = rotorDisplacementAngle.rotorDisplacementAngle, y = mechanicalPowerSensor.P, legend = "Mechanical power sensor P vs. rotor displacement angle")
+              }
+            )
+          }
+        ),
+        Figure(
+          title = "Current and torque vs. rotor displacement angle",
+          identifier = "c3184",
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = rotorDisplacementAngle.rotorDisplacementAngle, y = smee.tauElectrical, legend = "Motor torque vs. rotor displacement angle"),
+                Curve(x = rotorDisplacementAngle.rotorDisplacementAngle, y = currentQuasiRMSSensor.I, legend = "Stator current RMS vs. rotor displacement angle")
+              }
+            )
+          }
+        )
+      }
+    ));
 end SMEE_Generator;

--- a/Modelica/Electrical/Machines/Examples/SynchronousMachines/SMEE_LoadDump.mo
+++ b/Modelica/Electrical/Machines/Examples/SynchronousMachines/SMEE_LoadDump.mo
@@ -237,5 +237,22 @@ Voltage is controlled, the set point depends on speed. After start-up the genera
 <p>Default machine parameters are used.</p>
 
 <p>One could try to optimize the controller parameters.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "6c1f4",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = voltageQuasiRMSSensor.V, legend = "Stator current RMS"),
+                Curve(y = smee.tauElectrical, legend = "Motor torque"),
+                Curve(y = smee.ie, legend = "Motor excitation current")
+              }
+            )
+          }
+        )
+      }
+    ));
 end SMEE_LoadDump;

--- a/Modelica/Electrical/Machines/Examples/SynchronousMachines/SMPM_Inverter.mo
+++ b/Modelica/Electrical/Machines/Examples/SynchronousMachines/SMPM_Inverter.mo
@@ -138,5 +138,27 @@ and accelerating inertias. At time tStep a load step is applied.</p>
 
 <p>
 In practice it is nearly impossible to drive a PMSMD without current controller.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "e5cc1",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentQuasiRMSSensor.I, legend = "Stator current RMS"),
+                Curve(y = smpm.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = smpm.tauElectrical, legend = "Motor torque")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = rotorDisplacementAngle.rotorDisplacementAngle, legend = "Rotor displacement angle")
+              }
+            )
+          }
+        )
+      }
+    ));
 end SMPM_Inverter;

--- a/Modelica/Electrical/Machines/Examples/SynchronousMachines/SMR_Inverter.mo
+++ b/Modelica/Electrical/Machines/Examples/SynchronousMachines/SMR_Inverter.mo
@@ -131,5 +131,27 @@ and accelerating inertias. At time tStep a load step is applied.</p>
 </ul>
 
 <p>Default machine parameters are used.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "ca13f",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentQuasiRMSSensor.I, legend = "Stator current RMS"),
+                Curve(y = smr.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = smr.tauElectrical, legend = "Motor torque")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = rotorDisplacementAngle.rotorDisplacementAngle, legend = "Rotor displacement angle")
+              }
+            )
+          }
+        )
+      }
+    ));
 end SMR_Inverter;

--- a/Modelica/Electrical/PowerConverters/Examples/ACDC/Rectifier1Pulse/Thyristor1Pulse_R.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/ACDC/Rectifier1Pulse/Thyristor1Pulse_R.mo
@@ -28,5 +28,27 @@ equation
     Documentation(info="<html>
 <p>This example demonstrates the operational behavior of a single-phase controlled rectifier with constant firing angle and resistive load.</p>
 <p>Plot current <code>currentSensor.i</code>, average current <code>meanCurrent.y</code>, voltage <code>voltageSensor.v</code> and average voltage <code>meanVoltage.v</code>.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltage and current",
+          identifier = "4d927",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentSensor.i, legend = "Measured current value"),
+                Curve(y = meanCurrent.y, legend = "Mean value of current")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = voltagesensor.v, legend = "Measured voltage value"),
+                Curve(y = meanVoltage.y, legend = "Mean value of voltage")
+              }
+            )
+          }
+        )
+      }
+    ));
 end Thyristor1Pulse_R;

--- a/Modelica/Electrical/PowerConverters/Examples/ACDC/Rectifier1Pulse/Thyristor1Pulse_R_Characteristic.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/ACDC/Rectifier1Pulse/Thyristor1Pulse_R_Characteristic.mo
@@ -31,5 +31,20 @@ equation
     Documentation(info="<html>
 <p>This example demonstrates the operational behavior of a single-phase controlled rectifier with variable firing angle and resistive load. The average load voltage can be controlled by means of the firing angle.</p>
 <p><br>Plot average voltage <code>meanVoltage.v</code> versus firingAngle <code>pulse2.firingAngle</code> to see control characteristic of this type of rectifier with resistive load.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Average voltage vs. firing angle",
+          identifier = "670e6",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = pulse2.firingAngle, y = meanVoltage.y, legend = "Average voltage vs. firing angle")
+              }
+            )
+          }
+        )
+      }
+    ));
 end Thyristor1Pulse_R_Characteristic;

--- a/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierBridge2Pulse/ThyristorBridge2Pulse_R.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierBridge2Pulse/ThyristorBridge2Pulse_R.mo
@@ -28,5 +28,27 @@ equation
 <a href=\"modelica://Modelica.Electrical.PowerConverters.Examples.ACDC.RectifierBridge2Pulse.HalfControlledBridge2Pulse\">half controlled bridge</a>.</p>
 
 <p>Plot current <code>currentSensor.i</code>, average current <code>meanCurrent.y</code>, voltage <code>voltageSensor.v</code> and average voltage <code>meanVoltage.v</code>.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltage and current",
+          identifier = "c1417",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentSensor.i, legend = "Measured current value"),
+                Curve(y = meanCurrent.y, legend = "Mean value of current")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = voltagesensor.v, legend = "Measured voltage value"),
+                Curve(y = meanVoltage.y, legend = "Mean value of voltage")
+              }
+            )
+          }
+        )
+      }
+    ));
 end ThyristorBridge2Pulse_R;

--- a/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierBridge2mPulse/ThyristorBridge2mPulse_R.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierBridge2mPulse/ThyristorBridge2mPulse_R.mo
@@ -28,5 +28,27 @@ equation
 <a href=\"modelica://Modelica.Electrical.PowerConverters.Examples.ACDC.RectifierBridge2mPulse.HalfControlledBridge2mPulse\">half controlled bridge</a>.</p>
 
 <p>Plot current <code>currentSensor.i</code>, average current <code>meanCurrent.y</code>, voltage <code>voltageSensor.v</code> and average voltage <code>meanVoltage.v</code>.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltage and current",
+          identifier = "391aa",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentSensor.i, legend = "Measured value of current"),
+                Curve(y = meanCurrent.y, legend = "Mean value of current")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = voltagesensor.v, legend = "Measured value of voltage"),
+                Curve(y = meanVoltage.y, legend = "Mean value of voltage")
+              }
+            )
+          }
+        )
+      }
+    ));
 end ThyristorBridge2mPulse_R;

--- a/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierCenterTap2Pulse/ThyristorCenterTap2Pulse_R.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierCenterTap2Pulse/ThyristorCenterTap2Pulse_R.mo
@@ -27,5 +27,27 @@ equation
 <p>This example shows a controlled center tap two pulse rectifier with resistive load.</p>
 
 <p>Plot current <code>currentSensor.i</code>, average current <code>meanCurrent.y</code>, voltage <code>voltageSensor.v</code> and average voltage <code>meanVoltage.v</code>.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltage and current",
+          identifier = "97a8e",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentSensor.i, legend = "Measured current value"),
+                Curve(y = meanCurrent.y, legend = "Mean value of current")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = voltagesensor.v, legend = "Measured voltage value"),
+                Curve(y = meanVoltage.y, legend = "Mean value of votlage")
+              }
+            )
+          }
+        )
+      }
+    ));
 end ThyristorCenterTap2Pulse_R;

--- a/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierCenterTap2mPulse/ThyristorCenterTap2mPulse_R.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierCenterTap2mPulse/ThyristorCenterTap2mPulse_R.mo
@@ -27,5 +27,27 @@ equation
 <p>This example shows a controlled <code>2*m</code> pulse center tap rectifier with resistive load, where <code>m</code> is the number of phases.</p>
 
 <p>Plot current <code>currentSensor.i</code>, average current <code>meanCurrent.y</code>, voltage <code>voltageSensor.v</code> and average voltage <code>meanVoltage.v</code>.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltage and current",
+          identifier = "940bc",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentSensor.i, legend = "Measured value of current"),
+                Curve(y = meanCurrent.y, legend = "Mean value of current")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = voltagesensor.v, legend = "Measured value of voltage"),
+                Curve(y = meanVoltage.y, legend = "Mean value of voltage")
+              }
+            )
+          }
+        )
+      }
+    ));
 end ThyristorCenterTap2mPulse_R;

--- a/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierCenterTapmPulse/ThyristorCenterTapmPulse_R.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/ACDC/RectifierCenterTapmPulse/ThyristorCenterTapmPulse_R.mo
@@ -27,5 +27,27 @@ equation
 <p>This example shows a controlled <code>m</code> pulse center tap rectifier with resistive load, where <code>m</code> is the number of phases.</p>
 
 <p>Plot current <code>currentSensor.i</code>, average current <code>meanCurrent.y</code>, voltage <code>voltageSensor.v</code> and average voltage <code>meanVoltage.v</code>.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltage and current",
+          identifier = "7ba5e",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentSensor.i, legend = "Measured current value"),
+                Curve(y = meanCurrent.y, legend = "Mean value of current")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = voltagesensor.v, legend = "Measured value of voltage"),
+                Curve(y = meanVoltage.y, legend = "Mean value of voltage")
+              }
+            )
+          }
+        )
+      }
+    ));
 end ThyristorCenterTapmPulse_R;

--- a/Modelica/Electrical/PowerConverters/Examples/DCAC/PolyphaseTwoLevel/PolyphaseTwoLevel_R.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCAC/PolyphaseTwoLevel/PolyphaseTwoLevel_R.mo
@@ -106,5 +106,27 @@ equation
       Interval=0.00002),
     Documentation(info="<html>
 <p>Plot current <code>currentSensor.i[:]</code>, harmonic current magnitude <code>fundamentalWaveCurrent[:].y_RMS</code>, harmonic voltage magnitude <code>fundamentalWaveVoltage[:].y_RMS</code>. The instantaneous voltages <code>voltageSensor.i[:]</code> and currents <code>currentSensor.i[:]</code> directly show the switching pattern of the inverter. There is not smoothing effect due to an inductance in this example; see <a href=\"modelica://Modelica.Electrical.PowerConverters.Examples.DCAC.PolyphaseTwoLevel.PolyphaseTwoLevel_RL\">PolyphaseTwoLevel_RL</a>.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltage and current",
+          identifier = "16d44",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentSensor.i[1], legend = "Measure value of current[1]"),
+                Curve(y = fundamentalWaveCurrent[1].y_rms, legend = "Root mean square of current[1] in fundamentalWaveCurrent[1]")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = voltageSensor.v[1], legend = "Measure value of voltage[1]"),
+                Curve(y = fundamentalWaveVoltage[1].y_rms, legend = "Root mean square of voltage in fundamentalWaveVoltage[1]")
+              }
+            )
+          }
+        )
+      }
+    ));
 end PolyphaseTwoLevel_R;

--- a/Modelica/Electrical/PowerConverters/Examples/DCAC/PolyphaseTwoLevel/PolyphaseTwoLevel_RL.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCAC/PolyphaseTwoLevel/PolyphaseTwoLevel_RL.mo
@@ -118,5 +118,27 @@ equation
       Interval=0.00002),
     Documentation(info="<html>
 <p>Plot current <code>currentSensor.i[:]</code>, harmonic current magnitude <code>fundamentalWaveCurrent[:].y_RMS</code>, harmonic voltage magnitude <code>fundamentalWaveVoltage[:].y_RMS</code>. The instantaneous voltages <code>voltageSensor.i[:]</code> directly show the switching pattern of the inverter.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltage and current",
+          identifier = "5144d",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentSensor.i[1], legend = "Measured value of current[1]"),
+                Curve(y = fundamentalWaveCurrent[1].y_rms, legend = "Root mean square of current[1] in fundamentalWaveCurrent[1]")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = voltageSensor.v[1], legend = "Measured value of voltage[1]"),
+                Curve(y = fundamentalWaveVoltage[1].y_rms, legend = "Root mean square of voltage in fundamentalWaveVoltage[1]")
+              }
+            )
+          }
+        )
+      }
+    ));
 end PolyphaseTwoLevel_RL;

--- a/Modelica/Electrical/PowerConverters/Examples/DCAC/SinglePhaseTwoLevel/SinglePhaseTwoLevel_R.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCAC/SinglePhaseTwoLevel/SinglePhaseTwoLevel_R.mo
@@ -26,5 +26,27 @@ equation
       Interval=0.0002),
     Documentation(info="<html>
 <p>Plot current <code>currentSensor.i</code>, average current <code>meanCurrent.y</code>, voltage <code>voltageSensor.v</code> and average voltage <code>meanVoltage.v</code>. The instantaneous voltage and current directly show the switch pattern of the inverter. The average voltage and average current reveal the fundamental wave of the voltage and current, each of them being basically in phase with the command <code>sine.y</code>.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltage and current",
+          identifier = "03aa4",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentSensor.i, legend = "Measured value of current"),
+                Curve(y = fundamentalWaveCurrent.y_rms, legend = "Root mean square of current in fundamentalWaveCurrent")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = voltageSensor.v, legend = "Measure value of voltage"),
+                Curve(y = fundamentalWaveVoltage.y_rms, legend = "Root mean square of voltage in fundamentalWaveVoltage")
+              }
+            )
+          }
+        )
+      }
+    ));
 end SinglePhaseTwoLevel_R;

--- a/Modelica/Electrical/PowerConverters/Examples/DCAC/SinglePhaseTwoLevel/SinglePhaseTwoLevel_RL.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCAC/SinglePhaseTwoLevel/SinglePhaseTwoLevel_RL.mo
@@ -34,5 +34,27 @@ equation
       Interval=0.0002),
     Documentation(info="<html>
 <p>Plot current <code>currentSensor.i</code>, average current <code>meanCurrent.y</code>, voltage <code>voltageSensor.v</code> and average voltage <code>meanVoltage.v</code>. The instantaneous voltage directly show the switch pattern of the inverter. The current shows a particular ripple determined by the input voltage and the switching frequency. The average voltage is basically in phase with the command <code>sine.y</code>. The average current has a phase shift due to the R-L load.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltage and current",
+          identifier = "3d04b",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentSensor.i, legend = "Measure value of current"),
+                Curve(y = fundamentalWaveCurrent.y_rms, legend = "Root mean square of current in fundamentalWaveCurrent")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = voltageSensor.v, legend = "Measure value of voltage"),
+                Curve(y = fundamentalWaveVoltage.y_rms, legend = "Root mean square of voltage in fundamentalWaveVoltage")
+              }
+            )
+          }
+        )
+      }
+    ));
 end SinglePhaseTwoLevel_RL;

--- a/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_DC_Drive.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_DC_Drive.mo
@@ -109,5 +109,28 @@ The DC output voltage is equal to <code>2 * (dutyCycle - 0.5)</code> times the i
 
 <p>
 Plot machine current <code>dcpm.ia</code>, averaged current <code>meanCurrent.y</code>, machine speed <code>dcpm.wMechanical</code>, averaged machine speed <code>dcpm.va</code> and torque <code>dcpm.tauElectrical</code>.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltage, current and machine variables",
+          identifier = "31ac3",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = dcpm.ia, legend = "Machine current"),
+                Curve(y = meanCurrent.y, legend = "Mean value of current"),
+                Curve(y = dcpm.tauElectrical, legend = "Machine torque")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = dcpm.va, legend = "Armature voltage in machine"),
+                Curve(y = dcpm.wMechanical, legend = "Machine speed")
+              }
+            )
+          }
+        )
+      }
+    ));
 end HBridge_DC_Drive;

--- a/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_R.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_R.mo
@@ -22,5 +22,27 @@ equation
 <p>This example demonstrates the switching on of a resistive load operated by an H bridge.
 DC output voltage is equal to <code>2 * (dutyCycle - 0.5)</code> times the input voltage.
 Plot current <code>currentSensor.i</code>, averaged current <code>meanCurrent.y</code>, total voltage <code>voltageSensor.v</code> and voltage <code>meanVoltage.v</code>.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltage and current",
+          identifier = "78018",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentSensor.i, legend = "Measured value of current"),
+                Curve(y = meanCurrent.y, legend = "Mean value of current")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = voltageSensor.v, legend = "Measured value of voltage"),
+                Curve(y = meanVoltage.y, legend = "Mean value of voltage")
+              }
+            )
+          }
+        )
+      }
+    ));
 end HBridge_R;

--- a/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_RL.mo
+++ b/Modelica/Electrical/PowerConverters/Examples/DCDC/HBridge/HBridge_RL.mo
@@ -26,7 +26,29 @@ equation
 <p>This example demonstrates the switching on of an R-L load operated by an H bridge.
 DC output voltage is equal to <code>2 * (dutyCycle - 0.5)</code> times the input voltage.
 Plot current <code>currentSensor.i</code>, averaged current <code>meanCurrent.y</code>, total voltage <code>voltageSensor.v</code> and voltage <code>meanVoltage.v</code>. The waveform the average current is determined by the time constant <code>L/R</code> of the load.</p>
-</html>"),
+</html>",
+      figures = {
+        Figure(
+          title = "Voltage and current",
+          identifier = "b15df",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentSensor.i, legend = "Measured value of current"),
+                Curve(y = meanCurrent.y, legend = "Mean value of current")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = voltageSensor.v, legend = "Measured value of voltage"),
+                Curve(y = meanVoltage.y, legend = "Mean value of voltage")
+              }
+            )
+          }
+        )
+      }
+    ),
     experiment(
       StopTime=0.1,
       Interval=0.0002,

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/ParallelResonance.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/ParallelResonance.mo
@@ -86,6 +86,22 @@ equation
 The frequency of the current source is varied by a ramp.
 Plot length and angle of the voltage phasor, i.e., complexToPolar.len and .phi, versus time resp. frequency.
 </p>
-</html>"),
+</html>",
+      figures = {
+        Figure(
+          title = "Phasor length and angle vs. frequency",
+          identifier = "2f33b",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = currentSource.f, y = complexToPolar.phi, legend = "Complex angle phi vs. frequency of currentSource"),
+                Curve(x = currentSource.f, y = complexToPolar.len, legend = "Complex length len vs. frequency of currentSource")
+              }
+            )
+          }
+        )
+      }
+    ),
        experiment(StopTime=1.0, Interval=0.001));
 end ParallelResonance;

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/Rectifier.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/Rectifier.mo
@@ -138,6 +138,30 @@ It can be seen that at the DC side the current is represented by its averaged va
 The quasi-static model needs a grounding at the QS side as well as the DC side,
 whereas the transient model may have only one ground since AC side and DC side are connected via the diodes.
 </p>
-</html>"),
+</html>",
+      figures = {
+        Figure(
+          title = "Rectifier values",
+          identifier = "f6602",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = iQS.len, legend = "AC rms current"),
+                Curve(y = iAC.u, legend = "AC instantaneous current"),
+                Curve(y = iAC.y_rms, legend = "AC rms current")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = iDC1.i, legend = "DC current"),
+                Curve(y = iDC2.u, legend = "DC instantaneous current"),
+                Curve(y = iDC2.y, legend = "DC rms current")
+              }
+            )
+          }
+        )
+      }
+    ),
        experiment(StopTime=1.0, Interval=0.0001));
 end Rectifier;

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/SeriesResonance.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/SeriesResonance.mo
@@ -71,6 +71,22 @@ equation
 The frequency of the voltage source is varied by a ramp.
 Plot length and angle of the current phasor, i.e., complexToPolar.len and .phi, versus time resp. frequency.
 </p>
-</html>"),
+</html>",
+      figures = {
+        Figure(
+          title = "Phasor length and angle vs. frequency",
+          identifier = "4dbcf",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = voltageSource.f, y = complexToPolar.phi, legend = "Complex angle phi of current vs. frequency of voltageSource"),
+                Curve(x = voltageSource.f, y = complexToPolar.len, legend = "Complex length len of current vs. frequency of voltageSource")
+              }
+            )
+          }
+        )
+      }
+    ),
        experiment(StopTime=1.0, Interval=0.001));
 end SeriesResonance;

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/Transformer.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/Transformer.mo
@@ -96,5 +96,20 @@ circuit impedance"),
 </ul>
 
 <p>Plot the real part of the secondary voltage <code>idealTransformer.v2.re</code> on the x axis and <code>idealTransformer.v2.im</code> on the y axis. The locus of this complex voltage <code><u>v</u><sub>2</sub></code> is a circle. The center of the circle is the primary supply voltage divided by the transformation ratio of <code>n=5</code>. Since in this experiment the load current magnitude is constant, the voltage drop across the short circuit impedance of the transformer is constant, as well. The radius of the circle is equal to the constant magnitude of the voltage drop across the short circuit impedance.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Ideal transformer values",
+          identifier = "9a6ad",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = idealTransformer.v2.re, y = idealTransformer.v2.im, legend = "Imaginary vs Real part of the idealTransformer.v2")
+              }
+            )
+          }
+        )
+      }
+    ));
 end Transformer;


### PR DESCRIPTION
These originate from figures created for Wolfram System Modeler, and are likely to need cleanup and improvement.

Our one existing figure in MSL is probably a good style to follow:

https://github.com/modelica/ModelicaStandardLibrary/blob/3f72865f0764cad0f2fb2d47d1e3fc0bf96ec4e6/Modelica/Blocks/package.mo#L159-L180

Creating as Draft to indicate that library officer(s) probably want/should improve them before merging.