### PR TITLE
Fix PartialSimpleIdealGasMedium_setState_psX

### DIFF
--- a/Modelica/Media/package.mo
+++ b/Modelica/Media/package.mo
@@ -6277,8 +6277,7 @@ quantities are assumed to be constant.
       input MassFraction X[:]=reference_X "Mass fractions";
       output ThermodynamicState state "Thermodynamic state record";
     algorithm
-      state := ThermodynamicState(p=p, T=Modelica.Math.exp(s/cp_const +
-        Modelica.Math.log(reference_T) + R_gas*Modelica.Math.log(p/reference_p)));
+      state := ThermodynamicState(p=p, T=reference_T*Modelica.Math.exp(1/cp_const*(s + R_gas*Modelica.Math.log(p/reference_p))));
     end setState_psX;
 
     redeclare function setState_dTX


### PR DESCRIPTION
Closes #4749 .

Test model:

```
model PartialSimleIdealGasMediumTest "Checks Modelica.Media.Air.SimpleAir.setState_psX"

  replaceable package Medium = Modelica.Media.Air.SimpleAir;
  Medium.AbsolutePressure p=pressureSawTooth.y;
  Medium.Temperature T=temperatureSawTooth.y;
  Medium.SpecificEntropy s = Modelica.Media.Air.SimpleAir.specificEntropy_pTX(p,T, Medium.X_default);
  Medium.ThermodynamicState state = Medium.setState_psX(p,s); // This requires modification
  Medium.Temperature T1 = Medium.temperature_ps(p,s);

  Boolean check = abs(T-T1) < Modelica.Constants.eps; // Check passed

  Modelica.Blocks.Sources.SawTooth pressureSawTooth(
    amplitude=2e5,
    period=0.5,
    offset=0.5e5,
    startTime=0.1) annotation (Placement(transformation(extent={{-10,12},{10,32}})));
  Modelica.Blocks.Sources.SawTooth temperatureSawTooth(
    amplitude=200,
    period=0.5,
    offset=273.15,
    startTime=0.2) annotation (Placement(transformation(extent={{-10,-30},{10,-10}})));

end PartialSimleIdealGasMediumTest;
```