### PR TITLE
MoistAir isentropicExponent() and specificEntropy()

### DIFF
--- a/Modelica/Media/Air/MoistAir.mo
+++ b/Modelica/Media/Air/MoistAir.mo
@@ -1053,8 +1053,10 @@ Derivative function for <a href=\"modelica://Modelica.Media.Air.MoistAir.specifi
 
   redeclare function extends specificEntropy
     "Return specific entropy from thermodynamic state record, only valid for phi<1"
-
+  protected
+    MassFraction Xsat = Xsaturation(state) "Water mass fraction at saturation";
   algorithm
+    assert(state.X[Water] <= Xsat, "MoistAir.specificEntropy() is formally defined for unsaturated air; in supersaturated states results remain continuous but may exhibit deviations", level = AssertionLevel.warning);
     s := s_pTX(
           state.p,
           state.T,

--- a/Modelica/Media/Air/MoistAir.mo
+++ b/Modelica/Media/Air/MoistAir.mo
@@ -877,7 +877,10 @@ Derivative function for <a href=\"modelica://Modelica.Media.Air.MoistAir.h_pTX\"
 
   redeclare function extends isentropicExponent
     "Return isentropic exponent (only for gas fraction!)"
+  protected
+    MassFraction Xsat = Xsaturation(state) "Water mass fraction at saturation";
   algorithm
+    assert(state.X[Water] < 0.999*Xsat, "MoistAir.isentropicExponent() is invalid for saturated or supersaturated air; may yield grossly incorrect values (kappa = 3 instead of kappa = 1.4)", level = AssertionLevel.warning);
     gamma := specificHeatCapacityCp(state)/specificHeatCapacityCv(state);
   end isentropicExponent;
 


### PR DESCRIPTION
Closes #4728 (Runtime warning).

Test model:

```
package MoistAirTests "Tests MoistAir isentropicExponent() and specificEntropy()"
  extends Modelica.Icons.Package;

  model IsentropicExponent
    extends Modelica.Icons.Example;
    package Medium = Modelica.Media.Air.MoistAir;

    Medium.AbsolutePressure p = Medium.p_default;
    Medium.Temperature T = Medium.T_default;
    Real x_sat = Medium.xsaturation_pT(p,T) "[kg_H2O/kg_dryAir] at saturation";
    Medium.MassFraction X_sat = x_sat/(1+x_sat) "[kg_H2O/kg_tot] at saturation";
    Medium.MassFraction X = (0.99 + 0.02*time)*X_sat "[kg_H2O/kg_tot]";
    Real x = X/(1-X) "[kg_H2O/kg_dryAir]";

    Medium.ThermodynamicState state = Medium.setState_pTX(p,T,{X});

    Real phi = Medium.relativeHumidity(state) "p_H2O/p_H2O,sat";
    Real psi = x/x_sat;

    Medium.IsentropicExponent kappa = Medium.isentropicExponent(state); // Isentropic exponent is heavily discontinuous at phi = psi = 1, phi < 0.998 is on the safe side, phi < 0.999 is also fine IMO
    Medium.IsentropicExponent  kappa_ref = 1.39811 "Reference isentropic exponent";
    Real eps_rel_kappa = abs(kappa-kappa_ref)/kappa_ref;

  end IsentropicExponent;

  model IsentropicExponentAndSpecificEntropy
    extends Modelica.Icons.Example;
    package Medium = Modelica.Media.Air.MoistAir;

    Medium.AbsolutePressure p = 1e5;
    Medium.Temperature T = 293.15 + 20*cos(10*time);
    Medium.MassFraction X = 1e-2;
    Medium.ThermodynamicState state = Medium.setState_pTX(p,T,{X});

    Medium.MassFraction X_sat =  Medium.Xsaturation(state);
    Real x_sat = Medium.xsaturation_pT(p,T) "[kg_H2O/kg_dryAir] at saturation";
    Real x = X/(1-X) "[kg_H2O/kg_dryAir]";

    Real phi = Medium.relativeHumidity(state) "p_H2O/p_H2O,sat";
    Real psi = x/x_sat;

    Medium.SpecificEntropy s = Medium.specificEntropy(state); // Specific entropy is continuous at phi = psi = 1
    Medium.IsentropicExponent kappa = Medium.isentropicExponent(state); // Isentropic exponent is heavily discontinuous at phi = psi = 1, phi < 0.998 is on the safe side, phi < 0.999 is also fine IMO

  end IsentropicExponentAndSpecificEntropy;

  model SpecificEntropy "Checks MoistAir.specificEntropy()"
    extends Modelica.Icons.Example;
    package Medium = Modelica.Media.Air.MoistAir;

    Medium.AbsolutePressure p = Medium.p_default;
    Medium.Temperature T = Medium.T_default;
    Real x_sat = Medium.xsaturation_pT(p,T) "[kg_H2O/kg_dryAir] at saturation";
    Medium.MassFraction X_sat = x_sat/(1+x_sat) "[kg_H2O/kg_tot] at saturation";
    Medium.MassFraction X = (0 + 2*time)*X_sat "[kg_H2O/kg_tot]";
    Real x = X/(1-X) "[kg_H2O/kg_dryAir]";

    Medium.ThermodynamicState state = Medium.setState_pTX(p,T,{X});

    Medium.SpecificEntropy s = Medium.specificEntropy(state); // Specific entropy is continuous at phi = psi = 1
    Real phi = Medium.relativeHumidity(state) "p_H2O/p_H2O,sat";
    Real psi = x/x_sat;

  end SpecificEntropy;

end MoistAirTests;
```