### PR TITLE
Add starting point for figures in Magnetic.

### DIFF
--- a/Modelica/Magnetic/FluxTubes/Examples/BasicExamples/SaturatedInductor.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/BasicExamples/SaturatedInductor.mo
@@ -89,5 +89,42 @@ The magnetisation characteristics of the flux tube element representing the ferr
 <p>
 If the supply voltage has a zero-crossing when applied to the inductor at time t=0 (i.e., source.phase set to zero instead of &pi;/2), then the inrush current that is typical for switching of inductive loads can be observed.
 </p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Coil current",
+          identifier = "7b2ef",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = coil.i)
+              }
+            )
+          }
+        ),
+        Figure(
+          title = "Permeability vs flux density",
+          identifier = "faf9b",
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = r_mFe.mu_r, y = r_mFe.B, legend = "Relative permeability vs. flux density")
+              }
+            )
+          }
+        ),
+        Figure(
+          title = "Magnetisation curve",
+          identifier = "c6fcd",
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = r_mFe.B, y = r_mFe.H, legend = "Magnetisation curve B(H)")
+              }
+            )
+          }
+        )
+      }
+    ));
 end SaturatedInductor;

--- a/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/HysteresisModelComparison.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/HysteresisModelComparison.mo
@@ -125,5 +125,48 @@ Compared to the complex Preisach hysteresis model the Tellinen model is very sim
     </td>
   </tr>
 </table>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Flux density vs. field strength",
+          identifier = "10449",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = tellinenSoft.H, y = tellinenSoft.B, legend = "Magnetic flux density vs. magnetic field strength from TellinenSoft model")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(x = tellinenTable.H, y = tellinenTable.B, legend = "Magnetic flux density vs. magnetic field strength from TellinenTable model")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(x = preisachEverett.H, y = preisachEverett.B, legend = "Magnetic flux density vs. magnetic field strength from PreisachEverett model")
+              }
+            )
+          }
+        ),
+        Figure(
+          title = "Flux density and field strength",
+          identifier = "9bb26",
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = preisachEverett.H, legend = "Magnetic field strength for all models")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = tellinenSoft.B, legend = "Magnetic flux density for TellinenSoft model"),
+                Curve(y = tellinenTable.B, legend = "Magnetic flux density for TellinenTable model"),
+                Curve(y = preisachEverett.B, legend = "Magnetic flux density for PreisachEverett model")
+              }
+            )
+          }
+        )
+      }
+    ));
 end HysteresisModelComparison;

--- a/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/InductorWithHysteresis.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/InductorWithHysteresis.mo
@@ -46,5 +46,31 @@ This is a simple model of an inductor with a ferromagnetic core. The used Generi
     </td>
   </tr>
 </table>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Flux density vs. field strength",
+          identifier = "514be",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = core.H, y = core.B, legend = "Magnetic flux density vs. magnetic field strength of core, B(H)")
+              }
+            )
+          }
+        ),
+        Figure(
+          title = "Magnetic flux density",
+          identifier = "c206b",
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = core.B, legend = "Magnetic flux density from core, B(t)")
+              }
+            )
+          }
+        )
+      }
+    ));
 end InductorWithHysteresis;

--- a/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/SinglePhaseTransformerWithHysteresis1.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/SinglePhaseTransformerWithHysteresis1.mo
@@ -69,5 +69,37 @@ Then plot the flux density of the Core Core.B over the magnetic field strength C
   </tr>
 </table>
 
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Flux density vs. field strength",
+          identifier = "131b7",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = core.H, y = core.B, legend = "Magnetic flux density vs. magnetic field strength of core, B(H)")
+              }
+            )
+          }
+        ),
+        Figure(
+          title = "Currents and power loss",
+          identifier = "0a0be",
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = winding1.i, legend = "Primary current"),
+                Curve(y = winding2.i, legend = "Secondary current")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = core.LossPower, legend = "Power consumption of the iron core (LossPower)")
+              }
+            )
+          }
+        )
+      }
+    ));
 end SinglePhaseTransformerWithHysteresis1;

