### PR TITLE
Document how values are computed based on resonance frequency.

### DIFF
--- a/Modelica/Electrical/Analog/Examples/ParallelResonance.mo
+++ b/Modelica/Electrical/Analog/Examples/ParallelResonance.mo
@@ -2,6 +2,8 @@ within Modelica.Electrical.Analog.Examples;
 model ParallelResonance "Parallel resonance circuit"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
+  parameter Modelica.Units.SI.Frequency f0=100 "Resonance frequency";
+  parameter Modelica.Units.SI.Resistance R=10 "Scaling";
   Sources.SineCurrentVariableFrequencyAndAmplitude sineCurrent(
       useConstantAmplitude=true,                               phi(fixed=true))
     annotation (Placement(transformation(
@@ -14,12 +16,12 @@ model ParallelResonance "Parallel resonance circuit"
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-10,70})));
-  Basic.Inductor inductor1(i(fixed=true), L=0.1/(2*pi)) annotation (Placement(
+  Basic.Inductor inductor1(i(fixed=true), L=R/(2*pi*f0)) annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-10,40})));
-  Basic.Capacitor capacitor1(v(fixed=true), C=0.001/(2*pi)) annotation (
+  Basic.Capacitor capacitor1(v(fixed=true), C=1/(R*2*pi*f0)) annotation (
       Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
@@ -46,12 +48,12 @@ model ParallelResonance "Parallel resonance circuit"
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-10,-30})));
-  Basic.Inductor inductor2(i(fixed=true), L=0.1/(2*pi)) annotation (Placement(
+  Basic.Inductor inductor2(i(fixed=true), L=R/(2*pi*f0)) annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-10,-60})));
-  Basic.Capacitor capacitor2(v(fixed=true), C=0.001/(2*pi)) annotation (
+  Basic.Capacitor capacitor2(v(fixed=true), C=1/(R*2*pi*f0)) annotation (
       Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,

--- a/Modelica/Electrical/Analog/Examples/SeriesResonance.mo
+++ b/Modelica/Electrical/Analog/Examples/SeriesResonance.mo
@@ -2,6 +2,8 @@ within Modelica.Electrical.Analog.Examples;
 model SeriesResonance "Series resonance circuit"
   extends Modelica.Icons.Example;
   import Modelica.Constants.pi;
+  parameter Modelica.Units.SI.Frequency f0=100 "Resonance frequency";
+  parameter Modelica.Units.SI.Resistance R=10 "Scaling";
   Sources.SineVoltageVariableFrequencyAndAmplitude sineVoltage(
       useConstantAmplitude=true,                               phi(fixed=true))
     annotation (Placement(transformation(
@@ -14,9 +16,9 @@ model SeriesResonance "Series resonance circuit"
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={40,50})));
-  Basic.Inductor inductor1(i(fixed=true), L=0.1/(2*pi))
+  Basic.Inductor inductor1(i(fixed=true), L=R/(2*pi*f0))
     annotation (Placement(transformation(extent={{-30,60},{-10,80}})));
-  Basic.Capacitor capacitor1(v(fixed=true), C=0.001/(2*pi))
+  Basic.Capacitor capacitor1(v(fixed=true), C=1/(R*2*pi*f0))
     annotation (Placement(transformation(extent={{10,60},{30,80}})));
   Sensors.CurrentSensor currentSensor1
     annotation (Placement(transformation(extent={{10,20},{-10,40}})));
@@ -38,9 +40,9 @@ model SeriesResonance "Series resonance circuit"
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={40,-50})));
-  Basic.Inductor inductor2(i(fixed=true), L=0.1/(2*pi))
+  Basic.Inductor inductor2(i(fixed=true), L=R/(2*pi*f0))
     annotation (Placement(transformation(extent={{-30,-40},{-10,-20}})));
