### PR TITLE
Revert "Update to v4.2.0-dev"

### DIFF
--- a/Complex.mo
+++ b/Complex.mo
@@ -249,9 +249,9 @@ operator record Complex "Complex number with overloaded operators"
   end 'String';
 
 annotation (
-version="4.2.0-dev",
+version="4.2.0 dev",
 versionDate="20xx-xx-xx",
-dateModified="2025-05-23 15:00:00Z",
+dateModified = "2025-05-23 15:00:00Z",
 revisionId="$Format:%h %ci$",
 conversion(
  noneFromVersion="4.1.0",

--- a/Modelica/package.mo
+++ b/Modelica/package.mo
@@ -4,11 +4,11 @@ extends Modelica.Icons.Package;
 
 annotation (
 preferredView="info",
-version="4.2.0-dev",
+version="4.2.0 dev",
 versionDate="20xx-xx-xx",
-dateModified="2025-05-23 15:00:00Z",
+dateModified = "2025-05-23 15:00:00Z",
 revisionId="$Format:%h %ci$",
-uses(Complex(version="4.2.0-dev"), ModelicaServices(version="4.2.0-dev")),
+uses(Complex(version="4.2.0 dev"), ModelicaServices(version="4.2.0 dev")),
 conversion(
  noneFromVersion="4.1.0",
  noneFromVersion="4.0.0",

--- a/ModelicaReference/package.mo
+++ b/ModelicaReference/package.mo
@@ -7309,9 +7309,9 @@ end Icons;
 
 annotation (
   DocumentationClass=true,
-  version="4.2.0-dev",
+  version="4.2.0 dev",
   versionDate="20xx-xx-xx",
-  dateModified="2025-05-23 15:00:00Z",
+  dateModified = "2025-05-23 15:00:00Z",
   revisionId="$Format:%h %ci$",
   Documentation(info="<html>
 <p>

--- a/ModelicaServices/package.mo
+++ b/ModelicaServices/package.mo
@@ -232,11 +232,11 @@ Specification (version &ge; 3.3).
 
   annotation (
     preferredView="info",
-    version="4.2.0-dev",
+    version="4.2.0 dev",
     versionDate="20xx-xx-xx",
-    dateModified="2025-05-23 15:00:00Z",
+    dateModified = "2025-05-23 15:00:00Z",
     revisionId="$Format:%h %ci$",
-    uses(Modelica(version="4.2.0-dev")),
+    uses(Modelica(version="4.2.0 dev")),
     conversion(
       noneFromVersion="1.0",
       noneFromVersion="1.1",

--- a/ModelicaTest/package.mo
+++ b/ModelicaTest/package.mo
@@ -51,11 +51,11 @@ algorithm
 end testAllFunctions;
 
   annotation (preferredView="info",
-       version="4.2.0-dev",
+       version="4.2.0 dev",
        versionDate="20xx-xx-xx",
-       dateModified="2025-05-23 15:00:00Z",
+       dateModified = "2025-05-23 15:00:00Z",
        revisionId="$Format:%h %ci$",
-       uses(Modelica(version="4.2.0-dev")),
+       uses(Modelica(version="4.2.0 dev")),
     Documentation(info="<html>
 <p>
 This library provides models and functions to test components of

--- a/ModelicaTestOverdetermined.mo
+++ b/ModelicaTestOverdetermined.mo
@@ -608,11 +608,11 @@ The initial equations are consistent however and a tool shall reduce them approp
           fillColor={75,138,73},
           fillPattern=FillPattern.Solid)}),
        preferredView="info",
-       version="4.2.0-dev",
+       version="4.2.0 dev",
        versionDate="20xx-xx-xx",
-       dateModified="2025-05-23 15:00:00Z",
-       revisionId="$Format:%h %ci$",
-       uses(Modelica(version="4.2.0-dev")),
+       dateModified = "2025-05-23 15:00:00Z",
+       revisionId="$Id::                                       $",
+       uses(Modelica(version="4.2.0 dev")),
     Documentation(info="<html>
 <p>
 This library provides models and functions to test components of

--- a/ObsoleteModelica4.mo
+++ b/ObsoleteModelica4.mo
@@ -2875,10 +2875,10 @@ Obsolete saliency cage model, see
       end BasicMachines;
     end FundamentalWave;
   end Magnetic;
-  annotation (uses(Modelica(version="4.2.0-dev")),
-              version="4.2.0-dev",
+  annotation (uses(Modelica(version="4.2.0 dev")),
+              version="4.2.0 dev",
               versionDate="20xx-xx-xx",
-              dateModified="2025-05-23 15:00:00Z",
+              dateModified = "2025-05-23 15:00:00Z",
               revisionId="$Format:%h %ci$",
 Documentation(info="<html>
 <p>


### PR DESCRIPTION
Reverts modelica/ModelicaStandardLibrary#4692

As [noted by](https://github.com/modelica/ModelicaStandardLibrary/pull/4692#issuecomment-3290744514) @HansOlsson, the change went from a legal variant to an illegal variant.