### PR TITLE
Avoid that Constants.pi gets the unit "rad"

### DIFF
--- a/Modelica/Constants.mo
+++ b/Modelica/Constants.mo
@@ -7,8 +7,8 @@ package Constants
   import Modelica.Units.NonSI;
 
   // Mathematical constants
-  final constant Real e(final unit="1") = Modelica.Math.exp(1.0);
-  final constant Real pi = 2*Modelica.Math.asin(1.0); // 3.14159265358979;
+  final constant Real e(final unit="1") = exp(1.0);
+  final constant Real pi = 2 * asin(1.0); // 3.14159265358979;
   final constant Real D2R(final unit="rad/deg") = pi/180 "Degree to Radian";
   final constant Real R2D(final unit="deg/rad") = 180/pi "Radian to Degree";
   final constant Real gamma(final unit="1") = 0.57721566490153286061


### PR DESCRIPTION
The current definition of `Modelica.Constants.pi` gives it the unit `"rad"`, but based on the ongoing discussions about standardizing a definition of unit consistency in the Modelica specification, I find it clear that `pi` should have "empty" unit, making the constant behave just like a numeric literal.

For example, the following is expected to be allowed if `pi` has empty unit, but not if it has unit `"rad"`:
```
Modelica.Units.SI.Time piTime = Modelica.Constants.pi "π seconds";
```

With the unit `"rad"`, the workaround would be to insert a conversion factor,
```
Real conversionFactor(unit = "s/rad") = 1;
Modelica.Units.SI.Time piTime = conversionFactor * Modelica.Constants.pi "π seconds";
```
but I have a clear impression that our community wouldn't like to have to do it this way (even though it would be much more convenient once the factor can be given in-line as `1's/rad'`).

In this PR, the change for `pi` avoids that it gets the unit `"rad"`, and `e` is updated to keep the two definitions consistent.