--- a/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/SinglePhaseTransformerWithHysteresis2.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/Hysteresis/SinglePhaseTransformerWithHysteresis2.mo
@@ -48,5 +48,20 @@ The figure shows the magnetic hysteresis in the transformer core. In (a) the con
   </tr>
 </table>
 
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Flux density vs. field strength",
+          identifier = "1c0de",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = transformer.H, y = transformer.B, legend = "Magnetic flux density vs. magnetic field strength of core, B(H)")
+              }
+            )
+          }
+        )
+      }
+    ));
 end SinglePhaseTransformerWithHysteresis2;

--- a/Modelica/Magnetic/FluxTubes/Examples/MovingCoilActuator/ArmatureStroke.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/MovingCoilActuator/ArmatureStroke.mo
@@ -95,5 +95,31 @@ The initial current rise in both actuator models is due to the inductance of the
 <p>
 Whereas the steady state current is the same in both models, the steady state actuator force is not due to the neglect of the non-linear force component in the converter constant model. Differences in the current rise of both models are due to the neglect of the coil inductance variation in the converter constant model.
 </p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Constant actuator vs. permeance actuator",
+          identifier = "eeca9",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = cActuator.p.i, legend = "Input current to constant actuator model"),
+                Curve(y = pmActuator.p.i, legend = "Input current to permeance actuator model"),
+                Curve(y = cActuator.armature.flange_a.f, legend = "Actuator force of constant actuator model"),
+                Curve(y = pmActuator.armature.flange_a.f, legend = "Actuator force of permeance actuator model")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = cActuator.x, legend = "Armature position of constant actuator model"),
+                Curve(y = pmActuator.x, legend = "Armature position of permeance actuator model"),
+                Curve(y = cActuator.L, legend = "Inductance of constant actuator model"),
+                Curve(y = pmActuator.L, legend = "Inductance of permeance actuator model")
+              }
+            )
+          }
+        )
+      }
+    ));
 end ArmatureStroke;

--- a/Modelica/Magnetic/FluxTubes/Examples/MovingCoilActuator/ForceCurrentBehaviour.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/MovingCoilActuator/ForceCurrentBehaviour.mo
@@ -92,5 +92,22 @@ pmFixedPos.flange_b.f       // force of permeance model
 cFixedPos.flange_b.f        // force of converter constant model
 comparisonWithFEA.y[1]      // force of FEA model for comparison
 </pre></blockquote>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Force current characteristics",
+          identifier = "9ca98",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = iSensor.i, y = pmFixedPos.flange.f, legend = "Permeance actuator force vs. current"),
+                Curve(x = iSensor.i, y = cFixedPos.flange.f, legend = "Constant actuator force vs. current"),
+                Curve(x = iSensor.i, y = comparisonWithFEA.y[1], legend = "FEA force vs. current (use this as reference result)")
+              }
+            )
+          }
+        )
+      }
+    ));
 end ForceCurrentBehaviour;

--- a/Modelica/Magnetic/FluxTubes/Examples/MovingCoilActuator/ForceStrokeBehaviour.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/MovingCoilActuator/ForceStrokeBehaviour.mo
@@ -67,5 +67,34 @@ actuator.g_mb.G_m           // permeance G_mb
 actuator.L                  // inductance of permeance model
 comparisonWithFEA.y[3]      // inductance of FEA model for comparison (mu_rFe=const.=1000).
 </pre></blockquote>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Variables vs. armature position",
+          identifier = "ba806",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = feedX.flange.s, y = feedX.flange.f, legend = "Force of permeance model vs. armature position"),
+                Curve(x = feedX.flange.s, y = comparisonWithFEA.y[1], legend = "Force of FEA model with non-linear stator iron 1.0718 vs. armature position"),
+                Curve(x = feedX.flange.s, y = comparisonWithFEA.y[2], legend = "Force of FEA model with mu_rFe=const=1000 vs. armature position")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(x = feedX.flange.s, y = actuator.g_ma.G_m, legend = "Permeance G_ma vs. armature position"),
+                Curve(x = feedX.flange.s, y = actuator.g_mb.G_m, legend = "Permeance G_mb vs. armature position")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(x = feedX.flange.s, y = actuator.L, legend = "Inductance of permeance model vs. armature position"),
+                Curve(x = feedX.flange.s, y = comparisonWithFEA.y[3], legend = "Inductance of FEA model vs. armature position")
+              }
+            )
+          }
+        )
+      }
+    ));
 end ForceStrokeBehaviour;

