### PR TITLE
The tanks should be vertical

### DIFF
--- a/Modelica/StateGraph.mo
+++ b/Modelica/StateGraph.mo
@@ -1563,7 +1563,7 @@ buttons:
                 extent=DynamicSelect({{-60,-40},{-60,-40}}, {{-60,-40},{80,(-40
                      + level*100)}}),
                 lineThickness=0.5,
-                fillPattern=FillPattern.HorizontalCylinder,
+                fillPattern=FillPattern.VerticalCylinder,
                 fillColor={191,0,95})}));
     end Tank;
 


### PR DESCRIPTION
Change so that the tanks use vertical cylinders for visualization (a regular cylindrical tank: like an oil drum/coffee cup/glass of water) - not a cylinder on the side.

Found when investigating #4711 - but somewhat unrelated.