### PR TITLE
Adding missing bracket in doc string

### DIFF
--- a/Modelica/Electrical/Analog/Basic/Potentiometer.mo
+++ b/Modelica/Electrical/Analog/Basic/Potentiometer.mo
@@ -4,7 +4,7 @@ model Potentiometer "Adjustable resistor"
     "Resistance at temperature T_ref";
   parameter SI.Temperature T_ref=293.15 "Reference temperature";
   parameter SI.LinearTemperatureCoefficient alpha=0
-    "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(T_heatPort - T_ref))";
+    "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(T_heatPort - T_ref)))";
   extends Modelica.Electrical.Analog.Interfaces.ConditionalHeatPort(T=T_ref);
   parameter Boolean useRinput=false "Use input for 0<r<1 (else constant)"
     annotation (

--- a/Modelica/Electrical/Analog/Basic/Resistor.mo
+++ b/Modelica/Electrical/Analog/Basic/Resistor.mo
@@ -4,7 +4,7 @@ model Resistor "Ideal linear electrical resistor"
     "Resistance at temperature T_ref";
   parameter SI.Temperature T_ref=300.15 "Reference temperature";
   parameter SI.LinearTemperatureCoefficient alpha=0
-    "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(T_heatPort - T_ref))";
+    "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(T_heatPort - T_ref)))";
 
   extends Modelica.Electrical.Analog.Interfaces.OnePort;
   extends Modelica.Electrical.Analog.Interfaces.ConditionalHeatPort(T=T_ref);

--- a/Modelica/Electrical/Analog/Basic/VariableResistor.mo
+++ b/Modelica/Electrical/Analog/Basic/VariableResistor.mo
@@ -3,7 +3,7 @@ model VariableResistor
   "Ideal linear electrical resistor with variable resistance"
   parameter SI.Temperature T_ref=300.15 "Reference temperature";
   parameter SI.LinearTemperatureCoefficient alpha=0
-    "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(T_heatPort - T_ref))";
+    "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(T_heatPort - T_ref)))";
   extends Modelica.Electrical.Analog.Interfaces.OnePort;
   extends Modelica.Electrical.Analog.Interfaces.ConditionalHeatPort(T=T_ref);
   SI.Resistance R_actual

--- a/Modelica/Electrical/Analog/Lines/M_OLine.mo
+++ b/Modelica/Electrical/Analog/Lines/M_OLine.mo
@@ -29,9 +29,9 @@ public
   parameter Boolean useInternalGround=true "= true if internal ground is used, otherwise use reference pin"
     annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
   parameter SI.LinearTemperatureCoefficient alpha_R=0
-    "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
+    "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref)))";
   parameter SI.LinearTemperatureCoefficient alpha_G=0
-    "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref))";
+    "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref)))";
   parameter Boolean useHeatPort=false "= true, if heatPort is enabled"
     annotation (
     Evaluate=true,
@@ -66,9 +66,9 @@ public
     parameter Real Gl[dim_vector_lgc]=fill(1, dim_vector_lgc)
       "Conductance matrix";
     parameter SI.LinearTemperatureCoefficient alpha_R
-      "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
+      "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref)))";
     parameter SI.LinearTemperatureCoefficient alpha_G
-      "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref))";
+      "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref)))";
     parameter Boolean useHeatPort=false "= true, if heatPort is enabled"
       annotation (
       Evaluate=true,
@@ -172,7 +172,7 @@ public
     parameter Real Ll[dim_vector_lgc]=fill(1, dim_vector_lgc)
       "Inductance matrix";
     parameter SI.LinearTemperatureCoefficient alpha_R
-      "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
+      "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref)))";
     parameter Boolean useHeatPort=false "= true, if HeatPort is enabled"
       annotation (
       Evaluate=true,

--- a/Modelica/Electrical/Analog/Lines/OLine.mo
+++ b/Modelica/Electrical/Analog/Lines/OLine.mo
@@ -31,9 +31,9 @@ model OLine "Lossy Transmission Line"
       start=1) "Length of line";
   parameter Integer N(final min=1, start=1) "Number of lumped segments";
   parameter SI.LinearTemperatureCoefficient alpha_R=0
-    "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
+    "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref)))";
   parameter SI.LinearTemperatureCoefficient alpha_G=0
-    "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref))";
+    "Temperature coefficient of conductance (G_actual = G/(1 + alpha*(heatPort.T - T_ref)))";
   parameter Boolean useHeatPort=false "= true, if heatPort is enabled"
     annotation (
     Evaluate=true,

--- a/Modelica/Electrical/Analog/Lines/ULine.mo
+++ b/Modelica/Electrical/Analog/Lines/ULine.mo
@@ -24,7 +24,7 @@ model ULine "Lossy RC Line"
       start=1) "Length of line";
   parameter Integer N(final min=1, start=1) "Number of lumped segments";
   parameter SI.LinearTemperatureCoefficient alpha=0
-    "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref))";
+    "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(heatPort.T - T_ref)))";
   parameter Boolean useHeatPort=false "= true, if heatPort is enabled"
     annotation (
     Evaluate=true,

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/Admittance.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/Admittance.mo
@@ -6,7 +6,7 @@ model Admittance "Polyphase linear admittance"
   parameter SI.Temperature T_ref[m]=fill(293.15, m)
     "Reference temperatures";
   parameter SI.LinearTemperatureCoefficient alpha_ref[m]=zeros(m)
-    "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref))";
+    "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref)))";
   extends Modelica.Electrical.Polyphase.Interfaces.ConditionalHeatPort(final mh=m, T=T_ref);
   parameter Boolean frequencyDependent = false "Consider frequency dependency, if true"
     annotation(Evaluate=true, HideResult=true, choices(checkBox=true));

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/Impedance.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/Impedance.mo
@@ -6,7 +6,7 @@ model Impedance "Polyphase linear impedance"
   parameter SI.Temperature T_ref[m]=fill(293.15, m)
     "Reference temperatures";
   parameter SI.LinearTemperatureCoefficient alpha_ref[m]=zeros(m)
-    "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref))";
+    "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref)))";
   extends Modelica.Electrical.Polyphase.Interfaces.ConditionalHeatPort(final mh=m, T=T_ref);
   parameter Boolean frequencyDependent = false "Consider frequency dependency, if true"
     annotation(Evaluate=true, HideResult=true, choices(checkBox=true));

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/Resistor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/Resistor.mo
@@ -7,7 +7,7 @@ model Resistor "Polyphase linear resistor"
     "Reference temperatures";
   parameter SI.LinearTemperatureCoefficient alpha_ref[m]=
       zeros(m)
-    "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref))";
+    "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref)))";
   extends Modelica.Electrical.Polyphase.Interfaces.ConditionalHeatPort(
       final mh=m, T=T_ref);
   QuasiStatic.SinglePhase.Basic.Resistor resistor[m](

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/VariableAdmittance.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/VariableAdmittance.mo
@@ -4,7 +4,7 @@ model VariableAdmittance "Polyphase variable admittance"
   parameter SI.Temperature T_ref[m]=fill(293.15, m)
     "Reference temperatures";
   parameter SI.LinearTemperatureCoefficient alpha_ref[m]=zeros(m)
-    "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref))";
+    "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref)))";
   extends Modelica.Electrical.Polyphase.Interfaces.ConditionalHeatPort(final mh=m, T=T_ref);
   parameter Boolean frequencyDependent = false "Consider frequency dependency, if true"
     annotation(Evaluate=true, HideResult=true, choices(checkBox=true));

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/VariableConductor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/VariableConductor.mo
@@ -5,7 +5,7 @@ model VariableConductor "Polyphase variable conductor"
     "Reference temperatures";
   parameter SI.LinearTemperatureCoefficient alpha_ref[m]=
       zeros(m)
-    "Temperature coefficient of resistance (G_actual = G_ref/(1 + alpha_ref*(heatPort.T - T_ref))";
+    "Temperature coefficient of resistance (G_actual = G_ref/(1 + alpha_ref*(heatPort.T - T_ref)))";
   extends Modelica.Electrical.Polyphase.Interfaces.ConditionalHeatPort(
       final mh=m, T=T_ref);
   Modelica.Blocks.Interfaces.RealInput G_ref[m](each unit="S")

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/VariableImpedance.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/VariableImpedance.mo
@@ -4,7 +4,7 @@ model VariableImpedance "Polyphase variable impedance"
   parameter SI.Temperature T_ref[m]=fill(293.15, m)
     "Reference temperatures";
   parameter SI.LinearTemperatureCoefficient alpha_ref[m]=zeros(m)
-    "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref))";
+    "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref)))";
   extends Modelica.Electrical.Polyphase.Interfaces.ConditionalHeatPort(final mh=m, T=T_ref);
   parameter Boolean frequencyDependent = false "Consider frequency dependency, if true"
     annotation(Evaluate=true, HideResult=true, choices(checkBox=true));

--- a/Modelica/Electrical/QuasiStatic/Polyphase/Basic/VariableResistor.mo
+++ b/Modelica/Electrical/QuasiStatic/Polyphase/Basic/VariableResistor.mo
@@ -5,7 +5,7 @@ model VariableResistor "Polyphase variable resistor"
     "Reference temperatures";
   parameter SI.LinearTemperatureCoefficient alpha_ref[m]=
       zeros(m)
-    "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref))";
+    "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref)))";
   extends Modelica.Electrical.Polyphase.Interfaces.ConditionalHeatPort(
       final mh=m, T=T_ref);
   Modelica.Blocks.Interfaces.RealInput R_ref[m](each unit="Ohm")

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/Admittance.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/Admittance.mo
@@ -7,7 +7,7 @@ model Admittance "Single-phase linear admittance"
   import Modelica.ComplexMath.conj;
   parameter SI.ComplexAdmittance Y_ref(re(start=1),im(start=0)) "Complex admittance G_ref + j*B_ref";
   parameter SI.Temperature T_ref=293.15 "Reference temperature";
-  parameter SI.LinearTemperatureCoefficient alpha_ref=0 "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref))";
+  parameter SI.LinearTemperatureCoefficient alpha_ref=0 "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref)))";
   extends Modelica.Electrical.Analog.Interfaces.ConditionalHeatPort(T=T_ref);
   parameter Boolean frequencyDependent = false "Consider frequency dependency, if true"
     annotation(Evaluate=true, HideResult=true, choices(checkBox=true));

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/Impedance.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/Impedance.mo
@@ -7,7 +7,7 @@ model Impedance "Single-phase linear impedance"
   import Modelica.ComplexMath.conj;
   parameter SI.ComplexImpedance Z_ref(re(start=1),im(start=0)) "Complex impedance R_ref + j*X_ref";
   parameter SI.Temperature T_ref=293.15 "Reference temperature";
-  parameter SI.LinearTemperatureCoefficient alpha_ref=0 "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref))";
+  parameter SI.LinearTemperatureCoefficient alpha_ref=0 "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref)))";
   extends Modelica.Electrical.Analog.Interfaces.ConditionalHeatPort(T=T_ref);
   parameter Boolean frequencyDependent = false "Consider frequency dependency, if true"
     annotation(Evaluate=true, HideResult=true, choices(checkBox=true));

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/Resistor.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/Resistor.mo
@@ -5,7 +5,7 @@ model Resistor "Single-phase linear resistor"
   import Modelica.ComplexMath.conj;
   parameter SI.Resistance R_ref(start=1) "Reference resistance at T_ref";
   parameter SI.Temperature T_ref=293.15 "Reference temperature";
-  parameter SI.LinearTemperatureCoefficient alpha_ref=0 "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref))";
+  parameter SI.LinearTemperatureCoefficient alpha_ref=0 "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref)))";
   extends Modelica.Electrical.Analog.Interfaces.ConditionalHeatPort(T=T_ref);
   SI.Resistance R_actual "Resistance = R_ref*(1 + alpha_ref*(heatPort.T - T_ref))";
 equation

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/VariableAdmittance.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/VariableAdmittance.mo
@@ -5,7 +5,7 @@ model VariableAdmittance "Single-phase variable admittance"
   import Modelica.ComplexMath.imag;
   import Modelica.ComplexMath.conj;
   parameter SI.Temperature T_ref=293.15 "Reference temperature";
-  parameter SI.LinearTemperatureCoefficient alpha_ref=0 "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref))";
+  parameter SI.LinearTemperatureCoefficient alpha_ref=0 "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref)))";
   extends Modelica.Electrical.Analog.Interfaces.ConditionalHeatPort(T=T_ref);
   Modelica.ComplexBlocks.Interfaces.ComplexInput Y_ref "Variable complex admittance"
     annotation (Placement(transformation(

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/VariableImpedance.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/VariableImpedance.mo
@@ -5,7 +5,7 @@ model VariableImpedance "Single-phase variable impedance"
   import Modelica.ComplexMath.imag;
   import Modelica.ComplexMath.conj;
   parameter SI.Temperature T_ref=293.15 "Reference temperature";
-  parameter SI.LinearTemperatureCoefficient alpha_ref=0 "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref))";
+  parameter SI.LinearTemperatureCoefficient alpha_ref=0 "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref)))";
   extends Modelica.Electrical.Analog.Interfaces.ConditionalHeatPort(T=T_ref);
   Modelica.ComplexBlocks.Interfaces.ComplexInput Z_ref "Variable complex impedance"
     annotation (Placement(transformation(

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/VariableResistor.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Basic/VariableResistor.mo
@@ -4,7 +4,7 @@ model VariableResistor "Single-phase variable resistor"
   import Modelica.ComplexMath.real;
   import Modelica.ComplexMath.conj;
   parameter SI.Temperature T_ref=293.15 "Reference temperature";
-  parameter SI.LinearTemperatureCoefficient alpha_ref=0 "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref))";
+  parameter SI.LinearTemperatureCoefficient alpha_ref=0 "Temperature coefficient of resistance (R_actual = R_ref*(1 + alpha_ref*(heatPort.T - T_ref)))";
   extends Modelica.Electrical.Analog.Interfaces.ConditionalHeatPort(T=T_ref);
   SI.Resistance R_actual "Resistance = R_ref*(1 + alpha_ref*(heatPort.T - T_ref))";
   Modelica.Blocks.Interfaces.RealInput R_ref(unit="Ohm") "Variable resistance"


### PR DESCRIPTION
## Issue 

A closing bracket is missing in some documentation strings for some temperature coefficient in various models. 

## Changes

* Adding missing closing bracket in Temperature coefficient doc string in various locations.

  ```diff
  - "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(T_heatPort - T_ref))"
  + "Temperature coefficient of resistance (R_actual = R*(1 + alpha*(T_heatPort - T_ref)))" 
  ```

* My IDE is set up to removes trailing white space. If needed I can refactor this PR to exclude these changes, but in my opinion it is cleaner to remove trailing while spaces anyway.