--- a/Modelica/Magnetic/FluxTubes/Examples/SolenoidActuator/ComparisonPullInStroke.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/SolenoidActuator/ComparisonPullInStroke.mo
@@ -441,5 +441,36 @@ Plot window for position:
 <p>
 The characteristic current drop during pull-in is due to both armature motion and increasing inductance with decreasing air gap length. Bouncing occurs when  armature and load of each model arrive at the stopper at minimum position. Although the pull-in times of the two magnetic network models are relatively close to the time obtained with the reference model, the accuracy of the advanced solenoid model is better, as one can tell from a comparison of the current rise at the beginning of the stroke.
 </p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Simple vs advanced solenoid",
+          identifier = "ff1cf",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = simpleSolenoid.p.i, legend = "Current from simple solenoid model"),
+                Curve(y = advancedSolenoid.p.i, legend = "Current from advanced solenoid model"),
+                Curve(y = comparisonWithFEA.y[1], legend = "Current from FEA model")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = simpleSolenoid.armature.flange_a.f, legend = "Reluctance force of simple solenoid model"),
+                Curve(y = advancedSolenoid.armature.flange_a.f, legend = "Reluctance force of advanced solenoid model"),
+                Curve(y = comparisonWithFEA.y[2], legend = "Reluctance force of FEA model")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = simpleSolenoid.x, legend = "Armature position of simple solenoid model"),
+                Curve(y = advancedSolenoid.x, legend = "Armature position of advanced solenoid model"),
+                Curve(y = comparisonWithFEA.y[3], legend = "Armature position of FEA model")
+              }
+            )
+          }
+        )
+      }
+    ));
 end ComparisonPullInStroke;

--- a/Modelica/Magnetic/FluxTubes/Examples/SolenoidActuator/ComparisonQuasiStatic.mo
+++ b/Modelica/Magnetic/FluxTubes/Examples/SolenoidActuator/ComparisonQuasiStatic.mo
@@ -121,5 +121,36 @@ comparisonWithFEA.y[3]                 // static inductance obtained with FEA as
 <p>
 As mentioned in the description of both magnetic network models, one can tell the higher armature flux and inductance of the advanced solenoid model at large air gaps compared to that of the simple model. The effect of this difference on dynamic model behaviour can be analysed in <a href=\"modelica://Modelica.Magnetic.FluxTubes.Examples.SolenoidActuator.ComparisonPullInStroke\">ComparisonPullInStroke</a>.
 </p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Simple vs. advanced solenoid",
+          identifier = "e851b",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = x_set.y, y = simpleSolenoid.armature.flange_a.f, legend = "Simple solenoid model electromagnetic force vs. armature position"),
+                Curve(x = x_set.y, y = advancedSolenoid.armature.flange_a.f, legend = "Advanced solenoid model electromagnetic force vs. armature position"),
+                Curve(x = x_set.y, y = comparisonWithFEA.y[1], legend = "FEA model electromagnetic force vs. armature position")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(x = x_set.y, y = simpleSolenoid.g_mFeArm.Phi, legend = "Simple solenoid model magnetic flux vs. armature position"),
+                Curve(x = x_set.y, y = advancedSolenoid.g_mFeArm.Phi, legend = "Advanced solenoid model magnetic flux vs. armature position"),
+                Curve(x = x_set.y, y = comparisonWithFEA.y[2], legend = "FEA model magnetic flux vs. armature position")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(x = x_set.y, y = simpleSolenoid.coil.L_stat, legend = "Simple solenoid model static inductance vs. armature position"),
+                Curve(x = x_set.y, y = advancedSolenoid.L_statTot, legend = "Advanced solenoid model static inductance vs. armature position"),
+                Curve(x = x_set.y, y = comparisonWithFEA.y[3], legend = "FEA model static inductance vs. armature position")
+              }
+            )
+          }
+        )
+      }
+    ));
 end ComparisonQuasiStatic;

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_DOL.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMC_DOL.mo
@@ -196,5 +196,22 @@ Simulate for 1.5 seconds and plot (versus time):
 <li><code>aimcM|E.wMechanical</code>: machine speed</li>
 <li><code>aimcM|E.tauElectrical</code>: machine torque</li>
 </ul>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "aef89",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentRMSsensorM.I, legend = "Stator current RMS"),
