### PR TITLE
Added workflow file to trigger CI for testing pull requests 

### DIFF
--- a/.github/workflows/CI_ReSim_trigger.yml
+++ b/.github/workflows/CI_ReSim_trigger.yml
@@ -1,0 +1,38 @@
+name: Sync_CI_Repo
+
+on: pull_request_target
+
+permissions:
+  contents: read
+  
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.LTX_SIMULATION_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request?.number ?? context.payload.number;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const labels = (pr.labels || []).map(l => typeof l === 'string' ? l : l.name);
+            const hasLabel = labels.includes('c-code-checked');
+
+            await github.rest.repos.createDispatchEvent({
+              owner: '${{ secrets.PRIVATE_CI_OWNER }}',
+              repo: '${{ secrets.PRIVATE_CI_REPO }}',
+              event_type: 'CI_trigger_type',
+              client_payload: {
+                number: prNumber,
+                head_sha: pr.head.sha,
+                base_sha: pr.base.sha,
+                has_label: hasLabel,
+                github_repo: context.repo.full_name
+              }
+            });

--- a/.github/workflows/CI_ReSim_trigger.yml
+++ b/.github/workflows/CI_ReSim_trigger.yml
@@ -22,8 +22,9 @@ jobs:
             });
 
             const labels = (pr.labels || []).map(l => typeof l === 'string' ? l : l.name);
-            const hasLabel = labels.includes('c-code-checked');
-
+            const hasLabel = labels.includes('ready_for_ci');
+            const author = context.payload.pull_request.user.login
+            
             await github.rest.repos.createDispatchEvent({
               owner: '${{ secrets.PRIVATE_CI_OWNER }}',
               repo: '${{ secrets.PRIVATE_CI_REPO }}',
@@ -33,6 +34,7 @@ jobs:
                 head_sha: pr.head.sha,
                 base_sha: pr.base.sha,
                 has_label: hasLabel,
+                author: author,
                 github_repo: context.repo.full_name
               }
             });


### PR DESCRIPTION
This workflow acts only as a trigger.
The regression testing for pull requests itself will be performed in a private repository.
This is neccessary to avoid potential security issues and keep the use of commercial tools private.
The workflow is described in https://github.com/modelica/MA-Internal/blob/master/MA-Projects/MAP-LIB/MeetingMinutes/20260714-Monthly/20260714_RegressionTestingCI_Workflow.pdf
As a result, the workflow will approve the pull request or request changes (including links to reports) 