### PR TITLE
Remove duplicate entry "Magnetic" in package.order of ModelicaTest

### DIFF
--- a/ModelicaTest/package.order
+++ b/ModelicaTest/package.order
@@ -4,7 +4,6 @@ Tables
 Electrical
 Magnetic
 Fluid
-Magnetic
 Media
 Math
 MultiBody


### PR DESCRIPTION
Removed duplicate 'Magnetic' entry from package order.