### PR TITLE
Add starting point for figures in Electrical.Analog.

### DIFF
--- a/Modelica/Electrical/Analog/Examples/AD_DA_conversion.mo
+++ b/Modelica/Electrical/Analog/Examples/AD_DA_conversion.mo
@@ -58,5 +58,21 @@ equation
 <ul>
 <li><em>October 13, 2009  </em>by Matthias Franke</li>
 </ul>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltage conversion",
+          identifier = "a190f",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = aD_Converter.p.v, legend = "Voltage at the aD_Converter"),
+                Curve(y = dA_Converter.p.v, legend = "Voltage at the dA_Converter")
+              }
+            )
+          }
+        )
+      }
+    ));
 end AD_DA_conversion;

--- a/Modelica/Electrical/Analog/Examples/AmplifierWithOpAmpDetailed.mo
+++ b/Modelica/Electrical/Analog/Examples/AmplifierWithOpAmpDetailed.mo
@@ -70,5 +70,27 @@ equation
 </dl>
 </html>", info="<html>
 <p>With the test circuit AmplifierWithOpAmpDetailed a time domain analysis of the example arrangement with a sinusoidal input voltage (12 V amplitude, frequency 1 kHz) using the operational amplifier model OpAmpDetailed is carried out. The working voltages are 15 V and -15 V.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltages",
+          identifier = "7f61d",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = sineVoltage.v, legend = "Voltage from source sineVoltage")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = opAmp.outp.v, legend = "Output voltage from opAmp"),
+                Curve(y = opAmp.m_supply.v, legend = "Supply voltage in opAmp.m_supply (negative limit voltage)"),
+                Curve(y = opAmp.p_supply.v, legend = "Supply voltage in opAmp.p_supply (positive limit voltage)")
+              }
+            )
+          }
+        )
+      }
+    ));
 end AmplifierWithOpAmpDetailed;

--- a/Modelica/Electrical/Analog/Examples/CauerLowPassAnalog.mo
+++ b/Modelica/Electrical/Analog/Examples/CauerLowPassAnalog.mo
@@ -121,5 +121,37 @@ equation
 </html>", info="<html>
 <p>The example Cauer Filter is a low-pass-filter of the fifth order. It is realized using an analog network. The voltage source V is the input voltage (step), and the R2.p.v is the filter output voltage. The pulse response is calculated.</p>
 <p>The simulation end time should be 60. Please plot both V.p.v (input voltage) and R2.p.v (output voltage).</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Filter",
+          identifier = "da435",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = V.p.v, legend = "Input voltage"),
+                Curve(y = R2.p.v, legend = "Output voltage")
+              }
+            )
+          }
+        ),
+        Figure(
+          title = "Capacitor voltages",
+          identifier = "82d53",
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = C1.v, legend = "Voltage over C1"),
+                Curve(y = C2.v, legend = "Voltage over C2"),
+                Curve(y = C3.v, legend = "Voltage over C3"),
+                Curve(y = C4.v, legend = "Voltage over C4"),
+                Curve(y = C5.v, legend = "Voltage over C5"),
+                Curve(y = V.p.v, legend = "Input voltage")
+              }
+            )
+          }
+        )
+      }
+    ));
 end CauerLowPassAnalog;

--- a/Modelica/Electrical/Analog/Examples/CauerLowPassOPV.mo
+++ b/Modelica/Electrical/Analog/Examples/CauerLowPassOPV.mo
@@ -269,5 +269,37 @@ equation
 <p>This model is identical to the CauerLowPassAnalog example, but inverting. To get the same response as that of the CauerLowPassAnalog example, a negative voltage step is used as input.</p>
 <p>The simulation end time should be 60. Please plot both V.v (which is the inverted input voltage) and OP5.p.v (output voltage). Compare this result with the CauerLowPassAnalog result.</p>
 <p>During translation some warnings are issued concerning resistor values (Value=-1 not in range [0,1e100]). Do not worry about it. The negative values are o.k.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Filter",
