### PR TITLE
Implement missing media properties in TableBased

### DIFF
--- a/Modelica/Media/Incompressible.mo
+++ b/Modelica/Media/Incompressible.mo
@@ -364,6 +364,46 @@ which is only exactly true for a fluid with constant density d=d0.
      annotation(smoothOrder=2);
     end thermalConductivity;
 
+    redeclare function extends density_derp_h
+      "Return density derivative w.r.t. pressure at constant specific enthalpy"
+    algorithm
+      ddph := 0; // Correct if enthalpyOfT is true.
+    end density_derp_h;
+
+    redeclare function extends density_derh_p
+        "Return density derivative w.r.t. specific enthalpy at constant pressure"
+    algorithm
+      ddhp := density_derT_p(state) / specificHeatCapacityCp(state);
+    end density_derh_p;
+
+
+    redeclare function extends density_derp_T
+      "Return density derivative w.r.t. pressure at constant temperature"
+    algorithm
+      ddpT := 0; // Incompressible
+    end density_derp_T;
+
+    redeclare function extends density_derT_p
+        "Return density derivative w.r.t. temperature at constant pressure"
+    algorithm
+      ddTp := Polynomials.derivativeValue(poly_rho, if TinK then state.T else Cv.to_degC(state.T));
+    end density_derT_p;
+
+    redeclare function extends isobaricExpansionCoefficient
+      "Return isobaric expansion coefficient (beta) as a function of the thermodynamic state record"
+    algorithm
+      beta := -density_derT_p(state) / density(state);
+    annotation(
+        Documentation(info = "<html><head></head><body><p>The isobaric expansion coefficient <code>beta</code> is defined as</p>
+<blockquote><pre>1/v * der(v,T)
+</pre></blockquote>
+<p>with <code>v</code> = <code>1/d</code>, at constant pressure <code>p</code>.
+Using the chain rule:</p>
+<blockquote><pre>1/v * der(v,T) = d * (-der(d, T) / d^2)
+= -der(d, T) / d</pre><pre><br></pre></blockquote>
+</body></html>"));
+    end isobaricExpansionCoefficient;
+
     function s_T "Compute specific entropy"
       extends Modelica.Icons.Function;
       input Temperature T "Temperature";


### PR DESCRIPTION
Add density_derT_p, density_derh_p, density_derp_T, density_derp_h and isobaricExpansionCoefficient to Incompressible.TableBased. IsobaricExpansionCoefficient is useful e.g. when calculating heat transfer coefficients for free convection.