+                Curve(y = aimcM.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = aimcM.tauElectrical, legend = "Motor torque")
+              }
+            )
+          }
+        )
+      }
+    ));
 end IMC_DOL;

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMS_Start.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/InductionMachines/IMS_Start.mo
@@ -221,5 +221,22 @@ Simulate for 1.5 seconds and plot (versus time):
 <li><code>aimsM/E.wMechanical</code>: machine speed</li>
 <li><code>aimsM|E.tauElectrical</code>: machine torque</li>
 </ul>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "23d18",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentRMSsensorM.I, legend = "Stator current RMS"),
+                Curve(y = aimsM.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = aimsM.tauElectrical, legend = "Motor torque")
+              }
+            )
+          }
+        )
+      }
+    ));
 end IMS_Start;

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMEE_Generator.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMEE_Generator.mo
@@ -298,5 +298,25 @@ Simulate for 30 seconds and plot (versus <code>rotorAngleM.rotorDisplacementAngl
 <li><code>speedM|E.tauElectrical</code>: machine torque</li>
 <li><code>mechanicalPowerSensorM|E.P</code>: mechanical power</li>
 </ul>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Torque and power vs. rotor displacement angle",
+          identifier = "c7d67",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = rotorAngleM.rotorDisplacementAngle, y = smeeM.tauElectrical, legend = "Motor torque vs. rotor displacement angle")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(x = rotorAngleM.rotorDisplacementAngle, y = mechanicalPowerSensorM.P, legend = "Mechanical power vs. rotor displacement angle")
+              }
+            )
+          }
+        )
+      }
+    ));
 end SMEE_Generator;

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_Inverter.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMPM_Inverter.mo
@@ -220,5 +220,27 @@ and accelerate the inertias.</p>
 <li><code>smpmM|E.tauElectrical</code>: machine torque</li>
 <li><code>rotorAnglepmsmM|E.rotorDisplacementAngle</code>: rotor displacement angle</li>
 </ul>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "6c7bc",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentRMSsensorM.I, legend = "Stator current RMS"),
+                Curve(y = smpmM.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = smpmM.tauElectrical, legend = "Motor torque")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = rotorAngleM.rotorDisplacementAngle, legend = "Rotor displacement angle")
+              }
+            )
+          }
+        )
+      }
+    ));
 end SMPM_Inverter;

--- a/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMR_Inverter.mo
+++ b/Modelica/Magnetic/FundamentalWave/Examples/BasicMachines/SynchronousMachines/SMR_Inverter.mo
@@ -215,5 +215,27 @@ Simulate for 1.5 seconds and plot (versus time):
 <li><code>smrM|E.tauElectrical</code>: machine torque</li>
 <li><code>rotorAngleM|R.rotorDisplacementAngle</code>: rotor displacement angle</li>
 </ul>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Machine variables",
+          identifier = "33b98",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = currentRMSsensorM.I, legend = "Stator current RMS"),
+                Curve(y = smrM.wMechanical, legend = "Motor angular velocity of rotor against stator"),
+                Curve(y = smrM.tauElectrical, legend = "Motor torque")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = rotorAngleM.rotorDisplacementAngle, legend = "Rotor displacement angle")
+              }
+            )
+          }
+        )
+      }
+    ));
 end SMR_Inverter;


### PR DESCRIPTION
These originate from figures created for Wolfram System Modeler, and are likely to need cleanup and improvement.

Our one existing figure in MSL is probably a good style to follow:

https://github.com/modelica/ModelicaStandardLibrary/blob/3f72865f0764cad0f2fb2d47d1e3fc0bf96ec4e6/Modelica/Blocks/package.mo#L159-L180

Creating as Draft to indicate that library officer(s) probably want/should improve them before merging.