+          identifier = "4b9b8",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = V.v, legend = "Input voltage"),
+                Curve(y = Op5.out.v, legend = "Output voltage")
+              }
+            )
+          }
+        ),
+        Figure(
+          title = "Operation amplifier voltages",
+          identifier = "57787",
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = Op1.out.v, legend = "Voltage from Op1"),
+                Curve(y = Op2.out.v, legend = "Voltage from Op2"),
+                Curve(y = Op3.out.v, legend = "Voltage from Op3"),
+                Curve(y = Op4.out.v, legend = "Voltage from Op4"),
+                Curve(y = Op5.out.v, legend = "Voltage from Op5"),
+                Curve(y = V.v, legend = "Input signal")
+              }
+            )
+          }
+        )
+      }
+    ));
 end CauerLowPassOPV;

--- a/Modelica/Electrical/Analog/Examples/CauerLowPassSC.mo
+++ b/Modelica/Electrical/Analog/Examples/CauerLowPassSC.mo
@@ -281,5 +281,37 @@ equation
 <p>This model is identical to the CauerLowPassOPV example. But the resistors are realized by switched capacitors (see <a href=\"modelica://Modelica.Electrical.Analog.Examples.Utilities.SwitchedCapacitor\">SwitchedCapacitor</a>). There are two different types of instances, one with a value of <code>R=1</code> and one with a value of <code>R=-1</code>.</p>
 <p>The simulation end time should be 60. Please plot both V.v (which is the inverted input voltage) and OP5.out.v (output voltage). Compare this result with the CauerLowPassAnalog result.</p>
 <p>Due to the recharging of the capacitances after switching the performance of simulation is not as good as in the CauerLowPassOPV example.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Filter",
+          identifier = "9ed30",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = V.v, legend = "Input voltage"),
+                Curve(y = Op5.out.v, legend = "Output voltage")
+              }
+            )
+          }
+        ),
+        Figure(
+          title = "Operational ampfilier voltages",
+          identifier = "fdc56",
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = Op1.out.v, legend = "Voltage from Op1"),
+                Curve(y = Op2.out.v, legend = "Voltage from Op2"),
+                Curve(y = Op3.out.v, legend = "Voltage from Op3"),
+                Curve(y = Op4.out.v, legend = "Voltage from Op4"),
+                Curve(y = Op5.out.v, legend = "Voltage from Op5"),
+                Curve(y = V.v, legend = "Input voltage")
+              }
+            )
+          }
+        )
+      }
+    ));
 end CauerLowPassSC;

--- a/Modelica/Electrical/Analog/Examples/CharacteristicIdealDiodes.mo
+++ b/Modelica/Electrical/Analog/Examples/CharacteristicIdealDiodes.mo
@@ -92,6 +92,33 @@ Ideal.i versus Ideal.v, With_Ron_Goff.i versus With_Ron_Goff.v, With_Ron_Goff_Vk
        by Christoph Clauss<br> realized<br>
        </li>
 </ul>
-</html>"),
+</html>",
+      figures = {
+        Figure(
+          title = "Diode responses",
+          identifier = "b56f9",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(x = Ideal.i, y = Ideal.v, legend = "Ideal diode voltage vs. current")
+              },
+              x = Axis(min = -114.997, max = 10124.3),
+              y = Axis(min = -11.2936, max = 1.39137)
+            ),
+            Plot(
+              curves = {
+                Curve(x = With_Ron_Goff.i, y = With_Ron_Goff.v, legend = "Nearly ideal diode voltage vs. current")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(x = With_Ron_Goff_Vknee.i, y = With_Ron_Goff_Vknee.v, legend = "Nearly ideal and displaced diode voltage vs. current")
+              }
+            )
+          }
+        )
+      }
+    ),
     experiment(StopTime=1));
 end CharacteristicIdealDiodes;

