### PR TITLE
Tolerate floating-point rounding in friction pressure-drop assert

### DIFF
--- a/Modelica/Thermal/FluidHeatFlow/BaseClasses/SimpleFriction.mo
+++ b/Modelica/Thermal/FluidHeatFlow/BaseClasses/SimpleFriction.mo
@@ -24,8 +24,8 @@ protected
 initial algorithm
   assert(V_flowNominal>V_flowLaminar,
     "SimpleFriction: V_flowNominal has to be > V_flowLaminar!");
-  assert(dpNominal>=dpNomMin,
-    "SimpleFriction: dpNominal has to be > dpLaminar/V_flowLaminar*V_flowNominal!");
+  assert(dpNominal>=dpNomMin*(1 - 100*Modelica.Constants.eps),
+    "SimpleFriction: dpNominal has to be >= dpLaminar/V_flowLaminar*V_flowNominal!");
   k:=(dpNominal - dpNomMin)/(V_flowNominal - V_flowLaminar)^2;
 equation
   if volumeFlow > +V_flowLaminar then


### PR DESCRIPTION
The simple friction model's sanity-check assert compared two quantities that are mathematically equal at the default operating point but computed via different expressions, making it hypersensitive to rounding. On platforms with extended-precision intermediates the boundary-equal case can round just the wrong way and trip the assert. Relax the comparison by a tiny relative tolerance so the legitimate equality case passes on all platforms.

This fixes some of #3799.