### PR TITLE
Output interval less dense to reduce size of ReferenceResult

### DIFF
--- a/Modelica/Thermal/HeatTransfer/Examples/Motor.mo
+++ b/Modelica/Thermal/HeatTransfer/Examples/Motor.mo
@@ -110,5 +110,5 @@ Using Modelica.Thermal.FluidHeatFlow it would be possible to model the coolant a
 Simulate for 7200 s; plot Twinding.T and Tcore.T.
 </p>
 </html>"),
-    experiment(StopTime=7200, Interval=0.01));
+    experiment(StopTime=7200, Interval=1));
 end Motor;


### PR DESCRIPTION
Factor 100 is ok for the trajectories and should reduce size of ReferenceResults sufficiently. 
I suppose the dense output slipped in during development starting from an example with more intense transients.