--- a/Modelica/Electrical/Analog/Examples/CharacteristicThyristors.mo
+++ b/Modelica/Electrical/Analog/Examples/CharacteristicThyristors.mo
@@ -100,5 +100,39 @@ annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-1
        by Christoph Clauss<br> realized<br>
        </li>
 </ul>
-</html>"), experiment(StopTime=6));
+</html>",
+      figures = {
+        Figure(
+          title = "Ideal thyristors table input",
+          identifier = "11ab7",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = IdealThyristor1.v, legend = "Ideal thyristor voltage"),
+                Curve(y = IdealGTOThyristor1.v, legend = "Ideal GTO thyristor voltage")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = IdealThyristor1.off, legend = "Ideal thyristor off signal"),
+                Curve(y = IdealGTOThyristor1.off, legend = "Ideal GTO thyristor off signal")
+              }
+            )
+          }
+        ),
+        Figure(
+          title = "Ideal thyristors periodic input",
+          identifier = "9c2a0",
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = IdealThyristor2.v, legend = "Ideal thyristor voltage"),
+                Curve(y = IdealGTOThyristor2.v, legend = "Ideal GTO thyristor voltage")
+              }
+            )
+          }
+        )
+      }
+    ), experiment(StopTime=6));
 end CharacteristicThyristors;

--- a/Modelica/Electrical/Analog/Examples/CompareTransformers.mo
+++ b/Modelica/Electrical/Analog/Examples/CompareTransformers.mo
@@ -156,5 +156,45 @@ Plot in separate windows for comparison:
 <br>basicTransformer.p1.i and idealTransformer.p1.i
 <br>basicTransformer.p2.v and idealTransformer.p2.v
 basicTransformer.p2.i and idealTransformer.p2.i</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Left ports of transformers",
+          identifier = "ca3ee",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = basicTransformer.p1.v, legend = "Voltage in left positive port in basicTransformer"),
+                Curve(y = idealTransformer.p1.v, legend = "Voltage in left positive port in idealTransformer")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = basicTransformer.p1.i, legend = "Current in left positive port in basicTransformer"),
+                Curve(y = idealTransformer.p1.i, legend = "Current in left positive port in idealTransformer")
+              }
+            )
+          }
+        ),
+        Figure(
+          title = "Right ports of transformers",
+          identifier = "b4b28",
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = basicTransformer.p2.v, legend = "Voltage in right positive port in basicTransformer"),
+                Curve(y = idealTransformer.p2.v, legend = "Voltage in right positive port in idealTransformer")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = basicTransformer.p2.i, legend = "Current in right positive port in basicTransformer"),
+                Curve(y = idealTransformer.p2.i, legend = "Current in right positive port in idealTransformer")
+              }
+            )
+          }
+        )
+      }
+    ));
 end CompareTransformers;

--- a/Modelica/Electrical/Analog/Examples/ControlledSwitchWithArc.mo
+++ b/Modelica/Electrical/Analog/Examples/ControlledSwitchWithArc.mo
@@ -95,5 +95,21 @@ equation
        by Anton Haumer<br> initially realized<br>
        </li>
 </ul>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Switch currents",
+          identifier = "79601",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = switch1.i, legend = "Current in switch without arc, switch1"),
+                Curve(y = switch2.i, legend = "Current in switch with arc, switch2")
+              }
+            )
+          }
+        )
+      }
+    ));
 end ControlledSwitchWithArc;

--- a/Modelica/Electrical/Analog/Examples/HeatingNPN_NORGate.mo
+++ b/Modelica/Electrical/Analog/Examples/HeatingNPN_NORGate.mo
@@ -194,5 +194,47 @@ annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
        by Christoph Clauss<br> realized<br>
        </li>
 </ul>