-  Basic.Capacitor capacitor2(v(fixed=true), C=0.001/(2*pi))
+  Basic.Capacitor capacitor2(v(fixed=true), C=1/(R*2*pi*f0))
     annotation (Placement(transformation(extent={{10,-40},{30,-20}})));
   Sensors.CurrentSensor currentSensor2
     annotation (Placement(transformation(extent={{10,-80},{-10,-60}})));

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/ParallelResonance.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/ParallelResonance.mo
@@ -12,7 +12,9 @@ model ParallelResonance "Parallel resonance circuit"
         transformation(
         origin={-40,-50},
         extent={{-10,-10},{10,10}},
-        rotation=90)));
+      rotation=90)));
+  parameter Modelica.Units.SI.Frequency f0=1 "Resonance frequency";
+  parameter Modelica.Units.SI.Resistance R=1 "Scaling";
   Modelica.Blocks.Sources.Ramp f(
     height=2,
     duration=1,
@@ -32,12 +34,12 @@ model ParallelResonance "Parallel resonance circuit"
         origin={-10,20},
         extent={{-10,-10},{10,10}},
         rotation=270)));
-  QuasiStatic.SinglePhase.Basic.Inductor inductor(L=1/(2*Modelica.Constants.pi))
+  QuasiStatic.SinglePhase.Basic.Inductor inductor(L=R/(2*Modelica.Constants.pi*f0))
     annotation (Placement(transformation(
         origin={10,20},
         extent={{-10,-10},{10,10}},
         rotation=270)));
-  QuasiStatic.SinglePhase.Basic.Capacitor capacitor(C=1/(2*Modelica.Constants.pi))
+  QuasiStatic.SinglePhase.Basic.Capacitor capacitor(C=1/(R*2*Modelica.Constants.pi*f0))
     annotation (Placement(transformation(
         origin={30,20},
         extent={{-10,-10},{10,10}},

--- a/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/SeriesResonance.mo
+++ b/Modelica/Electrical/QuasiStatic/SinglePhase/Examples/SeriesResonance.mo
@@ -3,6 +3,8 @@ model SeriesResonance "Series resonance circuit"
   extends Modelica.Icons.Example;
   output SI.Current I_abs=complexToPolar.len "Current";
   output SI.Angle I_arg=complexToPolar.phi "Current phase";
+  parameter Modelica.Units.SI.Frequency f0=1 "Resonance frequency";
+  parameter Modelica.Units.SI.Resistance R=1 "Scaling";
   Modelica.Blocks.Sources.Constant V(k=1) annotation (Placement(
         transformation(
         origin={-40,50},
@@ -29,9 +31,9 @@ model SeriesResonance "Series resonance circuit"
     annotation (Placement(transformation(extent={{-40,-60},{-20,-40}})));
   QuasiStatic.SinglePhase.Basic.Resistor resistor(R_ref=0.1)
     annotation (Placement(transformation(extent={{10,-10},{30,10}})));
-  QuasiStatic.SinglePhase.Basic.Inductor inductor(L=1/(2*Modelica.Constants.pi))
+  QuasiStatic.SinglePhase.Basic.Inductor inductor(L=R/(2*Modelica.Constants.pi*f0))
     annotation (Placement(transformation(extent={{40,-10},{60,10}})));
-  QuasiStatic.SinglePhase.Basic.Capacitor capacitor(C=1/(2*Modelica.Constants.pi))
+  QuasiStatic.SinglePhase.Basic.Capacitor capacitor(C=1/(R*2*Modelica.Constants.pi*f0))
     annotation (Placement(transformation(extent={{70,-10},{90,10}})));
   QuasiStatic.SinglePhase.Sensors.CurrentSensor currentSensor
     annotation (Placement(transformation(extent={{-20,10},{0,-10}})));


### PR DESCRIPTION
It also makes the models unit correct, but the main goal is to make it easier to explain the models - by replacing literal values with unclear relations with somewhat understandable parameters, and clear formulas.
(It could be made even better by explaining the derivation of them.)

A benefit is that it is straightforward to modify the resonance frequency (or resistance.) and re-run the simulation to see the impact. (Based on similar idea in #4774 )

In terms of units more work is needed - there are more models that don't work well if pi have unit "rad" or "1"; all indicating unit issues e.g.,:
* More computations of inductance using similar formulas (in other models).
* Frequency calculations.

Does not require Modelica Language version 3.7 or updated pi-definition.