### PR TITLE
FluxTubes: material M330_50A

### DIFF
--- a/Modelica/Magnetic/FluxTubes/Material/SoftMagnetic/ElectricSheet/M330_50A.mo
+++ b/Modelica/Magnetic/FluxTubes/Material/SoftMagnetic/ElectricSheet/M330_50A.mo
@@ -1,5 +1,5 @@
 within Modelica.Magnetic.FluxTubes.Material.SoftMagnetic.ElectricSheet;
-record M330_50A "M330-50A (1.0809) @ 50Hz"
+record M330_50A "M330-50A (1.0809) @ 50Hz complete core"
   extends FluxTubes.Material.SoftMagnetic.BaseData(
     label="M330-50A",
     mu_i=500,
@@ -8,12 +8,18 @@ record M330_50A "M330-50A (1.0809) @ 50Hz"
     c_b=9.38,
     n=9.6);
   annotation (defaultComponentPrefixes="parameter",
+    preferredView="info",
     Documentation(info="<html>
 <p>
 Please refer to the description of  the enclosing package <a href=\"modelica://Modelica.Magnetic.FluxTubes.Material.SoftMagnetic\">SoftMagnetic</a> for a description of all soft magnetic material characteristics of this package.
 </p>
 <p>
 Sample: complete core after machining and packet assembling<br>
+</p>
+<h4>Note</h4>
+<p>
+This material has been measured under different conditions (complete core / machined and packeted) as the other electric sheets (sheet strip / Epstein frame).
+Direct comparison with other material is therefore not possible.
 </p>
 </html>"));
 end M330_50A;

--- a/Modelica/Magnetic/FluxTubes/Material/SoftMagnetic/package.mo
+++ b/Modelica/Magnetic/FluxTubes/Material/SoftMagnetic/package.mo
@@ -41,7 +41,7 @@ Additional user-specific materials can be defined as needed. This requires deter
 </p>
 
 <p>
-The magnetisation characteristics of the included soft magnetic materials were compiled and measured respectively by Thomas Roschke, now with Johnson Electric. 
+The magnetisation characteristics of the included soft magnetic materials were compiled and measured respectively by Thomas Roschke. 
 Provision of this data is highly appreciated. He also formulated the approximation function used for description of the magnetisation characteristics of these materials.
 </p>
 </html>"));

--- a/Modelica/Magnetic/FluxTubes/Material/SoftMagnetic/package.mo
+++ b/Modelica/Magnetic/FluxTubes/Material/SoftMagnetic/package.mo
@@ -2,27 +2,47 @@ within Modelica.Magnetic.FluxTubes.Material;
 package SoftMagnetic "Characteristics mu_r(B) of common soft magnetic materials; hysteresis neglected"
   extends Modelica.Icons.MaterialPropertiesPackage;
 
-  annotation (Documentation(info="<html>
+  annotation (preferredView="info",
+    Documentation(info="<html>
 <p>
-The magnetisation characteristics mu_r(B) of all soft magnetic materials currently included in this library are approximated with a <a href=\"modelica://Modelica.Magnetic.FluxTubes.Material.SoftMagnetic.mu_rApprox\">function</a>. Each material is characterised by the five parameters of this function. The approximated characteristics mu_r(B) for most of the ferromagnetic materials currently included are shown in the plots below (solid lines) together with the original data points compiled from measurements and literature.
+The magnetisation characteristics mu_r(B) of all soft magnetic materials currently included in this library are approximated 
+with a <a href=\"modelica://Modelica.Magnetic.FluxTubes.Material.SoftMagnetic.mu_rApprox\">function</a>. Each material is characterised by the five parameters of this function. 
+The approximated characteristics mu_r(B) for most of the ferromagnetic materials currently included are shown in the plots below (solid lines) 
+together with the original data points compiled from measurements and literature.
 </p>
 
 <div>
+<img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Material/SoftMagnetic/ElectricSheet.png\" alt=\"Approximated magnetization characteristics of included electric sheets\"><br>
 <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Material/SoftMagnetic/Steel.png\" alt=\"Approximated magnetization characteristics of selected steels\"><br>
 <img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Material/SoftMagnetic/Miscellaneous.png\" alt=\"Approximated magnetization characteristics of miscellaneous soft magnetic materials\"><br>
-<img src=\"modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Material/SoftMagnetic/ElectricSheet.png\" alt=\"Approximated magnetization characteristics of included electric sheets\"><br>
 </div>
 
+
+<h4>Note</h4>
 <p>
-For the nonlinear curve fit, data points for high flux densities (approximately B>1T) have been weighted higher than the ones for low flux densities. This is due to the large impact of saturated ferromagnetic sections in a magnetic circuit compared to that of non-saturated sections with relative permeabilities mu_r>>1.
+The material <a href=\"modelica://Modelica.Magnetic.FluxTubes.Material.SoftMagnetic.ElectricSheet.M330_50A\">M330-50A</a> has been measured 
+under different conditions (complete core / machined and packeted) as the other electric sheets (sheet strip / Epstein frame).
+Direct comparison with other material is therefore not possible.
 </p>
 
 <p>
-Note that the magnetisation characteristics largely depend on possible previous machining and on measurement conditions. A virgin material normally has a considerably higher permeability than the same material after machining (and packet assembling in case of electric sheets). This is indicated in the above plots by different magnetisation curves for similar materials. In most cases, the original data points represent commutating curves obtained with measurements at 50Hz.
+For the nonlinear curve fit, data points for high flux densities (approximately B>1T) have been weighted higher than the ones for low flux densities. 
+This is due to the large impact of saturated ferromagnetic sections in a magnetic circuit compared to that of non-saturated sections with relative permeabilities mu_r>>1.
+</p>
+
+<p>
+Note that the magnetisation characteristics largely depend on possible previous machining and on measurement conditions. 
+A virgin material normally has a considerably higher permeability than the same material after machining (and packet assembling in case of electric sheets). 
+This is indicated in the above plots by different magnetisation curves for similar materials. In most cases, the original data points represent commutating curves obtained with measurements at 50Hz.
 </p>
 
 <p>
 Additional user-specific materials can be defined as needed. This requires determination of the approximation parameters from the original data points, preferably with a nonlinear curve fit.
+</p>
+
+<p>
+The magnetisation characteristics of the included soft magnetic materials were compiled and measured respectively by Thomas Roschke, now with Johnson Electric. 
+Provision of this data is highly appreciated. He also formulated the approximation function used for description of the magnetisation characteristics of these materials.
 </p>
 </html>"));
 end SoftMagnetic;

--- a/Modelica/Magnetic/FluxTubes/Material/SoftMagnetic/package.mo
+++ b/Modelica/Magnetic/FluxTubes/Material/SoftMagnetic/package.mo
@@ -22,7 +22,7 @@ together with the original data points compiled from measurements and literature
 <p>
 The material <a href=\"modelica://Modelica.Magnetic.FluxTubes.Material.SoftMagnetic.ElectricSheet.M330_50A\">M330-50A</a> has been measured 
 under different conditions (complete core / machined and packeted) as the other electric sheets (sheet strip / Epstein frame).
-Direct comparison with other material is therefore not possible.
+Therefore, a direct comparison with other materials is not possible.
 </p>
 
 <p>


### PR DESCRIPTION
Material M330_50A was measured under different conditions (complete core / machined and packeted) than the oher electric sheet (sheet strip / Epstein frame). A clear hint is missing that M330_50A cannot bei compared directly to the other electric sheet.
Added this hint(s).