-</html>"), experiment(StopTime=200));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltages",
+          identifier = "1fae7",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = V1.v, legend = "Voltage from source V1"),
+                Curve(y = V2.v, legend = "Voltage from source V2"),
+                Curve(y = C2.v, legend = "Voltage from capacitor C2")
+              }
+            )
+          }
+        ),
+        Figure(
+          title = "Temperatures",
+          identifier = "ec9be",
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = HeatCapacitor1.port.T, legend = "Temperature in HeatCapacitor1"),
+                Curve(y = T1.heatPort.T, legend = "Temperature in T1"),
+                Curve(y = T2.heatPort.T, legend = "Temperature in T2")
+              }
+            )
+          }
+        ),
+        Figure(
+          title = "Heat flows",
+          identifier = "1d52f",
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = T1.heatPort.Q_flow, legend = "Heat flow from T1"),
+                Curve(y = T2.heatPort.Q_flow, legend = "Heat flow from T2")
+              }
+            )
+          }
+        )
+      }
+    ), experiment(StopTime=200));
 end HeatingNPN_NORGate;

--- a/Modelica/Electrical/Analog/Examples/IdealTriacCircuit.mo
+++ b/Modelica/Electrical/Analog/Examples/IdealTriacCircuit.mo
@@ -43,5 +43,27 @@ equation
 <p>The simple ideal TRIAC example shows how a triac is used within an alternating current circuit.</p>
 <p>The TRIAC is not conducting until the Boolean input becomes true (internally coded by 1, therefore the input is called fire<strong>1</strong>). Then it becomes &quot;conducting&quot;, the knee voltage is reached. If the TRIAC voltage falls below the knee voltage, the TRIAC becomes blocking. Due to the antiparallel connection of the internal two thyristors the same behavior is repeated in the negative half-wave.</p>
 <p>Simulate until 2 seconds. Display V.p.v (input voltage), booleanPulse.y (fire1 input), and both idealTriac.n.v and idealTriac.n.i, which demonstrate the TRIAC behavior.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltages and currents",
+          identifier = "330bf",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = V.p.v, legend = "Voltage from source V"),
+                Curve(y = idealTriac.n.v, legend = "Voltage in negative pin in idealTriac"),
+                Curve(y = idealTriac.n.i, legend = "Current in negative pin in idealTriac")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = booleanPulse.y, legend = "Boolean signal to control conductance in idealTriac")
+              }
+            )
+          }
+        )
+      }
+    ));
 end IdealTriacCircuit;

--- a/Modelica/Electrical/Analog/Examples/InvertingAmp.mo
+++ b/Modelica/Electrical/Analog/Examples/InvertingAmp.mo
@@ -77,7 +77,23 @@ equation
   annotation (
     Documentation(info="<html>
 <p>This is an inverting amplifier. Resistance R1 can be chosen, R2 is defined by the desired amplification k.</p>
-</html>"),
+</html>",
+      figures = {
+        Figure(
+          title = "Input and Output",
+          identifier = "466eb",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = vIn.v),
+                Curve(y = vOut.v)
+              }
+            )
+          }
+        )
+      }
+    ),
     experiment(
       StartTime=0,
       StopTime=1,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/InvertingAmplifier.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/InvertingAmplifier.mo
@@ -39,7 +39,35 @@ equation
   annotation (
     Documentation(info="<html>
 <p>This is an inverting amplifier.</p>
-</html>"),
+</html>",
+      figures = {
+        Figure(
+          title = "Voltages",
+          identifier = "1339b",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = vIn.v, legend = "Voltage from source vIn")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = gain.opAmp.v_out, legend = "Amplified voltage out from opAmp"),
+                Curve(y = gain.opAmp.Vns, legend = "Negative supply voltage in opAmp (negative limit voltage)"),
+                Curve(y = gain.opAmp.Vps, legend = "Positive supply voltage in opAmp (positive limit voltage)")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = gain.r1.R, legend = "Resistance in r1"),
+                Curve(y = gain.r2.R, legend = "Resistance in r2")
+              }
+            )
+          }
+        )
+      }
+    ),
     experiment(
       StartTime=0,
       StopTime=1,

--- a/Modelica/Electrical/Analog/Examples/OpAmps/NonInvertingAmplifier.mo
+++ b/Modelica/Electrical/Analog/Examples/OpAmps/NonInvertingAmplifier.mo
@@ -38,7 +38,34 @@ equation
     annotation (Line(points={{-10,-10},{-10,-20}}, color={0,0,255}));
   annotation (Documentation(info="<html>
 <p>This is a non inverting amplifier.</p>
-</html>"),
+</html>",
+      figures = {
+        Figure(
+          title = "Voltages",
+          identifier = "e8928",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = vIn.v, legend = "Voltage from source vIn")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = buffer.opAmp.v_out, legend = "Amplified voltage out from opAmp"),
+                Curve(y = buffer.opAmp.Vns, legend = "Negative supply voltage in opAmp (negative limit voltage)"),
+                Curve(y = buffer.opAmp.Vps, legend = "Positive supply voltage in opAmp (positive limit voltage)")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = buffer.k, legend = "Desired amplification")
+              }
+            )
+          }
+        )
+      }
+    ),
     experiment(
       StartTime=0,
       StopTime=1,

--- a/Modelica/Electrical/Analog/Examples/OvervoltageProtection.mo
+++ b/Modelica/Electrical/Analog/Examples/OvervoltageProtection.mo
@@ -63,5 +63,27 @@ equation
         by Matthias Franke<br>initially implemented
        </li>
 </ul>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltages and currents",
+          identifier = "9cea9",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = sineVoltage.p.v, legend = "Voltage from source sineVoltage"),
+                Curve(y = RL.p.v, legend = "Voltage at resistor RL"),
+                Curve(y = zDiode1.n.v, legend = "Voltage at diode zDiode1")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = zDiode.n.i, legend = "Current in diode zDiode")
+              }
+            )
+          }
+        )
+      }
+    ));
 end OvervoltageProtection;

