### PR TITLE
Fixed MoistAir.T_psX for size(X,1) not= nX

### DIFF
--- a/Modelica/Media/Air/MoistAir.mo
+++ b/Modelica/Media/Air/MoistAir.mo
@@ -1269,13 +1269,19 @@ end thermalConductivity;
     end f_nonlinear;
 
   algorithm
-    T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(
-      function f_nonlinear(p=p, s=s, X=X[1:nX]), 190, 647);
+      if size(X, 1) == nX then
+        T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(
+          function f_nonlinear(p=p, s=s, X=X), 190, 647);
+      else
+        T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(
+          function f_nonlinear(p=p, s=s, X=cat(1,X[1:nXi],{1 - sum(X[1:nXi])})), 190, 647);
+      end if;
     annotation (Documentation(info="<html>
 Temperature is computed from pressure, specific entropy and composition via numerical inversion of function <a href=\"modelica://Modelica.Media.Air.MoistAir.s_pTX\">s_pTX</a>.
 </html>",
         revisions="<html>
 <p>2012-01-12 Stefan Wischhusen: Initial Release.</p>
+<p>2026-04-08 Corentin Lepais: Fixed the algorithm to append X[Air] to the vector X when size(X,1) differs from nX.</p>
 </html>"));
   end T_psX;
 


### PR DESCRIPTION
Closes #4771.
Test example:

```
model MoistAirEntropy "Tests MoistAir.setState_psX()"

  replaceable package Medium = Modelica.Media.Air.MoistAir;
  Medium.AbsolutePressure p=pressureSawTooth.y;//Medium.p_default;
  Medium.Temperature T=temperatureSawTooth.y;//Medium.T_default;
  Medium.MassFraction Xi[:]={massFractionSawTooth.y};// Medium.X_default[1:Medium.nXi];
  Medium.MassFraction X[:] = {Xi[1], 1-Xi[1]}; // Medium.X_default;

  Medium.SpecificEntropy s1 = Medium.specificEntropy_pTX(p,T,Xi);
  Medium.SpecificEntropy s2 = Medium.specificEntropy_pTX(p,T,X);
  Boolean check1 = abs(s1-s2) < Modelica.Constants.eps; // Check passed

  Medium.ThermodynamicState state1 = Medium.setState_psX(p,s1,Xi); // This requires modification
  Medium.ThermodynamicState state2 = Medium.setState_psX(p,s1,X);
  Medium.Temperature T1 = Medium.temperature(state1);
  Medium.Temperature T2 = Medium.temperature(state2);
  Boolean check2 = abs(T1-T) < 1e-12; // Check passed
  Boolean check3 = abs(T2-T) < 1e-12; // Check passed

  Modelica.Blocks.Sources.SawTooth pressureSawTooth(
    amplitude=2e5,
    period=0.5,
    offset=0.5e5,
    startTime=0.1) annotation (Placement(transformation(extent={{-80,42},{-60,62}})));
  Modelica.Blocks.Sources.SawTooth temperatureSawTooth(
    amplitude=200,
    period=0.5,
    offset=273.15,
    startTime=0.2) annotation (Placement(transformation(extent={{-80,0},{-60,20}})));
  Modelica.Blocks.Sources.SawTooth massFractionSawTooth(
    amplitude=0.5,
    period=0.5,
    offset=0,
    startTime=0.3) annotation (Placement(transformation(extent={{-80,-40},{-60,-20}})));
end MoistAirEntropy;
```

