### PR TITLE
Fix units in Modelica.Media.Incompressible.Examples.TestGlycol

### DIFF
--- a/Modelica/Media/Incompressible.mo
+++ b/Modelica/Media/Incompressible.mo
@@ -66,7 +66,7 @@ package Incompressible
     Medium.SpecificEntropy s=Medium.specificEntropy(medium.state);
     Medium.SpecificHeatCapacity cv=Medium.specificHeatCapacityCv(medium.state);
     Medium.SpecificInternalEnergy u=Medium.specificInternalEnergy(medium.state);
-    Medium.SpecificInternalEnergy h=Medium.specificEnthalpy(medium.state);
+    Medium.SpecificEnthalpy h=Medium.specificEnthalpy(medium.state);
     Medium.Density d=Medium.density(medium.state);
     protected
     constant SI.Time timeUnit = 1;


### PR DESCRIPTION
A simple correction for a unit-issue in MSL; probably due to copy-pasting the lines above.
(It wasn't detected earlier for various reasons.)