--- a/Modelica/Electrical/Analog/Examples/Rectifier.mo
+++ b/Modelica/Electrical/Analog/Examples/Rectifier.mo
@@ -192,5 +192,34 @@ DC capacitors start at ideal no-load voltage, thus making easier initial transie
        by Anton Haumer<br> realized<br>
        </li>
 </ul>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltages and currents",
+          identifier = "bbe9c",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = uDC, legend = "Sum of voltages in Capacitor1 and Capacitor2")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = iAC[1], legend = "Current in Inductor1.n"),
+                Curve(y = iAC[2], legend = "Current in Inductor2.n"),
+                Curve(y = iAC[3], legend = "Current in Inductor3.n")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = uAC[1], legend = "Difference in voltage between Inductor1.n and Inductor2.n"),
+                Curve(y = uAC[2], legend = "Difference in voltage between Inductor2.n and Inductor3.n"),
+                Curve(y = uAC[3], legend = "Difference in voltage between Inductor3.n and Inductor1.n")
+              }
+            )
+          }
+        )
+      }
+    ));
 end Rectifier;

--- a/Modelica/Electrical/Analog/Examples/Resistor.mo
+++ b/Modelica/Electrical/Analog/Examples/Resistor.mo
@@ -40,5 +40,30 @@ equation
       points={{14,34},{32,34}}, color={191,0,0}));
 annotation (Documentation(info="<html>
 <p>This is a very simple circuit consisting of a voltage source and a resistor. The loss power in the resistor is transported to the environment via its heatPort.</p>
-</html>"), experiment(StopTime=5));
+</html>",
+      figures = {
+        Figure(
+          title = "Power loss",
+          identifier = "4910e",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = SineVoltage1.p.v, legend = "Source voltage")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = resistor.heatPort.T, legend = "Temperature in resistor")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = resistor.LossPower, legend = "Power loss in resistor")
+              }
+            )
+          }
+        )
+      }
+    ), experiment(StopTime=5));
 end Resistor;

