### PR TITLE
FluxTubes.Basic.ElectroMagneticConverter: L_stat

### DIFF
--- a/Modelica/Magnetic/FluxTubes/Basic/ElectroMagneticConverter.mo
+++ b/Modelica/Magnetic/FluxTubes/Basic/ElectroMagneticConverter.mo
@@ -18,7 +18,7 @@ model ElectroMagneticConverter "Ideal electromagnetic energy conversion"
 
   // For information only:
   SI.MagneticFlux Psi "Flux linkage";
-  SI.Inductance L_stat "Static inductance abs(Psi/i)";
+  SI.Inductance L_stat "Static inductance (valid if this coil is the only source)";
 
 protected
   Real eps=100*Modelica.Constants.eps;
@@ -38,7 +38,7 @@ equation
   // For information only
   Psi = N*Phi;
   // Use of abs() for positive results; due to Modelica sign conventions for flow into connectors
-  L_stat = noEvent(if abs(i) > eps then abs(Psi/i) else abs(Psi/eps));
+  L_stat = if noEvent(abs(i) > eps) then abs(Psi/i) else abs(Psi/eps);
 
   annotation (
     defaultComponentName="converter",
@@ -164,9 +164,12 @@ v is the induced voltage in the coil due to the derivative of magnetic flux &Phi
 If a coil wound clockwise has to be modeled instead, the parameter N (Number of turns) can be set to a negative value.
 </p>
 
+
+<h4>Note</h4>
 <p>
-The flux linkage &Psi; and the static inductance L_stat = |&Psi;/i| are calculated for information only. Note that L_stat is set to |&Psi;/eps| if |i| &lt; eps
-(= 100*Modelica.Constants.eps).
+The flux linkage &Psi; and the static inductance L_stat = |&Psi;/i| are calculated for information only. 
+Note that L_stat is set to |&Psi;/eps| if |i| &lt; eps (= 100*Modelica.Constants.eps).<br>
+<strong>Note</strong> that this local calculation of L_stat is only valid if this coil is the only source in the magnetic circuit.
 </p>
 </html>"));
 end ElectroMagneticConverter;

--- a/Modelica/Magnetic/FluxTubes/Basic/ElectroMagneticConverterWithLeakageInductance.mo
+++ b/Modelica/Magnetic/FluxTubes/Basic/ElectroMagneticConverterWithLeakageInductance.mo
@@ -35,7 +35,7 @@ model ElectroMagneticConverterWithLeakageInductance
 
   // For information only
   SI.MagneticFlux Psi "Flux linkage";
-  SI.Inductance L_stat "Static inductance abs(Psi/i)";
+  SI.Inductance L_stat "Static inductance (valid if this coil is the only source)";
 
 protected
   constant Real eps=100*Modelica.Constants.eps;
@@ -59,7 +59,7 @@ equation
   // For information only
   Psi = N*Phi_ind;
   //use of abs() for positive results; due to Modelica sign conventions for flow into connectors
-  L_stat = noEvent(if abs(i) > eps then abs(Psi/i) else abs(Psi/eps));
+  L_stat = if noEvent(abs(i) > eps) then abs(Psi/i) else abs(Psi/eps);
 
   annotation (
     defaultComponentName="converter",
@@ -158,7 +158,16 @@ equation
         Line(points={{-30,-100},{-30,-60}}, color={28,108,200})}),
     Documentation(info="<html>
 <p>
-Same as <a href=\"modelica://Modelica.Magnetic.FluxTubes.Basic.ElectroMagneticConverter\">ElectroMagneticConverter</a> with an additional leakage path on the magnetic side (leakage inductance, leakage flux). This model may improve stability especially when the magnetic circuit contains more than one electromagnetic converter.
+Same as <a href=\"modelica://Modelica.Magnetic.FluxTubes.Basic.ElectroMagneticConverter\">ElectroMagneticConverter</a> 
+with an additional leakage path on the magnetic side (leakage inductance, leakage flux). 
+This model may improve stability especially when the magnetic circuit contains more than one electromagnetic converter.
+</p>
+
+<h4>Note</h4>
+<p>
+The flux linkage &Psi; and the static inductance L_stat = |&Psi;/i| are calculated for information only. 
+Note that L_stat is set to |&Psi;/eps| if |i| &lt; eps (= 100*Modelica.Constants.eps).<br>
+<strong>Note</strong> that this local calculation of L_stat is only valid if this coil is the only source in the magnetic circuit.
 </p>
 </html>"));
 end ElectroMagneticConverterWithLeakageInductance;


### PR DESCRIPTION
Both the ElectrocMagenticConverter and the ElectroMagneticConverterWithLeakageInductance lack a warning that L_stat is only valid if the coil is the only source in the magnetic circuit, Otherwise the magnetc flux is at least partly driven by other sources, too, and the calculation of L_stat is misleading.
Additonally, in the equation for L_stat the usage of noEvent has been corrected.