### PR TITLE
SkipGradients

### DIFF
--- a/Modelica/Fluid/Examples/AST_BatchPlant.mo
+++ b/Modelica/Fluid/Examples/AST_BatchPlant.mo
@@ -894,14 +894,14 @@ Documentation for this example can be found on the <a href=\"modelica://Modelica
               textString="%name"),
             Polygon(
               points={{0,100},{200,70},{200,50},{200,50},{0,80},{0,100}},
-              fillPattern=FillPattern.HorizontalCylinder,
+              fillPattern=FillPattern.Solid,
               fillColor={0,0,255}),
             Polygon(
               points={{20,98},{30,74},{52,84},{66,72},{86,78},{98,66},{118,74},
                   {130,60},{144,70},{152,60},{168,66},{180,54},{196,74},{190,76},
                   {180,64},{170,70},{156,66},{148,76},{132,68},{120,80},{100,74},
                   {88,88},{70,78},{50,92},{32,82},{28,100},{20,98},{20,98}},
-              fillPattern=FillPattern.HorizontalCylinder,
+              fillPattern=FillPattern.Solid,
               fillColor={170,255,255}),
             Text(
               extent={{-193,30},{-3,10}},


### PR DESCRIPTION
Split off from #4711 

This is for the Modelica.Fluid.Examples.AST_BatchPlant.BaseClasses.TankWith3InletOutletArraysWithEvaporatorCondensor model used in Modelica.Fluid.Examples.AST_BatchPlant and is for the slanted pipe at the top:

This PR intends to get it to look as follows (this is also how it looks like in Dymola 2026x):

<img width="1080" height="427" alt="TankWith3InletOutletArraysWithEvaporatorCondensor" src="https://github.com/user-attachments/assets/2d889ec8-02e9-4c17-8efc-fcf2e8cebda7" />

Supporting gradients on polygons would instead give (notice the odd gradients for the top-pipe; to me this just looks odd):

<img width="1125" height="445" alt="TankWith3InletOutletArraysWithEvaporatorCondensor_Weird" src="https://github.com/user-attachments/assets/c81b0eba-d603-4f67-a393-a772e7aa63a1" />

I assume the idea was something like the following (using paint) - but that requires gradients along the axis of polygons, which seems quite difficult to support:

<img width="1431" height="594" alt="TankWith3InletOutletArraysWithEvaporatorCondensor_Intended" src="https://github.com/user-attachments/assets/8fed6570-04bf-4915-8241-8f7708910752" />