--- a/Modelica/Electrical/Analog/Examples/ShowSaturatingInductor.mo
+++ b/Modelica/Electrical/Analog/Examples/ShowSaturatingInductor.mo
@@ -58,5 +58,21 @@ equation
     Documentation(info="<html>
 <p>This simple circuit uses the saturating inductor which has a changing inductance.</p>
 <p>This circuit should be simulated until 1 s. Compare <code>SaturatingInductance1.p.i</code> with <code>Inductance1.p.i</code> to see the difference between saturating and ideal inductor.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Inductor currents",
+          identifier = "76d05",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = SaturatingInductance1.p.i, legend = "Current in the inductor SaturatingInductance1"),
+                Curve(y = Inductance1.p.i, legend = "Current in the inductor Inductance1")
+              }
+            )
+          }
+        )
+      }
+    ));
 end ShowSaturatingInductor;

--- a/Modelica/Electrical/Analog/Examples/ShowVariableResistor.mo
+++ b/Modelica/Electrical/Analog/Examples/ShowVariableResistor.mo
@@ -58,7 +58,34 @@ annotation (Documentation(info="<html>
        by Teresa Schlegel<br> realized<br>
        </li>
 </ul>
-</html>"),
+</html>",
+      figures = {
+        Figure(
+          title = "Voltages and resistance",
+          identifier = "60ce8",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = SineVoltage1.v, legend = "Voltage from source SineVoltage1")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = R2.v, legend = "Voltage in resistor R2"),
+                Curve(y = VariableResistor.v, legend = "Voltage in resistor VariableResistor")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = R2.R, legend = "Resistance in R2"),
+                Curve(y = VariableResistor.R, legend = "Resistance in VariableResistor")
+              }
+            )
+          }
+        )
+      }
+    ),
   experiment(StopTime=1),
     Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
             100,100}})));

--- a/Modelica/Electrical/Analog/Examples/SwitchWithArc.mo
+++ b/Modelica/Electrical/Analog/Examples/SwitchWithArc.mo
@@ -87,5 +87,21 @@ equation
        by Anton Haumer<br> initially realized<br>
        </li>
 </ul>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Switch currents",
+          identifier = "b383e",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = switch1.i, legend = "Current in the switch without arc, switch1"),
+                Curve(y = switch2.i, legend = "Current in the switch with arc, switch2")
+              }
+            )
+          }
+        )
+      }
+    ));
 end SwitchWithArc;

--- a/Modelica/Electrical/Analog/Examples/ThyristorBehaviourTest.mo
+++ b/Modelica/Electrical/Analog/Examples/ThyristorBehaviourTest.mo
@@ -50,5 +50,31 @@ equation
   annotation (experiment(StopTime=0.0002),
     Documentation(info="<html>
 <p>This is a simple test circuit, to test the behavior of the thyristor model.</p><p>Interesting values to plot are Cathode.v, Gate.v and sineVoltage.p.v. and in another plot window pulseCurrent.p.i</p><p>The simulation time should be from 0 seconds to 2e-4 seconds.</p>
-</html>"));
+</html>",
+      figures = {
+        Figure(
+          title = "Voltages and currents",
+          identifier = "d5a4c",
+          preferred = true,
+          plots = {
+            Plot(
+              curves = {
+                Curve(y = thyristor_v4_1.Cathode.v, legend = "Voltage in Cathode of thyristor_v4_1"),
+                Curve(y = thyristor_v4_1.Gate.v, legend = "Voltage in Gate of thyristor_v4_1")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = pulseCurrent.p.i, legend = "Current from source pulseCurrent")
+              }
+            ),
+            Plot(
+              curves = {
+                Curve(y = sineVoltage.p.v, legend = "Voltage from source sineVoltage")
+              }
+            )
+          }
+        )
+      }
+    ));
 end ThyristorBehaviourTest;


### PR DESCRIPTION
These originate from figures created for Wolfram System Modeler, and are likely to need cleanup and improvement.

Our one existing figure in MSL is probably a good style to follow:

https://github.com/modelica/ModelicaStandardLibrary/blob/3f72865f0764cad0f2fb2d47d1e3fc0bf96ec4e6/Modelica/Blocks/package.mo#L159-L180

Creating as Draft to indicate that library officer(s) probably want/should improve them before merging.