### PR TITLE
Remove unused constant in Modelica.Math.Special.erfInv

### DIFF
--- a/Modelica/Math/Special.mo
+++ b/Modelica/Math/Special.mo
@@ -199,8 +199,6 @@ erfc(0.5)  // = 0.4795001221869534
     extends Modelica.Icons.Function;
     input Real u "Input argument in the range -1 <= u <= 1";
     output Real y "= inverse of error function";
-  protected
-    constant Real eps = 0.1;
   algorithm
     if u >= 1 then
        y := Modelica.Constants.inf;


### PR DESCRIPTION
I just noticed that the `eps` constant in `erfInv` isn't actually used, looks like it got accidentally included when the function was added to the MSL.