### PR TITLE
Prefer warning instead of print message

### DIFF
--- a/Modelica/Electrical/Polyphase/Basic/MutualInductor.mo
+++ b/Modelica/Electrical/Polyphase/Basic/MutualInductor.mo
@@ -4,9 +4,7 @@ model MutualInductor "Linear mutual inductor"
   parameter Real epsilon=1e-9 "Relative accuracy tolerance of matrix symmetry";
   parameter SI.Inductance L[m, m] "Mutual inductance matrix";
 initial equation
-  if abs(Modelica.Math.Matrices.det(L)) < epsilon then
-    Modelica.Utilities.Streams.print("Warning: mutual inductance matrix singular!");
-  end if;
+  assert(abs(Modelica.Math.Matrices.det(L)) >= epsilon, "Mutual inductance matrix singular!", AssertionLevel.warning);
 equation
   assert(sum(abs(L - transpose(L))) < epsilon*sum(abs(L)),"Mutual inductance matrix is not symmetric");
   for j in 1:m loop

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/MultiDelta.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/MultiDelta.mo
@@ -16,12 +16,10 @@ model MultiDelta
   QuasiStatic.Polyphase.Basic.PlugToPins_n plugToPins_n(final m=m)
     annotation (Placement(transformation(extent={{80,-10},{60,10}})));
 protected
-  parameter Integer kP=if (mBasic<=2 or kPolygon<1 or kPolygon>integer(mBasic - 1)/2) then 1 else kPolygon;
+  final parameter Integer kP=if (mBasic<=2 or kPolygon<1 or kPolygon>integer(mBasic - 1)/2) then 1 else kPolygon;
 equation
   when initial() then
-    if (mBasic<=2 or kPolygon<1 or kPolygon>integer(mBasic - 1)/2) then
-      print("MultiDelta: replaced erroneous kPolygon = "+String(kPolygon)+" by kPolygon = 1");
-    end if;
+    assert(kP==kPolygon, "MultiDelta: replaced erroneous kPolygon = "+String(kPolygon)+" by kPolygon = 1", AssertionLevel.warning);
   end when;
   for k in 1:mSystems loop
     for j in 1:(mBasic - kP) loop

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/MutualInductor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/MutualInductor.mo
@@ -5,9 +5,7 @@ model MutualInductor "Linear mutual inductor"
   parameter Real epsilon=1e-9 "Relative accuracy tolerance of matrix symmetry";
   parameter SI.Inductance L[m, m] "Mutual inductance matrix";
 initial equation
-  if abs(Modelica.Math.Matrices.det(L)) < epsilon then
-    Modelica.Utilities.Streams.print("Warning: mutual inductance matrix singular!");
-  end if;
+  assert(Modelica.Math.Matrices.det(L) >= epsilon, "Mutual inductance matrix singular!", AssertionLevel.warning);
 equation
   assert(sum(abs(L - transpose(L))) < epsilon*sum(abs(L)),"Mutual inductance matrix is not symmetric");
   for l in 1:m loop


### PR DESCRIPTION
To me these print-messages starting with "Warning: " should be replaced by assertion-warnings.