### PR TITLE
Add starting point for figures in Thermal.

### DIFF
--- a/Modelica/Thermal/HeatTransfer/Examples/Motor.mo
+++ b/Modelica/Thermal/HeatTransfer/Examples/Motor.mo
@@ -109,6 +109,22 @@ Using Modelica.Thermal.FluidHeatFlow it would be possible to model the coolant a
 <p>
 Simulate for 7200 s; plot Twinding.T and Tcore.T.
 </p>
-</html>"),
+</html>",
+      figures = {
+        Figure(
+          title = "Temperatures",
+          identifier = "83343",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = Twinding.T, legend = "Temperature of winding"),
+                Curve(y = Tcore.T, legend = "Temperature of core")
+              }
+            )
+          }
+        )
+      }
+    ),
     experiment(StopTime=7200, Interval=0.01));
 end Motor;

--- a/Modelica/Thermal/HeatTransfer/Examples/TwoMasses.mo
+++ b/Modelica/Thermal/HeatTransfer/Examples/TwoMasses.mo
@@ -39,6 +39,23 @@ Simulate for 5 s and plot the variables<br>
 mass1.T, mass2.T, T_final_K or<br>
 Tsensor1.T, Tsensor2.T, T_final_degC
 </p>
-</html>"),
+</html>",
+      figures = {
+        Figure(
+          title = "Temperatures",
+          identifier = "cd25b",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = mass1.T, legend = "Temperature of mass1"),
+                Curve(y = mass2.T, legend = "Temperature of mass2"),
+                Curve(y = T_final_K, legend = "Projected final temperature")
+              }
+            )
+          }
+        )
+      }
+    ),
     experiment(StopTime=1.0, Interval=0.001));
 end TwoMasses;


### PR DESCRIPTION
These originate from figures created for Wolfram System Modeler, and are likely to need cleanup and improvement.

Our one existing figure in MSL is probably a good style to follow:

https://github.com/modelica/ModelicaStandardLibrary/blob/3f72865f0764cad0f2fb2d47d1e3fc0bf96ec4e6/Modelica/Blocks/package.mo#L159-L180

Creating as Draft to indicate that library officer(s) probably want/should improve them before merging.