### PR TITLE
Simplify cases for `erf`

### DIFF
--- a/Modelica/Math/Special.mo
+++ b/Modelica/Math/Special.mo
@@ -30,7 +30,7 @@ package Special "Library of special mathematical functions"
       inv := true;
     end if;
 
-    if z < sqrt(3.0*Modelica.Constants.eps/2.0) then
+    if z < sqrt(1.5*Modelica.Constants.eps) then
       // Maclaurin series to first order
       // alternating series estimated relative error < eps
       y := z*2.0/sqrt(Modelica.Constants.pi);


### PR DESCRIPTION
The local variable `z` is by construction non-negative and the linear case gives `y = 0` for `z = 0`.

~This makes the symbolic derivative of `erf` continuous around zero.~ (No longer relevant as soon as #4753 is merged.)

This simplifies the algorithm and clarifies the constant values.